### PR TITLE
Replace "Open Street Maps" with "OpenStreetMap"

### DIFF
--- a/docs/user/2-gatherpress-settings.md
+++ b/docs/user/2-gatherpress-settings.md
@@ -21,7 +21,7 @@ All settings for the GatherPress plugins are located in `Events > Settings > Gen
 As default, the event date is used as the date of the event you're adding to your website. You can toggle this change here to use the publish date instead.
 
 **Mapping Platform**
-You can select from two providers for Maps which are displayed on the event page. The default is `Open Street Maps`, but can be changed to `Google Maps` here.
+You can select from two providers for Maps which are displayed on the event page. The default is `OpenStreetMap`, but can be changed to `Google Maps` here.
 
 **Maximum Attendance Limit**
 This option allows you to choose the default number chosen as the maximum number of attendees you can have for an event. This is useful if you use the same venue which may have restrictions on occupancy. You can also amend this value on any event page. Choosing `0` will remove any limits.

--- a/includes/core/classes/settings/class-general.php
+++ b/includes/core/classes/settings/class-general.php
@@ -116,7 +116,7 @@ class General extends Base {
 							'options' => array(
 								'default' => 'osm',
 								'items'   => array(
-									'osm'    => __( 'Open Street Maps', 'gatherpress' ),
+									'osm'    => __( 'OpenStreetMap', 'gatherpress' ),
 									'google' => __( 'Google Maps', 'gatherpress' ),
 								),
 							),

--- a/src/components/OpenStreetMap.js
+++ b/src/components/OpenStreetMap.js
@@ -12,7 +12,7 @@ import { getFromGlobal } from '../helpers/globals';
 /**
  * OpenStreetMap component for GatherPress.
  *
- * This component is used to embed an Open Street Map with specified location,
+ * This component is used to embed an OpenStreetMap with specified location,
  * zoom level, and height using the Leaflet platform.
  *
  * @since 1.0.0


### PR DESCRIPTION
This commit replaces all instances of "Open Street Maps" with "OpenStreetMap" in the code and documentation.

Fixes #833

### Description of the Change
This change corrects the name "Open Street Maps" to "OpenStreetMap" throughout the GatherPress codebase, including documentation and map configuration settings.

The reason for this change is discussed in issue #833, where it's noted that the correct name is "OpenStreetMap."

### How to test the Change
1. Open any event in the GatherPress plugin that uses map settings.
2. Verify that "OpenStreetMap" is displayed as the mapping provider option.
3. Check the documentation for the correct mention of "OpenStreetMap."

### Changelog Entry
> Fixed - Corrected the name "Open Street Maps" to "OpenStreetMap" across the project.

### Credits
Props @matt-galdino.

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
