### PR TITLE
Updates to autoloader.

### DIFF
--- a/includes/core/classes/class-autoloader.php
+++ b/includes/core/classes/class-autoloader.php
@@ -33,10 +33,12 @@ class Autoloader {
 	public static function register(): void {
 		spl_autoload_register(
 			static function ( string $class_string = '' ): void {
+				$registered_autoloaders = apply_filters( 'gatherpress_autoloader', array() );
 				$default                = array(
 					'GatherPress' => GATHERPRESS_CORE_PATH,
 				);
-				$registered_autoloaders = apply_filters( 'gatherpress_autoloader', $default );
+				$registered_autoloaders = array_merge( $registered_autoloaders, $default );
+
 
 				foreach ( $registered_autoloaders as $namespace => $path ) {
 					$namespace_root = sprintf( '%s\\', $namespace );

--- a/includes/core/classes/class-autoloader.php
+++ b/includes/core/classes/class-autoloader.php
@@ -33,11 +33,34 @@ class Autoloader {
 	public static function register(): void {
 		spl_autoload_register(
 			static function ( string $class_string = '' ): void {
+				/**
+				 * Filters the registered autoloaders for GatherPress.
+				 *
+				 * This filter allows developers to add or modify autoloaders for GatherPress. By using this filter,
+				 * namespaces and their corresponding paths can be registered.
+				 *
+				 * @param array $registered_autoloaders An associative array of namespaces and their paths.
+				 * @return array Modified array of namespaces and their paths.
+				 * @since 1.0.0
+				 *
+				 * @example
+				 * function gatherpress_awesome_autoloader( array $namespace ): array {
+				 *     $namespace['GatherPress_Awesome'] = __DIR__;
+				 *
+				 *     return $namespace;
+				 * }
+				 * add_filter( 'gatherpress_autoloader', 'gatherpress_awesome_autoloader' );
+				 *
+				 * Example: The namespace 'GatherPress_Awesome\Setup' would map to 'gatherpress-awesome/includes/classes/class-setup.php'.
+				 */
 				$registered_autoloaders = apply_filters( 'gatherpress_autoloader', array() );
-				$default                = array(
-					'GatherPress' => GATHERPRESS_CORE_PATH,
+
+				$registered_autoloaders = array_merge(
+					$registered_autoloaders,
+					array(
+						'GatherPress' => GATHERPRESS_CORE_PATH,
+					)
 				);
-				$registered_autoloaders = array_merge( $registered_autoloaders, $default );
 
 				foreach ( $registered_autoloaders as $namespace => $path ) {
 					$namespace_root = sprintf( '%s\\', $namespace );

--- a/includes/core/classes/class-autoloader.php
+++ b/includes/core/classes/class-autoloader.php
@@ -39,7 +39,6 @@ class Autoloader {
 				);
 				$registered_autoloaders = array_merge( $registered_autoloaders, $default );
 
-
 				foreach ( $registered_autoloaders as $namespace => $path ) {
 					$namespace_root = sprintf( '%s\\', $namespace );
 					$class_string   = trim( $class_string, '\\' );


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
Changes to autoloader to allow companion plugins to register and utilize the autoloader via the `gatherpress_autoloader` filter. This filter is an array where the key is the namespace (eg `GatherPress`) and the value is the root directory (eg `__DIR__`).
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

### How to test the Change
Everything in GatherPress should work normally.
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Existing functionality


### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
