### PR TITLE
Fix & update phpcs rules

### DIFF
--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -340,9 +340,9 @@ class Event_Query {
 		$current = gmdate( Event::DATETIME_FORMAT, time() );
 
 		if ( 'upcoming' === $type ) {
-			$pieces['where'] .= $wpdb->prepare( ' AND %i.datetime_end_gmt >= %s', $table, $current );  // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnsupportedIdentifierPlaceholder
+			$pieces['where'] .= $wpdb->prepare( ' AND %i.datetime_end_gmt >= %s', $table, $current );
 		} elseif ( 'past' === $type ) {
-			$pieces['where'] .= $wpdb->prepare( ' AND %i.datetime_end_gmt < %s', $table, $current ); // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnsupportedIdentifierPlaceholder
+			$pieces['where'] .= $wpdb->prepare( ' AND %i.datetime_end_gmt < %s', $table, $current );
 		}
 
 		return $pieces;

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -757,7 +757,7 @@ class Settings {
 			isset( $old_value['urls'] ) && ! isset( $new_value['urls'] ) ||
 			$old_value['urls'] !== $new_value['urls']
 		) {
-			// Event_Setup->maybe_create_flush_rewrite_rules_flag // TODO maybe make this a public method ?!
+			// Event_Setup->maybe_create_flush_rewrite_rules_flag //@TODO https://github.com/GatherPress/gatherpress/issues/880 Maybe make this a public method ?!
 			add_option( 'gatherpress_flush_rewrite_rules_flag', true );
 		}
 	}

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -36,6 +36,39 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- Trigger a Warning on @todo comments. -->
 	<rule ref="Generic.Commenting.Todo"/>
+
+	<!-- @source:
+	- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset#the-annotated-sample-file
+	- https://github.com/squizlabs/PHP_CodeSniffer/issues/3769#issuecomment-1452605087
+
+	Here we are including a specific sniff but also changing
+	the error message of a specific message inside the sniff.
+	Note that the specific code for the message, which is
+	TaskFound in this case, is defined by the sniff developer.
+	You can display these codes by using the -s command line
+	argument when checking a file.
+
+	Also note that this message has a variable inside it,
+	which is why it is important that sniffs use a printf style
+	format for their error messages.
+
+	We also drop the severity of this message from the
+	default value (5) so that it is hidden by default. It can be
+	displayed by setting the minimum severity on the PHP_CodeSniffer
+	command line. This is great if you want to use some messages
+	only in code reviews and not have them block code commits.
+	-->
+	<!-- This error code is for when no description is found. -->
+	<rule ref="Generic.Commenting.Todo.CommentFound">
+		<message>Please review this TODO comment</message>
+		<severity>3</severity>
+	</rule>
+	<!-- This error code is used when a task description is found. -->
+	<rule ref="Generic.Commenting.Todo.TaskFound">
+		<message>Please review this TODO comment: %s</message>
+		<severity>3</severity>
+	</rule>
+
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -41,7 +41,11 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- Value: replace the text domain used. -->
-			<property name="text_domain" type="array" value="gatherpress"/>
+			<property name="text_domain" type="array">
+				<element value="gatherpress"/>
+				<!-- No need to translate 100%-core strings -->
+				<element value="default"/>
+			</property>
 		</properties>
 	</rule>
 	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -32,6 +32,8 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_wp_version" value="6.4"/>
 	<rule ref="WordPress"/>
+	<!-- Trigger a Warning on @todo comments. -->
+	<rule ref="Generic.Commenting.Todo"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -30,7 +30,7 @@
 	<!-- Rules: WordPress Coding Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="6.4"/>
+	<config name="minimum_wp_version" value="6.4"/>
 	<rule ref="WordPress"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -30,7 +30,7 @@
 	<!-- Rules: WordPress Coding Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="7.4"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 	<rule ref="WordPress"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -32,6 +32,8 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_wp_version" value="6.4"/>
 	<rule ref="WordPress"/>
+	<!-- Let's also check that everything is properly documented. -->
+	<rule ref="WordPress-Docs"/>
 	<!-- Trigger a Warning on @todo comments. -->
 	<rule ref="Generic.Commenting.Todo"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->
I stumbled upon this error

```sh
FILE: includes/core/classes/class-event-query.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 343 | ERROR | The %i modifier is only supported in WP 6.2 or higher. Found: "%i". (WordPress.DB.PreparedSQLPlaceholders.UnsupportedIdentifierPlaceholder)
 345 | ERROR | The %i modifier is only supported in WP 6.2 or higher. Found: "%i". (WordPress.DB.PreparedSQLPlaceholders.UnsupportedIdentifierPlaceholder)
---
```

after I removed a  `// phpcs:ignore ...` statement for the mentioned sniff. Curious about the 6.2 version, I started investigating and found that there were [two minor syntax errors](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-minimum-supported-wp-version-for-all-sniffs-in-one-go-wordpresscs-0140) in one of the config rules.

GatherPress tested itself against the minimum supported WordPress version of 7.4, what is ... let's say early.

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

1. I fixed the wrong syntax, which made my mentioned error disappear correctly.

   _then I started adding some **unrelated other things**_
   
2. Allowed to use the `'default'` textdomain for strings that are 100%-sure part of core.
3. Added a rule to alert with a warning on `@todo` comments _(Not quiet sure, if this is what we want, or if this makes more trouble)_
4. Added the `WordPress-Docs` ruleset to make sure everything is properly documented and prepare for an automated code-reference

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
See the results of the test runner.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Fix & updated phpcs rules

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
