### PR TITLE
Update .wp-env.json

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,6 +2,9 @@
 	"plugins": [
 		"."
 	],
+	"config": {
+		"WP_DEBUG_LOG": true
+	},
 	"mappings": {
 		"wp-content/plugins": "./wp-core/plugins",
 		"wp-content/themes": "./wp-core/themes"


### PR DESCRIPTION
It appears that wp-env has the `WP_DEBUG_LOG` set to `false` by default. This PR ensures that it is enabled when spinning up.
