### PR TITLE
Reflect changes to the venue term, when a venue post gets deleted.

### DIFF
--- a/includes/core/classes/class-venue.php
+++ b/includes/core/classes/class-venue.php
@@ -261,8 +261,8 @@ class Venue {
 			return;
 		}
 
-		// Only proceed if the venue post is being published.
-		if ( 'publish' !== $post_after->post_status ) {
+		// Only proceed if the venue post is being published or trashed.
+		if ( 'publish' !== $post_after->post_status && 'trash' !== $post_after->post_status ) {
 			return;
 		}
 

--- a/includes/core/classes/class-venue.php
+++ b/includes/core/classes/class-venue.php
@@ -262,7 +262,14 @@ class Venue {
 		}
 
 		// Only proceed if the venue post is being published or trashed.
-		if ( 'publish' !== $post_after->post_status && 'trash' !== $post_after->post_status ) {
+		if ( ! in_array(
+			$post_after->post_status,
+			array(
+				'publish',
+				'trash',
+			),
+			true
+		) ) {
 			return;
 		}
 

--- a/test/unit/php/includes/core/classes/class-test-venue.php
+++ b/test/unit/php/includes/core/classes/class-test-venue.php
@@ -267,6 +267,18 @@ class Test_Venue extends Base {
 			'Failed to assert that slugs do not match.'
 		);
 
+		// Setting back to trash should update the term.
+		$venue_after->post_status = 'trash';
+		$instance->maybe_update_term_slug( $venue_before->ID, $venue_after, $venue_before );
+
+		$term_object = get_term( $term['term_id'] );
+
+		$this->assertSame(
+			$term_object->slug,
+			$instance->get_venue_term_slug( $venue_after->post_name ),
+			'Failed to assert that slugs match.'
+		);
+
 		// Setting back to publish should update the term.
 		$venue_after->post_status = 'publish';
 		$instance->maybe_update_term_slug( $venue_before->ID, $venue_after, $venue_before );


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #730

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - The terms of the shadow taxonomy `_gatherpress_venue` were not deleted, when the corresponding `gatherpress_venue` posts were deleted


### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion, @mauteri 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
