### PR TITLE
Following a little :bug: into a :rabbit: hole

### DIFF
--- a/includes/core/classes/class-block.php
+++ b/includes/core/classes/class-block.php
@@ -86,6 +86,7 @@ class Block {
 	 *
 	 * @since 1.0.0
 	 * @see   https://developer.wordpress.org/reference/functions/register_block_pattern/
+	 * @see   https://developer.wordpress.org/reference/classes/wp_block_patterns_registry/register/#parameters
 	 *
 	 * @return void
 	 */
@@ -103,6 +104,80 @@ class Block {
 					'source'   => 'plugin',
 				),
 			),
+
+
+
+			array(
+				'gatherpress/event-content-1',
+				array(
+					'title'    => __( 'Event Content Starter Pattern 1', 'gatherpress' ),
+					'content'  => '<!-- wp:paragraph -->
+					<p>hallo pattern 1</p>
+					<!-- /wp:paragraph -->',
+					// 'inserter' => false,
+					// 'source'   => 'plugin',
+					// 'keywords' => array('starter'),
+					'blockTypes' => array( 'core/post-content' ),
+					'postTypes' => array( 'post', 'car', 'page', 'gatherpress_event' ),
+					// 'postTypes' => array( 'post', 'car', 'gatherpress_event', 'gatherpress_venue' ),
+					// 'templateTypes' => array( 'single-gatherpress_event' ),
+				),
+			),
+			array(
+				'gatherpress/event-content-2',
+				array(
+					'title'    => __( 'Event Content Starter Pattern 2', 'gatherpress' ),
+					// 'content'  => '<!-- wp:post-featured-image /--><!-- wp:pattern {"slug":"gatherpress/event-template"} /-->',
+					'content'  => '<!-- wp:post-featured-image /--><!-- wp:paragraph -->
+					<p>hallo pattern 2</p>
+					<!-- /wp:paragraph -->',
+					// 'inserter' => false,
+					// 'source'   => 'plugin',
+					// 'keywords' => array('starter'),
+					'blockTypes' => array( 'core/post-content' ),
+					'postTypes' => array( 'post', 'car', 'page', 'gatherpress_event' ),
+					// 'postTypes' => array( 'post', 'car', 'gatherpress_event', 'gatherpress_venue' ),
+					// 'templateTypes' => array( 'single-gatherpress_event' ),
+				),
+			),
+
+
+
+
+
+			/*
+			 * WORKING
+			 * 
+			 * Starter patterns for TEMPLATES
+			 * 
+			 * ....
+			 *  
+			array(
+				'gatherpress/event-starter-1',
+				array(
+					'title'    => __( 'Event Template Starter Pattern 1', 'gatherpress' ),
+					'description'   => _x( 'This is my first starter pattern', 'Block pattern description', 'textdomain' ),
+					'content'  => '<!-- wp:pattern {"slug":"gatherpress/event-template"} /-->',
+					'inserter' => false,
+					'source'   => 'plugin',
+					// 'blockTypes' => array( 'core/post-content' ),
+					'postTypes' => array( 'gatherpress_event' ),
+					'templateTypes' => array( 'single-gatherpress_event' ),
+				),
+			),
+			array(
+				'gatherpress/event-starter-2',
+				array(
+					'title'    => __( 'Event Template Starter Pattern 2', 'gatherpress' ),
+					'description'   => _x( 'This is my second starter pattern', 'Block pattern description', 'textdomain' ),
+					'content'  => '<!-- wp:post-featured-image /--><!-- wp:pattern {"slug":"gatherpress/event-template"} /-->',
+					'inserter' => false,
+					'source'   => 'plugin',
+					// 'blockTypes' => array( 'core/post-content' ),
+					'postTypes' => array( 'gatherpress_event' ),
+					'templateTypes' => array( 'single-gatherpress_event' ),
+				),
+			), */
 			array(
 				'gatherpress/venue-template',
 				array(

--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -534,7 +534,7 @@ class Event_Rest_Api {
 		// - The user is attending the event.
 		// - The event is in the future.
 		// - The code is not in an admin context.
-		$response->data['meta']['online_event_link'] = $event->maybe_get_online_event_link();
+		// $response->data['meta']['online_event_link'] = $event->maybe_get_online_event_link();
 
 		return $response;
 	}

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -124,7 +124,7 @@ class Event_Setup {
 					'thumbnail',
 					'comments',
 					'revisions',
-					'custom-fields',
+					// 'custom-fields',
 				),
 				'menu_icon'     => 'dashicons-nametag',
 				'has_archive'   => true,


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->
**This PR should help illustrating a problem; it's not (primarily meant to be merged)!**

---

I was thinking about #528 and the long thread @mauteri had with _Ed_ on the GatherPress slack, where they talked (among other things) about the default blocks that gets pre-populated when a **New Event** is created.

After a while .... I asked myself why GatherPress is not using the modal, provided by WP core since 5.8, that allows to select a starter-pattern for `core/post-content`. With an addition (I guess for WP 6.7) a user can now even disable this modal permanently for a given post_type, which would help GatherPress' work on #528.

_**I just wanted to try this fast**_, and if it could be made compatible with the new `register_block_template()` to create a UI for GatherPress starter-patterns for the post-content.

---

It took me a loooong while to find two weird :bug:s that prevented the modal from appearing.

https://github.com/user-attachments/assets/c26d727b-9976-4260-8c27-8962ea448e5f



### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @username, @username2, ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
