### PR TITLE
updated get_datetime function to return static post meta data

### DIFF
--- a/test/unit/php/includes/tests/core/classes/class-test-import.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-import.php
@@ -284,6 +284,9 @@ class Test_Import extends Base {
 		);
 		$instance->datetimes_callback( $post->ID, $meta_data_value );
 
+		// Create new Event instance to get fresh data after datetime save.
+		$event = new Event( $post->ID );
+
 		$expect = array(
 			'datetime_start'     => '2020-05-11 15:00:00',
 			'datetime_start_gmt' => '2020-05-11 19:00:00',


### PR DESCRIPTION
(solves [issue/1331](https://github.com/GatherPress/gatherpress/issues/1331))

<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
Updated `get_datetime()` function to return static post meta data as opposed to a cached custom database table call.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Resolves #1331 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Fire up GP and attempt to create a new event. You should see the time editable in the backend. Hit save and confirm you see the expected (set) time on the frontend.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - `get_datetime()`

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
@stephenerdelyi

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
