### PR TITLE
Wrap strings in backticks to make sprintf work

### DIFF
--- a/src/components/Rsvp.js
+++ b/src/components/Rsvp.js
@@ -197,11 +197,7 @@ const Rsvp = ({
 									'gatherpress'
 								),
 								`<a href=${getFromGlobal('urls.loginUrl')}>
-									${_x(
-										'Login',
-										'Context: You must ~ to RSVP to events.',
-										'gatherpress'
-									)}
+									${_x( 'Login', 'Context: You must ~ to RSVP to events.', 'gatherpress' )}
 								</a>`
 							)
 						)}
@@ -216,11 +212,7 @@ const Rsvp = ({
 										'gatherpress'
 									),
 									`<a href=${getFromGlobal('urls.registrationUrl')}>
-										${_x(
-											'Register',
-											'Context: ~ if you do not have an account.',
-											'gatherpress'
-										)}
+										${_x( 'Register', 'Context: ~ if you do not have an account.', 'gatherpress' )}
 									</a>`
 								)
 							)}

--- a/src/components/Rsvp.js
+++ b/src/components/Rsvp.js
@@ -196,13 +196,13 @@ const Rsvp = ({
 									'You must %s to RSVP to events.',
 									'gatherpress'
 								),
-								<a href={getFromGlobal('urls.loginUrl')}>
-									{_x(
+								`<a href=${getFromGlobal('urls.loginUrl')}>
+									${_x(
 										'Login',
 										'Context: You must ~ to RSVP to events.',
 										'gatherpress'
 									)}
-								</a>
+								</a>`
 							)
 						)}
 					</div>
@@ -215,17 +215,13 @@ const Rsvp = ({
 										'%s if you do not have an account.',
 										'gatherpress'
 									),
-									<a
-										href={getFromGlobal(
-											'urls.registrationUrl'
-										)}
-									>
-										{_x(
+									`<a href=${getFromGlobal('urls.registrationUrl')}>
+										${_x(
 											'Register',
 											'Context: ~ if you do not have an account.',
 											'gatherpress'
 										)}
-									</a>
+									</a>`
 								)
 							)}
 						</div>

--- a/src/components/Rsvp.js
+++ b/src/components/Rsvp.js
@@ -197,7 +197,7 @@ const Rsvp = ({
 									'gatherpress'
 								),
 								`<a href=${getFromGlobal('urls.loginUrl')}>
-									${_x( 'Login', 'Context: You must ~ to RSVP to events.', 'gatherpress' )}
+									${_x('Login', 'Context: You must ~ to RSVP to events.', 'gatherpress')}
 								</a>`
 							)
 						)}
@@ -212,7 +212,7 @@ const Rsvp = ({
 										'gatherpress'
 									),
 									`<a href=${getFromGlobal('urls.registrationUrl')}>
-										${_x( 'Register', 'Context: ~ if you do not have an account.', 'gatherpress' )}
+										${_x('Register', 'Context: ~ if you do not have an account.', 'gatherpress')}
 									</a>`
 								)
 							)}


### PR DESCRIPTION
This is follow-up to #633, because I wanted to start without the reverted commits.

I described in [a comment on the old PR](https://github.com/GatherPress/gatherpress/pull/633#issuecomment-2028942164) more in details what happened.
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #623 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->


1. Make sure you are not logged
2. Click RSVP button to RSVP to an event.
3. Login modal pops up with working Links for Login and Registration.


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix missing text in RSVP modal


### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @jmarx, @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
