### PR TITLE
Fix UI/UX bug with dropdown. Select child and automatically expand.

### DIFF
--- a/src/blocks/dropdown/edit.js
+++ b/src/blocks/dropdown/edit.js
@@ -86,12 +86,24 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 	// Track if dropdown or its children are selected for auto-close behavior.
 	const isDropdownOrChildSelected = useIsBlockOrDescendantSelected( clientId );
 
-	// Auto-close dropdown when clicking outside the dropdown tree.
+	// Get the currently selected block ID.
+	const selectedBlockId = useSelect(
+		( blockEditorSelect ) =>
+			blockEditorSelect( 'core/block-editor' ).getSelectedBlockClientId(),
+		[]
+	);
+
+	// Auto-expand dropdown when a child block is selected (e.g., from List View)
+	// and auto-close when clicking outside the dropdown tree.
 	useEffect( () => {
-		if ( ! isDropdownOrChildSelected && isExpanded ) {
+		if ( isDropdownOrChildSelected && selectedBlockId !== clientId ) {
+			// A child block is selected (not the dropdown itself), expand.
+			setIsExpanded( true );
+		} else if ( ! isDropdownOrChildSelected && isExpanded ) {
+			// Nothing in the dropdown tree is selected, close.
 			setIsExpanded( false );
 		}
-	}, [ isDropdownOrChildSelected, isExpanded ] );
+	}, [ isDropdownOrChildSelected, selectedBlockId, clientId, isExpanded ] );
 
 	// Generate a persistent unique ID for the dropdown if not already set.
 	useEffect( () => {


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
When selecting a child of a dropdown from list view, automatically expand the dropdown.
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @patriciabt @mauteri 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
