### PR TITLE
Basic functionality to show customised embeds for events

### DIFF
--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -110,6 +110,74 @@ class Setup {
 			),
 			array( $this, 'filter_plugin_action_links' )
 		);
+
+
+
+
+
+		/**
+		 * Embed needs to have trailing slash "/" to work!
+		 */
+		add_filter( 'embed_template', function ( $template ) {
+
+			if ( 'gatherpress_event' === get_post_type() ) {
+
+
+				add_action('embed_content',function() : void {
+					echo do_blocks('<!-- wp:separator -->
+					<hr class="wp-block-separator has-alpha-channel-opacity"/>
+					<!-- /wp:separator -->
+					
+					<!-- wp:gatherpress/event-date /-->
+					
+					<!-- wp:gatherpress/venue /-->
+					
+					<!-- wp:separator -->
+					<hr class="wp-block-separator has-alpha-channel-opacity"/>
+					<!-- /wp:separator -->');
+				}, 20 );
+				// Needed to show GatherPress block icons.
+				add_action( 'embed_head', 'wp_enqueue_scripts', -10 );
+				add_action( 'embed_head', function() : void {
+					// Fix icon positioning.
+					// Override ".dashicon" defaults loaded for oEmbeds.
+					echo '<style>.gatherpress-venue__icon .dashicon {top:0;}</style>';
+				}, 10 );
+
+				// add_action( 'embed_head', function() : void {
+				// 	wp_enqueue_style( 'global-styles' );
+				// }, 20 );
+
+				remove_action( 'embed_content_meta', 'print_embed_comments_button' );
+				remove_action( 'embed_content_meta', 'print_embed_sharing_button' );
+				remove_action( 'embed_footer', 'print_embed_sharing_dialog' );
+				add_action( 'embed_content_meta', function () {
+					if ( is_404() || ! ( get_comments_number() || comments_open() ) ) {
+						return;
+					}
+					?>
+					<div class="wp-embed-comments">
+						<a href="<?php comments_link(); ?>" target="_top">
+							<span class="dashicons dashicons-admin-comments"></span>
+							<?php
+							printf(
+								/* translators: %s: Number of comments. */
+								_n(
+									'%s <span class="screen-reader-text">Approved RSVP</span>',
+									'%s <span class="screen-reader-text">Approved RSVPs</span>',
+									get_comments_number()
+								),
+								number_format_i18n( get_comments_number() )
+							);
+							?>
+						</a>
+					</div>
+					<?php
+				}, 9 );
+			}
+			return $template;
+		} );
+
 	}
 
 	/**


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes ~~#1126~~ #2038 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Show date & venue in event embeds

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
