### PR TITLE
Fix Moment Timezone error for Manual Offset.

### DIFF
--- a/src/components/DateTimeEnd.js
+++ b/src/components/DateTimeEnd.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies.
- */
-import moment from 'moment';
-
-/**
  * WordPress dependencies.
  */
 import {
@@ -23,6 +18,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import { hasEventPastNotice } from '../helpers/event';
 import {
+	createMomentWithTimezone,
 	dateTimeDatabaseFormat,
 	dateTimeLabelFormat,
 	getTimezone,
@@ -64,7 +60,7 @@ const DateTimeEnd = () => {
 
 	useEffect( () => {
 		setDateTimeEnd(
-			moment.tz( dateTimeEnd, getTimezone() ).format( dateTimeDatabaseFormat ),
+			createMomentWithTimezone( dateTimeEnd, getTimezone() ).format( dateTimeDatabaseFormat ),
 		);
 
 		hasEventPastNotice();
@@ -90,8 +86,7 @@ const DateTimeEnd = () => {
 								aria-expanded={ isOpen }
 								variant="link"
 							>
-								{ moment
-									.tz( dateTimeEnd, getTimezone() )
+								{ createMomentWithTimezone( dateTimeEnd, getTimezone() )
 									.format( dateTimeLabelFormat() ) }
 							</Button>
 						) }

--- a/src/components/DateTimeRange.js
+++ b/src/components/DateTimeRange.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies.
- */
-import moment from 'moment';
-
-/**
  * WordPress dependencies.
  */
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -14,7 +9,7 @@ import { useEffect } from '@wordpress/element';
  */
 import {
 	dateTimeDatabaseFormat,
-	normalizeTimezoneForMoment,
+	createMomentWithTimezone,
 } from '../helpers/datetime';
 import DateTimeStart from '../components/DateTimeStart';
 import DateTimeEnd from '../components/DateTimeEnd';
@@ -65,17 +60,12 @@ const DateTimeRange = () => {
 	);
 	const { setDuration } = useDispatch( 'gatherpress/datetime' );
 
-	// Normalize timezone for Moment Timezone compatibility.
-	const normalizedTimezone = normalizeTimezoneForMoment( timezone );
-
 	useEffect( () => {
 		const payload = JSON.stringify( {
 			...dateTimeMetaData,
-			dateTimeStart: moment
-				.tz( dateTimeStart, normalizedTimezone )
+			dateTimeStart: createMomentWithTimezone( dateTimeStart, timezone )
 				.format( dateTimeDatabaseFormat ),
-			dateTimeEnd: moment
-				.tz( dateTimeEnd, normalizedTimezone )
+			dateTimeEnd: createMomentWithTimezone( dateTimeEnd, timezone )
 				.format( dateTimeDatabaseFormat ),
 			timezone,
 		} );
@@ -86,7 +76,6 @@ const DateTimeRange = () => {
 		dateTimeStart,
 		dateTimeEnd,
 		timezone,
-		normalizedTimezone,
 		dateTimeMetaData,
 		editPost,
 		setDuration,

--- a/src/components/DateTimeStart.js
+++ b/src/components/DateTimeStart.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies.
- */
-import moment from 'moment';
-
-/**
  * WordPress dependencies.
  */
 import {
@@ -23,6 +18,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import { hasEventPastNotice } from '../helpers/event';
 import {
+	createMomentWithTimezone,
 	dateTimeDatabaseFormat,
 	dateTimeLabelFormat,
 	dateTimeOffset,
@@ -66,8 +62,7 @@ const DateTimeStart = () => {
 
 	useEffect( () => {
 		setDateTimeStart(
-			moment
-				.tz( dateTimeStart, getTimezone() )
+			createMomentWithTimezone( dateTimeStart, getTimezone() )
 				.format( dateTimeDatabaseFormat ),
 		);
 
@@ -98,8 +93,7 @@ const DateTimeStart = () => {
 								aria-expanded={ isOpen }
 								variant="link"
 							>
-								{ moment
-									.tz( dateTimeStart, getTimezone() )
+								{ createMomentWithTimezone( dateTimeStart, getTimezone() )
 									.format( dateTimeLabelFormat() ) }
 							</Button>
 						) }

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -30,6 +30,27 @@ import DateTimePreview from '../components/DateTimePreview';
 export const dateTimeDatabaseFormat = 'YYYY-MM-DD HH:mm:ss';
 
 /**
+ * Get the default start date and time for an event.
+ * It is set to the current date and time plus one day at 18:00:00 in the application's timezone.
+ *
+ * @since 1.0.0
+ *
+ * @return {string} Formatted default start date and time in the application's timezone.
+ */
+function getDefaultDateTimeStart() {
+	const timezone = getTimezone();
+	return createMomentWithTimezone(
+		moment().format( 'YYYY-MM-DD HH:mm:ss' ),
+		timezone
+	)
+		.add( 1, 'day' )
+		.set( 'hour', 18 )
+		.set( 'minute', 0 )
+		.set( 'second', 0 )
+		.format( dateTimeDatabaseFormat );
+}
+
+/**
  * The default start date and time for an event.
  * It is set to the current date and time plus one day at 18:00:00 in the application's timezone.
  *
@@ -37,13 +58,23 @@ export const dateTimeDatabaseFormat = 'YYYY-MM-DD HH:mm:ss';
  *
  * @type {string} Formatted default start date and time in the application's timezone.
  */
-export const defaultDateTimeStart = moment
-	.tz( getTimezone() )
-	.add( 1, 'day' )
-	.set( 'hour', 18 )
-	.set( 'minute', 0 )
-	.set( 'second', 0 )
-	.format( dateTimeDatabaseFormat );
+export const defaultDateTimeStart = getDefaultDateTimeStart();
+
+/**
+ * Get the default end date and time for an event.
+ * It is calculated based on the default start date and time plus two hours in the application's timezone.
+ *
+ * @since 1.0.0
+ *
+ * @return {string} Formatted default end date and time in the application's timezone.
+ */
+function getDefaultDateTimeEnd() {
+	const timezone = getTimezone();
+	const startDateTime = getDefaultDateTimeStart();
+	return createMomentWithTimezone( startDateTime, timezone )
+		.add( 2, 'hours' )
+		.format( dateTimeDatabaseFormat );
+}
 
 /**
  * The default end date and time for an event.
@@ -53,10 +84,7 @@ export const defaultDateTimeStart = moment
  *
  * @type {string} Formatted default end date and time in the application's timezone.
  */
-export const defaultDateTimeEnd = moment
-	.tz( defaultDateTimeStart, getTimezone() )
-	.add( 2, 'hours' )
-	.format( dateTimeDatabaseFormat );
+export const defaultDateTimeEnd = getDefaultDateTimeEnd();
 
 /**
  * Predefined duration options for event scheduling.
@@ -112,8 +140,7 @@ export function durationOptions() {
  * @return {string} The adjusted date and time formatted in a database-compatible format.
  */
 export function dateTimeOffset( hours ) {
-	return moment
-		.tz( getDateTimeStart(), getTimezone() )
+	return createMomentWithTimezone( getDateTimeStart(), getTimezone() )
 		.add( hours, 'hours' )
 		.format( dateTimeDatabaseFormat );
 }
@@ -160,25 +187,42 @@ export function dateTimeLabelFormat() {
 }
 
 /**
- * Normalizes a timezone string for use with Moment Timezone.
+ * Checks if a timezone string is a manual offset (like +05:00 or -12:00).
  *
- * Converts UTC offset strings (+00:00, -00:00) to 'UTC' since Moment Timezone
- * requires IANA timezone identifiers, not offset strings.
+ * Manual offsets start with + or - and cannot be used with moment.tz().
  *
  * @since 1.0.0
  *
- * @param {string} timezone - The timezone string to normalize.
+ * @param {string} timezone - The timezone string to check.
  *
- * @return {string} The normalized timezone, converting offset-based UTC to 'UTC'.
+ * @return {boolean} True if the timezone is a manual offset, false otherwise.
  */
-export function normalizeTimezoneForMoment( timezone ) {
-	// Convert UTC+0 or UTC-0 offset strings to 'UTC'.
-	// Moment Timezone requires IANA timezone identifiers, not offset strings.
-	if ( '+00:00' === timezone || '-00:00' === timezone ) {
-		return 'UTC';
+export function isManualOffset( timezone ) {
+	return /^[+-]\d{2}:\d{2}$/.test( timezone );
+}
+
+/**
+ * Creates a moment object with the correct timezone handling.
+ *
+ * For IANA timezone identifiers (like 'America/New_York'), uses moment.tz().
+ * For manual offsets (like '+05:00'), uses moment with utcOffset, keeping local time.
+ *
+ * @since 1.0.0
+ *
+ * @param {string} datetime - The datetime string to parse.
+ * @param {string} timezone - The timezone or offset to use.
+ *
+ * @return {Object} A moment object with the correct timezone applied.
+ */
+export function createMomentWithTimezone( datetime, timezone ) {
+	if ( isManualOffset( timezone ) ) {
+		// For manual offsets, parse the datetime and apply the offset while keeping the local time.
+		// The 'true' parameter keeps the local time the same.
+		return moment( datetime ).utcOffset( timezone, true );
 	}
 
-	return timezone;
+	// For IANA timezone identifiers, use moment.tz().
+	return moment.tz( datetime, timezone );
 }
 
 /**
@@ -194,8 +238,12 @@ export function normalizeTimezoneForMoment( timezone ) {
 export function getTimezone(
 	timezone = getFromGlobal( 'eventDetails.dateTime.timezone' ),
 ) {
-	timezone = normalizeTimezoneForMoment( timezone );
+	// Manual offsets (like +05:00) are valid, return as-is.
+	if ( isManualOffset( timezone ) ) {
+		return timezone;
+	}
 
+	// For IANA timezone identifiers, validate with moment.tz.
 	if ( moment.tz.zone( timezone ) ) {
 		return timezone;
 	}
@@ -319,7 +367,9 @@ export function getDateTimeStart() {
 	dateTime =
 		'' === dateTime
 			? defaultDateTimeStart
-			: moment.tz( dateTime, getTimezone() ).format( dateTimeDatabaseFormat );
+			: createMomentWithTimezone( dateTime, getTimezone() ).format(
+				dateTimeDatabaseFormat,
+			);
 
 	setToGlobal( 'eventDetails.dateTime.datetime_start', dateTime );
 
@@ -341,7 +391,9 @@ export function getDateTimeEnd() {
 	dateTime =
 		'' === dateTime
 			? defaultDateTimeEnd
-			: moment.tz( dateTime, getTimezone() ).format( dateTimeDatabaseFormat );
+			: createMomentWithTimezone( dateTime, getTimezone() ).format(
+				dateTimeDatabaseFormat,
+			);
 
 	setToGlobal( 'eventDetails.dateTime.datetime_end', dateTime );
 
@@ -376,8 +428,7 @@ export function updateDateTimeStart(
 
 	// If in relative mode (duration is numeric), always update the end time to maintain the offset.
 	if ( 'number' === typeof currentDuration ) {
-		const dateTimeEnd = moment
-			.tz( date, getTimezone() )
+		const dateTimeEnd = createMomentWithTimezone( date, getTimezone() )
 			.add( currentDuration, 'hours' )
 			.format( dateTimeDatabaseFormat );
 
@@ -445,12 +496,15 @@ export function updateDateTimeEnd(
  * @return {void}
  */
 export function validateDateTimeStart( dateTimeStart, setDateTimeEnd = null, currentDuration = null ) {
-	const dateTimeEndNumeric = moment
-		.tz( getFromGlobal( 'eventDetails.dateTime.datetime_end' ), getTimezone() )
-		.valueOf();
-	const dateTimeStartNumeric = moment
-		.tz( dateTimeStart, getTimezone() )
-		.valueOf();
+	const tz = getTimezone();
+	const dateTimeEndNumeric = createMomentWithTimezone(
+		getFromGlobal( 'eventDetails.dateTime.datetime_end' ),
+		tz,
+	).valueOf();
+	const dateTimeStartNumeric = createMomentWithTimezone(
+		dateTimeStart,
+		tz,
+	).valueOf();
 
 	if ( dateTimeStartNumeric >= dateTimeEndNumeric ) {
 		// Use the passed duration if available, otherwise check current offset.
@@ -458,8 +512,7 @@ export function validateDateTimeStart( dateTimeStart, setDateTimeEnd = null, cur
 		const duration = null === currentDuration ? getDateTimeOffset() : currentDuration;
 		const hoursToAdd = ( false !== duration && 'number' === typeof duration ) ? duration : 2;
 
-		const dateTimeEnd = moment
-			.tz( dateTimeStartNumeric, getTimezone() )
+		const dateTimeEnd = createMomentWithTimezone( dateTimeStartNumeric, tz )
 			.add( hoursToAdd, 'hours' )
 			.format( dateTimeDatabaseFormat );
 
@@ -483,17 +536,18 @@ export function validateDateTimeStart( dateTimeStart, setDateTimeEnd = null, cur
  * @return {void}
  */
 export function validateDateTimeEnd( dateTimeEnd, setDateTimeStart = null ) {
-	const dateTimeStartNumeric = moment
-		.tz(
-			getFromGlobal( 'eventDetails.dateTime.datetime_start' ),
-			getTimezone(),
-		)
-		.valueOf();
-	const dateTimeEndNumeric = moment.tz( dateTimeEnd, getTimezone() ).valueOf();
+	const tz = getTimezone();
+	const dateTimeStartNumeric = createMomentWithTimezone(
+		getFromGlobal( 'eventDetails.dateTime.datetime_start' ),
+		tz,
+	).valueOf();
+	const dateTimeEndNumeric = createMomentWithTimezone(
+		dateTimeEnd,
+		tz,
+	).valueOf();
 
 	if ( dateTimeEndNumeric <= dateTimeStartNumeric ) {
-		const dateTimeStart = moment
-			.tz( dateTimeEndNumeric, getTimezone() )
+		const dateTimeStart = createMomentWithTimezone( dateTimeEndNumeric, tz )
 			.subtract( 2, 'hours' )
 			.format( dateTimeDatabaseFormat );
 		updateDateTimeStart( dateTimeStart, setDateTimeStart );

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { getTimezone } from './datetime';
+import { createMomentWithTimezone, getTimezone } from './datetime';
 import { getFromGlobal } from './globals';
 
 /**
@@ -84,14 +84,21 @@ export function hasValidEventId( postId = null ) {
  * @return {boolean} True if the event has passed; false otherwise.
  */
 export function hasEventPast() {
-	const dateTimeEnd = moment.tz(
+	const timezone = getTimezone();
+	const dateTimeEnd = createMomentWithTimezone(
 		getFromGlobal( 'eventDetails.dateTime.datetime_end' ),
-		getTimezone(),
+		timezone,
+	);
+
+	// Get current time in the event timezone.
+	const now = createMomentWithTimezone(
+		moment().format( 'YYYY-MM-DD HH:mm:ss' ),
+		timezone,
 	);
 
 	return (
 		'gatherpress_event' === select( 'core/editor' )?.getCurrentPostType() &&
-		moment.tz( getTimezone() ).valueOf() > dateTimeEnd.valueOf()
+		now.valueOf() > dateTimeEnd.valueOf()
 	);
 }
 


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
  Fixes "Moment Timezone has no data for +00:00" error that occurred when WordPress timezone was set to UTC+0 or any manual offset.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #799 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @patriciabt, @mauteri 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
