### PR TITLE
⚠️ Load later for i18n (Enhance i18n of attendees-email...)

### DIFF
--- a/gatherpress.php
+++ b/gatherpress.php
@@ -39,8 +39,15 @@ if ( ! require_once GATHERPRESS_CORE_PATH . '/includes/core/requirements-check.p
 require_once GATHERPRESS_CORE_PATH . '/includes/core/classes/class-autoloader.php';
 GatherPress\Core\Autoloader::register();
 
+register_activation_hook( GATHERPRESS_CORE_FILE, array( '\GatherPress\Core\Setup', 'activate_gatherpress_plugin' ) );
+register_deactivation_hook( GATHERPRESS_CORE_FILE, array( '\GatherPress\Core\Setup', 'deactivate_gatherpress_plugin' ) );
+
+
 // Initialize setups.
 add_action(
 	'plugins_loaded',
 	array( '\GatherPress\Core\Setup', 'get_instance' )
 );
+
+
+// GatherPress\Core\Setup::get_instance();

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -40,4 +40,7 @@ require_once GATHERPRESS_CORE_PATH . '/includes/core/classes/class-autoloader.ph
 GatherPress\Core\Autoloader::register();
 
 // Initialize setups.
-GatherPress\Core\Setup::get_instance();
+add_action(
+	'plugins_loaded',
+	array( '\GatherPress\Core\Setup', 'get_instance' )
+);

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -9,7 +9,6 @@
  * Requires PHP:      7.4
  * Requires at least: 6.4
  * Text Domain:       gatherpress
- * Domain Path:       /languages
  * License:           GNU General Public License v2.0 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  *

--- a/includes/core/classes/class-rest-api.php
+++ b/includes/core/classes/class-rest-api.php
@@ -457,7 +457,7 @@ class Rest_Api {
 				continue;
 			}
 			if ( $member->user_email ) {
-				$to = $member->user_email;
+				$to              = $member->user_email;
 				$switched_locale = switch_to_user_locale( $member->ID );
 
 				// Set the current user to the actual member to mail to,

--- a/includes/core/classes/class-rest-api.php
+++ b/includes/core/classes/class-rest-api.php
@@ -449,18 +449,6 @@ class Rest_Api {
 		}
 
 		$members = $this->get_members( $send, $post_id );
-		/* translators: %s: event title. */
-		$subject = sprintf( __( '📅 %s', 'gatherpress' ), get_the_title( $post_id ) );
-		$body    = Utility::render_template(
-			sprintf( '%s/includes/templates/admin/emails/event-email.php', GATHERPRESS_CORE_PATH ),
-			array(
-				'event_id' => $post_id,
-				'message'  => $message,
-			),
-		);
-		$headers = array( 'Content-Type: text/html; charset=UTF-8' );
-		$subject = stripslashes_deep( html_entity_decode( $subject, ENT_QUOTES, 'UTF-8' ) );
-
 		foreach ( $members as $member ) {
 			if ( '0' === get_user_meta( $member->ID, 'gatherpress_event_updates_opt_in', true ) ) {
 				continue;
@@ -468,8 +456,25 @@ class Rest_Api {
 
 			if ( $member->user_email ) {
 				$to = $member->user_email;
+				$switched_locale = switch_to_user_locale( $member->ID );
+
+				/* translators: %s: event title. */
+				$subject = sprintf( __( '📅 %s', 'gatherpress' ), get_the_title( $post_id ) );
+				$body    = Utility::render_template(
+					sprintf( '%s/includes/templates/admin/emails/event-email.php', GATHERPRESS_CORE_PATH ),
+					array(
+						'event_id' => $post_id,
+						'message'  => $message,
+					),
+				);
+				$headers = array( 'Content-Type: text/html; charset=UTF-8' );
+				$subject = stripslashes_deep( html_entity_decode( $subject, ENT_QUOTES, 'UTF-8' ) );
 
 				wp_mail( $to, $subject, $body, $headers );
+
+				if ( $switched_locale ) {
+					restore_previous_locale();
+				}
 			}
 		}
 

--- a/includes/core/classes/class-rest-api.php
+++ b/includes/core/classes/class-rest-api.php
@@ -448,15 +448,22 @@ class Rest_Api {
 			return false;
 		}
 
+		// Keep the currently logged-in user.
+		$current_user = wp_get_current_user();
+
 		$members = $this->get_members( $send, $post_id );
 		foreach ( $members as $member ) {
 			if ( '0' === get_user_meta( $member->ID, 'gatherpress_event_updates_opt_in', true ) ) {
 				continue;
 			}
-
 			if ( $member->user_email ) {
 				$to = $member->user_email;
 				$switched_locale = switch_to_user_locale( $member->ID );
+
+				// Set the current user to the actual member to mail to,
+				// to make sure the GatherPress filters for date- and time- format, as well as the users timezone,
+				// are recognized by the functions inside render_template().
+				wp_set_current_user( $member->ID );
 
 				/* translators: %s: event title. */
 				$subject = sprintf( __( '📅 %s', 'gatherpress' ), get_the_title( $post_id ) );
@@ -469,6 +476,9 @@ class Rest_Api {
 				);
 				$headers = array( 'Content-Type: text/html; charset=UTF-8' );
 				$subject = stripslashes_deep( html_entity_decode( $subject, ENT_QUOTES, 'UTF-8' ) );
+
+				// Reset the current user to the editor sending the email.
+				wp_set_current_user( $current_user->ID );
 
 				wp_mail( $to, $subject, $body, $headers );
 

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -82,12 +82,12 @@ class Setup {
 	 * @return void
 	 */
 	protected function setup_hooks(): void {
-		register_activation_hook( GATHERPRESS_CORE_FILE, array( $this, 'activate_gatherpress_plugin' ) );
-		register_deactivation_hook( GATHERPRESS_CORE_FILE, array( $this, 'deactivate_gatherpress_plugin' ) );
+		// register_activation_hook( GATHERPRESS_CORE_FILE, array( $this, 'activate_gatherpress_plugin' ) );
+		// register_deactivation_hook( GATHERPRESS_CORE_FILE, array( $this, 'deactivate_gatherpress_plugin' ) );
 
 		add_action( 'init', array( $this, 'maybe_flush_rewrite_rules' ) );
 		add_action( 'admin_notices', array( $this, 'check_users_can_register' ) );
-		add_action( 'admin_init', array( $this, 'check_gatherpress_alpha' ) );
+		add_action( 'admin_notices', array( $this, 'check_gatherpress_alpha' ) );
 		add_action( 'wp_initialize_site', array( $this, 'on_site_create' ) );
 
 		add_filter( 'block_categories_all', array( $this, 'register_gatherpress_block_category' ) );

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -82,8 +82,6 @@ class Setup {
 	 * @return void
 	 */
 	protected function setup_hooks(): void {
-		add_action( 'init', array( $this, 'load_gatherpress_textdomain' ), 0 );
-
 		register_activation_hook( GATHERPRESS_CORE_FILE, array( $this, 'activate_gatherpress_plugin' ) );
 		register_deactivation_hook( GATHERPRESS_CORE_FILE, array( $this, 'deactivate_gatherpress_plugin' ) );
 
@@ -111,37 +109,6 @@ class Setup {
 			),
 			array( $this, 'filter_plugin_action_links' )
 		);
-	}
-
-	/**
-	 * Load plugin textdomain.
-	 *
-	 * Make sure to load all translation fileseven for users
-	 * who chosed another than the sites default language.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/load_plugin_textdomain
-	 *
-	 * Calling load_plugin_textdomain() should be delayed until init action.
-	 * @see https://developer.wordpress.org/reference/functions/load_plugin_textdomain/#comment-1568
-	 *
-	 * load_plugin_textdomain() will try to load the mo file firstly from:
-	 * WP_LANG_DIR . ‘/plugins/’ . $mofile
-	 * Only if it is not able to it will load it from GATHERPRESS_DIR_NAME folder
-	 * @see https://developer.wordpress.org/reference/functions/load_plugin_textdomain/#comment-3521
-	 *
-	 * Since WordPress 4.6 translations now take translate.wordpress.org as priority and so
-	 * plugins that are translated via translate.wordpress.org DO NOT necessary require load_plugin_textdomain() anymore.
-	 * If you don’t want to add a load_plugin_textdomain() call to your plugin
-	 * you have to set the Requires at least: field in your readme.txt to 4.6 or more.
-	 * @see https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#plugins-on-wordpress-org
-	 *
-	 * BUT, ...!!!
-	 *
-	 * A call to load_plugin_textdomain() is ABSOLUTELY NEEDED to properly load all translation files
-	 * for users who chosed another than the sites default language in their /profile.php.
-	 */
-	public function load_gatherpress_textdomain() {
-		load_plugin_textdomain( 'gatherpress', false, false );
 	}
 
 	/**

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -116,6 +116,9 @@ class Setup {
 	/**
 	 * Load plugin textdomain.
 	 *
+	 * Make sure to load all translation fileseven for users
+	 * who chosed another than the sites default language.
+	 *
 	 * Calling load_plugin_textdomain() should be delayed until init action.
 	 * @see https://developer.wordpress.org/reference/functions/load_plugin_textdomain/#comment-1568
 	 *
@@ -133,7 +136,7 @@ class Setup {
 	 * BUT, ...!!!
 	 *
 	 * A call to load_plugin_textdomain() is ABSOLUTELY NEEDED to properly load all translation files
-	 * for users how chosed another than the sites default language in their /profile.php.
+	 * for users who chosed another than the sites default language in their /profile.php.
 	 */
 	public function load_gatherpress_textdomain() {
 		load_plugin_textdomain( 'gatherpress', false, false );

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -119,6 +119,8 @@ class Setup {
 	 * Make sure to load all translation fileseven for users
 	 * who chosed another than the sites default language.
 	 *
+	 * @see https://developer.wordpress.org/reference/functions/load_plugin_textdomain
+	 *
 	 * Calling load_plugin_textdomain() should be delayed until init action.
 	 * @see https://developer.wordpress.org/reference/functions/load_plugin_textdomain/#comment-1568
 	 *

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -83,7 +83,7 @@ class Setup {
 	 */
 	protected function setup_hooks(): void {
 		add_action( 'init', array( $this, 'load_gatherpress_textdomain' ), 0 );
- 
+
 		register_activation_hook( GATHERPRESS_CORE_FILE, array( $this, 'activate_gatherpress_plugin' ) );
 		register_deactivation_hook( GATHERPRESS_CORE_FILE, array( $this, 'deactivate_gatherpress_plugin' ) );
 
@@ -115,7 +115,7 @@ class Setup {
 
 	/**
 	 * Load plugin textdomain.
-	 * 
+	 *
 	 * Calling load_plugin_textdomain() should be delayed until init action.
 	 * @see https://developer.wordpress.org/reference/functions/load_plugin_textdomain/#comment-1568
 	 *
@@ -136,7 +136,7 @@ class Setup {
 	 * for users how chosed another than the sites default language in their /profile.php.
 	 */
 	public function load_gatherpress_textdomain() {
-		load_plugin_textdomain( 'gatherpress', false, false ); 
+		load_plugin_textdomain( 'gatherpress', false, false );
 	}
 
 	/**

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -136,12 +136,6 @@ class Setup {
 	 * for users how chosed another than the sites default language in their /profile.php.
 	 */
 	public function load_gatherpress_textdomain() {
-		// Keep as a fallback if translation files were not loaded from translate.wordpress.org ??
-		// load_plugin_textdomain( 'gatherpress', false, GATHERPRESS_DIR_NAME . '/languages' );
-	
-		// Or use it like that
-		// and DELETE the /languages folder,
-		// and "* Domain Path:       /languages" as well?
 		load_plugin_textdomain( 'gatherpress', false, false ); 
 	}
 

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -82,6 +82,8 @@ class Setup {
 	 * @return void
 	 */
 	protected function setup_hooks(): void {
+		add_action( 'init', array( $this, 'load_gatherpress_textdomain' ), 0 );
+ 
 		register_activation_hook( GATHERPRESS_CORE_FILE, array( $this, 'activate_gatherpress_plugin' ) );
 		register_deactivation_hook( GATHERPRESS_CORE_FILE, array( $this, 'deactivate_gatherpress_plugin' ) );
 
@@ -109,6 +111,38 @@ class Setup {
 			),
 			array( $this, 'filter_plugin_action_links' )
 		);
+	}
+
+	/**
+	 * Load plugin textdomain.
+	 * 
+	 * Calling load_plugin_textdomain() should be delayed until init action.
+	 * @see https://developer.wordpress.org/reference/functions/load_plugin_textdomain/#comment-1568
+	 *
+	 * load_plugin_textdomain() will try to load the mo file firstly from:
+	 * WP_LANG_DIR . ‘/plugins/’ . $mofile
+	 * Only if it is not able to it will load it from GATHERPRESS_DIR_NAME folder
+	 * @see https://developer.wordpress.org/reference/functions/load_plugin_textdomain/#comment-3521
+	 *
+	 * Since WordPress 4.6 translations now take translate.wordpress.org as priority and so
+	 * plugins that are translated via translate.wordpress.org DO NOT necessary require load_plugin_textdomain() anymore.
+	 * If you don’t want to add a load_plugin_textdomain() call to your plugin
+	 * you have to set the Requires at least: field in your readme.txt to 4.6 or more.
+	 * @see https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#plugins-on-wordpress-org
+	 *
+	 * BUT, ...!!!
+	 *
+	 * A call to load_plugin_textdomain() is ABSOLUTELY NEEDED to properly load all translation files
+	 * for users how chosed another than the sites default language in their /profile.php.
+	 */
+	public function load_gatherpress_textdomain() {
+		// Keep as a fallback if translation files were not loaded from translate.wordpress.org ??
+		// load_plugin_textdomain( 'gatherpress', false, GATHERPRESS_DIR_NAME . '/languages' );
+	
+		// Or use it like that
+		// and DELETE the /languages folder,
+		// and "* Domain Path:       /languages" as well?
+		load_plugin_textdomain( 'gatherpress', false, false ); 
 	}
 
 	/**

--- a/includes/core/classes/class-user.php
+++ b/includes/core/classes/class-user.php
@@ -214,8 +214,8 @@ class User {
 		}
 
 		update_user_meta( $user_id, 'gatherpress_event_updates_opt_in', intval( filter_input( INPUT_POST, 'gatherpress_event_updates_opt_in' ) ) );
-		update_user_meta( $user_id, 'gatherpress_date_format', sanitize_text_field( filter_input( INPUT_POST, 'gatherpress_date_format' ) ) );
-		update_user_meta( $user_id, 'gatherpress_time_format', sanitize_text_field( filter_input( INPUT_POST, 'gatherpress_time_format' ) ) );
+		update_user_meta( $user_id, 'gatherpress_date_format', sanitize_text_field( filter_input( INPUT_POST, 'gatherpress_date_format', FILTER_SANITIZE_ADD_SLASHES ) ) );
+		update_user_meta( $user_id, 'gatherpress_time_format', sanitize_text_field( filter_input( INPUT_POST, 'gatherpress_time_format', FILTER_SANITIZE_ADD_SLASHES ) ) );
 		update_user_meta( $user_id, 'gatherpress_timezone', sanitize_text_field( filter_input( INPUT_POST, 'gatherpress_timezone' ) ) );
 	}
 }

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -97,7 +97,7 @@ class Utility {
 	 * @return array An array of time zones with labels as keys and time zone choices as values.
 	 */
 	public static function timezone_choices(): array {
-		$timezones_raw   = explode( PHP_EOL, wp_timezone_choice( 'UTC' ) );
+		$timezones_raw   = explode( PHP_EOL, wp_timezone_choice( 'UTC', get_user_locale() ) );
 		$timezones_clean = array();
 		$group           = null;
 

--- a/includes/templates/admin/emails/event-email.php
+++ b/includes/templates/admin/emails/event-email.php
@@ -26,7 +26,7 @@ $gatherpress_venue = $gatherpress_event->get_venue_information()['name'];
 ?>
 
 <!DOCTYPE html>
-<html lang="en-US">
+<html <?php language_attributes(); ?>>
 	<head>
 		<title><?php echo wp_kses_post( get_the_title( $event_id ) ); ?></title>
 	</head>

--- a/includes/templates/admin/emails/event-email.php
+++ b/includes/templates/admin/emails/event-email.php
@@ -20,8 +20,9 @@ if ( ! isset( $event_id, $message ) ) {
 	return;
 }
 
-$gatherpress_event = new Event( $event_id );
-$gatherpress_venue = $gatherpress_event->get_venue_information()['name'];
+$gatherpress_event       = new Event( $event_id );
+$gatherpress_event_image = get_the_post_thumbnail_url( $event_id, 'full' );
+$gatherpress_venue       = $gatherpress_event->get_venue_information()['name'];
 
 ?>
 
@@ -36,8 +37,10 @@ $gatherpress_venue = $gatherpress_event->get_venue_information()['name'];
 				<?php echo wp_kses( nl2br( $message ), array( 'br' => array() ) ); ?>
 			</p>
 		<?php endif; ?>
-		<!-- Feature Image -->
-		<img src="<?php echo esc_url( get_the_post_thumbnail_url( $event_id, 'full' ) ); ?>" alt="<?php esc_attr_e( 'Event Image', 'gatherpress' ); ?>" style="max-width: 100%;">
+		<?php if ( $gatherpress_event_image ) : ?>
+			<!-- Feature Image -->
+			<img src="<?php echo esc_url( $gatherpress_event_image ); ?>" alt="<?php esc_attr_e( 'Event Image', 'gatherpress' ); ?>" style="max-width: 100%;">
+		<?php endif; ?>
 
 		<!-- Event Title -->
 		<h1 style="text-align: center;"><?php echo wp_kses_post( get_the_title( $event_id ) ); ?></h1>

--- a/test/unit/php/bootstrap.php
+++ b/test/unit/php/bootstrap.php
@@ -18,7 +18,8 @@ tests_add_filter(
 	static function () {
 		// Manually load our plugin without having to setup the development folder in the correct plugin folder.
 		require_once __DIR__ . '/../../../gatherpress.php';
-	}
+	},
+	9 // Require file on 9, because the plugin itself is loaded on 10.
 );
 
 $gatherpress_bootstrap_instance->start();


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Originally planned to only close #651, some additional findings are solved with this PR, too:
- [Load users locale before sending emails](https://github.com/GatherPress/gatherpress/pull/752/commits/ba03e3861740ca79c02da28cff9196189f0b62de) _(the first task or better rabbit hole)_
- [Make sure translation files are loaded properly.](https://github.com/GatherPress/gatherpress/pull/752/commits/67c5ff7da38b3f8eddb4a4b6b3d6da7ba349be20) 
This is important for users who selected a different from the sites default language.
- [Set html language attributes correctly for the email](https://github.com/GatherPress/gatherpress/pull/752/commits/4fec72876054bd736b6af1ca4591f27448403fea)
- [Conditionally render the featured image in the email, only if it is set.](https://github.com/GatherPress/gatherpress/pull/752/commits/da5707162467ecd19b262160e592a1f710fc7bba)
- [Set the current user to the actual member to mail to,](https://github.com/GatherPress/gatherpress/pull/752/commits/eb209060375ec135afb6e995392336ccdfb92cd0) to make sure the GatherPress filters for date- and time- format, as well as the users timezone, are recognized by the functions inside `render_template()`.
- [Bug fix: Keep slashes in user-defined date- and time-formats](https://github.com/GatherPress/gatherpress/pull/752#issuecomment-2308986251)

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Testing this PR might be a little tricky and is not possible with WordPress Playground because of the necessary sending & receiving of emails.

#### Preparation to test:

1. Setup at least two different users
2. One of the users creates an event, the other users attends. _(This will make sure, 2 emails are sent for the test)_
3. Assign a non-site-default language to one of the users in their `profile.php`
4. Go to _Updates_, get to the bottom of the page and hit the "**Update translations**" button.
5. Make sure that in the following screen, the translation files for the selected non-site-default language gets downloaded!

#### Testing this PR:

1. Edit the newly created event
2. **Compose** a message via Email
3. Send email
4. Check the results, one email should follow the user-defined language, while the other is sent in the default locale

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fix sending localised emails

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
