### PR TITLE
Fix event in past link issue.

### DIFF
--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -725,7 +725,8 @@ class Event {
 
 			if (
 				! isset( $user['status'] ) ||
-				'attending' !== $user['status']
+				'attending' !== $user['status'] ||
+				$this->has_event_past()
 			) {
 				return '';
 			}

--- a/test/unit/php/includes/core/classes/class-test-event.php
+++ b/test/unit/php/includes/core/classes/class-test-event.php
@@ -694,6 +694,24 @@ class Test_Event extends Base {
 			'Failed to assert online event link is present.'
 		);
 
+		$start = new DateTime( 'now' );
+		$end   = new DateTime( 'now' );
+
+		$start->modify( '-4 hours' );
+		$end->modify( '-2 hours' );
+
+		$params = array(
+			'datetime_start' => $start->format( Event::DATETIME_FORMAT ),
+			'datetime_end'   => $end->format( Event::DATETIME_FORMAT ),
+		);
+
+		$event->save_datetimes( $params );
+
+		$this->assertEmpty(
+			$event->maybe_get_online_event_link(),
+			'Failed to assert online event link is empty.'
+		);
+
 		Utility::set_and_get_hidden_property( $event, 'rsvp', null );
 
 		$this->assertEmpty(


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
Bug was introduced when we removed the `is_event_happening` check, which made the event active when it started. Issue is that it never went inactive after the event ended. Updated code and added unit test for this.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix


### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
