### PR TITLE
Added a new check to determine if gatherpress has already been installed/activated

### DIFF
--- a/gatherpress.php
+++ b/gatherpress.php
@@ -21,6 +21,11 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+// Ensure no other versions of GatherPress are currently running.
+if ( require_once __DIR__ . '/includes/core/duplicate-check.php' ) {
+	return;
+}
+
 // Constants.
 define( 'GATHERPRESS_CACHE_GROUP', 'gatherpress_cache' );
 define( 'GATHERPRESS_CORE_FILE', __FILE__ );

--- a/includes/core/duplicate-check.php
+++ b/includes/core/duplicate-check.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 $gatherpress_activated = false;
 
-if (defined( 'GATHERPRESS_VERSION' )) {
+if ( defined( 'GATHERPRESS_VERSION' ) ) {
 	add_action(
 		'admin_notices',
 		static function (): void {

--- a/includes/core/duplicate-check.php
+++ b/includes/core/duplicate-check.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Duplicate GatherPress Plugin Check.
+ *
+ * This file checks to determine if another version of GatherPress is already running.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+$gatherpress_activated = false;
+
+if (defined( 'GATHERPRESS_VERSION' )) {
+	add_action(
+		'admin_notices',
+		static function (): void {
+			wp_admin_notice(
+				esc_html__( 'You have more than one version of GatherPress installed and activated. Please activate only one version of GatherPress at a time.', 'gatherpress' ),
+				array(
+					'type' => 'error',
+				)
+			);
+		}
+	);
+
+	$gatherpress_activated = true;
+}
+
+return $gatherpress_activated;


### PR DESCRIPTION
…

<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

https://github.com/orgs/GatherPress/projects/1/views/1?pane=issue&itemId=107988139&issue=GatherPress%7Cgatherpress%7C1071

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes GP-1071

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Try to activate 2 different versions of GP at the same time and you will see an activation error message

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - new check to search for other instances of GP installation

### Credits
@stephenerdelyi 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
