### PR TITLE
TRY Fixing the playground-preview for outside collaborators.

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -6,9 +6,10 @@ name: Playground Preview
 # Inspired by, but not based on https://github.com/WordPress/gutenberg/blob/b89fb7b6eaf619bde0269e2a7fbf6245822f6cbf/.github/workflows/build-plugin-zip.yml#L153
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
     paths:
+    - '.github/workflows/playground-preview.yml'
     - 'build/**'
     - 'includes/**'
     - 'languages/**'
@@ -28,8 +29,8 @@ concurrency:
 # Permission can be added at job level or workflow level
 #
 # IS THIS STILL NEEDED ???
-permissions:
-  pull-requests: write
+# permissions:
+#   pull-requests: write
 
 jobs:
 


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
I'm looking for the playground preview once again. And I need the workflow to be in the repo first, like I described in the original PR, but missed an important aspect, that should be fixed with the new trigger `pull_request_target`, which I introduce with this PR.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~ Follow-up bug-fix for #666 & #741

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
