### PR TITLE
#684 | Add display options to "Event Date" block

### DIFF
--- a/src/blocks/event-date/block.json
+++ b/src/blocks/event-date/block.json
@@ -20,6 +20,27 @@
 		},
 		"textAlign": {
 			"type": "string"
+		},
+		"displayType": {
+			"type": "string",
+			"default": "both"
+		},
+		"startDateFormat": {
+			"type": "string",
+			"default": ""
+		},
+		"endDateFormat": {
+			"type": "string",
+			"default": ""
+		},
+		"separator": {
+			"//": "@todo Add this to plugin settings",
+			"type": "string",
+			"default": "to"
+		},
+		"showTimezone": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies.
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	AlignmentToolbar,
 	BlockControls,
@@ -18,7 +18,10 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 	PanelBody,
+	RadioControl,
+	SelectControl,
 	Spinner,
+	TextControl,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
@@ -29,10 +32,16 @@ import {
 	convertPHPToMomentFormat,
 	getTimezone,
 	getUtcOffset,
+	removeNonTimePHPFormatChars,
 } from '../../helpers/datetime';
 import DateTimeRange from '../../components/DateTimeRange';
 import { getFromGlobal } from '../../helpers/globals';
 import { isEventPostType } from '../../helpers/event';
+
+const globalDateFormat = getFromGlobal('settings.dateFormat');
+const globalTimeFormat = getFromGlobal('settings.timeFormat');
+const globalShowTimezone = getFromGlobal('settings.showTimezone');
+const defaultFormat = `${globalDateFormat} ${globalTimeFormat}`;
 
 /**
  * Similar to get_display_datetime method in class-event.php.
@@ -40,36 +49,75 @@ import { isEventPostType } from '../../helpers/event';
  * @param {string} dateTimeStart
  * @param {string} dateTimeEnd
  * @param {string} timezone
+ * @param {string} startFormat
+ * @param {string} endFormat
+ * @param {string} separator
+ * @param {string} showTimezone
  * @return {string} Displayed date.
  */
-const displayDateTime = (dateTimeStart, dateTimeEnd, timezone) => {
-	const dateFormat = convertPHPToMomentFormat(
-		getFromGlobal('settings.dateFormat')
-	);
-	const timeFormat = convertPHPToMomentFormat(
-		getFromGlobal('settings.timeFormat')
-	);
-	const timezoneFormat = getFromGlobal('settings.showTimezone') ? 'z' : '';
-	const startFormat = dateFormat + ' ' + timeFormat;
-
+const displayDateTime = (
+	dateTimeStart,
+	dateTimeEnd,
+	timezone,
+	startFormat,
+	endFormat,
+	separator,
+	showTimezone
+) => {
 	timezone = getTimezone(timezone);
+	let sameStartEndDay = false;
 
-	let endFormat = dateFormat + ' ' + timeFormat + ' ' + timezoneFormat;
-
-	if (
-		moment.tz(dateTimeStart, timezone).format(dateFormat) ===
-		moment.tz(dateTimeEnd, timezone).format(dateFormat)
-	) {
-		endFormat = timeFormat + ' ' + timezoneFormat;
+	// Check for default formatting with same event day before applying
+	// attribute-specific formats.
+	if (dateTimeStart && dateTimeEnd) {
+		const sameDayFormat = convertPHPToMomentFormat(globalDateFormat);
+		sameStartEndDay =
+			moment.tz(dateTimeStart, timezone).format(sameDayFormat) ===
+			moment.tz(dateTimeEnd, timezone).format(sameDayFormat);
 	}
 
-	return sprintf(
-		/* translators: %1$s: datetime start, %2$s: datetime end, %3$s timezone. */
-		__('%1$s to %2$s %3$s', 'gatherpress'),
-		moment.tz(dateTimeStart, timezone).format(startFormat),
-		moment.tz(dateTimeEnd, timezone).format(endFormat),
-		getUtcOffset(timezone)
-	);
+	const parts = [];
+
+	// Add start date/time.
+	if (dateTimeStart) {
+		startFormat = convertPHPToMomentFormat(
+			startFormat ? startFormat : defaultFormat
+		);
+		parts.push(moment.tz(dateTimeStart, timezone).format(startFormat));
+	}
+
+	// Add separator if start + end date/time(s).
+	if (dateTimeStart && dateTimeEnd) {
+		parts.push(separator);
+	}
+
+	// Add end date/time.
+	if (dateTimeEnd) {
+		// Fall formatting back to default.
+		endFormat = endFormat ? endFormat : defaultFormat;
+
+		endFormat = convertPHPToMomentFormat(
+			// Remove non-time characters from PHP date format if start and end
+			// are on the same day.
+			sameStartEndDay ? removeNonTimePHPFormatChars(endFormat) : endFormat
+		);
+		parts.push(moment.tz(dateTimeEnd, timezone).format(endFormat));
+	}
+
+	// Add timezone.
+	if (showTimezone ? 'yes' === showTimezone : globalShowTimezone) {
+		parts.push(
+			moment
+				.tz(dateTimeEnd ? dateTimeEnd : dateTimeStart, timezone)
+				.format('z')
+		);
+	}
+
+	// Add UTC offset if GMT (invalid site timezone).
+	parts.push(getUtcOffset(timezone));
+
+	// The filter removes empty values.
+	return parts.filter((part) => part).join(' ');
 };
 
 /**
@@ -97,7 +145,14 @@ const displayDateTime = (dateTimeStart, dateTimeEnd, timezone) => {
  * @see {@link displayDateTime} - Function for formatting and displaying date and time.
  */
 const Edit = ({ attributes, setAttributes, context }) => {
-	const { textAlign } = attributes;
+	const {
+		textAlign,
+		displayType,
+		startDateFormat,
+		endDateFormat,
+		separator,
+		showTimezone,
+	} = attributes;
 	const blockProps = useBlockProps({
 		className: clsx({
 			[`has-text-align-${textAlign}`]: textAlign,
@@ -150,6 +205,9 @@ const Edit = ({ attributes, setAttributes, context }) => {
 		);
 	}
 
+	const showStartTime = ['start', 'both'].includes(displayType);
+	const showEndTime = ['end', 'both'].includes(displayType);
+
 	return (
 		<div {...blockProps}>
 			<BlockControls>
@@ -160,13 +218,112 @@ const Edit = ({ attributes, setAttributes, context }) => {
 					}
 				/>
 			</BlockControls>
-			{displayDateTime(dateTimeStart, dateTimeEnd, timezone)}
+			{displayDateTime(
+				showStartTime ? dateTimeStart : null,
+				showEndTime ? dateTimeEnd : null,
+				timezone,
+				startDateFormat,
+				endDateFormat,
+				separator,
+				showTimezone
+			)}
 			{isEventPostType() && (
 				<InspectorControls>
 					<PanelBody>
 						<VStack spacing={4}>
 							<DateTimeRange />
 						</VStack>
+						<div style={{ height: '1rem' }} />
+						<RadioControl
+							label={__('Display', 'gatherpress')}
+							selected={displayType}
+							options={[
+								{
+									label: __(
+										'Start and end date',
+										'getherpress'
+									),
+									value: 'both',
+								},
+								{
+									label: __('Start date only', 'gatherpress'),
+									value: 'start',
+								},
+								{
+									label: __('End date only', 'gatherpress'),
+									value: 'end',
+								},
+							]}
+							onChange={(value) =>
+								setAttributes({ displayType: value })
+							}
+						/>
+						{'both' === displayType && (
+							<TextControl
+								label={__('Separator', 'gatherpress')}
+								value={separator}
+								placeholder={__('to', 'gatherpress')}
+								onChange={(value) =>
+									setAttributes({ separator: value })
+								}
+							/>
+						)}
+						{showStartTime && (
+							<TextControl
+								label={__('Start date format', 'gatherpress')}
+								value={startDateFormat}
+								placeholder={`${globalDateFormat} ${globalTimeFormat}`}
+								onChange={(value) =>
+									setAttributes({ startDateFormat: value })
+								}
+							/>
+						)}
+						{showEndTime && (
+							<TextControl
+								label={__('End date format', 'gatherpress')}
+								value={endDateFormat}
+								placeholder={`${globalDateFormat} ${globalTimeFormat}`}
+								onChange={(value) =>
+									setAttributes({ endDateFormat: value })
+								}
+							/>
+						)}
+						<p className="components-base-control__help">
+							<a
+								href="https://wordpress.org/documentation/article/customize-date-and-time-format/"
+								target="_blank"
+								rel="noreferrer"
+							>
+								{__(
+									'Date/time formatting documentation',
+									'gatherpress'
+								)}
+							</a>
+						</p>
+						<SelectControl
+							label={__('Show time zone', 'gatherpress')}
+							value={showTimezone}
+							options={[
+								{
+									label: __(
+										'Default (plugin setting)',
+										'gatherpress'
+									),
+									value: '',
+								},
+								{
+									label: __('Yes', 'gatherpress'),
+									value: 'yes',
+								},
+								{
+									label: __('No', 'gatherpress'),
+									value: 'no',
+								},
+							]}
+							onChange={(value) =>
+								setAttributes({ showTimezone: value })
+							}
+						/>
 					</PanelBody>
 				</InspectorControls>
 			)}

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -550,3 +550,62 @@ export function dateTimePreview() {
 		);
 	}
 }
+
+/**
+ * Non-time PHP Date format characters
+ *
+ * @since 1.0.0
+ *
+ * @see https://www.php.net/manual/en/datetime.format.php
+ *
+ * @type {Array}
+ */
+export const phpNonTimeFormatChars = [
+	'd',
+	'D',
+	'j',
+	'l',
+	'N',
+	'S',
+	'w',
+	'z',
+	'W',
+	'F',
+	'm',
+	'M',
+	'n',
+	't',
+	'L',
+	'o',
+	'X',
+	'x',
+	'Y',
+	'y',
+	'e',
+	'I',
+	'O',
+	'P',
+	'p',
+	'T',
+	'Z',
+	'c',
+	'r',
+	'U',
+	',',
+];
+
+/**
+ * Remove non-time characters from PHP format string
+ *
+ * @since 1.0.0
+ *
+ * @param {string} format - The PHP datetime format.
+ * @return {string} The PHP time-only format.
+ */
+export function removeNonTimePHPFormatChars(format) {
+	return format
+		.split('')
+		.filter((char) => !phpNonTimeFormatChars.includes(char))
+		.join('')
+		.trim();
+}


### PR DESCRIPTION
### Description of the Change
Adds new display options to the `gatherpress/event-date` block:

1. "Display" radio control for showing start, end, or both date/time(s)
2. "Separator" text control for customizing the separator "word" between the start and end dates/times (if both are being displayed)
3. Conditional text controls for start & end date PHP formatting
4. Dynamic **date** removal from end date (leaving only the time) if both the start and end **date** are the same
5. Timezone display option, including a default that inherits the plugin setting

<img width="281" height="799" alt="image" src="https://github.com/user-attachments/assets/d48b5ba6-5781-41f2-aa3c-6512c688d319" />

--------

Closes #684 

### How to test the Change
Go to an event post and add the "event date" block if it isn't already there. Select the block and change the new attribute inspector controls.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Display options for showing start vs end date/time, timezone, date formatting, and "separator"

### Credits
@JordanPak

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
