### PR TITLE
Add/repo templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,70 @@
+name: "\U0001F41B Bug report"
+description: "Report a bug with this project."
+labels: "bug"
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to fill out this bug report!  Please fill in as much of the template below as you can.
+    - type: textarea
+      attributes:
+          label: Describe the bug
+          description: Please write a clear and concise description of the bug, including what you expect to happen and what is currently happening.
+          placeholder: |
+              Feature '...' is not working properly. I expect '...' to happen, but '...' happens instead
+      validations:
+          required: true
+          
+    - type: textarea
+      attributes:
+          label: Steps to Reproduce
+          description: Please write the steps needed to reproduce the bug.
+          placeholder: |
+              1. Go to '...'
+              2. Click on '...'
+              3. Scroll down to '...'
+              4. See error
+      validations:
+          required: true
+
+    - type: textarea
+      attributes:
+          label: Screenshots, screen recording, code snippet
+          description: |
+              If possible, please upload a screenshot or screen recording which demonstrates the bug. You can use LIEcap to create a GIF screen recording: https://www.cockos.com/licecap/
+              Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+              For small snippets paste it directly here, or you can use GitHub Gist to share multiple code files: https://gist.github.com
+              Please ensure the shared code can be used by a developer to reproduce the issue—ideally it can be copied into a local development environment or executed in a browser console to help debug the issue
+      validations:
+          required: false
+          
+    - type: textarea
+      attributes:
+          label: Environment information
+          placeholder: |
+             - Device: <!-- [e.g. MacBook] -->
+             - OS: <!-- [e.g. MacOS 10.14.3] -->
+             - Browser and version: <!-- [e.g. Firefox 65.0.1, Chrome 73.0.3683.75, Safari 12.0.3] -->
+      validations:
+          required: false
+
+    - type: textarea
+      attributes:
+          label: WordPress information
+          placeholder: |
+             <!-- If your WordPress version is below 5.2, then please provide your WordPress, Plugins, Themes versions here. -->
+             <!-- If your WordPress version is 5.2 or higher, then please fill out the Site Health Info details below. -->
+             <details><summary>Site Health info:</summary>
+             <!-- Go to Tools > Site Health > Info tab, click "Copy site info to clipboard", and paste those details here. -->
+             </details>
+      validations:
+          required: false
+          
+    - type: checkboxes
+      id: terms
+      attributes:
+        label: Code of Conduct
+        description: By submitting this issue, you agree to follow our `Code of Conduct` (see the `CODE_OF_CONDUCT.md` file in the repo).
+        options:
+          - label: I agree to follow this project's Code of Conduct
+            required: true

--- a/.github/ISSUE_TEMPLATE/2-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2-enhancement.yml
@@ -1,0 +1,44 @@
+name: "\U0001F680 Enhancement"
+description: "Suggest an idea for this project."
+labels: "enhancement"
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thank you for suggesting an idea to make things better.  Please fill in as much of the template below as you can.
+    - type: textarea
+      attributes:
+          label: Is your enhancement related to a problem? Please describe.
+          description: Please describe the problem you are trying to solve.
+          placeholder: |
+              I use this project as a `...` and I would like `...` so that `...describe benefit...`.
+      validations:
+          required: true
+
+    - type: textarea
+      attributes:
+          label: Designs
+          description: |
+              If applicable, add mockups/screenshots/etc. to help explain your idea.
+              Tip: You can attach images or videos by clicking this area to highlight it and then dragging files in.
+      validations:
+          required: false
+
+    - type: textarea
+      attributes:
+          label: Describe alternatives you've considered
+          description: |
+              Please describe alternative solutions or features you have considered.
+          placeholder: |
+             I have also considered `...describe alternative...`, however I feel that my solution described above is better because of `...reason...`.
+      validations:
+          required: false
+
+    - type: checkboxes
+      id: terms
+      attributes:
+        label: Code of Conduct
+        description: By submitting this issue, you agree to follow our `Code of Conduct` (see the `CODE_OF_CONDUCT.md` file in the repo).
+        options:
+          - label: I agree to follow this project's Code of Conduct
+            required: true

--- a/.github/ISSUE_TEMPLATE/3-help.yml
+++ b/.github/ISSUE_TEMPLATE/3-help.yml
@@ -1,0 +1,23 @@
+name: "❓ Need help?"
+description: "Ask us a question, we are here to help!"
+labels: "question"
+body:
+    - type: markdown
+      attributes:
+          value: |
+              If you have a question that is neither a bug report nor an enhancement, then please post it here!  Please fill in as much of the template below as you can.
+    - type: textarea
+      attributes:
+          label: Describe your question
+          description: A clear and concise description of what your question is.
+      validations:
+          required: true
+
+    - type: checkboxes
+      id: terms
+      attributes:
+        label: Code of Conduct
+        description: By submitting this issue, you agree to follow our `Code of Conduct` (see the `CODE_OF_CONDUCT.md` file in the repo).
+        options:
+          - label: I agree to follow this project's Code of Conduct
+            required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--
+Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
+-->
+
+### Description of the Change
+<!--
+We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.
+
+Where possible, please also include:
+- verification steps to ensure your change has the desired effects and has not introduced any regressions
+- any benefits that will be realized
+- any alternative implementations or possible drawbacks that you considered
+- screenshots or screencasts
+-->
+
+<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
+Closes #
+
+### How to test the Change
+<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
+
+### Changelog Entry
+<!--
+Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
+> Added - New feature
+> Changed - Existing functionality
+> Deprecated - Soon-to-be removed feature
+> Removed - Feature
+> Fixed - Bug fix
+> Security - Vulnerability
+
+### Credits
+<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
+Props @username, @username2, ...
+
+### Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
+- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my change.
+- [ ] All new and existing tests pass.


### PR DESCRIPTION
This PR adds a PR template and three separate Issue templates to help standardize the information that's gathered in issues and pull requests.  Note that this ideally gets merged **after** #502 as these templates reference a `Code of Conduct` file.