### PR TITLE
Fix phpstan: Use stubs, instead of ignoring

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,13 +30,6 @@ parameters:
 #            - vendor/
 
     ignoreErrors:
-        - '#^Constant GATHERPRESS_CACHE_GROUP not found\.$#'
-        - '#^Constant GATHERPRESS_CORE_FILE not found\.$#'
-        - '#^Constant GATHERPRESS_CORE_PATH not found\.$#'
-        - '#^Constant GATHERPRESS_CORE_URL not found\.$#'
-        - '#^Constant GATHERPRESS_REST_NAMESPACE not found\.$#'
-        - '#^Constant GATHERPRESS_REQUIRES_PHP not found\.$#'
-
         # core/classes/class-setup.php
         #
         # A dev-only error, which can occur if the gatherpress is symlinked into a WP instance or called via wp-env or Playground.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,9 +10,7 @@ parameters:
     bootstrapFiles:
         # Constants, functions, etc. used by GatherPress
         - phpstan.stubs
-#        - vendor/pmc/unit-test/src/classes/autoloader.php
-#        - vendor/autoload.php
-#        - gatherpress.php
+
     parallel:
         maximumNumberOfProcesses: 1
         processTimeout: 300.0
@@ -23,11 +21,6 @@ parameters:
 
     paths:
         - includes/
-#        - test/
-
-#    excludePaths:
-#        analyse:
-#            - vendor/
 
     ignoreErrors:
         # core/classes/class-setup.php

--- a/phpstan.stubs
+++ b/phpstan.stubs
@@ -5,6 +5,14 @@
  */
 
 namespace {
+
+    define( 'GATHERPRESS_CACHE_GROUP', '');
+    define( 'GATHERPRESS_CORE_FILE', './gatherpress.php');
+    define( 'GATHERPRESS_CORE_PATH', '.');
+    define( 'GATHERPRESS_CORE_URL', '');
+    define( 'GATHERPRESS_REST_NAMESPACE', '');
+    define( 'GATHERPRESS_REQUIRES_PHP', '');
+
     /**
      * Used in includes/core/classes/class-export.php
      *


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

After #931 was merged, I realized, that GatherPress could still benefit from type checking for the ignored, not-loaded constants.

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Instead of ignoring, I created stubs, that provide at least the type of data.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

```bash
composer test:phpstan
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - phpstan: Use stubs, instead of ignoring

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
