### PR TITLE
Remove custom text-alignment controls in favor of core controls in event date block

### DIFF
--- a/src/blocks/event-date/block.json
+++ b/src/blocks/event-date/block.json
@@ -18,9 +18,6 @@
 		"eventStart": {
 			"type": "string"
 		},
-		"textAlign": {
-			"type": "string"
-		},
 		"displayType": {
 			"type": "string",
 			"default": "both"
@@ -61,6 +58,7 @@
 			"padding": true
 		},
 		"typography": {
+			"textAlign": true,
 			"fontSize": true,
 			"lineHeight": true,
 			"__experimentalFontFamily": true,

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -2,14 +2,12 @@
  * External dependencies.
  */
 import moment from 'moment';
-import clsx from 'clsx';
 
 /**
  * WordPress dependencies.
  */
 import { __, sprintf } from '@wordpress/i18n';
 import {
-	AlignmentToolbar,
 	BlockControls,
 	InspectorControls,
 	useBlockProps,
@@ -185,13 +183,11 @@ const calculateDisplayType = ( toggleType, showStartTime, showEndTime ) => {
  * @return {JSX.Element} The rendered Edit component for the GatherPress Event Date block.
  *
  * @see {@link DateTimeRange} - Component for editing date and time range.
- * @see {@link AlignmentToolbar} - Toolbar for text alignment control.
  * @see {@link useBlockProps} - Custom hook for block props.
  * @see {@link displayDateTime} - Function for formatting and displaying date and time.
  */
 const Edit = ( { attributes, setAttributes, context } ) => {
 	const {
-		textAlign,
 		displayType,
 		startDateFormat,
 		endDateFormat,
@@ -205,9 +201,6 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const isValidEvent = hasValidEventId( postId );
 
 	const blockProps = useBlockProps( {
-		className: clsx( {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
 		style: {
 			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : 0.3,
 		},
@@ -284,12 +277,6 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	return (
 		<div { ...blockProps }>
 			<BlockControls>
-				<AlignmentToolbar
-					value={ textAlign }
-					onChange={ ( newAlign ) =>
-						setAttributes( { textAlign: newAlign } )
-					}
-				/>
 				<ToolbarGroup>
 					<ToolbarButton
 						label={ __( 'Toggle start date', 'gatherpress' ) }


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

The event date block uses a custom block attribute for text alignment, which renders as button inside the block toolbar, but has no effect onto the frontend rendering. The selected block attribute is not transformed into a css class on the frontend.

Instead of fixing this "old way to do text-alignment in blocks", this PR removes all "old-way" in favor of the core block support `textAlign`, which shows as an identical button inside the editor and is properly working on the frontend.

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Text alignment for the event-date block

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
