### PR TITLE
Use latest demo-data event as prominent example in screenshots

### DIFF
--- a/.github/scripts/wordpress-org-screenshots/wporg.spec.ts
+++ b/.github/scripts/wordpress-org-screenshots/wporg.spec.ts
@@ -17,7 +17,7 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
             local_code,
             '.png'
         ].join('').toLowerCase();
-    }	// List all comments.
+    }
 
 
     test.beforeAll( async ( { requestUtils } ) => {
@@ -32,7 +32,6 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
         } );
 
         if ( latest_event && Array.isArray( latest_event ) && latest_event.length > 0 ) {
-            // console.log('Latest Event:', latest_event[0]);
             latest_event_data = latest_event[0];
         } else {
             console.warn('No event found or the response was invalid.');
@@ -96,7 +95,7 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
     });
 
     // The test-description should match the caption for screenshot-# in the readme.md
-    test('Quickedit an event', async ({
+    test('Quick Edit an event', async ({
         admin,
         editor,
         page,
@@ -108,14 +107,17 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
                 'post_type=gatherpress_event'
             );
             const tr = await page.locator( '#post-' + latest_event_data.id );
-            // Make Quickedit visible.
+
+            // Make Quick Edit visible.
             await expect(tr).toBeVisible();
-            
             await tr.hover();
-            // Open the Quickedit panel for the last event.
+
+            // Open the Quick Edit panel for the last event.
             await tr.getByText('Quick Edit').click();
+
             // Wait for 2 seconds
             await page.waitForTimeout(2000);
+
             // https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1
             await expect(page).toHaveScreenshot( getFileName( 'screenshot-3' ), {
                 fullPage: true

--- a/.github/scripts/wordpress-org-screenshots/wporg.spec.ts
+++ b/.github/scripts/wordpress-org-screenshots/wporg.spec.ts
@@ -6,7 +6,8 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
 	let
         language: string,
-        local_code: string;
+        local_code: string,
+        latest_event_data = null;
 
     // set the file name of the screenshot basaed on the current locale
     // https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/#filenames-2
@@ -16,9 +17,26 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
             local_code,
             '.png'
         ].join('').toLowerCase();
-    }
+    }	// List all comments.
+
 
     test.beforeAll( async ( { requestUtils } ) => {
+
+        const latest_event = await requestUtils.rest( {
+            path: '/wp/v2/gatherpress_events',
+            method: 'GET',
+            params: {
+                per_page: 1,
+                status: 'publish'
+            },
+        } );
+
+        if ( latest_event && Array.isArray( latest_event ) && latest_event.length > 0 ) {
+            // console.log('Latest Event:', latest_event[0]);
+            latest_event_data = latest_event[0];
+        } else {
+            console.warn('No event found or the response was invalid.');
+        }
 
         // https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-test-utils-playwright/src/request-utils/site-settings.ts#L34-L35
 		language = ( await requestUtils.getSiteSettings() ).language;
@@ -51,6 +69,61 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
     });
 
     // The test-description should match the caption for screenshot-# in the readme.md
+    test('Edit an event', async ({
+        admin,
+        editor,
+        page,
+    }) => {
+        if (latest_event_data) {
+
+            await admin.visitAdminPage(
+                'post.php',
+                'action=edit&post=' + latest_event_data.id
+            );
+            
+            await editor.setPreferences( 'core/edit-post', {
+                welcomeGuide: false,
+            });
+            
+            // Wait for 2 seconds
+            await page.waitForTimeout(2000);
+            
+            // https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1
+            await expect(page).toHaveScreenshot( getFileName( 'screenshot-2' ), {
+                fullPage: true
+            });
+        }
+    });
+
+    // The test-description should match the caption for screenshot-# in the readme.md
+    test('Quickedit an event', async ({
+        admin,
+        editor,
+        page,
+    }) => {
+        if (latest_event_data) {
+
+            await admin.visitAdminPage(
+                'edit.php',
+                'post_type=gatherpress_event'
+            );
+            const tr = await page.locator( '#post-' + latest_event_data.id );
+            // Make Quickedit visible.
+            await expect(tr).toBeVisible();
+            
+            await tr.hover();
+            // Open the Quickedit panel for the last event.
+            await tr.getByText('Quick Edit').click();
+            // Wait for 2 seconds
+            await page.waitForTimeout(2000);
+            // https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1
+            await expect(page).toHaveScreenshot( getFileName( 'screenshot-3' ), {
+                fullPage: true
+            });
+        }
+    });
+
+    // The test-description should match the caption for screenshot-# in the readme.md
     test('Create a new venue', async ({
         admin,
         editor,
@@ -69,7 +142,7 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
         await page.waitForTimeout(2000);
 
         // https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1
-        await expect(page).toHaveScreenshot( getFileName( 'screenshot-2' ), {
+        await expect(page).toHaveScreenshot( getFileName( 'screenshot-4' ), {
             fullPage: true
         });
     });
@@ -88,7 +161,7 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
         await page.waitForTimeout(2000);
 
         // https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1
-        await expect(page).toHaveScreenshot( getFileName( 'screenshot-3' ), {
+        await expect(page).toHaveScreenshot( getFileName( 'screenshot-5' ), {
             fullPage: true
         });
     });
@@ -107,7 +180,7 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
         await page.waitForTimeout(2000);
 
         // https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1
-        await expect(page).toHaveScreenshot( getFileName( 'screenshot-4' ), {
+        await expect(page).toHaveScreenshot( getFileName( 'screenshot-6' ), {
             fullPage: true
         });
     });

--- a/readme.md
+++ b/readme.md
@@ -206,8 +206,8 @@ As we continue to refine and develop the core plugin, we've created the [GatherP
    ![Create a new event](.wordpress-org/screenshot-1.png)
 2. Edit an event
    ![Edit an event](.wordpress-org/screenshot-2.png)
-3. Quickedit an event
-   ![Quickedit an event](.wordpress-org/screenshot-3.png)
+3. Quick Edit an event
+   ![Quick Edit an event](.wordpress-org/screenshot-3.png)
 4. Create a new venue
    ![Create a new venue](.wordpress-org/screenshot-4.png)
 5. General Settings

--- a/readme.md
+++ b/readme.md
@@ -204,12 +204,16 @@ As we continue to refine and develop the core plugin, we've created the [GatherP
 
 1. Create a new event
    ![Create a new event](.wordpress-org/screenshot-1.png)
-2. Create a new venue
-   ![Create a new venue](.wordpress-org/screenshot-2.png)
-3. General Settings
-   ![General Settings](.wordpress-org/screenshot-3.png)
-4. Leadership Settings
-   ![Leadership Settings](.wordpress-org/screenshot-4.png)
+2. Edit an event
+   ![Edit an event](.wordpress-org/screenshot-2.png)
+3. Quickedit an event
+   ![Quickedit an event](.wordpress-org/screenshot-3.png)
+4. Create a new venue
+   ![Create a new venue](.wordpress-org/screenshot-4.png)
+5. General Settings
+   ![General Settings](.wordpress-org/screenshot-5.png)
+6. Leadership Settings
+   ![Leadership Settings](.wordpress-org/screenshot-6.png)
 
 ## Changelog
 


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

I wanted to do something _nice_, _something visually appealing_.
... so I updated the screenshot generator to use the latest demo-data event as prominent example in screenshots ;)


https://github.com/user-attachments/assets/f4e7ce3e-2944-45b6-abc8-858d9254117d



### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Use latest demo-data event as prominent example in screenshots

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change. ;)
- [x] All new and existing tests pass.
