### PR TITLE
Fix date picker relative mode to maintain duration offset when start date changes

### DIFF
--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -345,9 +345,23 @@ export function updateDateTimeStart(
 	setDateTimeStart = null,
 	setDateTimeEnd = null,
 ) {
-	validateDateTimeStart( date, setDateTimeEnd );
+	// Store the current duration before updating the start time.
+	const currentDuration = getDateTimeOffset();
 
 	setToGlobal( 'eventDetails.dateTime.datetime_start', date );
+
+	// If in relative mode (duration is numeric), always update the end time to maintain the offset.
+	if ( 'number' === typeof currentDuration && false !== currentDuration ) {
+		const dateTimeEnd = moment
+			.tz( date, getTimezone() )
+			.add( currentDuration, 'hours' )
+			.format( dateTimeDatabaseFormat );
+
+		updateDateTimeEnd( dateTimeEnd, setDateTimeEnd );
+	} else {
+		// Otherwise, only validate to ensure end is after start.
+		validateDateTimeStart( date, setDateTimeEnd, currentDuration );
+	}
 
 	if ( 'function' === typeof setDateTimeStart ) {
 		setDateTimeStart( date );
@@ -394,17 +408,19 @@ export function updateDateTimeEnd(
  *
  * This function compares the provided start date and time with the current end date
  * and time of the event. If the start date is greater than or equal to the end date,
- * it adjusts the end date to ensure a minimum two-hour duration from the start date.
+ * it adjusts the end date. If there's an active duration (relative mode), it maintains
+ * that duration offset. Otherwise, it defaults to a two-hour duration.
  * If `setDateTimeEnd` is provided, it updates the end date accordingly.
  *
  * @since 1.0.0
  *
- * @param {string}        dateTimeStart  - The start date and time in a valid format.
- * @param {Function|null} setDateTimeEnd - Optional callback to update the end date and time.
+ * @param {string}        dateTimeStart   - The start date and time in a valid format.
+ * @param {Function|null} setDateTimeEnd  - Optional callback to update the end date and time.
+ * @param {number|false}  currentDuration - The current duration in hours (numeric for relative mode, false for absolute mode).
  *
  * @return {void}
  */
-export function validateDateTimeStart( dateTimeStart, setDateTimeEnd = null ) {
+export function validateDateTimeStart( dateTimeStart, setDateTimeEnd = null, currentDuration = null ) {
 	const dateTimeEndNumeric = moment
 		.tz( getFromGlobal( 'eventDetails.dateTime.datetime_end' ), getTimezone() )
 		.valueOf();
@@ -413,9 +429,14 @@ export function validateDateTimeStart( dateTimeStart, setDateTimeEnd = null ) {
 		.valueOf();
 
 	if ( dateTimeStartNumeric >= dateTimeEndNumeric ) {
+		// Use the passed duration if available, otherwise check current offset.
+		// Only use duration if it's numeric (relative mode), not if it's false (absolute mode).
+		const duration = null !== currentDuration ? currentDuration : getDateTimeOffset();
+		const hoursToAdd = ( false !== duration && 'number' === typeof duration ) ? duration : 2;
+
 		const dateTimeEnd = moment
 			.tz( dateTimeStartNumeric, getTimezone() )
-			.add( 2, 'hours' )
+			.add( hoursToAdd, 'hours' )
 			.format( dateTimeDatabaseFormat );
 
 		updateDateTimeEnd( dateTimeEnd, setDateTimeEnd );

--- a/test/unit/js/src/helpers/datetime.test.js
+++ b/test/unit/js/src/helpers/datetime.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { expect, test } from '@jest/globals';
+import { expect, test, jest, describe, beforeEach } from '@jest/globals';
 import 'moment-timezone';
 
 /**
@@ -10,9 +10,11 @@ import 'moment-timezone';
 import {
 	convertPHPToMomentFormat,
 	dateTimeLabelFormat,
+	dateTimeOffset,
 	defaultDateTimeEnd,
 	defaultDateTimeStart,
 	getDateTimeEnd,
+	getDateTimeOffset,
 	getDateTimeStart,
 	getTimezone,
 	getUtcOffset,
@@ -21,6 +23,7 @@ import {
 	maybeConvertUtcOffsetForSelect,
 	updateDateTimeEnd,
 	updateDateTimeStart,
+	validateDateTimeStart,
 } from '../../../../../src/helpers/datetime';
 
 /**
@@ -289,4 +292,166 @@ test( 'convertPHPToMomentFormat returns correct format that contains escaped cha
 	const format = convertPHPToMomentFormat( 'G:i \\U\\h\\r' ); // "20 Uhr" is german for "8 o'clock" (in the evening).
 
 	expect( format ).toBe( 'H:mm \\U\\h\\r' );
+} );
+
+/**
+ * Coverage for relative mode (duration) functionality.
+ */
+describe( 'Relative mode duration tests', () => {
+	beforeEach( () => {
+		// Reset global state before each test.
+		global.GatherPress = {
+			eventDetails: {
+				dateTime: {
+					timezone: 'America/New_York',
+					datetime_start: '2023-11-28 18:00:00',
+					datetime_end: '2023-11-28 20:00:00',
+				},
+			},
+		};
+	} );
+
+	test( 'dateTimeOffset calculates correct end time based on duration', () => {
+		global.GatherPress.eventDetails.dateTime.datetime_start = '2023-11-26 18:00:00';
+		const result = dateTimeOffset( 2 ); // 2 hours offset.
+		expect( result ).toBe( '2023-11-26 20:00:00' );
+	} );
+
+	test( 'getDateTimeOffset returns correct duration when end matches offset', () => {
+		// Start: 18:00, End: 20:00 = 2 hour duration.
+		const duration = getDateTimeOffset();
+		expect( duration ).toBe( 2 );
+	} );
+
+	test( 'getDateTimeOffset returns false when end does not match any duration option', () => {
+		// Set end time to something that doesn't match standard durations.
+		global.GatherPress.eventDetails.dateTime.datetime_end = '2023-11-28 22:30:00';
+		const duration = getDateTimeOffset();
+		expect( duration ).toBe( false );
+	} );
+
+	test( 'updateDateTimeStart maintains relative offset in relative mode', () => {
+		const setDateTimeStart = jest.fn();
+		const setDateTimeEnd = jest.fn();
+
+		// Initial setup: 2-hour duration (18:00-20:00).
+		const newStartDate = '2023-11-26 18:00:00';
+
+		updateDateTimeStart( newStartDate, setDateTimeStart, setDateTimeEnd );
+
+		expect( setDateTimeStart ).toHaveBeenCalledWith( newStartDate );
+		// Should maintain 2-hour offset.
+		expect( setDateTimeEnd ).toHaveBeenCalledWith( '2023-11-26 20:00:00' );
+		expect( global.GatherPress.eventDetails.dateTime.datetime_start ).toBe( newStartDate );
+	} );
+
+	test( 'updateDateTimeStart does not update end time in absolute mode', () => {
+		const setDateTimeStart = jest.fn();
+		const setDateTimeEnd = jest.fn();
+
+		// Set end time to not match any duration option (absolute mode).
+		global.GatherPress.eventDetails.dateTime.datetime_end = '2023-11-29 22:30:00';
+
+		const newStartDate = '2023-11-26 18:00:00';
+
+		updateDateTimeStart( newStartDate, setDateTimeStart, setDateTimeEnd );
+
+		expect( setDateTimeStart ).toHaveBeenCalledWith( newStartDate );
+		// End time should not be updated since we're in absolute mode.
+		expect( setDateTimeEnd ).not.toHaveBeenCalled();
+		expect( global.GatherPress.eventDetails.dateTime.datetime_start ).toBe( newStartDate );
+	} );
+
+	test( 'updateDateTimeStart validates when start >= end in absolute mode', () => {
+		const setDateTimeStart = jest.fn();
+		const setDateTimeEnd = jest.fn();
+
+		// Set end time to not match any duration option (absolute mode).
+		global.GatherPress.eventDetails.dateTime.datetime_end = '2023-11-26 17:00:00';
+
+		// Try to set start after end.
+		const newStartDate = '2023-11-26 18:00:00';
+
+		updateDateTimeStart( newStartDate, setDateTimeStart, setDateTimeEnd );
+
+		expect( setDateTimeStart ).toHaveBeenCalledWith( newStartDate );
+		// Should update end to be 2 hours after start due to validation.
+		expect( setDateTimeEnd ).toHaveBeenCalledWith( '2023-11-26 20:00:00' );
+	} );
+
+	test( 'validateDateTimeStart respects numeric duration in relative mode', () => {
+		const setDateTimeEnd = jest.fn();
+
+		// Test with 3-hour duration.
+		validateDateTimeStart( '2023-11-30 18:00:00', setDateTimeEnd, 3 );
+
+		// Should add 3 hours to the new start time.
+		expect( setDateTimeEnd ).toHaveBeenCalledWith( '2023-11-30 21:00:00' );
+	} );
+
+	test( 'validateDateTimeStart uses default 2 hours when duration is false', () => {
+		const setDateTimeEnd = jest.fn();
+
+		// Duration is false (absolute mode).
+		validateDateTimeStart( '2023-11-30 18:00:00', setDateTimeEnd, false );
+
+		// Should default to 2 hours.
+		expect( setDateTimeEnd ).toHaveBeenCalledWith( '2023-11-30 20:00:00' );
+	} );
+
+	test( 'validateDateTimeStart does not update end when start < end in absolute mode', () => {
+		const setDateTimeEnd = jest.fn();
+
+		global.GatherPress.eventDetails.dateTime.datetime_end = '2023-11-30 22:00:00';
+
+		// Start is before end, no validation needed.
+		validateDateTimeStart( '2023-11-30 18:00:00', setDateTimeEnd, false );
+
+		// Should not call setDateTimeEnd.
+		expect( setDateTimeEnd ).not.toHaveBeenCalled();
+	} );
+
+	test( 'relative mode works with different duration values', () => {
+		const setDateTimeStart = jest.fn();
+		const setDateTimeEnd = jest.fn();
+
+		// Test with 1 hour duration.
+		global.GatherPress.eventDetails.dateTime.datetime_end = '2023-11-28 19:00:00';
+
+		const newStartDate = '2023-11-26 18:00:00';
+		updateDateTimeStart( newStartDate, setDateTimeStart, setDateTimeEnd );
+
+		// Should maintain 1-hour offset.
+		expect( setDateTimeEnd ).toHaveBeenCalledWith( '2023-11-26 19:00:00' );
+	} );
+
+	test( 'relative mode works with 1.5 hour duration', () => {
+		const setDateTimeStart = jest.fn();
+		const setDateTimeEnd = jest.fn();
+
+		// Test with 1.5 hour duration.
+		global.GatherPress.eventDetails.dateTime.datetime_start = '2023-11-28 18:00:00';
+		global.GatherPress.eventDetails.dateTime.datetime_end = '2023-11-28 19:30:00';
+
+		const newStartDate = '2023-11-26 18:00:00';
+		updateDateTimeStart( newStartDate, setDateTimeStart, setDateTimeEnd );
+
+		// Should maintain 1.5-hour offset.
+		expect( setDateTimeEnd ).toHaveBeenCalledWith( '2023-11-26 19:30:00' );
+	} );
+
+	test( 'relative mode works with 3 hour duration', () => {
+		const setDateTimeStart = jest.fn();
+		const setDateTimeEnd = jest.fn();
+
+		// Test with 3 hour duration.
+		global.GatherPress.eventDetails.dateTime.datetime_start = '2023-11-28 18:00:00';
+		global.GatherPress.eventDetails.dateTime.datetime_end = '2023-11-28 21:00:00';
+
+		const newStartDate = '2023-11-26 18:00:00';
+		updateDateTimeStart( newStartDate, setDateTimeStart, setDateTimeEnd );
+
+		// Should maintain 3-hour offset.
+		expect( setDateTimeEnd ).toHaveBeenCalledWith( '2023-11-26 21:00:00' );
+	} );
 } );


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
  When using the date picker in relative mode (e.g., "2 hours after start"), changing the start date now correctly maintains the
  relative offset for the end date. Previously, the end date would remain fixed to the original date/time instead of adjusting
  relative to the new start date.

  Changes:
  - Updated updateDateTimeStart to always recalculate end time when in relative mode (duration is numeric)
  - Modified validation to respect relative vs absolute mode
  - Added comprehensive unit tests for relative mode functionality

  Example:
  - Before: Nov 28 6pm-8pm (2 hours) → Change to Nov 26 → End stays Nov 28 8pm ❌
  - After: Nov 28 6pm-8pm (2 hours) → Change to Nov 26 → End becomes Nov 26 8pm ✅
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1205 

### How to test the Change
  1. Create a new event in the WordPress block editor
  2. Test Relative Mode (Duration):
    - Set start date/time to any date at 6:00 PM
    - In the Duration dropdown, select "2 hours" (relative mode)
    - Note the end time shows 8:00 PM
    - Change the start date to 2 days earlier
    - ✅ Verify: End time should automatically update to the new date at 8:00 PM (maintaining 2-hour offset)
  3. Test Absolute Mode (Custom End Time):
    - Set start date/time to any date at 6:00 PM
    - In the Duration dropdown, select "Set an end time..."
    - Manually set end date/time to 3 days later at 10:00 PM
    - Change the start date to 1 day earlier
    - ✅ Verify: End time should remain at the original date/time (3 days later at 10:00 PM)
  4. Test Different Durations:
    - Try with "1 hour", "1.5 hours", and "3 hours" options
    - ✅ Verify: Each maintains its respective offset when changing start date
  5. Test Validation:
    - In absolute mode, try setting start date after the end date
    - ✅ Verify: End date automatically adjusts to 2 hours after start (prevents invalid range)
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
