### PR TITLE
Respect users locale and custom date- and time-formats in sent emails

### DIFF
--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -251,18 +251,6 @@ class Event_Rest_Api {
 		}
 
 		$members = $this->get_members( $send, $post_id );
-		/* translators: %s: event title. */
-		$subject = sprintf( __( '📅 %s', 'gatherpress' ), get_the_title( $post_id ) );
-		$body    = Utility::render_template(
-			sprintf( '%s/includes/templates/admin/emails/event-email.php', GATHERPRESS_CORE_PATH ),
-			array(
-				'event_id' => $post_id,
-				'message'  => $message,
-			),
-		);
-		$headers = array( 'Content-Type: text/html; charset=UTF-8' );
-		$subject = stripslashes_deep( html_entity_decode( $subject, ENT_QUOTES, 'UTF-8' ) );
-
 		foreach ( $members as $member ) {
 			if ( '0' === get_user_meta( $member->ID, 'gatherpress_event_updates_opt_in', true ) ) {
 				continue;
@@ -270,8 +258,25 @@ class Event_Rest_Api {
 
 			if ( $member->user_email ) {
 				$to = $member->user_email;
+				$switched_locale = switch_to_user_locale( $member->ID );
+
+				/* translators: %s: event title. */
+				$subject = sprintf( __( '📅 %s', 'gatherpress' ), get_the_title( $post_id ) );
+				$body    = Utility::render_template(
+					sprintf( '%s/includes/templates/admin/emails/event-email.php', GATHERPRESS_CORE_PATH ),
+					array(
+						'event_id' => $post_id,
+						'message'  => $message,
+					),
+				);
+				$headers = array( 'Content-Type: text/html; charset=UTF-8' );
+				$subject = stripslashes_deep( html_entity_decode( $subject, ENT_QUOTES, 'UTF-8' ) );
 
 				wp_mail( $to, $subject, $body, $headers );
+
+				if ( $switched_locale ) {
+					restore_previous_locale();
+				}
 			}
 		}
 

--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -250,15 +250,22 @@ class Event_Rest_Api {
 			return false;
 		}
 
+		// Keep the currently logged-in user.
+		$current_user = wp_get_current_user();
+
 		$members = $this->get_members( $send, $post_id );
 		foreach ( $members as $member ) {
 			if ( '0' === get_user_meta( $member->ID, 'gatherpress_event_updates_opt_in', true ) ) {
 				continue;
 			}
-
 			if ( $member->user_email ) {
 				$to = $member->user_email;
 				$switched_locale = switch_to_user_locale( $member->ID );
+
+				// Set the current user to the actual member to mail to,
+				// to make sure the GatherPress filters for date- and time- format, as well as the users timezone,
+				// are recognized by the functions inside render_template().
+				wp_set_current_user( $member->ID );
 
 				/* translators: %s: event title. */
 				$subject = sprintf( __( '📅 %s', 'gatherpress' ), get_the_title( $post_id ) );
@@ -271,6 +278,9 @@ class Event_Rest_Api {
 				);
 				$headers = array( 'Content-Type: text/html; charset=UTF-8' );
 				$subject = stripslashes_deep( html_entity_decode( $subject, ENT_QUOTES, 'UTF-8' ) );
+
+				// Reset the current user to the editor sending the email.
+				wp_set_current_user( $current_user->ID );
 
 				wp_mail( $to, $subject, $body, $headers );
 

--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -259,7 +259,7 @@ class Event_Rest_Api {
 				continue;
 			}
 			if ( $member->user_email ) {
-				$to = $member->user_email;
+				$to              = $member->user_email;
 				$switched_locale = switch_to_user_locale( $member->ID );
 
 				// Set the current user to the actual member to mail to,

--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -268,7 +268,7 @@ class Event_Rest_Api {
 				wp_set_current_user( $member->ID );
 
 				/* translators: %s: event title. */
-				$subject = sprintf( __( '📅 %s', 'gatherpress' ), get_the_title( $post_id ) );
+				$subject = sprintf( _x( '📅 %s', 'Email subject for event updates', 'gatherpress' ), get_the_title( $post_id ) );
 				$body    = Utility::render_template(
 					sprintf( '%s/includes/templates/admin/emails/event-email.php', GATHERPRESS_CORE_PATH ),
 					array(


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

Fragmentation of #752

Until this PR, sent emails dont respect the users locale nor her personal date- and time formatting settings.

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes that, by:

- Loading the users locale before sending emails & resetting it afterwards
- Set the _current user_ to the actual member to mail to, to make sure the GatherPress filters for date- and time- format, as well as the users timezone, are recognized by the functions inside `render_template()`

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Testing this PR might be a little tricky and is not possible with WordPress Playground because of the necessary sending & receiving of emails.

#### Preparation to test:

1. Setup at least two different users
2. One of the users creates an event, the other users attends. _(This will make sure, 2 emails are sent for the test)_
3. Assign a non-site-default language to one of the users in their `profile.php`
4. Go to _Updates_, get to the bottom of the page and hit the "**Update translations**" button.
5. Make sure that in the following screen, the translation files for the selected non-site-default language gets downloaded!

#### Testing this PR:

1. Edit the newly created event
2. **Compose** a message via Email
3. Send email
4. Check the results, one email should follow the user-defined language, while the other is sent in the default locale


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Respect users locale and custom date- and time-formats in sent emails

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
