### PR TITLE
Fix issue with default user datetime fallback.

### DIFF
--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -106,10 +106,12 @@ class Event {
 		$time_format = $settings->get_value( 'general', 'formatting', 'time_format' );
 		$timezone    = $settings->get_value( 'general', 'formatting', 'show_timezone' ) ? ' T' : '';
 
-		// If there is a user and they have custom date/time formats, use those.
+		// If there is a user, and they have custom date/time formats, use those.
 		if ( $user_id ) {
-			$date_format = get_user_meta( $user_id, 'gp_date_format', true ) ?? $date_format;
-			$time_format = get_user_meta( $user_id, 'gp_time_format', true ) ?? $time_format;
+			$user_date_format = get_user_meta( $user_id, 'gp_date_format', true );
+			$user_time_format = get_user_meta( $user_id, 'gp_date_format', true );
+			$date_format      = ! empty( $user_date_format ) ? $user_date_format : $date_format;
+			$time_format      = ! empty( $user_time_format ) ? $user_time_format : $time_format;
 		}
 
 		if ( $this->is_same_date() ) {


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @username, @username2, ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
