### PR TITLE
Make sure the build step runs at least once, when the PR is opened.

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -25,32 +25,37 @@ concurrency:
 
 jobs:
 
-  check-changes:
-    name: Check for changes in /src/ directory
+  needs-build:
+    name: Check if the pull request was just opened or if PR has changes in /src/ directory
     runs-on: ubuntu-latest
     outputs:
-      src_changed: ${{ steps.src_changed.outputs.src_changed }}
+      run_build: ${{ steps.set-run-build.outputs.run_build }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check if /src/ directory has changed
-        id: src_changed
+      - name: Set run_build for initial PR or /src/ changes
+        id: set-run-build
         run: |
-          # Check if there are changes in the /src/ directory between the base and head refs
-          if git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep -q '^src/'; then
-            echo "src_changed=true" >> $GITHUB_ENV
-            echo "::set-output name=src_changed::true"
+          # Check if the pull request was just opened
+          if [ "${{ github.event.action }}" == "opened" ]; then
+            echo "run_build=true" >> $GITHUB_ENV
+            echo "::set-output name=run_build::true"
+          # Check if there are changes in the /src/ directory
+          elif git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep -q '^src/'; then
+            echo "run_build=true" >> $GITHUB_ENV
+            echo "::set-output name=run_build::true"
           else
-            echo "src_changed=false" >> $GITHUB_ENV
-            echo "::set-output name=src_changed::false"
+            echo "run_build=false" >> $GITHUB_ENV
+            echo "::set-output name=run_build::false"
           fi
+
 
   zip:
     name: Build GatherPress plugin & upload as zipped artifact
     runs-on: ubuntu-latest
-    needs: check-changes
-    if: needs.check-changes.outputs.src_changed == 'true'  # Only run this job if there are changes in /src/
+    needs: needs-build
+    if: needs.needs-build.outputs.run_build == 'true'  # Only run this job if if the pull request was just opened or there are changes in /src/
     steps:
 
       - name: Checkout
@@ -92,7 +97,7 @@ jobs:
 
   comment:
     name: Comment with playground link
-    needs: [zip, check-changes]  # Ensure this runs after the zip and check-changes jobs
+    needs: [zip, needs-build]  # Ensure this runs after the zip and needs-build jobs
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->
When the playground-preview workflow is triggered and never will run the `build` step, because all changes were made to other (than the workflow triggering) files, nothing is uploaded as artifact and so the `comment` step would output a non-working playground link.

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR makes sure the `build` step runs at least once, when the PR is opened. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~ Testing & Clean-up after #666, #741, #749 & #750

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Test that it NOT runs
    1. Open a PR
    2. ...with changes to `.github/...` or `.wordpress-org/...`
    3. See that the whole workflow is NOT triggered.
2. Test that it runs _1/2_
    1. Open a PR
    2. ... with changes to `src/...`
    3. See that the workflow is triggered & the `build` step runs succesfully.
3. Test that it runs _2/2_
    1. Open a PR
    2. ... with changes to `includes/...`
    3. See that the workflow is triggered & the `build` step runs succesfully.
4. Test that it updates the comment _1/2_
    1. In one of the opened PRs
    2. ... do some changes to `src/...`
    3. See that the `build` step runs succesfully & the comment is updated.
5. Test that it updates the comment _2/2_
    1. In one of the opened PRs
    2. ... do some changes to `includes/...`
    3. See that the `build` step is skipped & the comment is updated.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Restrict workflow to only run when needed, for the :deciduous_tree: :deciduous_tree: :deciduous_tree:


### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
