### PR TITLE
Return 404 for event archive URL unless matching page exists.

### DIFF
--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -535,7 +535,6 @@ class Event_Setup {
 		// No page exists with this slug, so trigger a 404.
 		$wp_query->set_404();
 		status_header( 404 );
-		nocache_headers();
 	}
 
 	/**

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -11,6 +11,7 @@
 	<rule ref="rulesets/codesize.xml">
 		<exclude name="CyclomaticComplexity" />
 		<exclude name="TooManyPublicMethods" />
+		<exclude name="TooManyMethods" />
 		<exclude name="ExcessiveClassComplexity" />
 		<exclude name="NPathComplexity" />
 		<exclude name="ExcessiveMethodLength" />

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -27,6 +27,11 @@
 			<property name="ignorepattern" value="(^(__construct|getIterator|offsetExists|offsetGet|offsetSet|offsetUnset))i" />
 		</properties>
 	</rule>
+	<rule ref="rulesets/codesize.xml/TooManyMethods">
+		<properties>
+			<property name="maxmethods" value="30"/>
+		</properties>
+	</rule>
 	<rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
 		<properties>
 			<property name="maximum" value="103"/>


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
Visiting the event base URL (e.g., `/event/`) now returns a 404 instead of showing a confusing archive page. If a WordPress page exists with the same slug, that page is served instead.                                                                                                                                          
                                                                                                                                                                   
Feed URLs (`/event/feed/`) continue to work as expected. 
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

### How to test the Change
1. Visit `/event/` (or your configured event base URL) — should return 404                                                                                       
2. Create a page with slug `event` and publish it — visiting `/event/` should now show that page                                                                 
3. Visit `/event/feed/` — should still return the RSS feed    
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Existing functionality
> Fixed - Bug fix

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
