### PR TITLE
Show admin_notices only in relevant spots & also in multisite admin

### DIFF
--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -87,7 +87,9 @@ class Setup {
 
 		add_action( 'init', array( $this, 'maybe_flush_rewrite_rules' ) );
 		add_action( 'admin_notices', array( $this, 'check_users_can_register' ) );
+		add_action( 'network_admin_notices', array( $this, 'check_users_can_register' ) );
 		add_action( 'admin_notices', array( $this, 'check_gatherpress_alpha' ) );
+		add_action( 'network_admin_notices', array( $this, 'check_gatherpress_alpha' ) );
 		add_action( 'wp_initialize_site', array( $this, 'on_site_create' ) );
 
 		add_filter( 'block_categories_all', array( $this, 'register_gatherpress_block_category' ) );
@@ -391,8 +393,12 @@ class Setup {
 		if (
 			filter_var( get_option( 'users_can_register' ), FILTER_VALIDATE_BOOLEAN ) ||
 			filter_var( get_option( 'gatherpress_suppress_site_notification' ), FILTER_VALIDATE_BOOLEAN ) ||
-			filter_var( ! current_user_can( 'manage_options' ), FILTER_VALIDATE_BOOLEAN ) ||
-			false === strpos( get_current_screen()->id, 'gatherpress' )
+			filter_var( ! current_user_can( 'manage_options' ), FILTER_VALIDATE_BOOLEAN ) || (
+				false === strpos( get_current_screen()->id, 'gatherpress' ) &&
+				false === strpos( get_current_screen()->id, 'options-general' ) &&
+				false === strpos( get_current_screen()->id, 'settings-network' )
+				
+			)
 		) {
 			return;
 		}
@@ -426,12 +432,21 @@ class Setup {
 	 * @return void
 	 */
 	public function check_gatherpress_alpha(): void {
-		if ( ! is_plugin_active( 'gatherpress-alpha/gatherpress-alpha.php' ) ) {
-			Utility::render_template(
-				sprintf( '%s/includes/templates/admin/setup/gatherpress-alpha-check.php', GATHERPRESS_CORE_PATH ),
-				array(),
-				true
-			);
+		if (
+			is_plugin_active( 'gatherpress-alpha/gatherpress-alpha.php' ) ||
+			filter_var( ! current_user_can( 'install_plugins' ), FILTER_VALIDATE_BOOLEAN ) || (
+				false === strpos( get_current_screen()->id, 'plugins' ) &&
+				false === strpos( get_current_screen()->id, 'plugin-install' ) &&
+				false === strpos( get_current_screen()->id, 'gatherpress' )
+			)
+		) {
+			return;
 		}
+
+		Utility::render_template(
+			sprintf( '%s/includes/templates/admin/setup/gatherpress-alpha-check.php', GATHERPRESS_CORE_PATH ),
+			array(),
+			true
+		);
 	}
 }

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -397,7 +397,6 @@ class Setup {
 				false === strpos( get_current_screen()->id, 'gatherpress' ) &&
 				false === strpos( get_current_screen()->id, 'options-general' ) &&
 				false === strpos( get_current_screen()->id, 'settings-network' )
-				
 			)
 		) {
 			return;


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Show admin notices only in relevant spots, but also in multisite admin.

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
