### PR TITLE
Add Settings signpost to Plugin Actions

### DIFF
--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -75,13 +75,17 @@ class Setup {
 	/**
 	 * Add links to the plugin action links.
 	 *
-	 * @param array<string, string> $actions
-	 * @return array<string, string>
+	 * @param array $actions Array of links.
+	 *
+	 * @return array
 	 */
 	public function filter_plugin_action_links( array $actions ) {
-		return array_merge( array(
-			'settings' => '<a href="' . esc_url( admin_url( 'edit.php?post_type=gp_event&page=gp_general' ) ) . '">' . esc_html__( 'Settings', 'gatherpress' ) . '</a>',
-		), $actions );
+		return array_merge(
+			array(
+				'settings' => '<a href="' . esc_url( admin_url( 'edit.php?post_type=gp_event&page=gp_general' ) ) . '">' . esc_html__( 'Settings', 'gatherpress' ) . '</a>',
+			),
+			$actions 
+		);
 	}
 
 	/**

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -84,7 +84,7 @@ class Setup {
 			array(
 				'settings' => '<a href="' . esc_url( admin_url( 'edit.php?post_type=gp_event&page=gp_general' ) ) . '">' . esc_html__( 'Settings', 'gatherpress' ) . '</a>',
 			),
-			$actions 
+			$actions
 		);
 	}
 

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -68,6 +68,20 @@ class Setup {
 		add_filter( 'the_time', array( $this, 'get_the_event_date' ) );
 		add_filter( 'body_class', array( $this, 'body_class' ) );
 		add_filter( 'display_post_states', array( $this, 'set_event_archive_labels' ), 10, 2 );
+		add_filter( sprintf( 'plugin_action_links_%s/%s', basename( GATHERPRESS_CORE_PATH ), basename( GATHERPRESS_CORE_FILE ) ), array( $this, 'filter_plugin_action_links' ) );
+		add_filter( sprintf( 'network_admin_plugin_action_links_%s/%s', basename( GATHERPRESS_CORE_PATH ), basename( GATHERPRESS_CORE_FILE ) ), array( $this, 'filter_plugin_action_links' ) );
+	}
+
+	/**
+	 * Add links to the plugin action links.
+	 *
+	 * @param array<string, string> $actions
+	 * @return array<string, string>
+	 */
+	public function filter_plugin_action_links( array $actions ) {
+		return array_merge( array(
+			'settings' => '<a href="' . esc_url( admin_url( 'edit.php?post_type=gp_event&page=gp_general' ) ) . '">' . esc_html__( 'Settings', 'gatherpress' ) . '</a>',
+		), $actions );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a link to GatherPress settings on the plugins page, which quickly distinguishes where users are expected to make changes to plugin settings.

![settings-link](https://user-images.githubusercontent.com/5721313/221604771-87562e54-b39b-4c1e-8f72-eb3210e94731.gif)

