### PR TITLE
Fix Post Date block to display event date when setting is enabled

### DIFF
--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -400,6 +400,11 @@ class Assets {
 				'mapPlatform'         => $settings->get_value( 'general', 'general', 'map_platform' ),
 				'maxAttendanceLimit'  => $settings->get_value( 'general', 'general', 'max_attendance_limit' ),
 				'maxGuestLimit'       => $settings->get_value( 'general', 'general', 'max_guest_limit' ),
+				'postOrEventDate'     => ( 1 === (int) $settings->get_value(
+					'general',
+					'general',
+					'post_or_event_date'
+				) ),
 				'showTimezone'        => ( 1 === (int) $settings->get_value(
 					'general',
 					'formatting',

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -1198,6 +1198,8 @@ class Event_Setup {
 	 * @param array    $block         The full block, including name and attributes.
 	 * @param WP_Block $instance      The block instance.
 	 * @return string The filtered block content with event datetime.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) -- $block is required by the render_block filter signature.
 	 */
 	public function render_event_post_date_block( string $block_content, array $block, WP_Block $instance ): string {
 		$post_id = $instance->context['postId'] ?? get_the_ID();

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -18,6 +18,7 @@ use Exception;
 use GatherPress\Core\Traits\Singleton;
 use stdClass;
 use WP;
+use WP_Block;
 use WP_Post;
 use WP_Query;
 use WP_REST_Request;
@@ -105,8 +106,9 @@ class Event_Setup {
 		add_filter( 'query_vars', array( $this, 'query_vars' ) );
 		add_action( 'pre_get_posts', array( $this, 'handle_rsvp_sorting' ) );
 		add_action( 'pre_get_posts', array( $this, 'handle_venue_sorting' ) );
-		add_filter( 'get_the_date', array( $this, 'get_the_event_date' ) );
+		add_filter( 'get_the_date', array( $this, 'get_the_event_date' ), 10, 3 );
 		add_filter( 'the_time', array( $this, 'get_the_event_date' ) );
+		add_filter( 'render_block_core/post-date', array( $this, 'render_event_post_date_block' ), 10, 3 );
 		add_filter( 'display_post_states', array( $this, 'set_event_archive_labels' ), 10, 2 );
 		add_filter(
 			sprintf( 'manage_%s_posts_columns', Event::POST_TYPE ),
@@ -1145,28 +1147,93 @@ class Event_Setup {
 	 * Returns the event date instead of the publish date for events.
 	 *
 	 * This method retrieves the event date based on plugin settings, replacing the publish date
-	 * for event posts when appropriate.
+	 * for event posts when appropriate. When a specific date format is provided (e.g., 'c' for
+	 * ISO 8601), the event start datetime is returned in that format. This ensures compatibility
+	 * with the core/post-date block, which requests ISO 8601 format via block bindings.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $the_date The formatted date.
+	 * @param string       $the_date The formatted date.
+	 * @param string       $format   PHP date format.
+	 * @param WP_Post|null $post     The post object.
 	 * @return string The event date as a formatted string.
 	 *
 	 * @throws Exception If initializing the Event object fails or event data cannot be retrieved.
 	 */
-	public function get_the_event_date( string $the_date ): string {
+	public function get_the_event_date( string $the_date, string $format = '', $post = null ): string {
 		$settings       = Settings::get_instance();
 		$use_event_date = $settings->get_value( 'general', 'general', 'post_or_event_date' );
 
+		// Determine the post type and ID from the post object or global context.
+		$post_type = $post instanceof \WP_Post ? $post->post_type : get_post_type();
+		$post_id   = $post instanceof \WP_Post ? $post->ID : get_the_ID();
+
 		// Check if the post is of the 'Event' post type and if event date should be used.
-		if ( Event::POST_TYPE !== get_post_type() || 1 !== intval( $use_event_date ) ) {
+		if ( Event::POST_TYPE !== $post_type || 1 !== intval( $use_event_date ) ) {
 			return $the_date;
 		}
 
-		// Get the event date and return it as the formatted date.
-		$event = new Event( get_the_ID() );
+		// Get the event date and return it in the requested format.
+		$event = new Event( $post_id );
+
+		// When a specific format is requested, return the event start datetime in that format.
+		// This ensures compatibility with the core/post-date block (which uses ISO 8601 'c' format).
+		if ( ! empty( $format ) ) {
+			return $event->get_datetime_start( $format );
+		}
 
 		return $event->get_display_datetime();
+	}
+
+	/**
+	 * Filters the rendered core/post-date block to display the event datetime.
+	 *
+	 * When the "Display event date instead of publish date for events" setting is enabled,
+	 * this method replaces the Post Date block output with the GatherPress-formatted event
+	 * datetime (using the event format settings for date, time, and timezone).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string   $block_content The block content.
+	 * @param array    $block         The full block, including name and attributes.
+	 * @param WP_Block $instance      The block instance.
+	 * @return string The filtered block content with event datetime.
+	 */
+	public function render_event_post_date_block( string $block_content, array $block, WP_Block $instance ): string {
+		$post_id = $instance->context['postId'] ?? get_the_ID();
+
+		if ( ! $post_id || Event::POST_TYPE !== get_post_type( $post_id ) ) {
+			return $block_content;
+		}
+
+		$settings       = Settings::get_instance();
+		$use_event_date = $settings->get_value( 'general', 'general', 'post_or_event_date' );
+
+		if ( 1 !== intval( $use_event_date ) ) {
+			return $block_content;
+		}
+
+		$event        = new Event( $post_id );
+		$display_date = $event->get_display_datetime();
+		$iso_date     = $event->get_datetime_start( 'c' );
+
+		if ( empty( $display_date ) || '—' === $display_date ) {
+			return $block_content;
+		}
+
+		// Replace the datetime attribute and the displayed date text in the block output.
+		$block_content = preg_replace(
+			'/datetime="[^"]*"/',
+			'datetime="' . esc_attr( $iso_date ) . '"',
+			$block_content
+		);
+		$block_content = preg_replace(
+			'|(<time[^>]*>).*?(</time>)|s',
+			'$1' . esc_html( $display_date ) . '$2',
+			$block_content
+		);
+
+		return $block_content;
 	}
 
 	/**

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -1165,8 +1165,8 @@ class Event_Setup {
 		$use_event_date = $settings->get_value( 'general', 'general', 'post_or_event_date' );
 
 		// Determine the post type and ID from the post object or global context.
-		$post_type = $post instanceof \WP_Post ? $post->post_type : get_post_type();
-		$post_id   = $post instanceof \WP_Post ? $post->ID : get_the_ID();
+		$post_type = $post instanceof WP_Post ? $post->post_type : get_post_type();
+		$post_id   = $post instanceof WP_Post ? $post->ID : get_the_ID();
 
 		// Check if the post is of the 'Event' post type and if event date should be used.
 		if ( Event::POST_TYPE !== $post_type || 1 !== intval( $use_event_date ) ) {

--- a/includes/core/classes/settings/class-general.php
+++ b/includes/core/classes/settings/class-general.php
@@ -100,7 +100,7 @@ class General extends Base {
 							'name' => __( 'Publish Date', 'gatherpress' ),
 						),
 						'field'  => array(
-							'label'   => __( 'Show publish date as event date for events.', 'gatherpress' ),
+							'label'   => __( 'Display event date instead of publish date for events.', 'gatherpress' ),
 							'type'    => 'checkbox',
 							'options' => array(
 								'default' => '1',

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -4,6 +4,7 @@
 
 	<!-- What to scan -->
 	<file>.</file>
+	<exclude-pattern>/.git/</exclude-pattern>
 	<exclude-pattern>.gatherpress.org/playground-preview</exclude-pattern>
 	<exclude-pattern>*.asset.php</exclude-pattern>
 	<exclude-pattern>/data/credits.php</exclude-pattern>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -24,13 +24,13 @@
 	</rule>
 	<rule ref="rulesets/codesize.xml/TooManyPublicMethods">
 		<properties>
-			<property name="maxmethods" value="30"/>
+			<property name="maxmethods" value="35"/>
 			<property name="ignorepattern" value="(^(__construct|getIterator|offsetExists|offsetGet|offsetSet|offsetUnset))i" />
 		</properties>
 	</rule>
 	<rule ref="rulesets/codesize.xml/TooManyMethods">
 		<properties>
-			<property name="maxmethods" value="30"/>
+			<property name="maxmethods" value="35"/>
 		</properties>
 	</rule>
 	<rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">

--- a/src/editor.js
+++ b/src/editor.js
@@ -12,6 +12,7 @@ import { hasEventPastNotice } from './helpers/event';
 import EmailNotificationManager from './components/EmailNotificationManager';
 import './stores';
 import './supports/post-id-override';
+import './supports/post-date-override';
 import './supports/block-guard';
 import './formats/tooltip';
 

--- a/src/supports/post-date-override.js
+++ b/src/supports/post-date-override.js
@@ -1,0 +1,181 @@
+/**
+ * WordPress dependencies.
+ */
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies.
+ */
+import { getFromGlobal } from '../helpers/globals';
+import { isEventPostType } from '../helpers/event';
+import {
+	convertPHPToMomentFormat,
+	createMomentWithTimezone,
+	getTimezone,
+	getUtcOffset,
+	isManualOffset,
+	removeNonTimePHPFormatChars,
+} from '../helpers/datetime';
+import { __ } from '@wordpress/i18n';
+
+const globalDateFormat = getFromGlobal( 'settings.dateFormat' );
+const globalTimeFormat = getFromGlobal( 'settings.timeFormat' );
+const globalShowTimezone = getFromGlobal( 'settings.showTimezone' );
+const defaultFormat = `${ globalDateFormat } ${ globalTimeFormat }`;
+
+/**
+ * Formats event datetime for display, matching the PHP get_display_datetime output.
+ *
+ * @param {string} dateTimeStart - Event start datetime.
+ * @param {string} dateTimeEnd   - Event end datetime.
+ * @param {string} timezone      - Event timezone.
+ * @return {string} Formatted display datetime.
+ */
+const formatEventDateTime = ( dateTimeStart, dateTimeEnd, timezone ) => {
+	timezone = getTimezone( timezone );
+	let sameStartEndDay = false;
+
+	if ( dateTimeStart && dateTimeEnd ) {
+		const sameDayFormat = convertPHPToMomentFormat( globalDateFormat );
+		sameStartEndDay =
+			createMomentWithTimezone( dateTimeStart, timezone ).format(
+				sameDayFormat
+			) ===
+			createMomentWithTimezone( dateTimeEnd, timezone ).format(
+				sameDayFormat
+			);
+	}
+
+	const parts = [];
+
+	// Add start date/time.
+	if ( dateTimeStart ) {
+		const startFormat = convertPHPToMomentFormat( defaultFormat );
+		parts.push(
+			createMomentWithTimezone( dateTimeStart, timezone ).format(
+				startFormat
+			)
+		);
+	}
+
+	// Determine end format.
+	let endFormat = defaultFormat;
+	let showEnd = true;
+
+	if ( dateTimeEnd ) {
+		endFormat = sameStartEndDay
+			? removeNonTimePHPFormatChars( endFormat )
+			: endFormat;
+
+		if ( ! endFormat ) {
+			showEnd = false;
+		}
+	}
+
+	// Add separator if start + end.
+	if ( dateTimeStart && dateTimeEnd && showEnd ) {
+		parts.push( __( 'to', 'gatherpress' ) );
+	}
+
+	// Add end date/time.
+	if ( dateTimeEnd && showEnd && endFormat ) {
+		const momentEndFormat = convertPHPToMomentFormat( endFormat );
+		parts.push(
+			createMomentWithTimezone( dateTimeEnd, timezone ).format(
+				momentEndFormat
+			)
+		);
+	}
+
+	// Add timezone.
+	if ( globalShowTimezone ) {
+		if ( isManualOffset( timezone ) ) {
+			const sign = timezone.charAt( 0 );
+			const offset = timezone.substring( 1 ).replace( ':', '' );
+			parts.push( `GMT${ sign }${ offset }` );
+		} else {
+			parts.push(
+				createMomentWithTimezone(
+					dateTimeEnd || dateTimeStart,
+					timezone
+				).format( 'z' )
+			);
+		}
+	}
+
+	// Add UTC offset if GMT (invalid site timezone).
+	parts.push( getUtcOffset( timezone ) );
+
+	return parts.filter( Boolean ).join( ' ' );
+};
+
+/**
+ * Higher-Order Component to override the core/post-date block display
+ * with event datetime when the "Display event date instead of publish date"
+ * setting is enabled.
+ *
+ * @param {Function} BlockEdit - The original BlockEdit component.
+ * @return {Function} Enhanced BlockEdit component.
+ */
+const withEventPostDateOverride = createHigherOrderComponent(
+	( BlockEdit ) => {
+		return ( props ) => {
+			const { name } = props;
+
+			// Only apply to the core/post-date block.
+			if ( 'core/post-date' !== name ) {
+				return <BlockEdit { ...props } />;
+			}
+
+			// Check if the setting is enabled and we are editing an event.
+			const postOrEventDate = getFromGlobal(
+				'settings.postOrEventDate'
+			);
+
+			if ( ! postOrEventDate || ! isEventPostType() ) {
+				return <BlockEdit { ...props } />;
+			}
+
+			// Get event datetime from the gatherpress/datetime store.
+			const { dateTimeStart, dateTimeEnd, timezone } = useSelect(
+				( select ) => {
+					const datetimeStore =
+						select( 'gatherpress/datetime' );
+					return {
+						dateTimeStart:
+							datetimeStore.getDateTimeStart(),
+						dateTimeEnd: datetimeStore.getDateTimeEnd(),
+						timezone: datetimeStore.getTimezone(),
+					};
+				},
+				[]
+			);
+
+			if ( ! dateTimeStart ) {
+				return <BlockEdit { ...props } />;
+			}
+
+			const blockProps = useBlockProps();
+			const displayDate = formatEventDateTime(
+				dateTimeStart,
+				dateTimeEnd,
+				timezone
+			);
+
+			return <div { ...blockProps }>{ displayDate }</div>;
+		};
+	},
+	'withEventPostDateOverride'
+);
+
+/**
+ * Register the HOC as a filter for the BlockEdit component.
+ */
+addFilter(
+	'editor.BlockEdit',
+	'gatherpress/with-event-post-date-override',
+	withEventPostDateOverride
+);

--- a/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
@@ -1174,9 +1174,52 @@ class Test_Event_Setup extends Base {
 		// Set global post.
 		$this->go_to( get_permalink( $post_id ) );
 
-		$result = $instance->get_the_event_date( 'June 15, 2025' );
+		$post   = get_post( $post_id );
+		$result = $instance->get_the_event_date( 'June 15, 2025', '', $post );
 
 		$this->assertStringContainsString( 'June', $result, 'Should return event date.' );
+	}
+
+	/**
+	 * Coverage for get_the_event_date with ISO 8601 format for Post Date block compatibility.
+	 *
+	 * @covers ::get_the_event_date
+	 *
+	 * @return void
+	 */
+	public function test_get_the_event_date_iso_format(): void {
+		$instance = Event_Setup::get_instance();
+		$post_id  = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		$event = new Event( $post_id );
+		$event->save_datetimes(
+			array(
+				'datetime_start' => '2025-06-15 10:00:00',
+				'datetime_end'   => '2025-06-15 14:00:00',
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		// Set setting to use event date.
+		update_option(
+			'gatherpress_general',
+			array(
+				'general' => array(
+					'post_or_event_date' => '1',
+				),
+			)
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$post   = get_post( $post_id );
+		$result = $instance->get_the_event_date( '2025-06-15T10:00:00-04:00', 'c', $post );
+
+		// Should return ISO 8601 formatted event start datetime.
+		$this->assertStringContainsString( '2025-06-15', $result, 'Should return ISO 8601 formatted event date.' );
+		$this->assertStringContainsString( 'T', $result, 'Should contain time separator for ISO 8601 format.' );
 	}
 
 	/**
@@ -1204,8 +1247,9 @@ class Test_Event_Setup extends Base {
 
 		$this->go_to( get_permalink( $post_id ) );
 
+		$post          = get_post( $post_id );
 		$original_date = 'June 15, 2025';
-		$result        = $instance->get_the_event_date( $original_date );
+		$result        = $instance->get_the_event_date( $original_date, '', $post );
 
 		$this->assertSame( $original_date, $result, 'Should return original post date.' );
 	}
@@ -1223,10 +1267,129 @@ class Test_Event_Setup extends Base {
 
 		$this->go_to( get_permalink( $post_id ) );
 
+		$post          = get_post( $post_id );
 		$original_date = 'June 15, 2025';
-		$result        = $instance->get_the_event_date( $original_date );
+		$result        = $instance->get_the_event_date( $original_date, '', $post );
 
 		$this->assertSame( $original_date, $result, 'Should return original date for non-event posts.' );
+	}
+
+	/**
+	 * Coverage for render_event_post_date_block method with event post and setting enabled.
+	 *
+	 * @covers ::render_event_post_date_block
+	 *
+	 * @return void
+	 */
+	public function test_render_event_post_date_block_with_event(): void {
+		$instance = Event_Setup::get_instance();
+		$post_id  = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		$event = new Event( $post_id );
+		$event->save_datetimes(
+			array(
+				'datetime_start' => '2025-06-15 10:00:00',
+				'datetime_end'   => '2025-06-15 14:00:00',
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		// Set setting to use event date.
+		update_option(
+			'gatherpress_general',
+			array(
+				'general' => array(
+					'post_or_event_date' => '1',
+				),
+			)
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$block_content = '<div class="wp-block-post-date"><time datetime="2025-03-26T12:00:00+00:00">March 26, 2025</time></div>';
+		$block         = array(
+			'blockName' => 'core/post-date',
+			'attrs'     => array(),
+		);
+		$wp_block      = new \WP_Block(
+			$block,
+			array( 'postId' => $post_id )
+		);
+
+		$result = $instance->render_event_post_date_block( $block_content, $block, $wp_block );
+
+		$this->assertStringContainsString( 'June', $result, 'Should contain event date month.' );
+		$this->assertStringContainsString( '2025-06-15', $result, 'Should contain ISO event date in datetime attribute.' );
+	}
+
+	/**
+	 * Coverage for render_event_post_date_block method with setting disabled.
+	 *
+	 * @covers ::render_event_post_date_block
+	 *
+	 * @return void
+	 */
+	public function test_render_event_post_date_block_setting_disabled(): void {
+		$instance = Event_Setup::get_instance();
+		$post_id  = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		// Set setting to use post date (disabled).
+		update_option(
+			'gatherpress_general',
+			array(
+				'general' => array(
+					'post_or_event_date' => '0',
+				),
+			)
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$block_content = '<div class="wp-block-post-date"><time datetime="2025-03-26T12:00:00+00:00">March 26, 2025</time></div>';
+		$block         = array(
+			'blockName' => 'core/post-date',
+			'attrs'     => array(),
+		);
+		$wp_block      = new \WP_Block(
+			$block,
+			array( 'postId' => $post_id )
+		);
+
+		$result = $instance->render_event_post_date_block( $block_content, $block, $wp_block );
+
+		$this->assertSame( $block_content, $result, 'Should return original block content when setting is disabled.' );
+	}
+
+	/**
+	 * Coverage for render_event_post_date_block method with non-event post.
+	 *
+	 * @covers ::render_event_post_date_block
+	 *
+	 * @return void
+	 */
+	public function test_render_event_post_date_block_non_event(): void {
+		$instance = Event_Setup::get_instance();
+		$post_id  = $this->mock->post()->get()->ID;
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$block_content = '<div class="wp-block-post-date"><time datetime="2025-03-26T12:00:00+00:00">March 26, 2025</time></div>';
+		$block         = array(
+			'blockName' => 'core/post-date',
+			'attrs'     => array(),
+		);
+		$wp_block      = new \WP_Block(
+			$block,
+			array( 'postId' => $post_id )
+		);
+
+		$result = $instance->render_event_post_date_block( $block_content, $block, $wp_block );
+
+		$this->assertSame( $block_content, $result, 'Should return original block content for non-event posts.' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
@@ -8,7 +8,6 @@
 
 namespace GatherPress\Tests\Core;
 
-use Exception;
 use GatherPress\Core\Event;
 use GatherPress\Core\Event_Setup;
 use GatherPress\Core\Settings;
@@ -16,6 +15,7 @@ use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 use stdClass;
 use WP;
+use WP_Block;
 use WP_Query;
 use WP_REST_Request;
 
@@ -155,6 +155,12 @@ class Test_Event_Setup extends Base {
 				'name'     => 'the_time',
 				'priority' => 10,
 				'callback' => array( $instance, 'get_the_event_date' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'render_block_core/post-date',
+				'priority' => 10,
+				'callback' => array( $instance, 'render_event_post_date_block' ),
 			),
 			array(
 				'type'     => 'filter',
@@ -1313,7 +1319,7 @@ class Test_Event_Setup extends Base {
 			'blockName' => 'core/post-date',
 			'attrs'     => array(),
 		);
-		$wp_block      = new \WP_Block(
+		$wp_block      = new WP_Block(
 			$block,
 			array( 'postId' => $post_id )
 		);
@@ -1354,7 +1360,7 @@ class Test_Event_Setup extends Base {
 			'blockName' => 'core/post-date',
 			'attrs'     => array(),
 		);
-		$wp_block      = new \WP_Block(
+		$wp_block      = new WP_Block(
 			$block,
 			array( 'postId' => $post_id )
 		);
@@ -1382,7 +1388,7 @@ class Test_Event_Setup extends Base {
 			'blockName' => 'core/post-date',
 			'attrs'     => array(),
 		);
-		$wp_block      = new \WP_Block(
+		$wp_block      = new WP_Block(
 			$block,
 			array( 'postId' => $post_id )
 		);

--- a/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
@@ -1314,6 +1314,7 @@ class Test_Event_Setup extends Base {
 
 		$this->go_to( get_permalink( $post_id ) );
 
+		// phpcs:ignore Generic.Files.LineLength.TooLong -- Block HTML fixture.
 		$block_content = '<div class="wp-block-post-date"><time datetime="2025-03-26T12:00:00+00:00">March 26, 2025</time></div>';
 		$block         = array(
 			'blockName' => 'core/post-date',
@@ -1327,7 +1328,11 @@ class Test_Event_Setup extends Base {
 		$result = $instance->render_event_post_date_block( $block_content, $block, $wp_block );
 
 		$this->assertStringContainsString( 'June', $result, 'Should contain event date month.' );
-		$this->assertStringContainsString( '2025-06-15', $result, 'Should contain ISO event date in datetime attribute.' );
+		$this->assertStringContainsString(
+			'2025-06-15',
+			$result,
+			'Should contain ISO event date in datetime attribute.'
+		);
 	}
 
 	/**
@@ -1355,6 +1360,7 @@ class Test_Event_Setup extends Base {
 
 		$this->go_to( get_permalink( $post_id ) );
 
+		// phpcs:ignore Generic.Files.LineLength.TooLong -- Block HTML fixture.
 		$block_content = '<div class="wp-block-post-date"><time datetime="2025-03-26T12:00:00+00:00">March 26, 2025</time></div>';
 		$block         = array(
 			'blockName' => 'core/post-date',
@@ -1383,6 +1389,7 @@ class Test_Event_Setup extends Base {
 
 		$this->go_to( get_permalink( $post_id ) );
 
+		// phpcs:ignore Generic.Files.LineLength.TooLong -- Block HTML fixture.
 		$block_content = '<div class="wp-block-post-date"><time datetime="2025-03-26T12:00:00+00:00">March 26, 2025</time></div>';
 		$block         = array(
 			'blockName' => 'core/post-date',


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
- When "Display event date instead of publish date for events" is enabled, the core `Post Date` block now shows the full event datetime (using GatherPress date/time/timezone format settings) instead of the publish date
- Adds `render_block_core/post-date` filter to replace the block's frontend output with the GatherPress-formatted event datetime
- Adds editor support via `editor.BlockEdit` filter that reads from the `gatherpress/datetime` store so the Post Date block shows the event date in the editor as well
- Updates the setting label from "Show publish date as event date for events" to "Display event date instead of publish date for events" for clarity

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1324 

### How to test the Change
- Enable "Display event date instead of publish date for events" under GatherPress > Settings > General
- Add a `Post Date` block to an event with a set event date/time
- Verify the block shows the event datetime (not publish date) in the **editor**
- Verify the block shows the event datetime (not publish date) on the **frontend**
- Verify the displayed format matches GatherPress date/time/timezone settings
- Disable the setting and verify the Post Date block reverts to showing the publish date
- Verify non-event posts are unaffected
- Run `npm run test:unit:php`
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Bug fix

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
