### PR TITLE
Add Duplicate Post integration to sync event datetime on clone

### DIFF
--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use Exception;
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Integrations\Setup as Integrations;
 use WP_Site;
 
 /**
@@ -66,6 +67,7 @@ class Setup {
 		Feed::get_instance();
 		Geocoding::get_instance();
 		Import::get_instance();
+		Integrations::get_instance();
 		Rsvp_Cleanup::get_instance();
 		Rsvp_Form::get_instance();
 		Rsvp_Query::get_instance();

--- a/includes/integrations/classes/class-setup.php
+++ b/includes/integrations/classes/class-setup.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Manages third-party plugin integrations for GatherPress.
+ *
+ * @package GatherPress\Integrations
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Integrations;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Traits\Singleton;
+use GatherPress\Integrations\Duplicate_Post\Setup as Duplicate_Post_Setup;
+
+/**
+ * Class Setup.
+ *
+ * Bootstraps all third-party plugin integrations.
+ *
+ * @since 1.0.0
+ */
+class Setup {
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Constructor for the Setup class.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function __construct() {
+		$this->instantiate_classes();
+	}
+
+	/**
+	 * Instantiate integration classes.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function instantiate_classes(): void {
+		Duplicate_Post_Setup::get_instance();
+	}
+}

--- a/includes/integrations/duplicate-post/classes/class-setup.php
+++ b/includes/integrations/duplicate-post/classes/class-setup.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Integration with the Yoast Duplicate Post plugin.
+ *
+ * Ensures GatherPress event data is properly duplicated when
+ * using the Duplicate Post plugin to clone events.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Integrations\Duplicate_Post;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Event;
+use GatherPress\Core\Traits\Singleton;
+
+/**
+ * Class Setup.
+ *
+ * Handles integration with the Yoast Duplicate Post plugin.
+ *
+ * @since 1.0.0
+ */
+class Setup {
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Constructor for the Setup class.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Set up hooks for Duplicate Post integration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks(): void {
+		add_action( 'duplicate_post_post_copy', array( $this, 'sync_duplicated_event' ) );
+	}
+
+	/**
+	 * Sync the custom events table when an event is duplicated.
+	 *
+	 * When the Duplicate Post plugin clones an event, the post meta
+	 * is copied but the custom gatherpress_events table is not. This method
+	 * reads the cloned meta and writes it to the custom table.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $new_post_id The ID of the newly duplicated post.
+	 * @return void
+	 */
+	public function sync_duplicated_event( int $new_post_id ): void {
+		if ( Event::POST_TYPE !== get_post_type( $new_post_id ) ) {
+			return;
+		}
+
+		$event    = new Event( $new_post_id );
+		$datetime = $event->get_datetime();
+
+		if ( empty( $datetime['datetime_start'] ) ) {
+			return;
+		}
+
+		$event->save_datetimes(
+			array(
+				'post_id'        => $new_post_id,
+				'datetime_start' => $datetime['datetime_start'],
+				'datetime_end'   => $datetime['datetime_end'],
+				'timezone'       => $datetime['timezone'],
+			)
+		);
+	}
+}

--- a/phpunit-multisite.xml.dist
+++ b/phpunit-multisite.xml.dist
@@ -24,6 +24,7 @@
 	<coverage>
 		<include>
 			<directory suffix=".php">./includes/core/classes</directory>
+			<directory suffix=".php">./includes/integrations</directory>
 		</include>
 	</coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,7 @@
 	<coverage>
 		<include>
 			<directory suffix=".php">./includes/core/classes</directory>
+			<directory suffix=".php">./includes/integrations</directory>
 		</include>
 	</coverage>
 </phpunit>

--- a/test/unit/php/includes/tests/integrations/classes/class-test-setup.php
+++ b/test/unit/php/includes/tests/integrations/classes/class-test-setup.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Class handles unit tests for GatherPress\Integrations\Setup.
+ *
+ * @package GatherPress\Integrations
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Integrations;
+
+use GatherPress\Integrations\Setup;
+use GatherPress\Tests\Base;
+
+/**
+ * Class Test_Setup.
+ *
+ * @coversDefaultClass \GatherPress\Integrations\Setup
+ */
+class Test_Setup extends Base {
+	/**
+	 * Coverage for constructor.
+	 *
+	 * @covers ::__construct
+	 * @covers ::instantiate_classes
+	 *
+	 * @return void
+	 */
+	public function test_constructor(): void {
+		$instance = Setup::get_instance();
+
+		$this->assertInstanceOf( Setup::class, $instance, 'Failed to assert Integrations Setup instance.' );
+	}
+}

--- a/test/unit/php/includes/tests/integrations/classes/class-test-setup.php
+++ b/test/unit/php/includes/tests/integrations/classes/class-test-setup.php
@@ -10,6 +10,7 @@ namespace GatherPress\Tests\Integrations;
 
 use GatherPress\Integrations\Setup;
 use GatherPress\Tests\Base;
+use PMC\Unit_Test\Utility;
 
 /**
  * Class Test_Setup.
@@ -18,7 +19,7 @@ use GatherPress\Tests\Base;
  */
 class Test_Setup extends Base {
 	/**
-	 * Coverage for constructor.
+	 * Coverage for constructor and instantiate_classes.
 	 *
 	 * @covers ::__construct
 	 * @covers ::instantiate_classes
@@ -26,6 +27,9 @@ class Test_Setup extends Base {
 	 * @return void
 	 */
 	public function test_constructor(): void {
+		// Reset singleton so constructor re-runs with coverage.
+		Utility::set_and_get_hidden_static_property( Setup::class, 'instance', null );
+
 		$instance = Setup::get_instance();
 
 		$this->assertInstanceOf( Setup::class, $instance, 'Failed to assert Integrations Setup instance.' );

--- a/test/unit/php/includes/tests/integrations/duplicate-post/classes/class-test-setup.php
+++ b/test/unit/php/includes/tests/integrations/duplicate-post/classes/class-test-setup.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Class handles unit tests for GatherPress\Integrations\Duplicate_Post\Setup.
+ *
+ * @package GatherPress\Integrations
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Integrations\Duplicate_Post;
+
+use GatherPress\Core\Event;
+use GatherPress\Integrations\Duplicate_Post\Setup;
+use GatherPress\Tests\Base;
+
+/**
+ * Class Test_Setup.
+ *
+ * @coversDefaultClass \GatherPress\Integrations\Duplicate_Post\Setup
+ */
+class Test_Setup extends Base {
+	/**
+	 * Coverage for setup_hooks.
+	 *
+	 * @covers ::__construct
+	 * @covers ::setup_hooks
+	 *
+	 * @return void
+	 */
+	public function test_setup_hooks(): void {
+		$instance = Setup::get_instance();
+		$hooks    = array(
+			array(
+				'type'     => 'action',
+				'name'     => 'duplicate_post_post_copy',
+				'priority' => 10,
+				'callback' => array( $instance, 'sync_duplicated_event' ),
+			),
+		);
+
+		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * Coverage for sync_duplicated_event with an event post.
+	 *
+	 * @covers ::sync_duplicated_event
+	 *
+	 * @return void
+	 */
+	public function test_sync_duplicated_event(): void {
+		$instance = Setup::get_instance();
+
+		// Create an event with datetime.
+		$post_id = $this->factory->post->create(
+			array( 'post_type' => Event::POST_TYPE )
+		);
+
+		$event = new Event( $post_id );
+		$event->save_datetimes(
+			array(
+				'datetime_start' => '2025-12-25 10:00:00',
+				'datetime_end'   => '2025-12-25 14:00:00',
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		// Create a "cloned" post with the same meta (simulating duplicate-post).
+		$new_post_id = $this->factory->post->create(
+			array( 'post_type' => Event::POST_TYPE )
+		);
+
+		// Copy the meta keys to simulate what duplicate-post does.
+		$meta_keys = array(
+			'gatherpress_datetime_start',
+			'gatherpress_datetime_start_gmt',
+			'gatherpress_datetime_end',
+			'gatherpress_datetime_end_gmt',
+			'gatherpress_timezone',
+		);
+
+		foreach ( $meta_keys as $key ) {
+			$value = get_post_meta( $post_id, $key, true );
+			update_post_meta( $new_post_id, $key, $value );
+		}
+
+		// Run the sync — this should populate the custom table.
+		$instance->sync_duplicated_event( $new_post_id );
+
+		// Verify the custom table was populated.
+		$new_event    = new Event( $new_post_id );
+		$new_datetime = $new_event->get_datetime();
+
+		$this->assertSame(
+			'2025-12-25 10:00:00',
+			$new_datetime['datetime_start'],
+			'Cloned event should have the same start datetime.'
+		);
+		$this->assertSame(
+			'2025-12-25 14:00:00',
+			$new_datetime['datetime_end'],
+			'Cloned event should have the same end datetime.'
+		);
+		$this->assertSame(
+			'America/New_York',
+			$new_datetime['timezone'],
+			'Cloned event should have the same timezone.'
+		);
+	}
+
+	/**
+	 * Coverage for sync_duplicated_event with a non-event post.
+	 *
+	 * @covers ::sync_duplicated_event
+	 *
+	 * @return void
+	 */
+	public function test_sync_duplicated_event_non_event(): void {
+		$instance = Setup::get_instance();
+
+		$post_id = $this->factory->post->create(
+			array( 'post_type' => 'post' )
+		);
+
+		// Should return early without error.
+		$instance->sync_duplicated_event( $post_id );
+
+		$this->assertTrue( true, 'Should handle non-event posts gracefully.' );
+	}
+
+	/**
+	 * Coverage for sync_duplicated_event with no datetime meta.
+	 *
+	 * @covers ::sync_duplicated_event
+	 *
+	 * @return void
+	 */
+	public function test_sync_duplicated_event_no_datetime(): void {
+		$instance = Setup::get_instance();
+
+		$post_id = $this->factory->post->create(
+			array( 'post_type' => Event::POST_TYPE )
+		);
+
+		// No datetime meta — should return early.
+		$instance->sync_duplicated_event( $post_id );
+
+		$event    = new Event( $post_id );
+		$datetime = $event->get_datetime();
+
+		$this->assertEmpty(
+			$datetime['datetime_start'],
+			'Event with no meta should have empty datetime.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Adds integration with the Yoast Duplicate Post plugin so that event datetime data is properly cloned when duplicating an event.

## Problem

When using the Duplicate Post plugin to clone a GatherPress event, post meta was copied but the custom `gatherpress_events` table was not populated. This meant the cloned event appeared to have no datetime set, requiring users to manually re-enter it.

## Solution

- New `includes/integrations/` directory structure for third-party plugin integrations
- `Integrations\Setup` bootstraps all integrations from `Core\Setup`
- `Integrations\Duplicate_Post\Setup` hooks into `duplicate_post_post_copy` and syncs the custom events table from the cloned post meta
- Full test coverage: hook registration, event sync, non-event handling, and no-datetime edge case

## Test plan

- [ ] Install and activate the Duplicate Post plugin
- [ ] Create an event with a date, time, and timezone
- [ ] Clone the event using Duplicate Post
- [ ] Verify the cloned event has the same datetime in the editor
- [ ] Verify non-event posts are unaffected by the integration
- [ ] PHP lint, PHPStan, and unit tests pass

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1246

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
