### PR TITLE
Fix/license declarations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "gatherpress/gatherpress",
 	"description": "Powering Communities with WordPress",
 	"type": "project",
-	"license": "GNU General Public License v2.0",
+	"license": "GPL-2.0-or-later",
 	"repositories": [
 		{
 			"type": "vcs",

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -9,7 +9,8 @@
  * Requires PHP: 7.4
  * Text Domain:  gatherpress
  * Domain Path: /languages
- * License:      GPLv2 or later (license.txt)
+ * License:      GNU General Public License v2.0 or later
+ * License URI:  https://www.gnu.org/licenses/gpl-2.0.html
  *
  * This file serves as the main plugin file for GatherPress. It defines the plugin's basic information,
  * constants, and initializes the plugin.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 		"": {
 			"name": "gatherpress",
 			"version": "0.27.0",
-			"license": "GPL-2.0",
+			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@jest/globals": "^29.7.0",
 				"@playwright/test": "^1.40.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"events"
 	],
 	"author": "",
-	"license": "GPL-2.0",
+	"license": "GPL-2.0-or-later",
 	"bugs": {
 		"url": "https://github.com/GatherPress/gatherpress/issues"
 	},

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === GatherPress ===
 Contributors:      mauteri,hrmervin,jmarx,meaganhanes,pbrocks
 Tags:              events, event, meetup, community
-License:           GNU General Public License v2 or later
+License:           GNU General Public License v2.0 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Requires PHP:      7.4
 Requires at least: 6.4


### PR DESCRIPTION
This PR assumes the specific [GNU General Public License v2.0 or later](https://www.gnu.org/licenses/gpl-2.0.html) license is what is intended to be used for licensing `gatherpress` (as that is what is referenced in the `readme.txt` and `gatherpress.php` files) and updates across the codebase to properly reference [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html) as opposed to, say, [GPL-2.0-only](https://spdx.org/licenses/GPL-2.0-only.html) or the deprecated [GPL-2.0](https://spdx.org/licenses/GPL-2.0.html) to make the license declaration explicit to GPL v2 **or later**.