### PR TITLE
Added settings_errors() to GatherPress settings template.

### DIFF
--- a/includes/templates/admin/settings/index.php
+++ b/includes/templates/admin/settings/index.php
@@ -24,6 +24,9 @@ $gatherpress_settings = Settings::get_instance();
 	<h1 class="wp-heading-inline">
 		<?php esc_html_e( 'GatherPress Settings', 'gatherpress' ); ?>
 	</h1>
+
+	<?php settings_errors(); ?>
+
 	<h2 class="nav-tab-wrapper">
 		<?php
 		foreach ( $sub_pages as $gatherpress_sub_page => $gatherpress_value ) {


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
GatherPress Settings page was not showing `Settings saved.` or any kind of message after saving. This change adds that messaging.

<img width="710" alt="Screenshot 2024-01-28 at 9 50 31 AM" src="https://github.com/GatherPress/gatherpress/assets/818980/55337b76-89c0-4e54-a52e-b95dbde0846e">

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #510 

### How to test the Change
Go to Events -> Settings and save. Message will appear now.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
N/A

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
