### PR TITLE
Add caching of datetimes to improve performance.

### DIFF
--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -591,7 +591,8 @@ class Event {
 		}
 
 		$cache_key = sprintf( self::DATETIME_CACHE_KEY, $this->event->ID );
-		$data      = wp_cache_get( $cache_key ) ?? $this->datetimes;
+		$cache     = wp_cache_get( $cache_key );
+		$data      = ! empty( $cache ) ? $cache : $this->datetimes;
 
 		if ( empty( $data ) || ! is_array( $data ) ) {
 			$table = sprintf( static::TABLE_FORMAT, $wpdb->prefix );

--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -81,14 +81,6 @@ class Event {
 	protected array $datetimes = array();
 
 	/**
-	 * Storing and retrieving various formats for event datetimes.
-	 *
-	 * @since 1.0.0
-	 * @var array
-	 */
-	protected array $formatted_datetimes = array();
-
-	/**
 	 * RSVP instance.
 	 *
 	 * @var Rsvp|null
@@ -424,12 +416,6 @@ class Event {
 		string $which = 'start',
 		bool $local = true
 	): string {
-		$key = $format . ' ' . $which . ' ' . $local;
-
-		if ( isset( $this->formatted_datetimes[ $key ] ) ) {
-			return $this->formatted_datetimes[ $key ];
-		}
-
 		$dt             = $this->get_datetime();
 		$date           = $dt[ sprintf( 'datetime_%s_gmt', $which ) ];
 		$dt['timezone'] = static::maybe_convert_offset( $dt['timezone'] );
@@ -449,8 +435,6 @@ class Event {
 			$ts   = strtotime( $date );
 			$date = wp_date( $format, $ts, $tz );
 		}
-
-		$this->formatted_datetimes[ $key ] = $date;
 
 		return (string) $date;
 	}

--- a/test/unit/php/includes/core/classes/class-test-event.php
+++ b/test/unit/php/includes/core/classes/class-test-event.php
@@ -604,6 +604,7 @@ class Test_Event extends Base {
 			'Failed to assert that event has started.'
 		);
 
+		$event = new Event( $post->ID );
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
 
@@ -631,6 +632,7 @@ class Test_Event extends Base {
 			'Failed to assert that event has started with offset.'
 		);
 
+		$event = new Event( $post->ID );
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
 
@@ -686,6 +688,7 @@ class Test_Event extends Base {
 			'Failed to assert that event has past.'
 		);
 
+		$event = new Event( $post->ID );
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
 
@@ -703,6 +706,7 @@ class Test_Event extends Base {
 
 		$this->assertFalse( $output );
 
+		$event = new Event( $post->ID );
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
 
@@ -764,6 +768,7 @@ class Test_Event extends Base {
 			'Failed to assert that event is happening'
 		);
 
+		$event = new Event( $post->ID );
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
 

--- a/test/unit/php/includes/core/classes/class-test-event.php
+++ b/test/unit/php/includes/core/classes/class-test-event.php
@@ -604,7 +604,6 @@ class Test_Event extends Base {
 			'Failed to assert that event has started.'
 		);
 
-		$event = new Event( $post->ID );
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
 
@@ -632,7 +631,6 @@ class Test_Event extends Base {
 			'Failed to assert that event has started with offset.'
 		);
 
-		$event = new Event( $post->ID );
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
 
@@ -688,7 +686,6 @@ class Test_Event extends Base {
 			'Failed to assert that event has past.'
 		);
 
-		$event = new Event( $post->ID );
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
 
@@ -706,7 +703,6 @@ class Test_Event extends Base {
 
 		$this->assertFalse( $output );
 
-		$event = new Event( $post->ID );
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
 
@@ -768,7 +764,6 @@ class Test_Event extends Base {
 			'Failed to assert that event is happening'
 		);
 
-		$event = new Event( $post->ID );
 		$start = new DateTime( 'now' );
 		$end   = new DateTime( 'now' );
 


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
PR https://github.com/GatherPress/gatherpress/pull/508 was reverted due to bug not invalidating cache on update. This PR replaces cache with transient API so DB calls aren't repeated.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #507 

### How to test the Change
Functionality around datetime should remain same. Use Query Monitor to see no more repeated calls to `get_datetime` method, which resulted in duplicated DB calls.

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri, @deshabhishek007 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
