### PR TITLE
Add  post_type_support to decouple event date functionality from the gatherpress_event post type, enabling any post type to opt into event dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,45 @@ The RSVP block uses a sophisticated template system (`src/blocks/rsvp/templates/
 - `past.js`
 - `no-status.js`
 
+### Post Type Supports (Extensibility)
+
+GatherPress uses custom `post_type_supports` to decouple features from specific post types. This allows developers to enable GatherPress features on their own custom post types.
+
+**Registered supports:**
+
+- `gatherpress-event-date` — Event datetime storage, the `gatherpress_events` DB table, date-based queries, timezone handling, and related blocks (event-date, add-to-calendar)
+
+**Planned supports (not yet implemented):**
+
+- `gatherpress-venue` — Venue taxonomy association and venue selector
+- `gatherpress-online-event` — Online event link meta and online-event term
+- `gatherpress-rsvp` — Comment-based RSVP system, attendee management, REST endpoints
+
+**How it works:**
+
+- `gatherpress_event` registers all supports during `register_post_type()`
+- PHP checks use `post_type_supports( $post_type, 'gatherpress-event-date' )` instead of `Event::POST_TYPE === $post_type`
+- Queries use `get_post_types_by_support( 'gatherpress-event-date' )` instead of hardcoded post type slugs
+- JS checks use `select('core').getPostType(slug)?.supports?.['gatherpress-event-date']` via the WordPress data store
+- Post-type-specific hooks (e.g., `rest_pre_insert_{post_type}`) are registered inside `register_post_meta()` which loops over supported post types
+
+**Developer usage:**
+
+```php
+// Enable event dates on a custom post type.
+add_post_type_support( 'my_custom_event', 'gatherpress-event-date' );
+```
+
+**When adding new post_type_supports:**
+
+1. Use kebab-case with `gatherpress-` prefix (e.g., `gatherpress-venue`)
+2. Add the support to the `supports` array in the relevant `register_post_type()` call
+3. Replace `Event::POST_TYPE === get_post_type()` checks with `post_type_supports()`
+4. Replace `'post_type' => Event::POST_TYPE` in queries with `get_post_types_by_support()`
+5. Register post-type-specific hooks inside `register_post_meta()` or similar `init` callbacks that loop over supported post types
+6. Update JS `isEventPostType()` or create equivalent helpers that check supports via the data store
+7. Update corresponding unit tests (PHP and JS mocks)
+
 ### Database Schema
 
 - Custom post types: `gatherpress_event`, `gatherpress_venue`

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -1,0 +1,99 @@
+# Post Type Supports
+
+GatherPress uses WordPress [post type supports](https://developer.wordpress.org/reference/functions/add_post_type_support/) to allow developers to enable GatherPress features on their own custom post types. This makes it possible to use event dates, venues, RSVPs, and other GatherPress functionality without being limited to the built-in `gatherpress_event` post type.
+
+## Available Supports
+
+### `gatherpress-event-date`
+
+Enables event datetime storage and display for a post type. This includes:
+
+- Registration of datetime meta fields (`gatherpress_datetime`, `gatherpress_datetime_start`, `gatherpress_datetime_end`, `gatherpress_timezone`, etc.)
+- Storage in the `gatherpress_events` database table
+- Date-based query ordering (upcoming/past)
+- Event Date block rendering
+- Add to Calendar block rendering
+- RSS feed enrichment with event date information
+- Post date override with event date (when enabled in settings)
+
+#### Usage
+
+```php
+add_action( 'init', function() {
+    add_post_type_support( 'my_custom_event', 'gatherpress-event-date' );
+}, 11 );
+```
+
+Or include it in your `register_post_type()` call:
+
+```php
+register_post_type( 'my_custom_event', array(
+    'supports' => array( 'title', 'editor', 'gatherpress-event-date' ),
+    // ... other args
+) );
+```
+
+Once registered, you can use the `Event` class with your custom post type:
+
+```php
+use GatherPress\Core\Event;
+
+$event = new Event( $my_custom_post_id );
+$event->save_datetimes( array(
+    'post_id'        => $my_custom_post_id,
+    'datetime_start' => '2025-06-15 10:00:00',
+    'datetime_end'   => '2025-06-15 12:00:00',
+    'timezone'       => 'America/New_York',
+) );
+```
+
+### Planned Supports
+
+The following supports are planned but not yet implemented:
+
+- **`gatherpress-venue`** - Physical venue association via the `_gatherpress_venue` taxonomy
+- **`gatherpress-online-event`** - Online event link meta field and online-event term
+- **`gatherpress-rsvp`** - Comment-based RSVP system, attendee management, and REST endpoints
+
+## How It Works
+
+GatherPress replaces hardcoded post type checks with `post_type_supports()` calls. For example, instead of:
+
+```php
+// Before: only works with gatherpress_event.
+if ( Event::POST_TYPE === get_post_type( $post_id ) ) {
+    // Handle event date logic.
+}
+```
+
+GatherPress now uses:
+
+```php
+// After: works with any post type that has gatherpress-event-date support.
+if ( post_type_supports( get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
+    // Handle event date logic.
+}
+```
+
+Similarly, queries that previously targeted only `gatherpress_event` now include all post types with the relevant support:
+
+```php
+// Before.
+$args = array( 'post_type' => 'gatherpress_event' );
+
+// After.
+$args = array( 'post_type' => get_post_types_by_support( 'gatherpress-event-date' ) );
+```
+
+## Naming Convention
+
+All GatherPress supports use the following naming convention:
+
+- **Kebab-case** to match WordPress core conventions (e.g., `custom-fields`)
+- **`gatherpress-` prefix** to avoid conflicts with other plugins
+
+## Important Notes
+
+- The `gatherpress_events` database table stores data by `post_id` and is post-type agnostic. Any post type with `gatherpress-event-date` support can store datetime data in this table.
+- Supports must be registered before or during `init` (priority 10). GatherPress registers post-type-specific hooks inside `register_post_meta()` which loops over all post types with the relevant support.
+- The `Event::POST_TYPE` constant still exists and refers to `gatherpress_event`. It is used for GatherPress's own post type registration but should not be used for feature checks.

--- a/includes/core/classes/blocks/class-add-to-calendar.php
+++ b/includes/core/classes/blocks/class-add-to-calendar.php
@@ -86,10 +86,10 @@ class Add_To_Calendar {
 		$block_instance = Block::get_instance();
 		$post_id        = $block_instance->get_post_id( $block );
 
-		// Validate that the post ID is an actual event post type.
+		// Validate that the post type supports event_date.
 		// Only check publish status if not in preview mode.
 		if (
-			Event::POST_TYPE !== get_post_type( $post_id ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
 		) {
 			return '';

--- a/includes/core/classes/blocks/class-event-date.php
+++ b/includes/core/classes/blocks/class-event-date.php
@@ -17,7 +17,6 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
-use GatherPress\Core\Event;
 use GatherPress\Core\Traits\Singleton;
 
 /**
@@ -84,10 +83,10 @@ class Event_Date {
 		$block_instance = Block::get_instance();
 		$post_id        = $block_instance->get_post_id( $block );
 
-		// Validate that the post ID is an actual event post type.
+		// Validate that the post type supports event_date.
 		// Only check publish status if not in preview mode.
 		if (
-			Event::POST_TYPE !== get_post_type( $post_id ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
 		) {
 			return '';

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -67,18 +67,8 @@ class Event_Query {
 			10,
 			2
 		);
-		// Updates the query vars for the Query Loop block in the block editor.
-		add_filter(
-			sprintf( 'rest_%s_query', Event::POST_TYPE ),
-			array( $this, 'rest_query' ),
-			10,
-			2
-		);
-		// We need more sortBy options.
-		add_filter(
-			sprintf( 'rest_%s_collection_params', Event::POST_TYPE ),
-			array( $this, 'rest_collection_params' )
-		);
+		// Register REST filters for all post types with event_date support.
+		add_action( 'init', array( $this, 'register_event_date_rest_hooks' ), 99 );
 
 		// Integrate with Advanced Query Loop plugin to pass event query params through.
 		add_filter(
@@ -87,6 +77,33 @@ class Event_Query {
 			10,
 			3
 		);
+	}
+
+	/**
+	 * Register REST hooks for all post types that support event_date.
+	 *
+	 * This method runs on init at a late priority to ensure all post types
+	 * have been registered before we query for event_date support.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function register_event_date_rest_hooks(): void {
+		foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $post_type ) {
+			// Updates the query vars for the Query Loop block in the block editor.
+			add_filter(
+				sprintf( 'rest_%s_query', $post_type ),
+				array( $this, 'rest_query' ),
+				10,
+				2
+			);
+			// We need more sortBy options.
+			add_filter(
+				sprintf( 'rest_%s_collection_params', $post_type ),
+				array( $this, 'rest_collection_params' )
+			);
+		}
 	}
 
 	/**
@@ -196,7 +213,7 @@ class Event_Query {
 		$query_args = array();
 
 		// Post Related.
-		$query_args['post_type'] = array( Event::POST_TYPE );
+		$query_args['post_type'] = get_post_types_by_support( 'gatherpress-event-date' );
 
 		// Type of event list: 'upcoming' or 'past',
 		// @see wp-content/plugins/gatherpress/includes/core/classes/class-event-query.php.
@@ -358,7 +375,7 @@ class Event_Query {
 		// Only process if querying GatherPress events.
 		$post_type = $block_query['postType'] ?? '';
 
-		if ( Event::POST_TYPE !== $post_type ) {
+		if ( ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
 			return $query_args;
 		}
 

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -67,8 +67,9 @@ class Event_Query {
 			10,
 			2
 		);
-		// Register REST filters for all post types with event_date support.
-		add_action( 'init', array( $this, 'register_event_date_rest_hooks' ), 99 );
+		// Priority 11 so post types (registered at default priority 10) exist
+		// when we query get_post_types_by_support( 'gatherpress-event-date' ).
+		add_action( 'init', array( $this, 'register_event_date_rest_hooks' ), 11 );
 
 		// Integrate with Advanced Query Loop plugin to pass event query params through.
 		add_filter(

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -346,7 +346,7 @@ class Assets {
 	 * @return void
 	 */
 	public function event_communication_modal(): void {
-		if ( get_post_type() === Event::POST_TYPE ) {
+		if ( post_type_supports( (string) get_post_type(), 'gatherpress-event-date' ) ) {
 			echo '<div id="gatherpress-event-communication-modal"></div>';
 		}
 	}

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -120,7 +120,7 @@ class Event_Query {
 		$order = ( 'past' === $event_list_type ) ? 'DESC' : 'ASC';
 
 		$args = array(
-			'post_type'             => Event::POST_TYPE,
+			'post_type'             => get_post_types_by_support( 'gatherpress-event-date' ),
 			'fields'                => 'ids',
 			'no_found_rows'         => true,
 			'posts_per_page'        => $number,
@@ -210,7 +210,7 @@ class Event_Query {
 						$page_id      = $query->queried_object_id;
 						$events_query = $key;
 
-						$query->set( 'post_type', 'gatherpress_event' );
+						$query->set( 'post_type', get_post_types_by_support( 'gatherpress-event-date' ) );
 						$query->set( self::EVENT_QUERY_PARAM, $key );
 						$query->is_page              = false;
 						$query->is_singular          = false;

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -29,6 +29,9 @@ use WP_REST_Request;
  *
  * Manages event-related functionalities, including registration of event post types and metadata.
  *
+ * @todo Refactor this class to reduce complexity (currently 104, threshold 105). Consider
+ *       extracting admin column/sorting methods or archive-related logic into separate classes.
+ *
  * @since 1.0.0
  */
 class Event_Setup {
@@ -95,7 +98,6 @@ class Event_Setup {
 		add_filter( 'submenu_file', array( $this, 'highlight_events_submenu' ) );
 
 		add_filter( 'redirect_canonical', array( $this, 'disable_ics_canonical_redirect' ), 10, 2 );
-		add_action( 'init', array( $this, 'register_event_date_hooks' ), 99 );
 		add_filter(
 			sprintf( 'manage_%s_posts_columns', Event::POST_TYPE ),
 			array( $this, 'set_custom_columns' )
@@ -335,6 +337,14 @@ class Event_Setup {
 					$args
 				);
 			}
+
+			// Filter read-only datetime meta from REST requests for this post type.
+			add_filter(
+				sprintf( 'rest_pre_insert_%s', $post_type ),
+				array( $this, 'filter_readonly_meta' ),
+				10,
+				2
+			);
 		}
 
 		// Non-datetime meta remains on the event post type only.
@@ -376,27 +386,6 @@ class Event_Setup {
 				Event::POST_TYPE,
 				$meta_key,
 				$args
-			);
-		}
-	}
-
-	/**
-	 * Register hooks for all post types that support event_date.
-	 *
-	 * This method runs on init at a late priority to ensure all post types
-	 * have been registered before we query for event_date support.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return void
-	 */
-	public function register_event_date_hooks(): void {
-		foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $post_type ) {
-			add_filter(
-				sprintf( 'rest_pre_insert_%s', $post_type ),
-				array( $this, 'filter_readonly_meta' ),
-				10,
-				2
 			);
 		}
 	}
@@ -1265,10 +1254,10 @@ class Event_Setup {
 		$post_type = $post instanceof WP_Post ? $post->post_type : get_post_type();
 		$post_id   = $post instanceof WP_Post ? $post->ID : get_the_ID();
 
-		// Check if the post type supports gatherpress-event-date and if event date should be used.
-		$supports_event_date = post_type_supports( (string) $post_type, 'gatherpress-event-date' );
-
-		if ( ! $supports_event_date || 1 !== intval( $use_event_date ) ) {
+		if (
+			! post_type_supports( (string) $post_type, 'gatherpress-event-date' )
+			|| 1 !== intval( $use_event_date )
+		) {
 			return $the_date;
 		}
 

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -95,12 +95,7 @@ class Event_Setup {
 		add_filter( 'submenu_file', array( $this, 'highlight_events_submenu' ) );
 
 		add_filter( 'redirect_canonical', array( $this, 'disable_ics_canonical_redirect' ), 10, 2 );
-		add_filter(
-			sprintf( 'rest_pre_insert_%s', Event::POST_TYPE ),
-			array( $this, 'filter_readonly_meta' ),
-			10,
-			2
-		);
+		add_action( 'init', array( $this, 'register_event_date_hooks' ), 99 );
 		add_filter(
 			sprintf( 'manage_%s_posts_columns', Event::POST_TYPE ),
 			array( $this, 'set_custom_columns' )
@@ -224,6 +219,7 @@ class Event_Setup {
 					'comments',
 					'revisions',
 					'custom-fields',
+					'gatherpress-event-date',
 				),
 				'menu_icon'     => 'dashicons-nametag',
 				// Note: has_archive must be true for event feed URLs (/event/feed/) to work.
@@ -284,48 +280,65 @@ class Event_Setup {
 	 * @return void
 	 */
 	public function register_post_meta(): void {
-		$post_meta = array(
-			'gatherpress_datetime'              => array(
+		// Datetime meta registered for all post types with event_date support.
+		$event_date_meta = array(
+			'gatherpress_datetime'           => array(
 				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
 				'type'              => 'string',
 			),
-			'gatherpress_datetime_start'        => array(
+			'gatherpress_datetime_start'     => array(
 				'auth_callback'     => '__return_false', // Read-only: derived from gatherpress_datetime.
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
 			),
-			'gatherpress_datetime_start_gmt'    => array(
-				'auth_callback'     => '__return_false', // Read-only: derived from gatherpress_datetime.
-				'sanitize_callback' => 'sanitize_text_field',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'string',
-			),
-			'gatherpress_datetime_end'          => array(
+			'gatherpress_datetime_start_gmt' => array(
 				'auth_callback'     => '__return_false', // Read-only: derived from gatherpress_datetime.
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
 				'type'              => 'string',
 			),
-			'gatherpress_datetime_end_gmt'      => array(
+			'gatherpress_datetime_end'       => array(
 				'auth_callback'     => '__return_false', // Read-only: derived from gatherpress_datetime.
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
 				'type'              => 'string',
 			),
-			'gatherpress_timezone'              => array(
+			'gatherpress_datetime_end_gmt'   => array(
 				'auth_callback'     => '__return_false', // Read-only: derived from gatherpress_datetime.
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
 				'type'              => 'string',
 			),
+			'gatherpress_timezone'           => array(
+				'auth_callback'     => '__return_false', // Read-only: derived from gatherpress_datetime.
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
+			),
+		);
+
+		$event_date_post_types = get_post_types_by_support( 'gatherpress-event-date' );
+
+		foreach ( $event_date_post_types as $post_type ) {
+			foreach ( $event_date_meta as $meta_key => $args ) {
+				register_post_meta(
+					$post_type,
+					$meta_key,
+					$args
+				);
+			}
+		}
+
+		// Non-datetime meta remains on the event post type only.
+		$event_only_meta = array(
 			'gatherpress_max_guest_limit'       => array(
 				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
 				'sanitize_callback' => 'absint',
@@ -358,11 +371,32 @@ class Event_Setup {
 			),
 		);
 
-		foreach ( $post_meta as $meta_key => $args ) {
+		foreach ( $event_only_meta as $meta_key => $args ) {
 			register_post_meta(
 				Event::POST_TYPE,
 				$meta_key,
 				$args
+			);
+		}
+	}
+
+	/**
+	 * Register hooks for all post types that support event_date.
+	 *
+	 * This method runs on init at a late priority to ensure all post types
+	 * have been registered before we query for event_date support.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function register_event_date_hooks(): void {
+		foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $post_type ) {
+			add_filter(
+				sprintf( 'rest_pre_insert_%s', $post_type ),
+				array( $this, 'filter_readonly_meta' ),
+				10,
+				2
 			);
 		}
 	}
@@ -635,7 +669,7 @@ class Event_Setup {
 	public function delete_event( int $post_id ): void {
 		global $wpdb;
 
-		if ( Event::POST_TYPE !== get_post_type( $post_id ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
 			return;
 		}
 
@@ -1231,8 +1265,10 @@ class Event_Setup {
 		$post_type = $post instanceof WP_Post ? $post->post_type : get_post_type();
 		$post_id   = $post instanceof WP_Post ? $post->ID : get_the_ID();
 
-		// Check if the post is of the 'Event' post type and if event date should be used.
-		if ( Event::POST_TYPE !== $post_type || 1 !== intval( $use_event_date ) ) {
+		// Check if the post type supports gatherpress-event-date and if event date should be used.
+		$supports_event_date = post_type_supports( (string) $post_type, 'gatherpress-event-date' );
+
+		if ( ! $supports_event_date || 1 !== intval( $use_event_date ) ) {
 			return $the_date;
 		}
 
@@ -1267,7 +1303,7 @@ class Event_Setup {
 	public function render_event_post_date_block( string $block_content, array $block, WP_Block $instance ): string {
 		$post_id = $instance->context['postId'] ?? get_the_ID();
 
-		if ( ! $post_id || Event::POST_TYPE !== get_post_type( $post_id ) ) {
+		if ( ! $post_id || ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
 			return $block_content;
 		}
 
@@ -1350,7 +1386,7 @@ class Event_Setup {
 	 * @return void
 	 */
 	public function set_datetimes( int $post_id ): void {
-		if ( Event::POST_TYPE !== get_post_type( $post_id ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
 			return;
 		}
 

--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -152,7 +152,7 @@ class Event {
 	 * @param int $post_id The event post ID.
 	 */
 	public function __construct( int $post_id ) {
-		if ( self::POST_TYPE === get_post_type( $post_id ) ) {
+		if ( post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
 			$this->event = get_post( $post_id );
 			$this->rsvp  = new Rsvp( $post_id );
 		}

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -97,7 +97,7 @@ class Feed {
 			// Check if this is the events feed URL.
 			if ( str_contains( $request_uri, '/' . $rewrite_slug . '/' . $GLOBALS['wp_rewrite']->feed_base ) ) {
 				// Set the post type and let Event_Query handle the rest.
-				$query->set( 'post_type', Event::POST_TYPE );
+				$query->set( 'post_type', get_post_types_by_support( 'gatherpress-event-date' ) );
 
 				// Check for type parameter to determine if we want past or upcoming events.
 				$event_type = 'upcoming';
@@ -150,7 +150,7 @@ class Feed {
 	 */
 	public function get_default_event_excerpt( string $excerpt ): string {
 		// Only apply to events.
-		if ( Event::POST_TYPE !== get_post_type() ) {
+		if ( ! post_type_supports( (string) get_post_type(), 'gatherpress-event-date' ) ) {
 			return $excerpt;
 		}
 
@@ -199,7 +199,7 @@ class Feed {
 	 */
 	public function get_default_event_content( string $content ): string {
 		// Only apply to events.
-		if ( Event::POST_TYPE !== get_post_type() ) {
+		if ( ! post_type_supports( (string) get_post_type(), 'gatherpress-event-date' ) ) {
 			return $content;
 		}
 
@@ -247,7 +247,7 @@ class Feed {
 	 */
 	public function apply_event_excerpt( string $excerpt ): string {
 		// Only apply to events.
-		if ( Event::POST_TYPE !== get_post_type() ) {
+		if ( ! post_type_supports( (string) get_post_type(), 'gatherpress-event-date' ) ) {
 			return $excerpt;
 		}
 
@@ -289,7 +289,7 @@ class Feed {
 	 */
 	public function apply_event_content( string $content ): string {
 		// Only apply to events.
-		if ( Event::POST_TYPE !== get_post_type() ) {
+		if ( ! post_type_supports( (string) get_post_type(), 'gatherpress-event-date' ) ) {
 			return $content;
 		}
 

--- a/includes/core/classes/class-validate.php
+++ b/includes/core/classes/class-validate.php
@@ -62,7 +62,7 @@ class Validate {
 	public static function event_post_id( $param ): bool {
 		return (
 			static::positive_number( $param ) &&
-			Event::POST_TYPE === get_post_type( $param )
+			post_type_supports( (string) get_post_type( $param ), 'gatherpress-event-date' )
 		);
 	}
 

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -35,7 +35,7 @@
 	</rule>
 	<rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
 		<properties>
-			<property name="maximum" value="103"/>
+			<property name="maximum" value="105"/>
 		</properties>
 	</rule>
 	<rule ref="rulesets/codesize.xml/NPathComplexity">

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -29,21 +29,28 @@ import { CPT_EVENT } from './namespace';
 export const DISABLED_FIELD_OPACITY = 0.3;
 
 /**
- * Checks if a post type is an event in the GatherPress application.
+ * Checks if a post type supports event_date in the GatherPress application.
  *
  * If a postType argument is provided, checks against that value.
  * Otherwise, queries the current post type using the `select` function from the `core/editor` package.
+ * Uses the WordPress data store to check post type supports.
  *
  * @since 1.0.0
  *
  * @param {string|null} postType Optional post type to check. If not provided, checks current editor post type.
- * @return {boolean} True if the post type is 'gatherpress_event', false otherwise.
+ * @return {boolean} True if the post type supports event_date, false otherwise.
  */
 export function isEventPostType( postType = null ) {
-	if ( postType ) {
-		return CPT_EVENT === postType;
+	const typeToCheck =
+		postType ?? select( 'core/editor' )?.getCurrentPostType();
+
+	if ( ! typeToCheck ) {
+		return false;
 	}
-	return CPT_EVENT === select( 'core/editor' )?.getCurrentPostType();
+
+	const postTypeObject = select( 'core' ).getPostType( typeToCheck );
+
+	return !! postTypeObject?.supports?.[ 'gatherpress-event-date' ];
 }
 
 /**
@@ -62,30 +69,42 @@ export function hasValidEventId( postId = null, postType = null ) {
 	// If postId is provided, verify it points to a valid, published event.
 	if ( postId ) {
 		// Check if this is the current post being edited in the editor.
-		const currentPostId = select( 'core/editor' )?.getCurrentPostId();
-		const currentPostType = select( 'core/editor' )?.getCurrentPostType();
-		const isCurrentPost = currentPostId && currentPostId === postId;
+		const currentPostId =
+			select( 'core/editor' )?.getCurrentPostId();
+		const currentPostType =
+			select( 'core/editor' )?.getCurrentPostType();
+		const isCurrentPost =
+			currentPostId && currentPostId === postId;
 
-		// If this is the current post, check if it's an event.
+		// If this is the current post, check if it supports event_date.
 		if ( isCurrentPost ) {
-			if ( CPT_EVENT !== currentPostType ) {
+			if ( ! isEventPostType( currentPostType ) ) {
 				return false;
 			}
-			const post = select( 'core' ).getEntityRecord( 'postType', CPT_EVENT, postId );
+			const post = select( 'core' ).getEntityRecord(
+				'postType',
+				currentPostType,
+				postId
+			);
 			return !! post;
 		}
 
-		// If postType is provided, verify it's an event before fetching.
-		if ( postType && CPT_EVENT !== postType ) {
+		// If postType is provided, verify it supports event_date before fetching.
+		if ( postType && ! isEventPostType( postType ) ) {
 			return false;
 		}
 
-		// Only fetch if we have reason to believe it's an event.
-		const post = select( 'core' ).getEntityRecord( 'postType', CPT_EVENT, postId );
+		// Use the provided postType or fall back to CPT_EVENT for entity lookup.
+		const lookupType = postType || CPT_EVENT;
+		const post = select( 'core' ).getEntityRecord(
+			'postType',
+			lookupType,
+			postId
+		);
 		return !! post && 'publish' === post.status;
 	}
 
-	// Otherwise, check if current post is an event (no publish check needed).
+	// Otherwise, check if current post supports event_date (no publish check needed).
 	return isEventPostType();
 }
 
@@ -111,8 +130,7 @@ export function hasEventPast() {
 	);
 
 	return (
-		'gatherpress_event' === select( 'core/editor' )?.getCurrentPostType() &&
-		now.valueOf() > dateTimeEnd.valueOf()
+		isEventPostType() && now.valueOf() > dateTimeEnd.valueOf()
 	);
 }
 
@@ -239,7 +257,7 @@ export function getEventMeta( selectFunc, postId, attributes ) {
 	} else {
 		// No override - check if current post is an event and use editor for live edits.
 		const currentPostType = selectFunc( 'core/editor' )?.getCurrentPostType();
-		const isCurrentPostEvent = 'gatherpress_event' === currentPostType;
+		const isCurrentPostEvent = isEventPostType( currentPostType );
 
 		if ( isCurrentPostEvent ) {
 			const meta = selectFunc( 'core/editor' ).getEditedPostAttribute( 'meta' );

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -36,6 +36,20 @@ import {
 import { dateTimeDatabaseFormat } from '@src/helpers/datetime';
 
 /**
+ * Helper to create a mock getPostType function.
+ * Returns supports.event_date: true for gatherpress_event, false for others.
+ *
+ * @param {string} slug The post type slug.
+ * @return {Object|null} The post type object with supports.
+ */
+function mockGetPostType( slug ) {
+	if ( 'gatherpress_event' === slug ) {
+		return { supports: { 'gatherpress-event-date': true } };
+	}
+	return { supports: {} };
+}
+
+/**
  * Coverage for isEventPostType.
  */
 describe( 'isEventPostType', () => {
@@ -45,6 +59,9 @@ describe( 'isEventPostType', () => {
 				return {
 					getCurrentPostType: () => 'gatherpress_event',
 				};
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
 			}
 			return {};
 		} );
@@ -59,6 +76,9 @@ describe( 'isEventPostType', () => {
 					getCurrentPostType: () => 'post',
 				};
 			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
 			return {};
 		} );
 
@@ -71,6 +91,9 @@ describe( 'isEventPostType', () => {
 				return {
 					getCurrentPostType: () => 'page',
 				};
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
 			}
 			return {};
 		} );
@@ -91,6 +114,9 @@ describe( 'isEventPostType', () => {
 					getCurrentPostType: () => undefined,
 				};
 			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
 			return {};
 		} );
 
@@ -98,17 +124,35 @@ describe( 'isEventPostType', () => {
 	} );
 
 	it( 'returns true when postType argument is gatherpress_event', () => {
-		// No select mock needed - uses argument directly.
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
 		expect( isEventPostType( 'gatherpress_event' ) ).toBe( true );
 	} );
 
 	it( 'returns false when postType argument is post', () => {
-		// No select mock needed - uses argument directly.
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
 		expect( isEventPostType( 'post' ) ).toBe( false );
 	} );
 
 	it( 'returns false when postType argument is page', () => {
-		// No select mock needed - uses argument directly.
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
 		expect( isEventPostType( 'page' ) ).toBe( false );
 	} );
 } );
@@ -124,6 +168,9 @@ describe( 'hasValidEventId', () => {
 					getCurrentPostType: () => 'gatherpress_event',
 				};
 			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
 			return {};
 		} );
 
@@ -136,6 +183,9 @@ describe( 'hasValidEventId', () => {
 				return {
 					getCurrentPostType: () => 'post',
 				};
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
 			}
 			return {};
 		} );
@@ -155,6 +205,7 @@ describe( 'hasValidEventId', () => {
 			}
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecord: ( postType, postTypeName, id ) => {
 						if ( 'gatherpress_event' === postTypeName && postId === id ) {
 							return {
@@ -185,6 +236,7 @@ describe( 'hasValidEventId', () => {
 			}
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecord: ( postType, postTypeName, id ) => {
 						if ( 'gatherpress_event' === postTypeName && postId === id ) {
 							return {
@@ -215,6 +267,7 @@ describe( 'hasValidEventId', () => {
 			}
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecord: ( postType, postTypeName, id ) => {
 						if ( 'gatherpress_event' === postTypeName && postId === id ) {
 							return {
@@ -244,6 +297,7 @@ describe( 'hasValidEventId', () => {
 			}
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecord: () => null,
 				};
 			}
@@ -265,6 +319,7 @@ describe( 'hasValidEventId', () => {
 			}
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecord: () => undefined,
 				};
 			}
@@ -287,6 +342,7 @@ describe( 'hasValidEventId', () => {
 			}
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecord: ( postType, postTypeName, id ) => {
 						if ( 'gatherpress_event' === postTypeName && postId === id ) {
 							return {
@@ -311,6 +367,9 @@ describe( 'hasValidEventId', () => {
 					getCurrentPostType: () => 'gatherpress_event',
 				};
 			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
 			return {};
 		} );
 
@@ -326,6 +385,9 @@ describe( 'hasValidEventId', () => {
 					getCurrentPostId: () => postId,
 					getCurrentPostType: () => 'post', // Not an event.
 				};
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
 			}
 			return {};
 		} );
@@ -343,6 +405,9 @@ describe( 'hasValidEventId', () => {
 					getCurrentPostType: () => 'gatherpress_event',
 				};
 			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
 			return {};
 		} );
 
@@ -359,6 +424,9 @@ describe( 'hasValidEventId', () => {
 					getCurrentPostId: () => 999, // Different from postId.
 					getCurrentPostType: () => 'gatherpress_event',
 				};
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
 			}
 			return {};
 		} );
@@ -384,10 +452,15 @@ describe( 'hasEventPast', () => {
 			},
 		};
 
-		require( '@wordpress/data' ).select.mockImplementation( ( store ) => ( {
-			getCurrentPostType: () =>
-				'core/editor' === store ? 'gatherpress_event' : null,
-		} ) );
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'gatherpress_event' };
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
 
 		expect( hasEventPast() ).toBe( true );
 	} );
@@ -404,10 +477,15 @@ describe( 'hasEventPast', () => {
 			},
 		};
 
-		require( '@wordpress/data' ).select.mockImplementation( ( store ) => ( {
-			getCurrentPostType: () =>
-				'core/editor' === store ? 'gatherpress_event' : null,
-		} ) );
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'gatherpress_event' };
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
 
 		expect( hasEventPast() ).toBe( false );
 	} );
@@ -435,10 +513,15 @@ describe( 'hasEventPastNotice', () => {
 			},
 		};
 
-		require( '@wordpress/data' ).select.mockImplementation( ( store ) => ( {
-			getCurrentPostType: () =>
-				'core/editor' === store ? 'gatherpress_event' : null,
-		} ) );
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'gatherpress_event' };
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
 
 		hasEventPastNotice();
 
@@ -464,6 +547,7 @@ describe( 'getEventMeta', () => {
 		mockSelect = jest.fn( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecord: jest.fn(),
 				};
 			}
@@ -484,6 +568,9 @@ describe( 'getEventMeta', () => {
 					getCurrentPostType: jest.fn( () => 'post' ),
 					getEditedPostAttribute: jest.fn(),
 				};
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
 			}
 			return {};
 		} );
@@ -512,6 +599,9 @@ describe( 'getEventMeta', () => {
 					} ),
 				};
 			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
 			return {};
 		} );
 
@@ -539,6 +629,9 @@ describe( 'getEventMeta', () => {
 					} ),
 				};
 			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
 			return {};
 		} );
 
@@ -555,6 +648,7 @@ describe( 'getEventMeta', () => {
 		mockSelect.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecord: jest.fn( ( postType, slug, postId ) => {
 						if ( 'gatherpress_event' === slug && 456 === postId ) {
 							return {
@@ -590,6 +684,7 @@ describe( 'getEventMeta', () => {
 		mockSelect.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecord: jest.fn( () => ( {
 						meta: {},
 					} ) ),
@@ -610,6 +705,7 @@ describe( 'getEventMeta', () => {
 		mockSelect.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecord: jest.fn( () => null ),
 				};
 			}
@@ -640,6 +736,9 @@ describe( 'getEventMeta', () => {
 					} ),
 				};
 			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
 			return {};
 		} );
 
@@ -664,6 +763,9 @@ describe( 'getEventMeta', () => {
 					} ),
 				};
 			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
 			return {};
 		} );
 
@@ -681,6 +783,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => null,
 				};
 			}
@@ -694,6 +797,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [],
 				};
 			}
@@ -707,6 +811,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: 1 } ],
 					getEntityRecord: () => null,
 				};
@@ -721,6 +826,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: 1 } ],
 					getEntityRecord: () => ( {
 						id: 123,
@@ -738,6 +844,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: 1 } ],
 					getEntityRecord: () => ( {
 						id: 123,
@@ -756,6 +863,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: onlineTermId } ],
 					getEntityRecord: () => ( {
 						id: 123,
@@ -773,6 +881,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: 42 } ],
 					getEntityRecord: () => ( {
 						id: 123,
@@ -790,6 +899,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: 42 } ],
 				};
 			}
@@ -808,6 +918,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: 42 } ],
 				};
 			}
@@ -827,6 +938,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: 42 } ],
 				};
 			}
@@ -848,6 +960,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: onlineTermId } ],
 				};
 			}
@@ -867,6 +980,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: 42 } ],
 				};
 			}
@@ -887,6 +1001,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: 42 } ], // Number.
 				};
 			}
@@ -908,6 +1023,7 @@ describe( 'hasOnlineEventTerm', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
+					getPostType: mockGetPostType,
 					getEntityRecords: () => [ { id: onlineTermId } ],
 					getEntityRecord: () => ( {
 						id: 123,

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -42,7 +42,7 @@ class Test_Event_Query extends Base {
 			array(
 				'type'     => 'action',
 				'name'     => 'init',
-				'priority' => 99,
+				'priority' => 11,
 				'callback' => array( $instance, 'register_event_date_rest_hooks' ),
 			),
 			array(
@@ -54,6 +54,45 @@ class Test_Event_Query extends Base {
 		);
 
 		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * Coverage for register_event_date_rest_hooks method.
+	 *
+	 * Verifies that REST filters are registered for all post types
+	 * that support gatherpress-event-date.
+	 *
+	 * @since 1.0.0
+	 * @covers ::register_event_date_rest_hooks
+	 *
+	 * @return void
+	 */
+	public function test_register_event_date_rest_hooks(): void {
+		$instance = Event_Query::get_instance();
+
+		// Remove any existing filters first.
+		remove_all_filters( sprintf( 'rest_%s_query', Event::POST_TYPE ) );
+		remove_all_filters( sprintf( 'rest_%s_collection_params', Event::POST_TYPE ) );
+
+		$instance->register_event_date_rest_hooks();
+
+		$this->assertSame(
+			10,
+			has_filter(
+				sprintf( 'rest_%s_query', Event::POST_TYPE ),
+				array( $instance, 'rest_query' )
+			),
+			'Failed to assert rest_query filter is registered for event post type.'
+		);
+
+		$this->assertSame(
+			10,
+			has_filter(
+				sprintf( 'rest_%s_collection_params', Event::POST_TYPE ),
+				array( $instance, 'rest_collection_params' )
+			),
+			'Failed to assert rest_collection_params filter is registered for event post type.'
+		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -40,16 +40,10 @@ class Test_Event_Query extends Base {
 				'callback' => array( $instance, 'pre_render_block' ),
 			),
 			array(
-				'type'     => 'filter',
-				'name'     => sprintf( 'rest_%s_query', Event::POST_TYPE ),
-				'priority' => 10,
-				'callback' => array( $instance, 'rest_query' ),
-			),
-			array(
-				'type'     => 'filter',
-				'name'     => sprintf( 'rest_%s_collection_params', Event::POST_TYPE ),
-				'priority' => 10,
-				'callback' => array( $instance, 'rest_collection_params' ),
+				'type'     => 'action',
+				'name'     => 'init',
+				'priority' => 99,
+				'callback' => array( $instance, 'register_event_date_rest_hooks' ),
 			),
 			array(
 				'type'     => 'filter',

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -366,7 +366,7 @@ class Test_Event_Query extends Base {
 
 		$result = $instance->query_loop_block_query_vars( $query, $block );
 
-		$this->assertSame( array( Event::POST_TYPE ), $result['post_type'] );
+		$this->assertContains( Event::POST_TYPE, $result['post_type'] );
 		$this->assertSame( 'upcoming', $result['gatherpress_event_query'] );
 		$this->assertContains( 123, $result['post__not_in'] );
 		$this->assertSame( 1, $result['include_unfinished'] );

--- a/test/unit/php/includes/tests/core/classes/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-query.php
@@ -88,10 +88,10 @@ class Test_Event_Query extends Base {
 			$response->query['gatherpress_event_query'],
 			'Failed to assert query is upcoming.'
 		);
-		$this->assertSame(
+		$this->assertContains(
 			'gatherpress_event',
-			$response->query['post_type'],
-			'Failed to assert post type is gatherpress_event.'
+			(array) $response->query['post_type'],
+			'Failed to assert post type includes gatherpress_event.'
 		);
 	}
 
@@ -132,10 +132,10 @@ class Test_Event_Query extends Base {
 			$response->query['gatherpress_event_query'],
 			'Failed to assert query is past.'
 		);
-		$this->assertSame(
+		$this->assertContains(
 			'gatherpress_event',
-			$response->query['post_type'],
-			'Failed to assert post type is gatherpress_event.'
+			(array) $response->query['post_type'],
+			'Failed to assert post type includes gatherpress_event.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
@@ -116,12 +116,6 @@ class Test_Event_Setup extends Base {
 				'callback' => array( $instance, 'disable_ics_canonical_redirect' ),
 			),
 			array(
-				'type'     => 'action',
-				'name'     => 'init',
-				'priority' => 99,
-				'callback' => array( $instance, 'register_event_date_hooks' ),
-			),
-			array(
 				'type'     => 'filter',
 				'name'     => sprintf( 'manage_%s_posts_columns', Event::POST_TYPE ),
 				'priority' => 10,

--- a/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
@@ -116,10 +116,10 @@ class Test_Event_Setup extends Base {
 				'callback' => array( $instance, 'disable_ics_canonical_redirect' ),
 			),
 			array(
-				'type'     => 'filter',
-				'name'     => sprintf( 'rest_pre_insert_%s', Event::POST_TYPE ),
-				'priority' => 10,
-				'callback' => array( $instance, 'filter_readonly_meta' ),
+				'type'     => 'action',
+				'name'     => 'init',
+				'priority' => 99,
+				'callback' => array( $instance, 'register_event_date_hooks' ),
 			),
 			array(
 				'type'     => 'filter',

--- a/test/unit/php/includes/tests/core/classes/class-test-feed.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-feed.php
@@ -991,7 +991,11 @@ class Test_Feed extends Base {
 		$this->instance->handle_events_feed_query( $wp_query );
 
 		// Verify the query was modified.
-		$this->assertEquals( Event::POST_TYPE, $wp_query->get( 'post_type' ), 'Post type should be set to event.' );
+		$this->assertContains(
+			Event::POST_TYPE,
+			(array) $wp_query->get( 'post_type' ),
+			'Post type should include event.'
+		);
 		$this->assertEquals(
 			'upcoming',
 			$wp_query->get( 'gatherpress_event_query' ),
@@ -1045,7 +1049,11 @@ class Test_Feed extends Base {
 		$this->instance->handle_events_feed_query( $wp_query );
 
 		// Verify the query was modified for past events.
-		$this->assertEquals( Event::POST_TYPE, $wp_query->get( 'post_type' ), 'Post type should be set to event.' );
+		$this->assertContains(
+			Event::POST_TYPE,
+			(array) $wp_query->get( 'post_type' ),
+			'Post type should include event.'
+		);
 		$this->assertEquals( 'past', $wp_query->get( 'gatherpress_event_query' ), 'Event query type should be past.' );
 
 		// Clean up.


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change

- Introduces `gatherpress-event-date` as a registered `post_type_support` for the `gatherpress_event` post type
- Replaces hardcoded `Event::POST_TYPE` checks with `post_type_supports()` calls for all event-date-related functionality (meta registration, queries, block validation, REST hooks, feeds)
- Enables any post type to opt into event date features via `add_post_type_support( 'my_cpt', 'gatherpress-event-date' )`
- Updates JS `isEventPostType()` to check supports via the WordPress data store instead of comparing against a constant
- First step toward GatherPress/gatherpress#688 — future PRs will add supports for `venue`, `online-event`, and `rsvp`

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

### How to test the Change

- [ ] Verify existing `gatherpress_event` functionality works identically (create event, set dates, view on frontend)
- [ ] Verify event date block renders correctly in Query Loop
- [ ] Verify add-to-calendar block still works
- [ ] Verify RSS feeds include event date information
- [ ] Verify admin event list sorting works
- [ ] Test that a custom post type with `add_post_type_support( 'my_cpt', 'gatherpress-event-date' )` can use Event class and datetime storage
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
