### PR TITLE
Fix deprecations

### DIFF
--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -86,7 +86,7 @@ class Rsvp_Template {
 		$block_instance = Block::get_instance();
 		$tag            = new WP_HTML_Tag_Processor( $block_content );
 
-		if ( $tag->next_tag() ) {
+		if ( $tag->next_tag() && ! empty( $tag->get_attribute( 'data-blocks' ) ) ) {
 			$inner_blocks = (array) json_decode( $tag->get_attribute( 'data-blocks' ), true );
 			$inner_blocks = $block_instance->get_block_names( $inner_blocks );
 

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -148,7 +148,7 @@ class Assets {
 	 * @return string The block content.
 	 */
 	public function maybe_enqueue_styles( string $block_content, array $block ): string {
-		if ( 0 === strpos( $block['blockName'], 'gatherpress/' ) ) {
+		if ( isset( $block['blockName'] ) && str_contains( $block['blockName'], 'gatherpress/' ) ) {
 			$asset = $this->get_asset_data( 'utility_style' );
 
 			wp_enqueue_style( 'gatherpress-utility-style' );


### PR DESCRIPTION
### Description of the Change

This fixes #1076 by adding a `! empty()` check. And #1047 by checking if the given array has the key we want to check.
Also replaced `strpos()` with `str_contains()` as it is available as polyfill since WordPress 5.x

Closes #1076
Closes #1047 

### How to test the Change
Open a topic listing with WP_DEBUG active.

### Changelog Entry
> Fixed - Deprecated: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated
> Fixed - Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @apermo, @shawfactor 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
