### PR TITLE
Add  post_type_support to decouple RSVP functionality from the gatherpress_event post type, enabling any post type to opt into RSVPs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,12 +102,12 @@ GatherPress uses custom `post_type_supports` to decouple features from specific 
 **Registered supports:**
 
 - `gatherpress-event-date` — Event datetime storage, the `gatherpress_events` DB table, date-based queries, timezone handling, and related blocks (event-date, add-to-calendar)
+- `gatherpress-rsvp` — Comment-based RSVP system, attendee management, waiting list, RSVP blocks (rsvp, rsvp-form, rsvp-response, rsvp-template)
 
 **Planned supports (not yet implemented):**
 
 - `gatherpress-venue` — Venue taxonomy association and venue selector
 - `gatherpress-online-event` — Online event link meta and online-event term
-- `gatherpress-rsvp` — Comment-based RSVP system, attendee management, REST endpoints
 
 **How it works:**
 

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -16,7 +16,7 @@ Enables event datetime storage and display for a post type. This includes:
 - RSS feed enrichment with event date information
 - Post date override with event date (when enabled in settings)
 
-#### Usage
+#### Usage for gatherpress-event-date
 
 ```php
 add_action( 'init', function() {
@@ -57,7 +57,7 @@ Enables the comment-based RSVP system for a post type. This includes:
 - RSVP token-based email verification for anonymous attendees
 - Comment count adjustment to reflect RSVP activity
 
-#### Usage
+#### Usage for gatherpress-rsvp
 
 ```php
 add_action( 'init', function() {

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -47,13 +47,39 @@ $event->save_datetimes( array(
 ) );
 ```
 
+### `gatherpress-rsvp`
+
+Enables the comment-based RSVP system for a post type. This includes:
+
+- RSVP response tracking (attending, not attending, waiting list)
+- Attendee management and waiting list processing
+- RSVP blocks rendering (rsvp, rsvp-form, rsvp-response, rsvp-template)
+- RSVP token-based email verification for anonymous attendees
+- Comment count adjustment to reflect RSVP activity
+
+#### Usage
+
+```php
+add_action( 'init', function() {
+    add_post_type_support( 'my_custom_event', 'gatherpress-rsvp' );
+}, 11 );
+```
+
+Or include it in your `register_post_type()` call:
+
+```php
+register_post_type( 'my_custom_event', array(
+    'supports' => array( 'title', 'editor', 'gatherpress-event-date', 'gatherpress-rsvp' ),
+    // ... other args
+) );
+```
+
 ### Planned Supports
 
 The following supports are planned but not yet implemented:
 
 - **`gatherpress-venue`** - Physical venue association via the `_gatherpress_venue` taxonomy
 - **`gatherpress-online-event`** - Online event link meta field and online-event term
-- **`gatherpress-rsvp`** - Comment-based RSVP system, attendee management, and REST endpoints
 
 ## How It Works
 

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -114,10 +114,10 @@ class Rsvp_Form {
 		$block_instance = Block::get_instance();
 		$post_id        = $block_instance->get_post_id( $block );
 
-		// Validate that the post ID is an actual event post type.
+		// Validate that the post type supports RSVP.
 		// Only check publish status if not in preview mode.
 		if (
-			Event::POST_TYPE !== get_post_type( $post_id ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
 		) {
 			return '';

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -13,7 +13,6 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
-use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
@@ -92,10 +91,10 @@ class Rsvp_Response {
 		$block_instance = Block::get_instance();
 		$post_id        = $block_instance->get_post_id( $block );
 
-		// Validate that the post ID is an actual event post type.
+		// Validate that the post type supports RSVP.
 		// Only check publish status if not in preview mode.
 		if (
-			Event::POST_TYPE !== get_post_type( $post_id ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
 		) {
 			return '';

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -124,10 +124,10 @@ class Rsvp_Template {
 		$post_id = (int) $instance->context['postId'];
 		$event   = new Event( $post_id );
 
-		// Only process if we have a valid event post.
+		// Only process if the post type supports RSVP.
 		// Only check publish status if not in preview mode.
 		if (
-			Event::POST_TYPE !== get_post_type( $post_id ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
 		) {
 			return $block_content;

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -101,10 +101,10 @@ class Rsvp {
 		$block_instance = Block::get_instance();
 		$post_id        = $block_instance->get_post_id( $block );
 
-		// Validate that the post ID is an actual event post type.
+		// Validate that the post type supports RSVP.
 		// Only check publish status if not in preview mode.
 		if (
-			Event::POST_TYPE !== get_post_type( $post_id ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
 		) {
 			return '';

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -86,7 +86,7 @@ class Event_Setup {
 		add_action( 'template_redirect', array( $this, 'handle_event_archive_redirect' ) );
 		add_action( 'delete_post', array( $this, 'delete_event' ) );
 		add_action( 'wp_after_insert_post', array( $this, 'set_datetimes' ) );
-		add_action( sprintf( 'save_post_%s', Event::POST_TYPE ), array( $this, 'check_waiting_list' ) );
+		add_action( 'save_post', array( $this, 'check_waiting_list' ) );
 		add_action(
 			sprintf( 'manage_%s_posts_custom_column', Event::POST_TYPE ),
 			array( $this, 'custom_columns' ),
@@ -222,6 +222,7 @@ class Event_Setup {
 					'revisions',
 					'custom-fields',
 					'gatherpress-event-date',
+					'gatherpress-rsvp',
 				),
 				'menu_icon'     => 'dashicons-nametag',
 				// Note: has_archive must be true for event feed URLs (/event/feed/) to work.
@@ -639,6 +640,10 @@ class Event_Setup {
 	 * @return void
 	 */
 	public function check_waiting_list( int $post_id ): void {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
+			return;
+		}
+
 		$rsvp = new Rsvp( $post_id );
 
 		$rsvp->check_waiting_list();

--- a/includes/core/classes/class-rsvp-form.php
+++ b/includes/core/classes/class-rsvp-form.php
@@ -152,8 +152,8 @@ class Rsvp_Form {
 		$email   = Utility::get_http_input( INPUT_POST, 'email', 'sanitize_email' );
 		$post_id = intval( $comment_data['comment_post_ID'] );
 
-		// Validate that the post is an event.
-		if ( Event::POST_TYPE !== get_post_type( $post_id ) ) {
+		// Validate that the post supports RSVP.
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
 			wp_die(
 				esc_html__( 'Invalid event ID.', 'gatherpress' ),
 				esc_html__( 'Invalid Request', 'gatherpress' ),

--- a/includes/core/classes/class-rsvp-query.php
+++ b/includes/core/classes/class-rsvp-query.php
@@ -114,7 +114,7 @@ class Rsvp_Query {
 	 */
 	public function get_rsvps( array $args ) {
 		$args['type']         = Rsvp::COMMENT_TYPE;
-		$args['post_type']    = Event::POST_TYPE;
+		$args['post_type']    = array_values( get_post_types_by_support( 'gatherpress-rsvp' ) );
 		$args['type__in']     = array();
 		$args['type__not_in'] = array();
 

--- a/includes/core/classes/class-rsvp-setup.php
+++ b/includes/core/classes/class-rsvp-setup.php
@@ -156,7 +156,7 @@ class Rsvp_Setup {
 	 * @return int Adjusted number of comments.
 	 */
 	public function adjust_comments_number( int $comments_number, int $post_id ): int {
-		if ( Event::POST_TYPE !== get_post_type( $post_id ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
 			return $comments_number;
 		}
 
@@ -178,7 +178,7 @@ class Rsvp_Setup {
 	 * @return void
 	 */
 	public function maybe_process_waiting_list( int $post_id ): void {
-		if ( Event::POST_TYPE !== get_post_type( $post_id ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
 			return;
 		}
 

--- a/includes/core/classes/class-rsvp-token.php
+++ b/includes/core/classes/class-rsvp-token.php
@@ -242,7 +242,7 @@ class Rsvp_Token {
 
 		$post = get_post( (int) $comment->comment_post_ID );
 
-		if ( ! $post || Event::POST_TYPE !== get_post_type( $post ) ) {
+		if ( ! $post || ! post_type_supports( (string) get_post_type( $post ), 'gatherpress-rsvp' ) ) {
 			return null;
 		}
 

--- a/includes/core/classes/class-rsvp.php
+++ b/includes/core/classes/class-rsvp.php
@@ -476,7 +476,7 @@ class Rsvp {
 			),
 		);
 
-		if ( Event::POST_TYPE !== get_post_type( $post_id ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
 			return $retval;
 		}
 

--- a/src/blocks/rsvp-count/edit.js
+++ b/src/blocks/rsvp-count/edit.js
@@ -11,7 +11,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies.
  */
 import { getFromGlobal } from '../../helpers/globals';
-import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isEventPostType } from '../../helpers/event';
+import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isPostTypeSupporting } from '../../helpers/event';
 import { isInFSETemplate } from '../../helpers/editor';
 
 /**
@@ -49,8 +49,8 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	// Check if we're inside a query loop.
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
 
-	// Check if context post type is an event.
-	const isEventContext = isEventPostType( context?.postType );
+	// Check if context post type supports RSVP.
+	const isEventContext = isPostTypeSupporting( 'gatherpress-rsvp', context?.postType );
 
 	// Only use postId if context is an event or have an explicit override.
 	const postId =

--- a/src/blocks/rsvp-response/edit.js
+++ b/src/blocks/rsvp-response/edit.js
@@ -26,7 +26,7 @@ import { useState, useEffect } from '@wordpress/element';
 import RsvpManager from './rsvp-manager';
 import TEMPLATE from './template';
 import { getFromGlobal } from '../../helpers/globals';
-import { hasValidEventId, isEventPostType, DISABLED_FIELD_OPACITY } from '../../helpers/event';
+import { hasValidEventId, isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
 import { getEditorDocument, isInFSETemplate } from '../../helpers/editor';
 
 /**
@@ -65,9 +65,9 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const [ loading, setLoading ] = useState( true );
 	const [ error, setError ] = useState( null );
 
-	// Check if we're inside a query loop and if context is an event.
+	// Check if we're inside a query loop and if context is an RSVP-enabled post type.
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
-	const isEventContext = isEventPostType( context?.postType );
+	const isEventContext = isPostTypeSupporting( 'gatherpress-rsvp', context?.postType );
 
 	// Only use postId if context is an event or have an explicit override.
 	const postId =
@@ -227,7 +227,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 						) }
 					</PanelBody>
 				</InspectorControls>
-				{ isEventPostType() && (
+				{ isPostTypeSupporting( 'gatherpress-rsvp' ) && (
 					<BlockControls>
 						<ToolbarGroup>
 							<ToolbarButton

--- a/src/blocks/rsvp/edit.js
+++ b/src/blocks/rsvp/edit.js
@@ -17,7 +17,7 @@ import { createBlock, parse, serialize } from '@wordpress/blocks';
  * Internal dependencies.
  */
 import TEMPLATES from './templates';
-import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isEventPostType } from '../../helpers/event';
+import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isPostTypeSupporting } from '../../helpers/event';
 import { isInFSETemplate, getEditorDocument } from '../../helpers/editor';
 
 /**
@@ -53,9 +53,9 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 	const { serializedInnerBlocks = '{}', selectedStatus } = attributes;
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 
-	// Check if we're inside a query loop and if context is an event.
+	// Check if we're inside a query loop and if context is an RSVP-enabled post type.
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
-	const isEventContext = isEventPostType( context?.postType );
+	const isEventContext = isPostTypeSupporting( 'gatherpress-rsvp', context?.postType );
 
 	// Only use postId if context is an event or have an explicit override.
 	const postId =

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -29,7 +29,7 @@ import { CPT_EVENT } from './namespace';
 export const DISABLED_FIELD_OPACITY = 0.3;
 
 /**
- * Checks if a post type supports event_date in the GatherPress application.
+ * Checks if a post type has a given GatherPress post type support.
  *
  * If a postType argument is provided, checks against that value.
  * Otherwise, queries the current post type using the `select` function from the `core/editor` package.
@@ -37,10 +37,11 @@ export const DISABLED_FIELD_OPACITY = 0.3;
  *
  * @since 1.0.0
  *
+ * @param {string}      support  The post type support to check (e.g. 'gatherpress-event-date').
  * @param {string|null} postType Optional post type to check. If not provided, checks current editor post type.
- * @return {boolean} True if the post type supports event_date, false otherwise.
+ * @return {boolean} True if the post type has the given support, false otherwise.
  */
-export function isEventPostType( postType = null ) {
+export function isPostTypeSupporting( support, postType = null ) {
 	const typeToCheck =
 		postType ?? select( 'core/editor' )?.getCurrentPostType();
 
@@ -50,7 +51,19 @@ export function isEventPostType( postType = null ) {
 
 	const postTypeObject = select( 'core' ).getPostType( typeToCheck );
 
-	return !! postTypeObject?.supports?.[ 'gatherpress-event-date' ];
+	return !! postTypeObject?.supports?.[ support ];
+}
+
+/**
+ * Checks if a post type supports event_date in the GatherPress application.
+ *
+ * @since 1.0.0
+ *
+ * @param {string|null} postType Optional post type to check. If not provided, checks current editor post type.
+ * @return {boolean} True if the post type supports event_date, false otherwise.
+ */
+export function isEventPostType( postType = null ) {
+	return isPostTypeSupporting( 'gatherpress-event-date', postType );
 }
 
 /**

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -28,6 +28,7 @@ jest.mock( '@wordpress/core-data', () => ( {
 import {
 	hasEventPast,
 	hasEventPastNotice,
+	isPostTypeSupporting,
 	isEventPostType,
 	hasValidEventId,
 	getEventMeta,
@@ -44,10 +45,72 @@ import { dateTimeDatabaseFormat } from '@src/helpers/datetime';
  */
 function mockGetPostType( slug ) {
 	if ( 'gatherpress_event' === slug ) {
-		return { supports: { 'gatherpress-event-date': true } };
+		return {
+			supports: {
+				'gatherpress-event-date': true,
+				'gatherpress-rsvp': true,
+			},
+		};
 	}
 	return { supports: {} };
 }
+
+/**
+ * Coverage for isPostTypeSupporting.
+ */
+describe( 'isPostTypeSupporting', () => {
+	it( 'returns true when post type supports the given feature', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return {
+					getCurrentPostType: () => 'gatherpress_event',
+				};
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
+		expect( isPostTypeSupporting( 'gatherpress-event-date' ) ).toBe( true );
+		expect( isPostTypeSupporting( 'gatherpress-rsvp' ) ).toBe( true );
+	} );
+
+	it( 'returns false when post type does not support the given feature', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return {
+					getCurrentPostType: () => 'post',
+				};
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
+		expect( isPostTypeSupporting( 'gatherpress-event-date' ) ).toBe( false );
+		expect( isPostTypeSupporting( 'gatherpress-rsvp' ) ).toBe( false );
+	} );
+
+	it( 'returns true when postType argument supports the feature', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
+		expect( isPostTypeSupporting( 'gatherpress-rsvp', 'gatherpress_event' ) ).toBe( true );
+		expect( isPostTypeSupporting( 'gatherpress-rsvp', 'post' ) ).toBe( false );
+	} );
+
+	it( 'returns false when select returns undefined', () => {
+		require( '@wordpress/data' ).select.mockReturnValue( undefined );
+
+		expect( isPostTypeSupporting( 'gatherpress-rsvp' ) ).toBe( false );
+	} );
+} );
 
 /**
  * Coverage for isEventPostType.

--- a/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
@@ -81,7 +81,7 @@ class Test_Event_Setup extends Base {
 			),
 			array(
 				'type'     => 'action',
-				'name'     => sprintf( 'save_post_%s', Event::POST_TYPE ),
+				'name'     => 'save_post',
 				'priority' => 10,
 				'callback' => array( $instance, 'check_waiting_list' ),
 			),


### PR DESCRIPTION
**Description:**

Adds `gatherpress-rsvp` as a registered post type support on `gatherpress_event`, decoupling RSVP functionality from the hardcoded post type. Any post type can now opt into the full RSVP system via `add_post_type_support('my_cpt', 'gatherpress-rsvp')`.

Changes include:
- Replacing `Event::POST_TYPE === get_post_type()` checks with `post_type_supports( get_post_type(), 'gatherpress-rsvp' )` across all RSVP-related PHP classes and blocks
- `get_rsvps()` now queries all post types with `gatherpress-rsvp` support instead of hardcoding `gatherpress_event`
- `save_post_gatherpress_event` hook replaced with `save_post` + support check for waiting list processing
- Adds `isPostTypeSupporting( support, postType )` generic JS helper; `isEventPostType()` becomes a thin wrapper around it; RSVP blocks use it to check `gatherpress-rsvp` for editor dimming context
- Adds developer documentation

**Scope**: Covers `gatherpress-rsvp` only. Venue and online-event supports are planned for future PRs.

---

**Ways to test:**

1. **Existing events work unchanged** — Create/edit a `gatherpress_event` post, confirm RSVP blocks render in the editor and on the frontend, RSVP form submissions work, waiting list processes correctly
2. **Custom post type opt-in** — Register a CPT with `gatherpress-rsvp` support, confirm RSVP blocks render and are not dimmed in the editor, and RSVP form submissions work on the frontend
3. **Non-supported post types are blocked** — Confirm RSVP blocks dim in the editor on a regular `post` or `page`, and RSVP form submissions are rejected with a 400 error
4. **RSVP token emails** — Confirm anonymous RSVP email verification links still work for `gatherpress_event`
5. **Waiting list** — Set a max attendance limit, fill it up, confirm waiting list triggers on save for `gatherpress_event`
6. **PHP unit tests** — `npm run test:unit:php`
7. **JS unit tests** — `npm run test:unit:js`
### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @mauteri

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
