### PR TITLE
Added offset to event started and event past methods.

### DIFF
--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -284,14 +284,18 @@ class Event {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param int $offset The time offset, in minutes, to adjust the consideration of the event end time.
+	 *                    A positive value extends the period of considering the event ongoing,
+	 *                    while a negative value checks for an earlier end.
+	 *                    Default is 0, checking if the event is ongoing at the exact current time.
 	 * @return bool True if the event is in the future, false otherwise.
 	 */
-	public function has_event_started(): bool {
+	public function has_event_started( int $offset = 0 ): bool {
 		$data    = $this->get_datetime();
 		$start   = $data['datetime_start_gmt'];
 		$current = time();
 
-		return ( ! empty( $start ) && $current >= strtotime( $start ) );
+		return ( ! empty( $start ) && $current >= ( strtotime( $start ) + ( $offset * 60 ) ) );
 	}
 
 	/**
@@ -302,14 +306,17 @@ class Event {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param int $offset The time offset, in minutes, to adjust the consideration of the event start time.
+	 *                    A positive value delays the event start, while a negative value checks for an earlier start.
+	 *                    Default is 0, checking if the event has started at the exact current time.
 	 * @return bool True if the event is in the past, false otherwise.
 	 */
-	public function has_event_past(): bool {
+	public function has_event_past( int $offset = 0 ): bool {
 		$data    = $this->get_datetime();
 		$end     = $data['datetime_end_gmt'];
-		$current = time();
+		$current = time() - ( $offset * 60 );
 
-		return ( ! empty( $end ) && $current > strtotime( $end ) );
+		return ( ! empty( $end ) && $current > ( strtotime( $end ) + ( $offset * 60 ) ) );
 	}
 
 	/**
@@ -319,10 +326,17 @@ class Event {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param int $started_offset The time offset, in minutes, to adjust the consideration of the event start time.
+	 *                            A positive value delays the event start, while a negative value checks for an earlier start.
+	 *                            Default is 0, checking if the event has started at the exact current time.
+	 * @param int $past_offset    The time offset, in minutes, to adjust the consideration of the event end time.
+	 *                            A positive value extends the period of considering the event ongoing,
+	 *                            while a negative value checks for an earlier end.
+	 *                            Default is 0, checking if the event is ongoing at the exact current time.
 	 * @return bool True if the event has started and is not in the past, false otherwise.
 	 */
-	public function is_event_happening(): bool {
-		return $this->has_event_started() && ! $this->has_event_past();
+	public function is_event_happening( int $started_offset = 0, int $past_offset = 0 ): bool {
+		return $this->has_event_started( $started_offset ) && ! $this->has_event_past( $past_offset );
 	}
 
 	/**
@@ -923,7 +937,7 @@ class Event {
 			if (
 				! isset( $user['status'] ) ||
 				'attending' !== $user['status'] ||
-				! $this->is_event_happening()
+				! $this->is_event_happening( -5 )
 			) {
 				return '';
 			}

--- a/test/unit/php/includes/core/classes/class-test-event.php
+++ b/test/unit/php/includes/core/classes/class-test-event.php
@@ -600,7 +600,37 @@ class Test_Event extends Base {
 
 		$output = $event->has_event_started();
 
-		$this->assertTrue( $output );
+		$this->assertTrue(
+			$output,
+			'Failed to assert that event has started.'
+		);
+
+		$start = new DateTime( 'now' );
+		$end   = new DateTime( 'now' );
+
+		$start->modify( '+2 minutes' );
+		$end->modify( '+2 hours' );
+
+		$params = array(
+			'datetime_start' => $start->format( Event::DATETIME_FORMAT ),
+			'datetime_end'   => $end->format( Event::DATETIME_FORMAT ),
+		);
+
+		$event->save_datetimes( $params );
+
+		$output = $event->has_event_started();
+
+		$this->assertFalse(
+			$output,
+			'Failed to assert that event has not started.'
+		);
+
+		$output = $event->has_event_started( -3 );
+
+		$this->assertTrue(
+			$output,
+			'Failed to assert that event has started with offset.'
+		);
 
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
@@ -617,7 +647,10 @@ class Test_Event extends Base {
 
 		$output = $event->has_event_started();
 
-		$this->assertFalse( $output );
+		$this->assertFalse(
+			$output,
+			'Failed to assert that event has not started.'
+		);
 	}
 
 	/**
@@ -649,7 +682,10 @@ class Test_Event extends Base {
 
 		$output = $event->has_event_past();
 
-		$this->assertTrue( $output );
+		$this->assertTrue(
+			$output,
+			'Failed to assert that event has past.'
+		);
 
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
@@ -667,6 +703,33 @@ class Test_Event extends Base {
 		$output = $event->has_event_past();
 
 		$this->assertFalse( $output );
+
+		$start = new DateTime( 'now' );
+		$end   = new DateTime( 'now' );
+
+		$start->modify( '-1 hour' );
+		$end->modify( '-1 minute' );
+
+		$params = array(
+			'datetime_start' => $start->format( Event::DATETIME_FORMAT ),
+			'datetime_end'   => $end->format( Event::DATETIME_FORMAT ),
+		);
+
+		$event->save_datetimes( $params );
+
+		$output = $event->has_event_past();
+
+		$this->assertTrue(
+			$output,
+			'Failed to assert that event has past.'
+		);
+
+		$output = $event->has_event_past( 5 );
+
+		$this->assertFalse(
+			$output,
+			'Failed to assert that event has not past with offset.'
+		);
 	}
 
 	/**
@@ -697,7 +760,10 @@ class Test_Event extends Base {
 
 		$output = $event->is_event_happening();
 
-		$this->assertTrue( $output );
+		$this->assertTrue(
+			$output,
+			'Failed to assert that event is happening'
+		);
 
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
@@ -714,7 +780,10 @@ class Test_Event extends Base {
 
 		$output = $event->is_event_happening();
 
-		$this->assertFalse( $output );
+		$this->assertFalse(
+			$output,
+			'Failed to assert event is not happening.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
* Adds an offset option to `has_event_started`, `has_event_past` methods, and `is_event_happening` methods. 
* Updated call to `is_event_happening` method to have a `-5` (minute) offset when enabling an online event link.
* Update unit tests to test offsets.