### PR TITLE
Create `wordpress-version-checker.yml`

### DIFF
--- a/.github/workflows/wordpress-version-checker.yml
+++ b/.github/workflows/wordpress-version-checker.yml
@@ -1,0 +1,24 @@
+name: "WordPress version checker"
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  issues: write
+
+jobs:
+  wordpress-version-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: WordPress version checker
+        uses: skaut/wordpress-version-checker@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wordpress-version-checker.yml
+++ b/.github/workflows/wordpress-version-checker.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: WordPress version checker
-        uses: skaut/wordpress-version-checker@v2
+        uses: skaut/wordpress-version-checker@v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Action that checks weekly (on Mondays) to see if the current listed "Tested up to" value in the `readme.txt` file equals the current major WordPress version (as well as any in-development major WordPress version at the Release Candidate stage or later).  If the "Tested up to" value is below that version, then an issue is automatically opened in the repo to alert the team here to test for compatibility and bump the "Tested up to" value accordingly.  This helps to remind the contributor team here to check GatherPress for regular compatibility with WordPress so that the broader community can rely on GatherPress to most fully support event management needs with the most modern version of WordPress.