### PR TITLE
fix(ics): correctly escape newlines without mutating the letter 'n'

### DIFF
--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -737,7 +737,7 @@ class Event {
 	 * @return string The escaped text suitable for ICS content.
 	 */
 	protected function escape_ics_text( string $text ): string {
-		return addcslashes( $text, ",;\\n" );
+		return str_replace( array( "\\", ",", ";", "\n", "\r" ), array( "\\\\", "\\,", "\\;", "\\n", "" ), $text );
 	}
 
 	/**


### PR DESCRIPTION
## Problem
The ICS export logic used `addcslashes( $text, ",;\\n" )` to escape content. In PHP, the double-quoted string `",;\\n"` evaluates to the characters `,`, `;`, `\`, and the literal letter `n`. As a result, `addcslashes` incorrectly escaped every lowercase 'n' character into `\n`, rather than escaping actual line feeds.

## Solution  
Replaced `addcslashes` with a strict `str_replace` sequence that explicitly matches actual newline (`\n`), carriage return (`\r`), comma, semicolon, and backslash characters and encodes them into their literal ICS counterparts (e.g. `\\n`, `\\,`). Carriage returns are stripped out to avoid trailing `\r` anomalies.

## Testing
Verified string replacement rules match RFC 5545 specifications for TEXT fields. A text containing the letter 'n' will now remain untouched while true line-breaks are converted safely to `\\n`.

Closes #1413