### PR TITLE
Fix ICS export escaping of lowercase "n" characters

### DIFF
--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -737,7 +737,7 @@ class Event {
 	 * @return string The escaped text suitable for ICS content.
 	 */
 	protected function escape_ics_text( string $text ): string {
-		return addcslashes( $text, ",;\\n" );
+		return addcslashes( $text, ",;\n" );
 	}
 
 	/**

--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -737,7 +737,7 @@ class Event {
 	 * @return string The escaped text suitable for ICS content.
 	 */
 	protected function escape_ics_text( string $text ): string {
-		return addcslashes( $text, ",;\n" );
+		return addcslashes( $text, "\\,;\n" );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event.php
@@ -1119,6 +1119,14 @@ class Test_Event extends Base {
 		$result = $method->invoke( $event, 'Test, text' );
 		$this->assertStringContainsString( '\,', $result, 'Failed to escape commas.' );
 
+		// Test newline escaping.
+		$result = $method->invoke( $event, "Line 1\nLine 2" );
+		$this->assertStringContainsString( '\\n', $result, 'Failed to escape newline characters.' );
+
+		// Ensure lowercase n is not escaped.
+		$result = $method->invoke( $event, 'Berlin in June' );
+		$this->assertSame( 'Berlin in June', $result, 'Lowercase n should not be escaped.' );
+
 		// Test that method is callable.
 		$this->assertTrue( true );
 	}


### PR DESCRIPTION
Fixes #1413

## Problem
`escape_ics_text()` used `addcslashes($text, ",;\\n")`, which escapes literal lowercase `n` characters, causing words like `Berlin` to become `Berli\n` in exported ICS fields.

## Changes
- Updated ICS escaping charlist to escape actual newline characters (plus comma/semicolon), not the letter `n`.
- Added regression assertions in unit tests:
  - newline is escaped as `\n`
  - lowercase `n` remains unchanged

## Files
- `includes/core/classes/class-event.php`
- `test/unit/php/includes/tests/core/classes/class-test-event.php`

## Validation
- `php -l includes/core/classes/class-event.php`
- `php -l test/unit/php/includes/tests/core/classes/class-test-event.php`
