### PR TITLE
Venue sorting is working

### DIFF
--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -1160,6 +1160,7 @@ class Event_Setup {
 
 		// Modify the query to sort by venue name alphabetically.
 		add_filter( 'posts_join_paged', array( $this, 'venue_sorting_join_paged' ) );
+		add_filter( 'posts_groupby', array( $this, 'venue_sorting_groupby' ) );
 		add_filter( 'posts_orderby', array( $this, 'venue_sorting_orderby' ) );
 
 		// Store the order for use in orderby method.
@@ -1187,6 +1188,24 @@ class Event_Setup {
 	}
 
 	/**
+	 * Group by post ID for venue sorting to prevent duplicate results.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $groupby The GROUP BY clause of the query.
+	 * @return string Modified GROUP BY clause.
+	 */
+	public function venue_sorting_groupby( string $groupby ): string {
+		global $wpdb;
+
+		if ( empty( $groupby ) ) {
+			$groupby = "{$wpdb->posts}.ID";
+		}
+
+		return $groupby;
+	}
+
+	/**
 	 * Modify the ORDER BY clause for venue sorting.
 	 *
 	 * @since 1.0.0
@@ -1200,6 +1219,7 @@ class Event_Setup {
 
 		// Remove the filters to prevent them from affecting other queries.
 		remove_filter( 'posts_join_paged', array( $this, 'venue_sorting_join_paged' ) );
+		remove_filter( 'posts_groupby', array( $this, 'venue_sorting_groupby' ) );
 		remove_filter( 'posts_orderby', array( $this, 'venue_sorting_orderby' ) );
 
 		// Sort by venue name, with NULL/empty values last.

--- a/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
@@ -817,6 +817,26 @@ class Test_Event_Setup extends Base {
 	}
 
 	/**
+	 * Coverage for venue_sorting_groupby method.
+	 *
+	 * @covers ::venue_sorting_groupby
+	 *
+	 * @return void
+	 */
+	public function test_venue_sorting_groupby(): void {
+		global $wpdb;
+		$instance = Event_Setup::get_instance();
+
+		$result = $instance->venue_sorting_groupby( '' );
+		$this->assertEquals( "{$wpdb->posts}.ID", $result );
+
+		// Test with existing groupby - should keep the existing value.
+		$existing_groupby = 'existing_group';
+		$result           = $instance->venue_sorting_groupby( $existing_groupby );
+		$this->assertEquals( 'existing_group', $result );
+	}
+
+	/**
 	 * Coverage for venue_sorting_orderby method.
 	 *
 	 * Note: This method relies on the global $wp_query, so we test the method's structure
@@ -1970,12 +1990,17 @@ class Test_Event_Setup extends Base {
 			'Should add posts_join_paged filter for venue sorting'
 		);
 		$this->assertNotFalse(
+			has_filter( 'posts_groupby', array( $instance, 'venue_sorting_groupby' ) ),
+			'Should add posts_groupby filter for venue sorting'
+		);
+		$this->assertNotFalse(
 			has_filter( 'posts_orderby', array( $instance, 'venue_sorting_orderby' ) ),
 			'Should add posts_orderby filter for venue sorting'
 		);
 
 		// Clean up.
 		remove_filter( 'posts_join_paged', array( $instance, 'venue_sorting_join_paged' ) );
+		remove_filter( 'posts_groupby', array( $instance, 'venue_sorting_groupby' ) );
 		remove_filter( 'posts_orderby', array( $instance, 'venue_sorting_orderby' ) );
 		set_current_screen( 'front' );
 	}
@@ -2015,6 +2040,7 @@ class Test_Event_Setup extends Base {
 
 		// Clean up.
 		remove_filter( 'posts_join_paged', array( $instance, 'venue_sorting_join_paged' ) );
+		remove_filter( 'posts_groupby', array( $instance, 'venue_sorting_groupby' ) );
 		remove_filter( 'posts_orderby', array( $instance, 'venue_sorting_orderby' ) );
 		set_current_screen( 'front' );
 	}


### PR DESCRIPTION
### Description of the Change

When sorting events by venue on the GatherPress admin events list page, duplicate events appeared in the results. Each event was rendered once per row returned by the database query rather than once per event.

**Root cause:** `handle_venue_sorting` adds LEFT JOINs on `wp_term_relationships`, `wp_term_taxonomy`, and `wp_terms` to enable sorting by venue name. When an event has term relationship rows (or the JOIN produces multiple matches), MySQL returns a separate result row for each match. Without a `GROUP BY` clause to deduplicate by post ID, each event appears multiple times.

The sibling method `handle_rsvp_sorting` correctly handles this by also registering a `posts_groupby` filter that adds `GROUP BY wp_posts.ID`. The venue sorting implementation was missing this step.

**Fix:**
- Added `venue_sorting_groupby()` method that sets `GROUP BY wp_posts.ID` (mirrors `rsvp_sorting_groupby`)
- Registered the new method on the `posts_groupby` filter inside `handle_venue_sorting`
- Updated `venue_sorting_orderby` to remove the `posts_groupby` filter on cleanup, consistent with how the join and orderby filters are removed

Closes #1371

### How to test the Change

1. Install GatherPress and create several events, assigning different venues to each
2. Navigate to **Events → All Events** in the WordPress admin
3. Click the **Venue** column header to sort by venue
4. Verify events are listed once each — no duplicates appear
5. Click again to reverse the sort order and confirm the same behavior
6. Run the PHP unit tests: `npm run test:unit:php`

### Changelog Entry

> Fixed - Sorting events by venue in the admin list no longer causes duplicate events to appear.

### Credits

Props @richsalvucci

### Checklist:
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
