### PR TITLE
Don't include the .wordpress-org directory in the released versions of the plugin

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -40,6 +40,7 @@ yarn.lock
 
 # Dot Files and Directories
 .gatherpress-org
+.wordpress-org
 .git
 .github
 .wordpress-version-checker.json

--- a/.distignore
+++ b/.distignore
@@ -51,6 +51,7 @@ Thumbs.db
 node_modules
 vendor
 src
+docs
 
 # Miscellaneous and SQL Archives
 behat.yml


### PR DESCRIPTION


<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change

While looking at https://plugins.trac.wordpress.org/browser/gatherpress/#tags/0.32.2 and https://plugins.trac.wordpress.org/browser/gatherpress/trunk I noticed that you've included the `.wordpress-org` directory in the released versions of the plugin, although this is intended to be the `assets/` folder only.

See https://github.com/10up/action-wordpress-plugin-deploy?tab=readme-ov-file#excluding-files-from-deployment

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Fixed - smaller release ZIPs as we no longer ship the screenshots as part of the release.


### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
