### PR TITLE
Set html language attributes correctly for emails

### DIFF
--- a/includes/templates/admin/emails/event-email.php
+++ b/includes/templates/admin/emails/event-email.php
@@ -26,7 +26,7 @@ $gatherpress_venue = $gatherpress_event->get_venue_information()['name'];
 ?>
 
 <!DOCTYPE html>
-<html lang="en-US">
+<html <?php language_attributes(); ?>>
 	<head>
 		<title><?php echo wp_kses_post( get_the_title( $event_id ) ); ?></title>
 	</head>


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->


Fragmentation of #752

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Until this PR GatherPress sends email with a fixed language attribute of "en-us", which doesn't reflect the sites or users locale.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Change your sites default language to anything else, than en_US.
2. Send yourself an email via an event
3. Check the html of the sent email for the lang-attribute on the html element.
4. This should reflect your set language

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Set html language attributes correctly for emails

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
