### PR TITLE
Fix markup issue with self-closing div tag.

### DIFF
--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -264,7 +264,7 @@ class Assets {
 	 */
 	public function event_communication_modal(): void {
 		if ( get_post_type() === Event::POST_TYPE ) {
-			echo '<div id="gp-event-communication-modal" />';
+			echo '<div id="gp-event-communication-modal"></div>';
 		}
 	}
 

--- a/test/unit/php/includes/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/core/classes/class-test-assets.php
@@ -108,7 +108,7 @@ class Test_Assets extends Base {
 		$output = Utility::buffer_and_return( array( $instance, 'event_communication_modal' ) );
 
 		$this->assertSame(
-			'<div id="gp-event-communication-modal" />',
+			'<div id="gp-event-communication-modal"></div>',
 			$output,
 			'Failed to assert event_communication_modal output div.'
 		);


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
Fixes issue with endless calls to admin ajax due to erroneous self-closing div tag in FireFox.
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #605 

### How to test the Change
See issue it closes, that should not happen anymore. This issue only happens in FireFox, not Chrome.
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion, @mauteri 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
