### PR TITLE
decouple and user filters

### DIFF
--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -103,8 +103,8 @@ class Event {
 	 */
 	public function get_display_datetime(): string {
 		$settings    = Settings::get_instance();
-		$date_format = apply_filters( 'gatherpress_user_set_date_format', $settings->get_value( 'general', 'formatting', 'date_format' ) );
-		$time_format = apply_filters( 'gatherpress_user_set_time_format', $settings->get_value( 'general', 'formatting', 'time_format' ) );
+		$date_format = apply_filters( 'gatherpress_date_format', $settings->get_value( 'general', 'formatting', 'date_format' ) );
+		$time_format = apply_filters( 'gatherpress_time_format', $settings->get_value( 'general', 'formatting', 'time_format' ) );
 		$timezone    = $settings->get_value( 'general', 'formatting', 'show_timezone' ) ? ' T' : '';
 
 		if ( $this->is_same_date() ) {
@@ -338,7 +338,7 @@ class Event {
 			(array) $data
 		);
 
-		$data['timezone'] = apply_filters( 'gatherpress_user_set_timezone', $data['timezone'] );
+		$data['timezone'] = apply_filters( 'gatherpress_timezone', $data['timezone'] );
 
 		return $data;
 	}

--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -88,12 +88,10 @@ class Event {
 	}
 
 	/**
-	 * Retrieves and formats the event's date and time for display, adjusting for user settings.
+	 * Retrieves and formats the event's date and time for display.
 	 *
-	 * This method generates a formatted string that represents the event's start and end dates and times,
-	 * tailored to the user's date and time format preferences if available. It also considers whether the
-	 * event's start and end occur on the same day to adjust the format accordingly. If user-specific
-	 * formatting settings are set, they override the default site settings for date and time formatting.
+	 * This method generates a formatted string that represents the event's start and end dates and times.
+	 * It also considers whether the event's start and end occur on the same day to adjust the format accordingly.
 	 * Additionally, it can append the timezone to the formatted string based on settings.
 	 *
 	 * @since 1.0.0
@@ -105,8 +103,8 @@ class Event {
 	 */
 	public function get_display_datetime(): string {
 		$settings    = Settings::get_instance();
-		$date_format = apply_filters( 'gatherpress_date_format', $settings->get_value( 'general', 'formatting', 'date_format' ) );
-		$time_format = apply_filters( 'gatherpress_time_format', $settings->get_value( 'general', 'formatting', 'time_format' ) );
+		$date_format = apply_filters( 'gatherpress_user_set_date_format', $settings->get_value( 'general', 'formatting', 'date_format' ) );
+		$time_format = apply_filters( 'gatherpress_user_set_time_format', $settings->get_value( 'general', 'formatting', 'time_format' ) );
 		$timezone    = $settings->get_value( 'general', 'formatting', 'show_timezone' ) ? ' T' : '';
 
 		if ( $this->is_same_date() ) {
@@ -297,8 +295,7 @@ class Event {
 	 * This method fetches the event's start and end dates and times, along with timezone information,
 	 * either from a custom database table associated with the event or user metadata. It uses caching
 	 * to optimize database interactions, ensuring that data is fetched and stored efficiently for
-	 * future requests. If a user is logged in and not in an admin context, their preferred timezone
-	 * is used; otherwise, the site's timezone settings are applied.
+	 * future requests.
 	 *
 	 * @since 1.0.0
 	 *
@@ -341,7 +338,7 @@ class Event {
 			(array) $data
 		);
 
-		$data['timezone'] = apply_filters( 'gatherpress_timezone', $data['timezone'] );
+		$data['timezone'] = apply_filters( 'gatherpress_user_set_timezone', $data['timezone'] );
 
 		return $data;
 	}

--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -105,8 +105,8 @@ class Event {
 	 */
 	public function get_display_datetime(): string {
 		$settings    = Settings::get_instance();
-		$date_format = apply_filters( 'gp_date_format', $settings->get_value( 'general', 'formatting', 'date_format' ) );
-		$time_format = apply_filters( 'gp_time_format', $settings->get_value( 'general', 'formatting', 'time_format' ) );
+		$date_format = apply_filters( 'gatherpress_date_format', $settings->get_value( 'general', 'formatting', 'date_format' ) );
+		$time_format = apply_filters( 'gatherpress_time_format', $settings->get_value( 'general', 'formatting', 'time_format' ) );
 		$timezone    = $settings->get_value( 'general', 'formatting', 'show_timezone' ) ? ' T' : '';
 
 		if ( $this->is_same_date() ) {
@@ -341,7 +341,7 @@ class Event {
 			(array) $data
 		);
 
-		$data['timezone'] = apply_filters( 'gp_timezone', $data['timezone'] );
+		$data['timezone'] = apply_filters( 'gatherpress_timezone', $data['timezone'] );
 
 		return $data;
 	}

--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -104,19 +104,10 @@ class Event {
 	 * @throws Exception If date/time formatting fails or settings cannot be retrieved.
 	 */
 	public function get_display_datetime(): string {
-		$user_id     = get_current_user_id();
 		$settings    = Settings::get_instance();
-		$date_format = $settings->get_value( 'general', 'formatting', 'date_format' );
-		$time_format = $settings->get_value( 'general', 'formatting', 'time_format' );
+		$date_format = apply_filters( 'gp_date_format', $settings->get_value( 'general', 'formatting', 'date_format' ) );
+		$time_format = apply_filters( 'gp_time_format', $settings->get_value( 'general', 'formatting', 'time_format' ) );
 		$timezone    = $settings->get_value( 'general', 'formatting', 'show_timezone' ) ? ' T' : '';
-
-		// If there is a user, and they have custom date/time formats, use those.
-		if ( $user_id ) {
-			$user_date_format = get_user_meta( $user_id, 'gp_date_format', true );
-			$user_time_format = get_user_meta( $user_id, 'gp_time_format', true );
-			$date_format      = ! empty( $user_date_format ) ? $user_date_format : $date_format;
-			$time_format      = ! empty( $user_time_format ) ? $user_time_format : $time_format;
-		}
 
 		if ( $this->is_same_date() ) {
 			$start = $this->get_datetime_start( $date_format . ' ' . $time_format );
@@ -350,13 +341,7 @@ class Event {
 			(array) $data
 		);
 
-		$user_id = get_current_user_id();
-
-		// If not in an admin page, use the user's timezone if set.
-		if ( ! is_admin() && $user_id ) {
-			$gp_timezone      = get_user_meta( $user_id, 'gp_timezone', true );
-			$data['timezone'] = ! empty( $gp_timezone ) ? $gp_timezone : $data['timezone'];
-		}
+		$data['timezone'] = apply_filters( 'gp_timezone', $data['timezone'] );
 
 		return $data;
 	}

--- a/includes/core/classes/class-user.php
+++ b/includes/core/classes/class-user.php
@@ -56,9 +56,9 @@ class User {
 		add_action( 'edit_user_profile', array( $this, 'profile_fields' ) );
 		add_action( 'personal_options_update', array( $this, 'save_profile_fields' ) );
 		add_action( 'edit_user_profile_update', array( $this, 'save_profile_fields' ) );
-		add_filter( 'gatherpress_date_format', array( $this, 'gp_date_format' ) );
-		add_filter( 'gatherpress_time_format', array( $this, 'gp_time_format' ) );
-		add_filter( 'gatherpress_timezone', array( $this, 'gp_timezone' ) );
+		add_filter( 'gatherpress_user_set_date_format', array( $this, 'gp_date_format' ) );
+		add_filter( 'gatherpress_user_set_time_format', array( $this, 'gp_time_format' ) );
+		add_filter( 'gatherpress_user_set_timezone', array( $this, 'gp_timezone' ) );
 	}
 
 	/**

--- a/includes/core/classes/class-user.php
+++ b/includes/core/classes/class-user.php
@@ -56,9 +56,9 @@ class User {
 		add_action( 'edit_user_profile', array( $this, 'profile_fields' ) );
 		add_action( 'personal_options_update', array( $this, 'save_profile_fields' ) );
 		add_action( 'edit_user_profile_update', array( $this, 'save_profile_fields' ) );
-		add_filter( 'gatherpress_user_set_date_format', array( $this, 'gp_date_format' ) );
-		add_filter( 'gatherpress_user_set_time_format', array( $this, 'gp_time_format' ) );
-		add_filter( 'gatherpress_user_set_timezone', array( $this, 'gp_timezone' ) );
+		add_filter( 'gatherpress_date_format', array( $this, 'user_set_date_format' ) );
+		add_filter( 'gatherpress_time_format', array( $this, 'user_set_time_format' ) );
+		add_filter( 'gatherpress_timezone', array( $this, 'user_set_timezone' ) );
 	}
 
 	/**
@@ -72,7 +72,7 @@ class User {
 	 *
 	 * @return string The user's date format preference or the default if not set
 	 */
-	public function gp_date_format( $date_format ): string {
+	public function user_set_date_format( $date_format ): string {
 		$user_id = get_current_user_id();
 
 		if ( $user_id ) {
@@ -94,7 +94,7 @@ class User {
 	 *
 	 * @return string The user's time format preference or the default if not set
 	 */
-	public function gp_time_format( $time_format ): string {
+	public function user_set_time_format( $time_format ): string {
 		$user_id = get_current_user_id();
 
 		if ( $user_id ) {
@@ -116,7 +116,7 @@ class User {
 	 *
 	 * @return string The user's timezone preference or the default if not set.
 	 */
-	public function gp_timezone( $timezone ): string {
+	public function user_set_timezone( $timezone ): string {
 		$user_id = get_current_user_id();
 
 		if ( ! is_admin() && $user_id ) {

--- a/includes/core/classes/class-user.php
+++ b/includes/core/classes/class-user.php
@@ -56,9 +56,9 @@ class User {
 		add_action( 'edit_user_profile', array( $this, 'profile_fields' ) );
 		add_action( 'personal_options_update', array( $this, 'save_profile_fields' ) );
 		add_action( 'edit_user_profile_update', array( $this, 'save_profile_fields' ) );
-		add_filter( 'gp_date_format', array( $this, 'gp_date_format' ) );
-		add_filter( 'gp_time_format', array( $this, 'gp_time_format' ) );
-		add_filter( 'gp_timezone', array( $this, 'gp_timezone' ) );
+		add_filter( 'gatherpress_date_format', array( $this, 'gp_date_format' ) );
+		add_filter( 'gatherpress_time_format', array( $this, 'gp_time_format' ) );
+		add_filter( 'gatherpress_timezone', array( $this, 'gp_timezone' ) );
 	}
 
 	/**
@@ -68,7 +68,7 @@ class User {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param $date_format string The default date format
+	 * @param string $date_format The default date format.
 	 *
 	 * @return string The user's date format preference or the default if not set
 	 */
@@ -90,14 +90,14 @@ class User {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param $time_format string The default time format
+	 * @param string $time_format The default time format.
 	 *
 	 * @return string The user's time format preference or the default if not set
 	 */
 	public function gp_time_format( $time_format ): string {
 		$user_id = get_current_user_id();
 
-		if ( $user_id )	{
+		if ( $user_id ) {
 			$user_time_format = get_user_meta( $user_id, 'gp_time_format', true );
 			$time_format      = ! empty( $user_time_format ) ? $user_time_format : $time_format;
 		}
@@ -112,7 +112,7 @@ class User {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param $timezone string The default timezone
+	 * @param string $timezone The default timezone.
 	 *
 	 * @return string The user's timezone preference or the default if not set.
 	 */

--- a/includes/core/classes/class-user.php
+++ b/includes/core/classes/class-user.php
@@ -56,6 +56,75 @@ class User {
 		add_action( 'edit_user_profile', array( $this, 'profile_fields' ) );
 		add_action( 'personal_options_update', array( $this, 'save_profile_fields' ) );
 		add_action( 'edit_user_profile_update', array( $this, 'save_profile_fields' ) );
+		add_filter( 'gp_date_format', array( $this, 'gp_date_format' ) );
+		add_filter( 'gp_time_format', array( $this, 'gp_time_format' ) );
+		add_filter( 'gp_timezone', array( $this, 'gp_timezone' ) );
+	}
+
+	/**
+	 * Get date format for a user if logged in.
+	 *
+	 * This is a filter to get a user defined date format. 'gp_date_format'
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param $date_format string The default date format
+	 *
+	 * @return string The user's date format preference or the default if not set
+	 */
+	public function gp_date_format( $date_format ): string {
+		$user_id = get_current_user_id();
+
+		if ( $user_id ) {
+			$user_date_format = get_user_meta( $user_id, 'gp_date_format', true );
+			$date_format      = ! empty( $user_date_format ) ? $user_date_format : $date_format;
+		}
+
+		return $date_format;
+	}
+
+	/**
+	 * Get time format for a user if logged in.
+	 *
+	 * This is a filter to get a user defined time format. 'gp_time_format'
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param $time_format string The default time format
+	 *
+	 * @return string The user's time format preference or the default if not set
+	 */
+	public function gp_time_format( $time_format ): string {
+		$user_id = get_current_user_id();
+
+		if ( $user_id )	{
+			$user_time_format = get_user_meta( $user_id, 'gp_time_format', true );
+			$time_format      = ! empty( $user_time_format ) ? $user_time_format : $time_format;
+		}
+
+		return $time_format;
+	}
+
+	/**
+	 * Get timezone for a user if logged in.
+	 *
+	 * This is a filter to get a user defined timezone. 'gp_timezone'
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param $timezone string The default timezone
+	 *
+	 * @return string The user's timezone preference or the default if not set.
+	 */
+	public function gp_timezone( $timezone ): string {
+		$user_id = get_current_user_id();
+
+		if ( ! is_admin() && $user_id ) {
+			$gp_timezone = get_user_meta( $user_id, 'gp_timezone', true );
+			$timezone    = ! empty( $gp_timezone ) ? $gp_timezone : $timezone;
+		}
+
+		return $timezone;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
Decouples and adds filters for better manageability.
<!--
Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #577 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Make sure date/time/timezone users settings are still functioning as expected.

### Changelog Entry
> Changed - Existing functionality
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @linusx

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests pass.
