### PR TITLE
Hide Admin Notice about alpha-plugin, also if installed via the branch-named zip

### DIFF
--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -432,7 +432,7 @@ class Setup {
 	 */
 	public function check_gatherpress_alpha(): void {
 		if (
-			is_plugin_active( 'gatherpress-alpha/gatherpress-alpha.php' ) ||
+			is_plugin_active( 'gatherpress-alpha-main/gatherpress-alpha.php' ) ||
 			filter_var( ! current_user_can( 'install_plugins' ), FILTER_VALIDATE_BOOLEAN ) || (
 				false === strpos( get_current_screen()->id, 'plugins' ) &&
 				false === strpos( get_current_screen()->id, 'plugin-install' ) &&

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -432,12 +432,7 @@ class Setup {
 	 */
 	public function check_gatherpress_alpha(): void {
 		if (
-			// While a plugin from w.org would have a unigue slug to check against,
-			// it different for .zips downloaded from github.com.
-			// A download via "<> Code ⏷" > "Download ZIP" will include the branch in the file name.
-			is_plugin_active( 'gatherpress-alpha-main/gatherpress-alpha.php' ) ||
-			// A download via "Releases" will provide a zip without a branch name attached.
-			is_plugin_active( 'gatherpress-alpha/gatherpress-alpha.php' ) ||
+			defined( 'GATHERPRESS_ALPHA_VERSION' ) ||
 			filter_var( ! current_user_can( 'install_plugins' ), FILTER_VALIDATE_BOOLEAN ) || (
 				false === strpos( get_current_screen()->id, 'plugins' ) &&
 				false === strpos( get_current_screen()->id, 'plugin-install' ) &&

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -434,9 +434,9 @@ class Setup {
 		if (
 			// While a plugin from w.org would have a unigue slug to check against,
 			// it different for .zips downloaded from github.com.
-			// A download via "<> Code ⏷" > "Download ZIP" will include the branch in the file name,
+			// A download via "<> Code ⏷" > "Download ZIP" will include the branch in the file name.
 			is_plugin_active( 'gatherpress-alpha-main/gatherpress-alpha.php' ) ||
-			// while a download via "Releases" will provide a zip without a branch name attached.
+			// A download via "Releases" will provide a zip without a branch name attached.
 			is_plugin_active( 'gatherpress-alpha/gatherpress-alpha.php' ) ||
 			filter_var( ! current_user_can( 'install_plugins' ), FILTER_VALIDATE_BOOLEAN ) || (
 				false === strpos( get_current_screen()->id, 'plugins' ) &&

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -432,7 +432,12 @@ class Setup {
 	 */
 	public function check_gatherpress_alpha(): void {
 		if (
+			// While a plugin from w.org would have a unigue slug to check against,
+			// it different for .zips downloaded from github.com.
+			// A download via "<> Code ⏷" > "Download ZIP" will include the branch in the file name,
 			is_plugin_active( 'gatherpress-alpha-main/gatherpress-alpha.php' ) ||
+			// while a download via "Releases" will provide a zip without a branch name attached.
+			is_plugin_active( 'gatherpress-alpha/gatherpress-alpha.php' ) ||
 			filter_var( ! current_user_can( 'install_plugins' ), FILTER_VALIDATE_BOOLEAN ) || (
 				false === strpos( get_current_screen()->id, 'plugins' ) &&
 				false === strpos( get_current_screen()->id, 'plugin-install' ) &&


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

While a plugin from w.org would have a unigue slug to check against,
this is different for .zips downloaded from github.com.

A download via "<> Code ⏷" > "Download ZIP" will include the branch in the file name,
while a download via "Releases" will provide a zip without a branch name attached.

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR makes sure, that GatherPress checks against both possible slugs inside the condition to whether or not to show the admin notice about the alpha-plugin.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #807

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Hide Admin Notice about alpha-plugin, also if installed via the branch-named zip

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
