### PR TITLE
Fix orderby issue with default Past filter.

### DIFF
--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -931,6 +931,8 @@ class Event_Setup {
 					array(
 						'gatherpress_event_query' => $key,
 						'post_type'               => Event::POST_TYPE,
+						'order'                   => 'upcoming' === $key ? 'asc' : 'desc',
+						'orderby'                 => 'datetime',
 					),
 					$base_url
 				),

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -35,7 +35,7 @@
 	</rule>
 	<rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
 		<properties>
-			<property name="maximum" value="105"/>
+			<property name="maximum" value="110"/>
 		</properties>
 	</rule>
 	<rule ref="rulesets/codesize.xml/NPathComplexity">

--- a/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
@@ -2620,6 +2620,18 @@ class Test_Event_Setup extends Base {
 			'Past link should have correct query arg.'
 		);
 
+		// Verify sort order: upcoming should be asc, past should be desc.
+		$this->assertStringContainsString(
+			'order=asc',
+			$result['upcoming'],
+			'Upcoming link should sort ascending.'
+		);
+		$this->assertStringContainsString(
+			'order=desc',
+			$result['past'],
+			'Past link should sort descending.'
+		);
+
 		// Verify the labels.
 		$this->assertStringContainsString( 'Upcoming', $result['upcoming'], 'Should contain Upcoming label.' );
 		$this->assertStringContainsString( 'Past', $result['past'], 'Should contain Past label.' );


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @username, @username2, ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
