### PR TITLE
Improve and fix accessibility issues in modal and dropdown blocks.

### DIFF
--- a/includes/core/classes/blocks/class-modal-manager.php
+++ b/includes/core/classes/blocks/class-modal-manager.php
@@ -154,6 +154,7 @@ class Modal_Manager {
 
 				$tag->set_attribute( 'data-wp-interactive', 'gatherpress' );
 				$tag->set_attribute( 'data-wp-on--click', 'actions.closeModal' );
+				$tag->set_attribute( 'data-close-modal', true );
 			}
 		}
 

--- a/src/blocks/modal-manager/view.js
+++ b/src/blocks/modal-manager/view.js
@@ -55,6 +55,7 @@ const { actions } = store('gatherpress', {
 								focusableSelectors.join(',')
 							)
 						);
+
 						// Focus the first focusable element, if available.
 						if (focusableElements[0]) {
 							setTimeout(() => {

--- a/src/blocks/modal-manager/view.js
+++ b/src/blocks/modal-manager/view.js
@@ -49,12 +49,12 @@ const { actions } = store('gatherpress', {
 							'select:not([disabled])',
 							'[tabindex]:not([tabindex="-1"])',
 						];
+
 						const focusableElements = Array.from(
 							modalContent.querySelectorAll(
 								focusableSelectors.join(',')
 							)
 						);
-
 						// Focus the first focusable element, if available.
 						if (focusableElements[0]) {
 							setTimeout(() => {
@@ -71,85 +71,109 @@ const { actions } = store('gatherpress', {
 						modalContent.cleanupCloseHandlers = setupCloseHandlers(
 							'.wp-block-gatherpress-modal',
 							'.wp-block-gatherpress-modal-content',
-							() => {
-								modal.classList.remove(
-									'gatherpress--is-visible'
-								);
-								modal.setAttribute('aria-hidden', 'true');
-
-								// Clean up focus trap if applicable.
-								if (
-									modalContent &&
-									'function' ===
-										typeof modalContent.cleanupFocusTrap
-								) {
-									modalContent.cleanupFocusTrap();
-								}
+							(e) => {
+								actions.closeModal(null, e);
 							}
 						);
-					}
-
-					// Handle explicit close button logic.
-					const closeButton = modal.querySelector(
-						'.gatherpress--close-modal'
-					);
-					if (closeButton) {
-						closeButton.addEventListener('click', () => {
-							modal.classList.remove('gatherpress--is-visible');
-							modal.setAttribute('aria-hidden', 'true');
-
-							// Clean up focus trap if applicable.
-							if (
-								modalContent &&
-								'function' ===
-									typeof modalContent.cleanupFocusTrap
-							) {
-								modalContent.cleanupFocusTrap();
-							}
-
-							// Clean up close handlers if applicable.
-							if (
-								modalContent &&
-								'function' ===
-									typeof modalContent.cleanupCloseHandlers
-							) {
-								modalContent.cleanupCloseHandlers();
-							}
-						});
 					}
 				}
 			}
 		},
-		openModalOnEnter(event) {
-			if ('Enter' === event.key) {
-				actions.openModal(event);
-			}
-		},
-		closeModal(event = null, element = null) {
+		closeModal(event = null, element = null, findActiveSibling = true) {
 			if (event) {
 				event.preventDefault();
 			}
 
-			element = element ?? event.target;
+			// Determine the element to work with.
+			element = element ?? event?.target;
 
-			const modalManager = element.closest(
+			if (!element) {
+				return;
+			}
+
+			// Find the modal manager and modal.
+			let modalManager = element.closest(
 				'.wp-block-gatherpress-modal-manager'
 			);
 
-			if (modalManager) {
-				const modal = modalManager.querySelector(
-					'.wp-block-gatherpress-modal'
+			/**
+			 * When switching between RSVP states, modals are hidden/shown dynamically.
+			 * If findActiveSibling=true, this code finds the currently visible modal manager
+			 * when the original one is hidden (has a parent with gatherpress--is-not-visible class).
+			 * This ensures focus and functionality transfer to the currently visible modal.
+			 */
+			if (
+				findActiveSibling &&
+				modalManager.closest('.gatherpress--is-not-visible')
+			) {
+				const hiddenContainer = modalManager.closest(
+					'.gatherpress--is-not-visible'
 				);
+				const parent = hiddenContainer.parentElement;
 
-				if (modal) {
-					modal.classList.remove('gatherpress--is-visible');
-					modal.setAttribute('aria-hidden', 'true');
+				// Look for visible siblings (both previous and next).
+				if (parent) {
+					// Try siblings.
+					for (const sibling of parent.children) {
+						if (
+							sibling !== hiddenContainer &&
+							!sibling.classList.contains(
+								'gatherpress--is-not-visible'
+							)
+						) {
+							const visibleModalManager = sibling.querySelector(
+								'.wp-block-gatherpress-modal-manager'
+							);
+							if (visibleModalManager) {
+								modalManager = visibleModalManager;
+								break;
+							}
+						}
+					}
 				}
 			}
-		},
-		closeModalOnEnter(event) {
-			if ('Enter' === event.key) {
-				actions.closeModal(event);
+
+			if (!modalManager) {
+				return;
+			}
+
+			const modal = modalManager.querySelector(
+				'.wp-block-gatherpress-modal'
+			);
+
+			if (!modal) {
+				return;
+			}
+
+			// Handle modal closing.
+			modal.classList.remove('gatherpress--is-visible');
+			modal.setAttribute('aria-hidden', 'true');
+
+			// Clean up focus trap if applicable.
+			const modalContent = modal.querySelector('.modal-content');
+
+			if (
+				modalContent &&
+				'function' === typeof modalContent.cleanupFocusTrap
+			) {
+				modalContent.cleanupFocusTrap();
+			}
+
+			// Clean up close handlers if applicable.
+			if (
+				modalContent &&
+				'function' === typeof modalContent.cleanupCloseHandlers
+			) {
+				modalContent.cleanupCloseHandlers();
+			}
+
+			// Return focus to the open modal button.
+			const openButton = modalManager.querySelector(
+				'.gatherpress--open-modal button'
+			);
+
+			if (openButton) {
+				openButton.focus();
 			}
 		},
 	},

--- a/src/blocks/rsvp/view.js
+++ b/src/blocks/rsvp/view.js
@@ -101,14 +101,29 @@ const { state, actions } = store('gatherpress', {
 							rsvpContainer.querySelector(
 								'[data-rsvp-status="attending"] .gatherpress--update-rsvp'
 							);
+						const closeButton = rsvpContainer.querySelector(
+							'[data-rsvp-status="attending"] .gatherpress--close-modal button'
+						);
 
 						actions.openModal(null, attendingStatusButton);
-					}
 
-					// Close the current modal after a short delay to prevent flicker.
-					setTimeout(() => {
-						actions.closeModal(null, element.ref);
-					}, 1);
+						/**
+						 * When keeping a modal open after an action, use findActiveSibling=false
+						 * to prevent focus from moving to a different modal manager.
+						 */
+						setTimeout(() => {
+							actions.closeModal(null, element.ref, false);
+							closeButton.focus();
+						}, 1);
+					} else {
+						/**
+						 * When fully closing a modal, use findActiveSibling=true
+						 * to allow focus to move to any visible modal manager in sibling containers.
+						 */
+						setTimeout(() => {
+							actions.closeModal(null, element.ref, true);
+						}, 1);
+					}
 				}
 			);
 		},

--- a/src/blocks/rsvp/view.js
+++ b/src/blocks/rsvp/view.js
@@ -101,6 +101,7 @@ const { state, actions } = store('gatherpress', {
 							rsvpContainer.querySelector(
 								'[data-rsvp-status="attending"] .gatherpress--update-rsvp'
 							);
+
 						const closeButton = rsvpContainer.querySelector(
 							'[data-rsvp-status="attending"] .gatherpress--close-modal button'
 						);


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
Gen Herres was kind enough to review the accessibility with me in of our new blocks that were reworked in 0.32.0. While they were improved, some issues were still discovered.

- After clicking escape, close, or clicking outside the modal which closes it, focus should return to the button that original opened the modal. Right now, focus is lost.
- After clicking "Attending," the modal does not close (which is correct), however, focus should be on "Close" as that's the next logical step (if close button exists).
- In addition, I fixed escape on dropdown to return to the triggering element.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1041

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
