### PR TITLE
Past events feed

### DIFF
--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -172,7 +172,7 @@ class Event_Query {
 		// Retrieve the query from the passed block context.
 		$block_query = $block->context['query'];
 
-		if ( ! is_array( $block_query ) || ! isset( $block_query['gatherpress_events_query'] ) ) {
+		if ( ! is_array( $block_query ) || ! isset( $block_query['gatherpress_event_query'] ) ) {
 			return $query;
 		}
 
@@ -184,7 +184,7 @@ class Event_Query {
 
 		// Type of event list: 'upcoming' or 'past',
 		// @see wp-content/plugins/gatherpress/includes/core/classes/class-event-query.php.
-		$query_args['gatherpress_events_query'] = $block_query['gatherpress_events_query'];
+		$query_args['gatherpress_event_query'] = $block_query['gatherpress_event_query'];
 
 		// Exclude Posts.
 		$exclude_ids = $this->get_exclude_ids( $block_query );
@@ -235,7 +235,7 @@ class Event_Query {
 
 		// Type of event list: 'upcoming' or 'past',
 		// @see wp-content/plugins/gatherpress/includes/core/classes/class-event-query.php .
-		$custom_args['gatherpress_events_query'] = $request->get_param( 'gatherpress_events_query' );
+		$custom_args['gatherpress_event_query'] = $request->get_param( 'gatherpress_event_query' );
 
 		// Exclusion Related.
 		$exclude_current = $request->get_param( 'exclude_current' );

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -3,7 +3,7 @@
  * Manages event-related queries and filtering.
  *
  * This class is responsible for handling all queries related to events, including retrieving
- * upcoming and past events, applying filters, and ordering events. It also handles adjustments
+ * upcoming and past events, applying filters and ordering events. It also handles adjustments
  * for event pages and admin queries.
  *
  * @package GatherPress\Core

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -106,12 +106,12 @@ class Event_Query {
 		array $venues = array()
 	): WP_Query {
 		$args = array(
-			'post_type'               => Event::POST_TYPE,
-			'fields'                  => 'ids',
-			'no_found_rows'           => true,
-			'posts_per_page'          => $number,
-			'gatherpress_event_query' => $event_list_type,
-			'order'                   => 'ASC',
+			'post_type'                => Event::POST_TYPE,
+			'fields'                   => 'ids',
+			'no_found_rows'            => true,
+			'posts_per_page'           => $number,
+			'gatherpress_events_query' => $event_list_type,
+			'order'                    => 'ASC',
 		);
 
 		$tax_query = array();
@@ -162,7 +162,7 @@ class Event_Query {
 	 * @return void
 	 */
 	public function prepare_event_query_before_execution( WP_Query $query ): void {
-		$events_query = $query->get( 'gatherpress_event_query' );
+		$events_query = $query->get( 'gatherpress_events_query' );
 
 		if ( ! is_admin() && $query->is_main_query() ) {
 			$general = get_option( Utility::prefix_key( 'general' ) );
@@ -191,7 +191,7 @@ class Event_Query {
 						$events_query = $key;
 
 						$query->set( 'post_type', 'gatherpress_event' );
-						$query->set( 'gatherpress_event_query', $key );
+						$query->set( 'gatherpress_events_query', $key );
 						$query->is_page              = false;
 						$query->is_singular          = false;
 						$query->is_archive           = true;

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -106,12 +106,12 @@ class Event_Query {
 		array $venues = array()
 	): WP_Query {
 		$args = array(
-			'post_type'                => Event::POST_TYPE,
-			'fields'                   => 'ids',
-			'no_found_rows'            => true,
-			'posts_per_page'           => $number,
+			'post_type'               => Event::POST_TYPE,
+			'fields'                  => 'ids',
+			'no_found_rows'           => true,
+			'posts_per_page'          => $number,
 			'gatherpress_event_query' => $event_list_type,
-			'order'                    => 'ASC',
+			'order'                   => 'ASC',
 		);
 
 		$tax_query = array();

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -106,12 +106,12 @@ class Event_Query {
 		array $venues = array()
 	): WP_Query {
 		$args = array(
-			'post_type'                => Event::POST_TYPE,
-			'fields'                   => 'ids',
-			'no_found_rows'            => true,
-			'posts_per_page'           => $number,
-			'gatherpress_events_query' => $event_list_type,
-			'order'                    => 'ASC',
+			'post_type'               => Event::POST_TYPE,
+			'fields'                  => 'ids',
+			'no_found_rows'           => true,
+			'posts_per_page'          => $number,
+			'gatherpress_event_query' => $event_list_type,
+			'order'                   => 'ASC',
 		);
 
 		$tax_query = array();
@@ -162,7 +162,7 @@ class Event_Query {
 	 * @return void
 	 */
 	public function prepare_event_query_before_execution( WP_Query $query ): void {
-		$events_query = $query->get( 'gatherpress_events_query' );
+		$events_query = $query->get( 'gatherpress_event_query' );
 
 		if ( ! is_admin() && $query->is_main_query() ) {
 			$general = get_option( Utility::prefix_key( 'general' ) );
@@ -191,7 +191,7 @@ class Event_Query {
 						$events_query = $key;
 
 						$query->set( 'post_type', 'gatherpress_event' );
-						$query->set( 'gatherpress_events_query', $key );
+						$query->set( 'gatherpress_event_query', $key );
 						$query->is_page              = false;
 						$query->is_singular          = false;
 						$query->is_archive           = true;

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -187,10 +187,10 @@ class Event_Query {
 					$page = $value[0];
 
 					if ( $page->id === $query->queried_object_id ) {
-						$query->set( 'post_type', 'gatherpress_event' );
-
 						$page_id      = $query->queried_object_id;
 						$events_query = $key;
+
+						$query->set( 'post_type', 'gatherpress_event' );
 						$query->set( 'gatherpress_events_query', $key );
 						$query->is_page              = false;
 						$query->is_singular          = false;

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -191,6 +191,7 @@ class Event_Query {
 
 						$page_id                     = $query->queried_object_id;
 						$events_query                = $key;
+						$query->set( 'gatherpress_events_query', $key );
 						$query->is_page              = false;
 						$query->is_singular          = false;
 						$query->is_archive           = true;

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -189,8 +189,8 @@ class Event_Query {
 					if ( $page->id === $query->queried_object_id ) {
 						$query->set( 'post_type', 'gatherpress_event' );
 
-						$page_id                     = $query->queried_object_id;
-						$events_query                = $key;
+						$page_id      = $query->queried_object_id;
+						$events_query = $key;
 						$query->set( 'gatherpress_events_query', $key );
 						$query->is_page              = false;
 						$query->is_singular          = false;

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -110,7 +110,7 @@ class Event_Query {
 			'fields'                   => 'ids',
 			'no_found_rows'            => true,
 			'posts_per_page'           => $number,
-			'gatherpress_events_query' => $event_list_type,
+			'gatherpress_event_query' => $event_list_type,
 			'order'                    => 'ASC',
 		);
 
@@ -162,7 +162,7 @@ class Event_Query {
 	 * @return void
 	 */
 	public function prepare_event_query_before_execution( WP_Query $query ): void {
-		$events_query = $query->get( 'gatherpress_events_query' );
+		$events_query = $query->get( 'gatherpress_event_query' );
 
 		if ( ! is_admin() && $query->is_main_query() ) {
 			$general = get_option( Utility::prefix_key( 'general' ) );
@@ -191,7 +191,7 @@ class Event_Query {
 						$events_query = $key;
 
 						$query->set( 'post_type', 'gatherpress_event' );
-						$query->set( 'gatherpress_events_query', $key );
+						$query->set( 'gatherpress_event_query', $key );
 						$query->is_page              = false;
 						$query->is_singular          = false;
 						$query->is_archive           = true;

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -32,6 +32,14 @@ class Event_Query {
 	use Singleton;
 
 	/**
+	 * Query parameter name for event type filtering.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const EVENT_QUERY_PARAM = 'gatherpress_event_query';
+
+	/**
 	 * Class constructor.
 	 *
 	 * This method initializes the object and sets up necessary hooks.
@@ -106,12 +114,12 @@ class Event_Query {
 		array $venues = array()
 	): WP_Query {
 		$args = array(
-			'post_type'               => Event::POST_TYPE,
-			'fields'                  => 'ids',
-			'no_found_rows'           => true,
-			'posts_per_page'          => $number,
-			'gatherpress_event_query' => $event_list_type,
-			'order'                   => 'ASC',
+			'post_type'             => Event::POST_TYPE,
+			'fields'                => 'ids',
+			'no_found_rows'         => true,
+			'posts_per_page'        => $number,
+			self::EVENT_QUERY_PARAM => $event_list_type,
+			'order'                 => 'ASC',
 		);
 
 		$tax_query = array();
@@ -162,7 +170,7 @@ class Event_Query {
 	 * @return void
 	 */
 	public function prepare_event_query_before_execution( WP_Query $query ): void {
-		$events_query = $query->get( 'gatherpress_event_query' );
+		$events_query = $query->get( self::EVENT_QUERY_PARAM );
 
 		if ( ! is_admin() && $query->is_main_query() ) {
 			$general = get_option( Utility::prefix_key( 'general' ) );
@@ -191,7 +199,7 @@ class Event_Query {
 						$events_query = $key;
 
 						$query->set( 'post_type', 'gatherpress_event' );
-						$query->set( 'gatherpress_event_query', $key );
+						$query->set( self::EVENT_QUERY_PARAM, $key );
 						$query->is_page              = false;
 						$query->is_singular          = false;
 						$query->is_archive           = true;

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -98,13 +98,13 @@ class Feed {
 			if ( str_contains( $request_uri, '/' . $rewrite_slug . '/' . $GLOBALS['wp_rewrite']->feed_base ) ) {
 				// Set the post type and let Event_Query handle the rest.
 				$query->set( 'post_type', Event::POST_TYPE );
-				
+
 				// Check for type parameter to determine if we want past or upcoming events.
 				$event_type = 'upcoming'; // Default to upcoming events.
 				if ( isset( $_GET['type'] ) && 'past' === sanitize_text_field( wp_unslash( $_GET['type'] ) ) ) {
 					$event_type = 'past';
 				}
-				
+
 				$query->set( 'gatherpress_events_query', $event_type );
 			}
 		}
@@ -323,14 +323,13 @@ class Feed {
 	 */
 	public function modify_feed_link_for_past_events( $feed_link, $feed ): string {
 		global $wp_query;
-		
+
 		// Check if we're on the past events page by looking for the gatherpress_events_query var.
 		if ( isset( $wp_query->query_vars['gatherpress_events_query'] ) && $wp_query->query_vars['gatherpress_events_query'] === 'past' ) {
 			// Add type=past parameter.
 			return add_query_arg( 'type', 'past', $feed_link );
 		}
-		
+
 		return $feed_link;
 	}
-
 }

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -110,7 +110,7 @@ class Feed {
 					$event_type = 'past';
 				}
 
-				$query->set( 'gatherpress_event_query', $event_type );
+				$query->set( 'gatherpress_events_query', $event_type );
 			}
 		}
 	}
@@ -330,10 +330,10 @@ class Feed {
 	public function modify_feed_link_for_past_events( $feed_link ): string {
 		global $wp_query;
 
-		// Check if we're on the past events page by looking for the gatherpress_event_query var.
+		// Check if we're on the past events page by looking for the gatherpress_events_query var.
 		if (
-			isset( $wp_query->query_vars['gatherpress_event_query'] ) &&
-			'past' === $wp_query->query_vars['gatherpress_event_query']
+			isset( $wp_query->query_vars['gatherpress_events_query'] ) &&
+			'past' === $wp_query->query_vars['gatherpress_events_query']
 		) {
 			// Add type=past parameter.
 			return add_query_arg( 'type', 'past', $feed_link );

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -65,7 +65,7 @@ class Feed {
 		add_action( 'pre_get_posts', array( $this, 'handle_events_feed_query' ) );
 
 		// Modify feed link for past events page.
-		add_filter( 'post_type_archive_feed_link', array( $this, 'modify_feed_link_for_past_events' ), 10, 1 );
+		add_filter( 'post_type_archive_feed_link', array( $this, 'modify_feed_link_for_past_events' ) );
 	}
 
 	/**
@@ -100,8 +100,12 @@ class Feed {
 				$query->set( 'post_type', Event::POST_TYPE );
 
 				// Check for type parameter to determine if we want past or upcoming events.
-				$event_type = 'upcoming'; // Default to upcoming events.
-				if ( isset( $_GET['type'] ) && 'past' === sanitize_text_field( wp_unslash( $_GET['type'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public feed URL parameter, nonce not required.
+				$event_type = 'upcoming';
+				// Default to upcoming events.
+				if (
+					isset( $_GET['type'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public feed URL parameter, nonce not required.
+					'past' === sanitize_text_field( wp_unslash( $_GET['type'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public feed URL parameter, nonce not required.
+				) {
 					// Nonce verification not required for public feed URLs.
 					$event_type = 'past';
 				}
@@ -318,6 +322,8 @@ class Feed {
 	/**
 	 * Modify feed link for past events page.
 	 *
+	 * @since 1.0.0
+	 *
 	 * @param string $feed_link The feed link URL.
 	 * @return string The modified feed link URL.
 	 */
@@ -325,7 +331,10 @@ class Feed {
 		global $wp_query;
 
 		// Check if we're on the past events page by looking for the gatherpress_events_query var.
-		if ( isset( $wp_query->query_vars['gatherpress_events_query'] ) && 'past' === $wp_query->query_vars['gatherpress_events_query'] ) {
+		if (
+			isset( $wp_query->query_vars['gatherpress_events_query'] ) &&
+			'past' === $wp_query->query_vars['gatherpress_events_query']
+		) {
 			// Add type=past parameter.
 			return add_query_arg( 'type', 'past', $feed_link );
 		}

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -69,7 +69,8 @@ class Feed {
 	 * Handle events feed queries by setting the appropriate parameters.
 	 *
 	 * This method works in conjunction with Event_Query::prepare_event_query_before_execution()
-	 * to ensure feeds show upcoming events with proper sorting.
+	 * to ensure feeds show upcoming events with proper sorting. Supports ?type=past parameter
+	 * to show past events instead of upcoming events.
 	 *
 	 * @since 1.0.0
 	 *
@@ -94,7 +95,14 @@ class Feed {
 			if ( str_contains( $request_uri, '/' . $rewrite_slug . '/' . $GLOBALS['wp_rewrite']->feed_base ) ) {
 				// Set the post type and let Event_Query handle the rest.
 				$query->set( 'post_type', Event::POST_TYPE );
-				$query->set( 'gatherpress_events_query', 'upcoming' );
+				
+				// Check for type parameter to determine if we want past or upcoming events.
+				$event_type = 'upcoming'; // Default to upcoming events.
+				if ( isset( $_GET['type'] ) && 'past' === sanitize_text_field( wp_unslash( $_GET['type'] ) ) ) {
+					$event_type = 'past';
+				}
+				
+				$query->set( 'gatherpress_events_query', $event_type );
 			}
 		}
 	}

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -110,7 +110,7 @@ class Feed {
 					$event_type = 'past';
 				}
 
-				$query->set( 'gatherpress_events_query', $event_type );
+				$query->set( 'gatherpress_event_query', $event_type );
 			}
 		}
 	}
@@ -330,10 +330,10 @@ class Feed {
 	public function modify_feed_link_for_past_events( $feed_link ): string {
 		global $wp_query;
 
-		// Check if we're on the past events page by looking for the gatherpress_events_query var.
+		// Check if we're on the past events page by looking for the gatherpress_event_query var.
 		if (
-			isset( $wp_query->query_vars['gatherpress_events_query'] ) &&
-			'past' === $wp_query->query_vars['gatherpress_events_query']
+			isset( $wp_query->query_vars['gatherpress_event_query'] ) &&
+			'past' === $wp_query->query_vars['gatherpress_event_query']
 		) {
 			// Add type=past parameter.
 			return add_query_arg( 'type', 'past', $feed_link );

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -101,7 +101,8 @@ class Feed {
 
 				// Check for type parameter to determine if we want past or upcoming events.
 				$event_type = 'upcoming'; // Default to upcoming events.
-				if ( isset( $_GET['type'] ) && 'past' === sanitize_text_field( wp_unslash( $_GET['type'] ) ) ) {
+				if ( isset( $_GET['type'] ) && 'past' === sanitize_text_field( wp_unslash( $_GET['type'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public feed URL parameter, nonce not required.
+					// Nonce verification not required for public feed URLs.
 					$event_type = 'past';
 				}
 
@@ -318,14 +319,13 @@ class Feed {
 	 * Modify feed link for past events page.
 	 *
 	 * @param string $feed_link The feed link URL.
-	 * @param string $feed The feed type.
 	 * @return string The modified feed link URL.
 	 */
-	public function modify_feed_link_for_past_events( $feed_link, $feed ): string {
+	public function modify_feed_link_for_past_events( $feed_link ): string {
 		global $wp_query;
 
 		// Check if we're on the past events page by looking for the gatherpress_events_query var.
-		if ( isset( $wp_query->query_vars['gatherpress_events_query'] ) && $wp_query->query_vars['gatherpress_events_query'] === 'past' ) {
+		if ( isset( $wp_query->query_vars['gatherpress_events_query'] ) && 'past' === $wp_query->query_vars['gatherpress_events_query'] ) {
 			// Add type=past parameter.
 			return add_query_arg( 'type', 'past', $feed_link );
 		}

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -63,6 +63,9 @@ class Feed {
 
 		// Hook into the main query to handle events feeds.
 		add_action( 'pre_get_posts', array( $this, 'handle_events_feed_query' ) );
+
+		// Modify feed link for past events page.
+		add_filter( 'post_type_archive_feed_link', array( $this, 'modify_feed_link_for_past_events' ), 10, 2 );
 	}
 
 	/**
@@ -310,4 +313,24 @@ class Feed {
 		 */
 		return apply_filters( 'gatherpress_event_feed_content', $content );
 	}
+
+	/**
+	 * Modify feed link for past events page.
+	 *
+	 * @param string $feed_link The feed link URL.
+	 * @param string $feed The feed type.
+	 * @return string The modified feed link URL.
+	 */
+	public function modify_feed_link_for_past_events( $feed_link, $feed ): string {
+		global $wp_query;
+		
+		// Check if we're on the past events page by looking for the gatherpress_events_query var.
+		if ( isset( $wp_query->query_vars['gatherpress_events_query'] ) && $wp_query->query_vars['gatherpress_events_query'] === 'past' ) {
+			// Add type=past parameter.
+			return add_query_arg( 'type', 'past', $feed_link );
+		}
+		
+		return $feed_link;
+	}
+
 }

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -65,7 +65,7 @@ class Feed {
 		add_action( 'pre_get_posts', array( $this, 'handle_events_feed_query' ) );
 
 		// Modify feed link for past events page.
-		add_filter( 'post_type_archive_feed_link', array( $this, 'modify_feed_link_for_past_events' ), 10, 2 );
+		add_filter( 'post_type_archive_feed_link', array( $this, 'modify_feed_link_for_past_events' ), 10, 1 );
 	}
 
 	/**

--- a/src/variations/core/query/components.js
+++ b/src/variations/core/query/components.js
@@ -145,7 +145,7 @@ export const EventIncludeUnfinishedControls = ( {
  *
  * Lets the editor choose whether the query returns "upcoming" or "past" events.
  * Toggled via a ToggleControl between upcoming (future) or past (archived) events,
- * stored as `gatherpress_events_query` in attributes.
+ * stored as `gatherpress_event_query` in attributes.
  *
  * @param {Object}   props
  * @param {Object}   props.attributes    Block attributes.
@@ -154,7 +154,7 @@ export const EventIncludeUnfinishedControls = ( {
  */
 export const EventListTypeControls = ( { attributes, setAttributes } ) => {
 	const {
-		query: { gatherpress_events_query: eventListType = 'upcoming' } = {},
+		query: { gatherpress_event_query: eventListType = 'upcoming' } = {},
 	} = attributes;
 
 	const currentPost = useSelect( ( select ) => {
@@ -182,7 +182,7 @@ export const EventListTypeControls = ( { attributes, setAttributes } ) => {
 				setAttributes( {
 					query: {
 						...attributes.query,
-						gatherpress_events_query: value ? 'upcoming' : 'past',
+						gatherpress_event_query: value ? 'upcoming' : 'past',
 					},
 				} );
 			} }

--- a/src/variations/core/query/controls.js
+++ b/src/variations/core/query/controls.js
@@ -52,7 +52,7 @@ const QueryPosttypeObserver = ( { attributes, setAttributes } ) => {
 				namespace: NAME,
 				query: {
 					...attributes.query,
-					gatherpress_events_query: 'upcoming',
+					gatherpress_event_query: 'upcoming',
 					include_unfinished: 1,
 					order: 'asc',
 					orderBy: 'datetime',

--- a/src/variations/core/query/index.js
+++ b/src/variations/core/query/index.js
@@ -20,7 +20,7 @@ const QUERY_ATTRIBUTES = {
 		pages: 0,
 		offset: 0,
 		postType: 'gatherpress_event',
-		gatherpress_events_query: 'upcoming',
+		gatherpress_event_query: 'upcoming',
 		include_unfinished: 1,
 		order: 'asc',
 		orderBy: 'datetime',

--- a/test/unit/php/includes/tests/core/classes/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-query.php
@@ -83,7 +83,7 @@ class Test_Event_Query extends Base {
 
 		$this->assertSame( $response->posts[0], $post->ID, 'Failed to assert that event ID is in array.' );
 		$this->assertSame( 1, $response->query['posts_per_page'], 'Failed to assert post per page limit.' );
-		$this->assertSame( 'upcoming', $response->query['gatherpress_event_query'], 'Failed to assert query is upcoming.' );
+		$this->assertSame( 'upcoming', $response->query['gatherpress_events_query'], 'Failed to assert query is upcoming.' );
 		$this->assertSame( 'gatherpress_event', $response->query['post_type'], 'Failed to assert post type is gatherpress_event.' );
 	}
 
@@ -119,7 +119,7 @@ class Test_Event_Query extends Base {
 
 		$this->assertSame( $response->posts[0], $post->ID, 'Failed to assert that event ID is in array.' );
 		$this->assertSame( 1, $response->query['posts_per_page'], 'Failed to assert post per page limit.' );
-		$this->assertSame( 'past', $response->query['gatherpress_event_query'], 'Failed to assert query is past.' );
+		$this->assertSame( 'past', $response->query['gatherpress_events_query'], 'Failed to assert query is past.' );
 		$this->assertSame( 'gatherpress_event', $response->query['post_type'], 'Failed to assert post type is gatherpress_event.' );
 	}
 
@@ -205,7 +205,7 @@ class Test_Event_Query extends Base {
 		$instance = Event_Query::get_instance();
 		$query    = new WP_Query();
 
-		$query->set( 'gatherpress_event_query', 'upcoming' );
+		$query->set( 'gatherpress_events_query', 'upcoming' );
 		$instance->prepare_event_query_before_execution( $query );
 
 		$this->assertEquals(
@@ -232,7 +232,7 @@ class Test_Event_Query extends Base {
 		$instance = Event_Query::get_instance();
 		$query    = new WP_Query();
 
-		$query->set( 'gatherpress_event_query', 'past' );
+		$query->set( 'gatherpress_events_query', 'past' );
 		$instance->prepare_event_query_before_execution( $query );
 
 		$this->assertEquals(
@@ -275,7 +275,7 @@ class Test_Event_Query extends Base {
 			->method( 'get' )
 			->willReturnCallback(
 				function ( $key ) {
-					return 'gatherpress_event_query' === $key ? 'past' : null;
+					return 'gatherpress_events_query' === $key ? 'past' : null;
 				}
 			);
 

--- a/test/unit/php/includes/tests/core/classes/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-query.php
@@ -83,7 +83,7 @@ class Test_Event_Query extends Base {
 
 		$this->assertSame( $response->posts[0], $post->ID, 'Failed to assert that event ID is in array.' );
 		$this->assertSame( 1, $response->query['posts_per_page'], 'Failed to assert post per page limit.' );
-		$this->assertSame( 'upcoming', $response->query['gatherpress_events_query'], 'Failed to assert query is upcoming.' );
+		$this->assertSame( 'upcoming', $response->query['gatherpress_event_query'], 'Failed to assert query is upcoming.' );
 		$this->assertSame( 'gatherpress_event', $response->query['post_type'], 'Failed to assert post type is gatherpress_event.' );
 	}
 
@@ -119,7 +119,7 @@ class Test_Event_Query extends Base {
 
 		$this->assertSame( $response->posts[0], $post->ID, 'Failed to assert that event ID is in array.' );
 		$this->assertSame( 1, $response->query['posts_per_page'], 'Failed to assert post per page limit.' );
-		$this->assertSame( 'past', $response->query['gatherpress_events_query'], 'Failed to assert query is past.' );
+		$this->assertSame( 'past', $response->query['gatherpress_event_query'], 'Failed to assert query is past.' );
 		$this->assertSame( 'gatherpress_event', $response->query['post_type'], 'Failed to assert post type is gatherpress_event.' );
 	}
 
@@ -205,7 +205,7 @@ class Test_Event_Query extends Base {
 		$instance = Event_Query::get_instance();
 		$query    = new WP_Query();
 
-		$query->set( 'gatherpress_events_query', 'upcoming' );
+		$query->set( 'gatherpress_event_query', 'upcoming' );
 		$instance->prepare_event_query_before_execution( $query );
 
 		$this->assertEquals(
@@ -232,7 +232,7 @@ class Test_Event_Query extends Base {
 		$instance = Event_Query::get_instance();
 		$query    = new WP_Query();
 
-		$query->set( 'gatherpress_events_query', 'past' );
+		$query->set( 'gatherpress_event_query', 'past' );
 		$instance->prepare_event_query_before_execution( $query );
 
 		$this->assertEquals(
@@ -275,7 +275,7 @@ class Test_Event_Query extends Base {
 			->method( 'get' )
 			->willReturnCallback(
 				function ( $key ) {
-					return 'gatherpress_events_query' === $key ? 'past' : null;
+					return 'gatherpress_event_query' === $key ? 'past' : null;
 				}
 			);
 

--- a/test/unit/php/includes/tests/core/classes/class-test-feed.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-feed.php
@@ -137,6 +137,36 @@ class Test_Feed extends Base {
 	}
 
 	/**
+	 * Test handle_events_feed_query method with type parameter.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @covers ::handle_events_feed_query
+	 *
+	 * @return void
+	 */
+	public function test_handle_events_feed_query_with_type_parameter(): void {
+		// Mock the request URI for events feed with type=past.
+		$_SERVER['REQUEST_URI'] = '/events/feed/';
+		$_GET['type'] = 'past';
+
+		// Create a mock query for event feed.
+		$query = $this->createMock( WP_Query::class );
+		$query->method( 'is_main_query' )->willReturn( true );
+		$query->method( 'is_feed' )->willReturn( true );
+
+		// Test that the method doesn't error when type parameter is provided.
+		$this->instance->handle_events_feed_query( $query );
+
+		// Verify the method completed without error.
+		$this->assertTrue( true );
+
+		// Clean up.
+		unset( $_SERVER['REQUEST_URI'] );
+		unset( $_GET['type'] );
+	}
+
+	/**
 	 * Test get_default_event_excerpt method.
 	 *
 	 * @since 1.0.0

--- a/test/unit/php/includes/tests/core/classes/class-test-feed.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-feed.php
@@ -199,7 +199,7 @@ class Test_Feed extends Base {
 
 		// Create a mock WP_Query object with the required query_vars.
 		$mock_query             = $this->createMock( WP_Query::class );
-		$mock_query->query_vars = array( 'gatherpress_event_query' => 'past' );
+		$mock_query->query_vars = array( 'gatherpress_events_query' => 'past' );
 
 		// Temporarily replace the global wp_query.
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Testing requires global manipulation.

--- a/test/unit/php/includes/tests/core/classes/class-test-feed.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-feed.php
@@ -148,7 +148,7 @@ class Test_Feed extends Base {
 	public function test_handle_events_feed_query_with_type_parameter(): void {
 		// Mock the request URI for events feed with type=past.
 		$_SERVER['REQUEST_URI'] = '/events/feed/';
-		$_GET['type'] = 'past';
+		$_GET['type']           = 'past';
 
 		// Create a mock query for event feed.
 		$query = $this->createMock( WP_Query::class );
@@ -195,12 +195,12 @@ class Test_Feed extends Base {
 	public function test_modify_feed_link_for_past_events_adds_type_parameter(): void {
 		// Mock the global wp_query with gatherpress_events_query set to 'past'.
 		global $wp_query;
-		$wp_query = $this->createMock( WP_Query::class );
+		$wp_query             = $this->createMock( WP_Query::class );
 		$wp_query->query_vars = array( 'gatherpress_events_query' => 'past' );
 
 		// Test the method with a feed link.
 		$feed_link = 'http://example.com/event/feed/';
-		$result = $this->instance->modify_feed_link_for_past_events( $feed_link, 'gatherpress_event' );
+		$result    = $this->instance->modify_feed_link_for_past_events( $feed_link, 'gatherpress_event' );
 
 		// Verify the result contains the type=past parameter.
 		$this->assertStringContainsString( 'type=past', $result );

--- a/test/unit/php/includes/tests/core/classes/class-test-feed.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-feed.php
@@ -167,6 +167,49 @@ class Test_Feed extends Base {
 	}
 
 	/**
+	 * Test modify_feed_link_for_past_events method.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @covers ::modify_feed_link_for_past_events
+	 *
+	 * @return void
+	 */
+	public function test_modify_feed_link_for_past_events(): void {
+		// Test that the method doesn't error when called.
+		$result = $this->instance->modify_feed_link_for_past_events( 'http://example.com/event/feed/', 'gatherpress_event' );
+
+		// Verify the method completed without error.
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test modify_feed_link_for_past_events method adds type=past parameter.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @covers ::modify_feed_link_for_past_events
+	 *
+	 * @return void
+	 */
+	public function test_modify_feed_link_for_past_events_adds_type_parameter(): void {
+		// Mock the global wp_query with gatherpress_events_query set to 'past'.
+		global $wp_query;
+		$wp_query = $this->createMock( WP_Query::class );
+		$wp_query->query_vars = array( 'gatherpress_events_query' => 'past' );
+
+		// Test the method with a feed link.
+		$feed_link = 'http://example.com/event/feed/';
+		$result = $this->instance->modify_feed_link_for_past_events( $feed_link, 'gatherpress_event' );
+
+		// Verify the result contains the type=past parameter.
+		$this->assertStringContainsString( 'type=past', $result );
+
+		// Clean up.
+		$wp_query = null;
+	}
+
+	/**
 	 * Test get_default_event_excerpt method.
 	 *
 	 * @since 1.0.0

--- a/test/unit/php/includes/tests/core/classes/class-test-feed.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-feed.php
@@ -177,7 +177,7 @@ class Test_Feed extends Base {
 	 */
 	public function test_modify_feed_link_for_past_events(): void {
 		// Test that the method doesn't error when called.
-		$result = $this->instance->modify_feed_link_for_past_events( 'http://example.com/event/feed/', 'gatherpress_event' );
+		$result = $this->instance->modify_feed_link_for_past_events( 'http://example.com/event/feed/' );
 
 		// Verify the method completed without error.
 		$this->assertTrue( true );
@@ -193,20 +193,29 @@ class Test_Feed extends Base {
 	 * @return void
 	 */
 	public function test_modify_feed_link_for_past_events_adds_type_parameter(): void {
-		// Mock the global wp_query with gatherpress_events_query set to 'past'.
+		// Store original global state.
 		global $wp_query;
-		$wp_query             = $this->createMock( WP_Query::class );
-		$wp_query->query_vars = array( 'gatherpress_events_query' => 'past' );
+		$original_wp_query = $wp_query;
+
+		// Create a mock WP_Query object with the required query_vars.
+		$mock_query             = $this->createMock( WP_Query::class );
+		$mock_query->query_vars = array( 'gatherpress_events_query' => 'past' );
+
+		// Temporarily replace the global wp_query.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Testing requires global manipulation.
+		$wp_query = $mock_query;
 
 		// Test the method with a feed link.
 		$feed_link = 'http://example.com/event/feed/';
-		$result    = $this->instance->modify_feed_link_for_past_events( $feed_link, 'gatherpress_event' );
+		$result    = $this->instance->modify_feed_link_for_past_events( $feed_link );
 
 		// Verify the result contains the type=past parameter.
 		$this->assertStringContainsString( 'type=past', $result );
+		$this->assertStringContainsString( 'http://example.com/event/feed/', $result );
 
-		// Clean up.
-		$wp_query = null;
+		// Restore original global state.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Testing requires global manipulation.
+		$wp_query = $original_wp_query;
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-feed.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-feed.php
@@ -199,7 +199,7 @@ class Test_Feed extends Base {
 
 		// Create a mock WP_Query object with the required query_vars.
 		$mock_query             = $this->createMock( WP_Query::class );
-		$mock_query->query_vars = array( 'gatherpress_events_query' => 'past' );
+		$mock_query->query_vars = array( 'gatherpress_event_query' => 'past' );
 
 		// Temporarily replace the global wp_query.
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Testing requires global manipulation.


### PR DESCRIPTION

### Description of the Change
<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1188

### How to test the Change
**Test the past events feed:**
Visit http://yoursite.com/event/feed/?type=past - should show past events
Visit http://yoursite.com/event/feed/ - should show upcoming events
**Test the automatic feed link on past events page:**
Configure a past events archive page in GatherPress Settings
Visit that page and check the RSS feed link in page source
Verify the link includes ?type=past parameter
Test edge cases:
?type=invalid should default to upcoming events
?type= should default to upcoming events

### Changelog Entry
Adds support for past events RSS feeds via ?type=past parameter. When viewing the past events archive page, the RSS feed link automatically includes this parameter.
Added - Past events RSS feed support with ?type=past parameter


### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @jmarx 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my change.
- [X] All new and existing tests pass.
