### PR TITLE
Add `$schema` prop to `wp-env` config

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
 	"plugins": [
 		"."
 	],


### PR DESCRIPTION
### Description of the Change
Adds schema to `wp-env` config JSON.

### How to test the Change
Check the branch out and see if your code editor will auto-complete props in `.wp-env.json`.

### Credits
@JordanPak