### PR TITLE
Add `mu-plugins` to `.gitignore` (for `.wp-env.override.json` mapping)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ wp-core
 coverage.xml
 .env
 .wp-env.override.json
+mu-plugins/
 
 # Playwright #
 ##########


### PR DESCRIPTION
### Description of the Change
Adds root `mu-plugins` to the gitignore so contributors can conveniently map some local `mu-plugins`.

### How to test the Change
1. Create a `.wp-env.override.json` with
```
{
	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
	"mappings": {
		"wp-content/mu-plugins": "./mu-plugins"
	}
}
```
2. Make a `mu-plugins` directory in the root and throw a drop-in plugin in there.
3. The plugin should load after restarting the WordPress environment, and it won't be tracked in the repo.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Add `mu-plugins/` to `.gitignore` for `mappings` in potential `.wp-env.override.json`

### Credits
@JordanPak 
