### PR TITLE
Update/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@
 GatherPress is the result of the WordPress community's desire for new event management tools that meet the diverse needs of event organizers and members.
 
 ## 📃 The Project
+
 This project is for the collaborative effort to build a compelling event management application using open source tools such as _WordPress_ and _BuddyPress_ and the grit sweat and love of **the community, for the community**.
 
 We're creating the very network features we need to host events and gather well.
 
 ### 🤝 How to Get Involved
-If you wish to share in the collaborative of work to build _GatherPress_, please drop us a line either via WordPress Slack, or message us directly on our site [https://gatherpress.org/get-involved](htps://gatherpress.org/get-involved)
+
+If you wish to share in the collaborative of work to build _GatherPress_, please drop us a line either via [WordPress Slack](https://make.wordpress.org/chat/) or on [GatherPress.org](htps://gatherpress.org/get-involved).
 
 ### 🔑 Collaborator Access
 
@@ -91,7 +93,6 @@ In the Venue block, you can define:
 Go to WP Admin > GatherPress  > Topics
 
 Topics are like post categories, but for events.
-
 
 # Developer Documentation
 

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -1,15 +1,17 @@
 <?php
 /**
- * Plugin Name:  GatherPress
- * Plugin URI:   https://gatherpress.org/
- * Description:  Powering Communities with WordPress.
- * Author:       The GatherPress Community
- * Author URI:   https://gatherpress.org/
- * Version:      0.27.0
- * Requires PHP: 7.4
- * Text Domain:  gatherpress
- * Domain Path: /languages
- * License:      GPLv2 or later (license.txt)
+ * Plugin Name:       GatherPress
+ * Plugin URI:        https://gatherpress.org/
+ * Description:       Powering Communities with WordPress.
+ * Author:            The GatherPress Community
+ * Author URI:        https://gatherpress.org/
+ * Version:           0.27.0
+ * Requires PHP:      7.4
+ * Requires at least: 6.4
+ * Text Domain:       gatherpress
+ * Domain Path:       /languages
+ * License:           GPLv2 or later (license.txt)
+ * Update URI:        https://gatherpress.org/
  *
  * This file serves as the main plugin file for GatherPress. It defines the plugin's basic information,
  * constants, and initializes the plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -1,24 +1,20 @@
 === GatherPress ===
-Contributors:      mauteri,hrmervin,jmarx,meaganhanes,pbrocks
+Contributors:      mauteri, hrmervin, jmarx, meaganhanes, pbrocks
 Tags:              events, event, meetup, community
 License:           GNU General Public License v2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Requires PHP:      7.4
-Requires at least: 6.4
 Tested up to:      6.4
 Stable tag:        0.27.0
 
-GatherPress, a plugin created by and for the WordPress community, is a response to the community's desire for novel event management tools. Its agenda and roadmap align with that of the WordPress community, ensuring that it evolves in tandem with our collective wants and needs.
+GatherPress, powering our community's event management needs.
 
 == Description ==
 
-Lipsum
+GatherPress, a plugin created by and for the WordPress community, is a response to the community's desire for novel event management tools. Its agenda and roadmap align with that of the WordPress community, ensuring that it evolves in tandem with our collective wants and needs.
 
 = Contribute to GatherPress =
 
-If you wish to share in the collaborative of work to build GatherPress, please drop us a line either via WordPress Slack, or message us directly on our site https://gatherpress.org/get-involved
-
-Lipsum
+If you wish to share in the collaborative of work to build _GatherPress_, please drop us a line either via [WordPress Slack](https://make.wordpress.org/chat/) or on [GatherPress.org](https://gatherpress.org/get-involved).
 
 == Installation ==
 
@@ -32,7 +28,15 @@ To run GatherPress, we recommend your host supports:
 
 = Automatic installation =
 
-Lipsum
+@TODO
+
+== Screenshots ==
+
+@TODO
+
+== Changelog ==
+
+See complete changelog at https://github.com/GatherPress/gatherpress/releases.
 
 == Upgrade Notice ==
 


### PR DESCRIPTION
This PR:
- adds the `Update URI` header value to avoid naming conflicts should another plugin get published to WP.org before this plugin does (if this plugin gets published there, the Update URI header can be removed)
- removes the `Requires PHP` and `Requires at least` header values from readme.txt as they're [no longer needed there as of WP 5.8](https://core.trac.wordpress.org/ticket/48520#comment:18)
- adds the `Requires at least` header value to gatherpress.php as the correct location for that
- reduces the length of the short description in readme.txt to be under 150 characters per requirements on WP.org
- moves the former short description to the long description in readme.txt
- tweaks the copy and links in the contribution sections in README.md and readme.txt
- adds the `Screenshots` and `Changelog` sections to readme.txt (with a todo reference to add in screenshots as the come available from the work in #406).

Relates to #50, #406.