### PR TITLE
Create `wordpress-org-deploy.yml`

### DIFF
--- a/.github/workflows/wordpress-org-deploy.yml
+++ b/.github/workflows/wordpress-org-deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to WordPress.org Repository
+
+on:
+  release:
+    types: [published]
+    
+jobs:
+  deploy_to_wp_repository:
+    name: Deploy to WP.org
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Build
+      run: |
+        npm install
+        npm run build
+    - name: WordPress.org Plugin Deploy
+      id: deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      with:
+        generate-zip: true
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+    - name: Upload release asset
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ${{ github.workspace }}/${{ github.event.repository.name }}.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR adds a GitHub Action that is triggered when a new GitHub Release is published and will deploy that version to the WordPress.org SVN repository.  Note that any icon, banner, or screenshot images are assumed to be within a `.wordpress-org` folder so if those are maintained elsewhere then set that with the `ASSETS_DIR` environment variable.

Before this action can work properly, you'll need to [submit a version to the WordPress.org Plugin Review Team](https://wordpress.org/plugins/developers/add/) who, after approval, will create an SVN repo for the plugin.  Note that I recommend to be logged into the account that you want viewed as the primary "owner" of the plugin (e.g. https://profiles.wordpress.org/gatherpress) when submitting the plugin.

Once the SVN repo exists, add the SVN username and password to secrets in this GitHub repo as `SVN_USERNAME` and `SVN_PASSWORD` respectively.

Then all future releases published on GitHub will trigger this GitHub Action and deploy that version to WP.org's SVN repo.  Automation hooray!

### How to test the Change
Check any of the >2,500 public repos already using this action: https://github.com/10up/action-wordpress-plugin-deploy/network/dependents

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
