### PR TITLE
Skip the version-checker-workflow outside of GatherPress org

### DIFF
--- a/.github/workflows/wordpress-version-checker.yml
+++ b/.github/workflows/wordpress-version-checker.yml
@@ -16,6 +16,10 @@ permissions:
 
 jobs:
   wordpress-version-checker:
+    # Prevent this workflow to run on forks outside of the GatherPress organization,
+    # because the required permission to create an issue would not be given and the workflow would fail.
+    # Using a condition check will skip the test.
+    if: github.repository_owner == 'GatherPress'
     runs-on: ubuntu-latest
     steps:
       - name: WordPress version checker


### PR DESCRIPTION
Currently, the *WordPress version checker* workflow runs on every PR, even when made from outside the *GatherPress* organization.

I'd like to prevent this workflow to run on forks outside of the GatherPress organization, because the required permission to create an issue would not be given and the workflow would fail.
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Using a condition check, to test for the *GatherPress* org will skip the test for every PR, that is opened from an external namespace.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Fork GatherPress into your namespace
2. Create a new branch, commit and publish some changes
3. open a PR to merge your new branch into the `main` branch 
4. See the workflow to be skipped, [like I did](https://github.com/carstingaxion/gatherpress/pull/11#issuecomment-1981876745).

![](https://private-user-images.githubusercontent.com/198883/310677679-ed8c1bd2-7c37-409c-9dd4-f8fb4d470369.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDk3NjMzOTEsIm5iZiI6MTcwOTc2MzA5MSwicGF0aCI6Ii8xOTg4ODMvMzEwNjc3Njc5LWVkOGMxYmQyLTdjMzctNDA5Yy05ZGQ0LWY4ZmI0ZDQ3MDM2OS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwMzA2JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDMwNlQyMjExMzFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1jZjk3MDIxNzcxYmVlMjM5NDM3NTMxMDU1Yjk1ZTJhNDNlZGI4MTNmOGNhNWIyMzRjNzZjNzc3MzI5MTI3Yzk2JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.swoJd3Y-gwzNwVYMs-w3TLmHLRCkVe0lYOPu18GmK7Q)

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Prevent the *WordPress version checker* workflow to run & fail for PRs from outside the *GatherPress* organization.

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
