### PR TITLE
Add GDPR-compliant opt-in filter for event notifications.

### DIFF
--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -460,8 +460,9 @@ class Event_Rest_Api {
 		foreach ( $recipients as $recipient ) {
 			// Check opt-in preference based on recipient type.
 			if ( $recipient['is_user'] ) {
-				// For WordPress users, check user meta.
-				if ( '0' === get_user_meta( $recipient['user_id'], 'gatherpress_event_updates_opt_in', true ) ) {
+				// For WordPress users, use the centralized helper method.
+				$user = User::get_instance();
+				if ( ! $user->has_event_updates_opt_in( $recipient['user_id'] ) ) {
 					continue;
 				}
 			} elseif ( '0' === get_comment_meta( $recipient['comment_id'], 'gatherpress_event_updates_opt_in', true ) ) {


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
  Adds a filter to control the default opt-in state for event notifications, enabling GDPR compliance in regions that require explicit
  consent.

  Changes:
  - New `gatherpress_event_updates_default_opt_in` filter to control default opt-in state
  - `has_event_updates_opt_in()` helper method in User class to centralize opt-in logic
  - Refactored `Event_Rest_Api` to use the centralized helper
  - Added comprehensive unit tests

  Usage:
```
  // Default notifications to unchecked for GDPR compliance
  add_filter( 'gatherpress_event_updates_default_opt_in', '__return_zero' );
```
  This maintains backward compatibility (defaults to opted-in) while allowing sites to comply with privacy regulations.
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #916 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Existing functionality

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
