### PR TITLE
Revert 889 as it breaks Event Lists block. This code will need to be …

### DIFF
--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -6,6 +6,8 @@
  * upcoming and past events, applying filters, and ordering events. It also handles adjustments
  * for event pages and admin queries.
  *
+ * @todo Reverted this PR, but needs to be investigated again to work with Query block https://github.com/GatherPress/gatherpress/pull/889
+ *
  * @package GatherPress\Core
  * @since 1.0.0
  */
@@ -53,7 +55,7 @@ class Event_Query {
 	 */
 	protected function setup_hooks(): void {
 		add_action( 'pre_get_posts', array( $this, 'prepare_event_query_before_execution' ) );
-		add_filter( 'posts_clauses', array( $this, 'adjust_admin_event_sorting' ), 10, 2 );
+		add_filter( 'posts_clauses', array( $this, 'adjust_admin_event_sorting' ) );
 	}
 
 	/**
@@ -231,10 +233,10 @@ class Event_Query {
 		switch ( $events_query ) {
 			case 'upcoming':
 				remove_filter( 'posts_clauses', array( $this, 'adjust_sorting_for_past_events' ) );
-				add_filter( 'posts_clauses', array( $this, 'adjust_sorting_for_upcoming_events' ), 10, 2 );
+				add_filter( 'posts_clauses', array( $this, 'adjust_sorting_for_upcoming_events' ) );
 				break;
 			case 'past':
-				add_filter( 'posts_clauses', array( $this, 'adjust_sorting_for_past_events' ), 10, 2 );
+				add_filter( 'posts_clauses', array( $this, 'adjust_sorting_for_past_events' ) );
 				remove_filter( 'posts_clauses', array( $this, 'adjust_sorting_for_upcoming_events' ) );
 				break;
 			default:
@@ -249,22 +251,13 @@ class Event_Query {
 	 * This method modifies the SQL query pieces, including join, where, orderby, etc., to adjust the sorting criteria
 	 * for upcoming events in the query. It ensures that events are ordered by their start datetime in ascending order.
 	 *
-	 * @see https://developer.wordpress.org/reference/hooks/posts_clauses/
-	 *
 	 * @since 1.0.0
 	 *
-	 * @param array    $query_pieces An array containing pieces of the SQL query.
-	 * @param WP_Query $query        The WP_Query instance (passed by reference).
+	 * @param array $query_pieces An array containing pieces of the SQL query.
 	 * @return array The modified SQL query pieces with adjusted sorting criteria for upcoming events.
 	 */
-	public function adjust_sorting_for_upcoming_events( array $query_pieces, WP_Query $query ): array {
-		return $this->adjust_event_sql(
-			$query_pieces,
-			'upcoming',
-			$query->get( 'order' ),
-			$query->get( 'orderby' ),
-			(bool) $query->get( 'include_unfinished' )
-		);
+	public function adjust_sorting_for_upcoming_events( array $query_pieces ): array {
+		return $this->adjust_event_sql( $query_pieces, 'upcoming', 'ASC' );
 	}
 
 	/**
@@ -273,18 +266,11 @@ class Event_Query {
 	 * This method modifies the SQL query pieces, including join, where, orderby, etc., to adjust the sorting criteria
 	 * for past events in the query. It ensures that events are ordered by their start datetime in the desired order.
 	 *
-	 * @param array    $query_pieces An array containing pieces of the SQL query.
-	 * @param WP_Query $query        The WP_Query instance (passed by reference).
+	 * @param array $query_pieces An array containing pieces of the SQL query.
 	 * @return array The modified SQL query pieces with adjusted sorting criteria for past events.
 	 */
-	public function adjust_sorting_for_past_events( array $query_pieces, WP_Query $query ): array {
-		return $this->adjust_event_sql(
-			$query_pieces,
-			'past',
-			$query->get( 'order' ),
-			$query->get( 'orderby' ),
-			(bool) $query->get( 'include_unfinished' )
-		);
+	public function adjust_sorting_for_past_events( array $query_pieces ): array {
+		return $this->adjust_event_sql( $query_pieces, 'past' );
 	}
 
 	/**
@@ -295,17 +281,18 @@ class Event_Query {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array    $query_pieces An array containing pieces of the SQL query.
-	 * @param WP_Query $query        The WP_Query instance (passed by reference).
+	 * @param array $query_pieces An array containing pieces of the SQL query.
 	 * @return array The modified SQL query pieces with adjusted sorting criteria.
 	 */
-	public function adjust_admin_event_sorting( array $query_pieces, WP_Query $query ): array {
+	public function adjust_admin_event_sorting( array $query_pieces ): array {
 		if ( ! is_admin() ) {
 			return $query_pieces;
 		}
 
-		if ( 'datetime' === $query->get( 'orderby' ) ) {
-			$query_pieces = $this->adjust_event_sql( $query_pieces, 'all', $query->get( 'order' ) );
+		global $wp_query;
+
+		if ( 'datetime' === $wp_query->get( 'orderby' ) ) {
+			$query_pieces = $this->adjust_event_sql( $query_pieces, 'all', $wp_query->get( 'order' ) );
 		}
 
 		return $query_pieces;
@@ -318,26 +305,15 @@ class Event_Query {
 	 * the `gatherpress_events` table in the database join. It allows querying events based on different
 	 * criteria such as upcoming or past events and specifying the event order (DESC or ASC).
 	 *
-	 * @see https://developer.wordpress.org/reference/hooks/posts_join/
-	 * @see https://developer.wordpress.org/reference/hooks/posts_orderby/
-	 * @see https://developer.wordpress.org/reference/hooks/posts_where/
-	 *
 	 * @since 1.0.0
 	 *
-	 * @param array           $pieces    An array of query pieces, including join, where, orderby, and more.
-	 * @param string          $type      The type of events to query (options: 'all', 'upcoming', 'past') (Default: 'all').
-	 * @param string          $order     The event order ('DESC' for descending or 'ASC' for ascending) (Default: 'DESC').
-	 * @param string[]|string $order_by  List  or singular string of ORDERBY statement(s) (Default: ['datetime']).
-	 * @param bool            $inclusive Whether to include currently running events in the query (Default: true).
+	 * @param array  $pieces An array of query pieces, including join, where, orderby, and more.
+	 * @param string $type   The type of events to query (options: 'all', 'upcoming', 'past').
+	 * @param string $order  The event order ('DESC' for descending or 'ASC' for ascending).
+	 *
 	 * @return array An array containing adjusted SQL clauses for the Event query.
 	 */
-	public function adjust_event_sql(
-		array $pieces,
-		string $type = 'all',
-		string $order = 'DESC',
-		$order_by = array( 'datetime' ),
-		bool $inclusive = true
-	): array {
+	public function adjust_event_sql( array $pieces, string $type = 'all', string $order = 'DESC' ): array {
 		global $wpdb;
 
 		$defaults        = array(
@@ -350,34 +326,13 @@ class Event_Query {
 			'limits'   => '',
 		);
 		$pieces          = array_merge( $defaults, $pieces );
-		$table           = sprintf( Event::TABLE_FORMAT, $wpdb->prefix ); // Could also be (just) $wpdb->{gatherpress_events}.
+		$table           = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 		$pieces['join'] .= ' LEFT JOIN ' . esc_sql( $table ) . ' ON ' . esc_sql( $wpdb->posts ) . '.ID='
 						. esc_sql( $table ) . '.post_id';
 		$order           = strtoupper( $order );
 
 		if ( in_array( $order, array( 'DESC', 'ASC' ), true ) ) {
-			// ORDERBY is an array, which allows to orderby multiple values.
-			// Currently, it is only allowed to order events by ONE value.
-			$order_by = ( is_array( $order_by ) ) ? $order_by[0] : $order_by;
-
-			switch ( strtolower( $order_by ) ) {
-				case 'id':
-					$pieces['orderby'] = sprintf( esc_sql( $wpdb->posts ) . '.ID %s', esc_sql( $order ) );
-					break;
-				case 'title':
-					$pieces['orderby'] = sprintf( esc_sql( $wpdb->posts ) . '.post_name %s', esc_sql( $order ) );
-					break;
-				case 'modified':
-					$pieces['orderby'] = sprintf( esc_sql( $wpdb->posts ) . '.post_modified_gmt %s', esc_sql( $order ) );
-					break;
-				case 'rand':
-					$pieces['orderby'] = esc_sql( 'RAND()' );
-					break;
-				case 'datetime':
-				default:
-					$pieces['orderby'] = sprintf( esc_sql( $table ) . '.datetime_start_gmt %s', esc_sql( $order ) );
-					break;
-			}
+			$pieces['orderby'] = sprintf( esc_sql( $table ) . '.datetime_start_gmt %s', esc_sql( $order ) );
 		}
 
 		if ( 'all' === $type ) {
@@ -385,40 +340,13 @@ class Event_Query {
 		}
 
 		$current = gmdate( Event::DATETIME_FORMAT, time() );
-		$column  = $this->get_datetime_comparison_column( $type, $inclusive );
 
 		if ( 'upcoming' === $type ) {
-			$pieces['where'] .= $wpdb->prepare( ' AND %i.%i >= %s', $table, $column, $current );
+			$pieces['where'] .= $wpdb->prepare( ' AND %i.datetime_end_gmt >= %s', $table, $current );
 		} elseif ( 'past' === $type ) {
-			$pieces['where'] .= $wpdb->prepare( ' AND %i.%i < %s', $table, $column, $current );
+			$pieces['where'] .= $wpdb->prepare( ' AND %i.datetime_end_gmt < %s', $table, $current );
 		}
 
 		return $pieces;
-	}
-
-	/**
-	 * Determine which db column to compare against,
-	 * based on the type of event query (either upcoming or past)
-	 * and if started but unfinished events should be included.
-	 *
-	 * @param  string $type      The type of events to query (options: 'all', 'upcoming', 'past') (Cannot be 'all' anymore).
-	 * @param  bool   $inclusive Whether to include currently running events in the query.
-	 *
-	 * @return string Name of the DB column, which content to compare against the current time.
-	 */
-	protected static function get_datetime_comparison_column( string $type, bool $inclusive ): string {
-		if (
-			// Upcoming events, including ones that are running.
-			( $inclusive && 'upcoming' === $type ) ||
-			// Past events, that are finished already.
-			( ! $inclusive && 'past' === $type )
-		) {
-			return 'datetime_end_gmt';
-		}
-
-		// All others, means:
-		// - Upcoming events, without running events.
-		// - Past events, that are still running.
-		return 'datetime_start_gmt';
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-query.php
@@ -14,7 +14,6 @@ use GatherPress\Core\Event_Query;
 use GatherPress\Core\Topic;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
-use PMC\Unit_Test\Utility;
 use WP_Query;
 
 /**
@@ -374,11 +373,12 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_adjust_admin_event_sorting(): void {
-		$instance = Event_Query::get_instance();
 		global $wp_query;
 
+		$instance = Event_Query::get_instance();
+
 		$this->mock->user( false, 'admin' );
-		$response = $instance->adjust_admin_event_sorting( array(), $wp_query );
+		$response = $instance->adjust_admin_event_sorting( array() );
 		$this->assertEmpty( $response, 'Failed to assert array is not empty' );
 
 		$this->mock->user( true, 'admin' );
@@ -387,7 +387,7 @@ class Test_Event_Query extends Base {
 		$wp_query->set( 'orderby', 'datetime' );
 
 		// Run function with empty array passed as 'pieces' argument.
-		$response = $instance->adjust_admin_event_sorting( array(), $wp_query );
+		$response = $instance->adjust_admin_event_sorting( array() );
 
 		// Assert that an array was generated from the adjustsql argument. todo: make this test more meaningful.
 		$this->assertNotEmpty( $response, 'Failed to assert array is empty' );
@@ -408,71 +408,17 @@ class Test_Event_Query extends Base {
 		$table  = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 		$retval = $instance->adjust_event_sql( array(), 'all', 'DESC' );
 
-		$this->assertStringContainsString( '.datetime_start_gmt DESC', $retval['orderby'] );
+		$this->assertStringContainsString( 'DESC', $retval['orderby'] );
 		$this->assertEmpty( $retval['where'] );
 
-		$retval = $instance->adjust_event_sql( array(), 'past', 'desc' ); // inclusive will be TRUE by default.
+		$retval = $instance->adjust_event_sql( array(), 'past', 'desc' );
 
-		$this->assertStringContainsString( '.datetime_start_gmt DESC', $retval['orderby'] );
-		$this->assertStringContainsString( "AND `{$table}`.`datetime_start_gmt` <", $retval['where'] );
-
-		$retval = $instance->adjust_event_sql( array(), 'past', 'desc', 'datetime', false );
-
-		$this->assertStringContainsString( '.datetime_start_gmt DESC', $retval['orderby'] );
-		$this->assertStringContainsString( "AND `{$table}`.`datetime_end_gmt` <", $retval['where'] );
+		$this->assertStringContainsString( 'DESC', $retval['orderby'] );
+		$this->assertStringContainsString( "AND `{$table}`.datetime_end_gmt <", $retval['where'] );
 
 		$retval = $instance->adjust_event_sql( array(), 'upcoming', 'ASC' );
 
-		$this->assertStringContainsString( '.datetime_start_gmt ASC', $retval['orderby'] );
-		$this->assertStringContainsString( "AND `{$table}`.`datetime_end_gmt` >=", $retval['where'] );
-
-		$retval = $instance->adjust_event_sql( array(), 'past', 'desc', 'id', false );
-
-		$this->assertStringContainsString( '.ID DESC', $retval['orderby'] );
-
-		$retval = $instance->adjust_event_sql( array(), 'past', 'desc', 'title', false );
-
-		$this->assertStringContainsString( '.post_name DESC', $retval['orderby'] );
-
-		$retval = $instance->adjust_event_sql( array(), 'past', 'desc', 'modified', false );
-
-		$this->assertStringContainsString( '.post_modified_gmt DESC', $retval['orderby'] );
-
-		$retval = $instance->adjust_event_sql( array(), 'upcoming', 'desc', 'rand', false );
-
-		$this->assertStringContainsString( 'RAND()', $retval['orderby'] );
-	}
-
-	/**
-	 * Coverage for get_datetime_comparison_column method.
-	 *
-	 * @covers ::get_datetime_comparison_column
-	 *
-	 * @return void
-	 */
-	public function test_get_datetime_comparison_column(): void {
-		$instance = Event_Query::get_instance();
-
-		$this->assertSame(
-			'datetime_end_gmt',
-			Utility::invoke_hidden_method( $instance, 'get_datetime_comparison_column', array( 'upcoming', true ) ),
-			'Failed to assert, that inclusive, upcoming events should be ordered by datetime_end_gmt.'
-		);
-		$this->assertSame(
-			'datetime_start_gmt',
-			Utility::invoke_hidden_method( $instance, 'get_datetime_comparison_column', array( 'upcoming', false ) ),
-			'Failed to assert, that non-inclusive, upcoming events should be ordered by datetime_start_gmt.'
-		);
-
-		$this->assertSame(
-			'datetime_start_gmt',
-			Utility::invoke_hidden_method( $instance, 'get_datetime_comparison_column', array( 'past', true ) ),
-			'Failed to assert, that inclusive, past events should be ordered by datetime_start_gmt.'
-		);
-		$this->assertSame(
-			'datetime_end_gmt',
-			Utility::invoke_hidden_method( $instance, 'get_datetime_comparison_column', array( 'past', false ) ),
-			'Failed to assert, that non-inclusive, past events should be ordered by datetime_end_gmt.'
-		);
+		$this->assertStringContainsString( 'ASC', $retval['orderby'] );
+		$this->assertStringContainsString( "AND `{$table}`.datetime_end_gmt >=", $retval['where'] );
 	}
 }


### PR DESCRIPTION
…revisited when we work on Query loop block and still work with upcoming/past archive pages.

<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
Reverts https://github.com/GatherPress/gatherpress/pull/889 due to sorting bugs.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
