### PR TITLE
Decouple venue and online-event features from hardcoded post types via post_type_supports

### DIFF
--- a/.github/coverage-config.json
+++ b/.github/coverage-config.json
@@ -43,10 +43,5 @@
     "src/helpers/urlrewrite.js",
     "src/helpers/interactivity.js",
     "src/blocks/rsvp-response/rsvp-manager.js"
-  ],
-  "allowLowCoverage": [
-    "includes/core/classes/class-setup.php",
-    "includes/core/classes/class-event-setup.php"
-  ],
-  "allowLowCoverageReason": "Contains multisite-specific code that cannot be tested in single-site environment, or code requiring HTTP response handling (ICS downloads)"
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,12 @@ Based on WordPress Coding Standards (WPCS), always ensure:
 
 ### PHP Testing Guidelines
 
+**Multisite test group**: GatherPress runs two separate PHPUnit test suites in CI — a standard single-site run and a multisite run. Tests that require a multisite WordPress environment are annotated with `@group multisite`. The standard `phpunit.xml.dist` excludes this group so it does not run locally via `npm run test:unit:php`, but CI runs it separately and merges the coverage data before the PR coverage check.
+
+- **Never remove `@group multisite`** from test classes that carry it — those tests exist and run in CI.
+- **Never add `@codeCoverageIgnore`** to multisite-only code paths (e.g., `switch_to_blog`, `get_sites`, `is_plugin_active_for_network` branches) — those lines are covered by the multisite test run.
+- If the PR coverage check shows 0% for a class whose tests are in `@group multisite`, the most likely cause is that the multisite test suite is **failing** (e.g., a `test_setup_hooks` assertion no longer matches after a hook was changed). Fix the failing test rather than suppressing coverage.
+
 When writing PHPUnit tests that need WordPress post context:
 
 - **Global variable override**: Never directly assign to `$GLOBALS['post']` - WordPress Coding Standards prohibit this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,37 +99,59 @@ The RSVP block uses a sophisticated template system (`src/blocks/rsvp/templates/
 
 GatherPress uses custom `post_type_supports` to decouple features from specific post types. This allows developers to enable GatherPress features on their own custom post types.
 
-**Registered supports:**
+**Event post type supports** (declared on post types that act as events):
 
-- `gatherpress-event-date` — Event datetime storage, the `gatherpress_events` DB table, date-based queries, timezone handling, and related blocks (event-date, add-to-calendar)
+- `gatherpress-event-date` — **Core event identifier.** Datetime storage, the `gatherpress_events` DB table, date-based queries, timezone handling, and related blocks (event-date, add-to-calendar)
 - `gatherpress-rsvp` — Comment-based RSVP system, attendee management, waiting list, RSVP blocks (rsvp, rsvp-form, rsvp-response, rsvp-template)
-- `gatherpress-venue` — Venue taxonomy association, venue selector, and venue block rendering
-- `gatherpress-online-event` — Online event link meta, online-event term, and online-event block rendering
+- `gatherpress-venue` — Association with a venue post type via the `_gatherpress_venue` taxonomy, venue selector in the editor, and venue block rendering
+- `gatherpress-online-event` — Online event link meta (stored on the event), online-event term in the taxonomy, and online-event block rendering
+
+**Venue post type supports** (declared on post types that act as venues):
+
+- `gatherpress-venue-information` — **Core venue identifier.** Address, phone, website, lat/lng meta (JSON), venue detail blocks, and automatic `_gatherpress_venue` taxonomy term management. Declaring this support is what makes a post type a venue source.
+- `gatherpress-venue-map` — Map display meta (show/zoom/height) and the venue map block
 
 **How it works:**
 
-- `gatherpress_event` registers all supports during `register_post_type()`
+- `gatherpress_event` registers all event supports during `register_post_type()`
+- `gatherpress_venue` registers all venue supports during `register_post_type()`
 - PHP checks use `post_type_supports( $post_type, 'gatherpress-event-date' )` instead of `Event::POST_TYPE === $post_type`
-- Queries use `get_post_types_by_support( 'gatherpress-event-date' )` instead of hardcoded post type slugs
+- PHP checks use `post_type_supports( $post_type, 'gatherpress-venue-information' )` instead of `Venue::POST_TYPE === $post_type`
+- Queries use `get_post_types_by_support( 'gatherpress-event-date' )` or `get_post_types_by_support( 'gatherpress-venue-information' )` instead of hardcoded post type slugs
 - JS checks use `select('core').getPostType(slug)?.supports?.['gatherpress-event-date']` via the WordPress data store
-- Post-type-specific hooks (e.g., `rest_pre_insert_{post_type}`) are registered inside `register_post_meta()` which loops over supported post types
+- JS venue post type resolution uses `select('core/editor').getEditorSettings()?.gatherpress?.venuePostTypes` (exposed via `block_editor_settings_all` filter)
+- Post-type-specific hooks are registered inside `register_post_meta()` or similar `init` callbacks that loop over supported post types at priority 11
 
 **Developer usage:**
 
 ```php
-// Enable event dates on a custom post type.
+// Enable event dates on a custom event post type.
 add_post_type_support( 'my_custom_event', 'gatherpress-event-date' );
+
+// Create a custom venue post type.
+register_post_type( 'my_custom_venue', array(
+    'supports' => array( 'title', 'editor', 'gatherpress-venue-information', 'gatherpress-venue-map' ),
+) );
+
+// Map a custom event post type to a custom venue post type.
+add_filter( 'gatherpress_venue_post_type', function( $post_type, $event_post_type ) {
+    if ( 'my_custom_event' === $event_post_type ) {
+        return 'my_custom_venue';
+    }
+    return $post_type;
+}, 10, 2 );
 ```
 
 **When adding new post_type_supports:**
 
-1. Use kebab-case with `gatherpress-` prefix (e.g., `gatherpress-venue`)
+1. Use kebab-case with `gatherpress-` prefix (e.g., `gatherpress-venue-map`)
 2. Add the support to the `supports` array in the relevant `register_post_type()` call
-3. Replace `Event::POST_TYPE === get_post_type()` checks with `post_type_supports()`
-4. Replace `'post_type' => Event::POST_TYPE` in queries with `get_post_types_by_support()`
-5. Register post-type-specific hooks inside `register_post_meta()` or similar `init` callbacks that loop over supported post types
-6. Update JS `isEventPostType()` or create equivalent helpers that check supports via the data store
-7. Update corresponding unit tests (PHP and JS mocks)
+3. Replace `Event::POST_TYPE === get_post_type()` checks with `post_type_supports( ..., 'gatherpress-event-date' )`
+4. Replace `Venue::POST_TYPE === get_post_type()` checks with `post_type_supports( ..., 'gatherpress-venue-information' )`
+5. Replace `'post_type' => Event::POST_TYPE` in queries with `get_post_types_by_support( 'gatherpress-event-date' )`
+6. Register post-type-specific hooks inside `register_post_meta()` or similar `init` callbacks at priority 11 that loop over supported post types
+7. Update JS helpers to check supports via `select('core').getPostType(slug)?.supports`
+8. Update corresponding unit tests (PHP and JS mocks)
 
 ### Database Schema
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,11 +103,8 @@ GatherPress uses custom `post_type_supports` to decouple features from specific 
 
 - `gatherpress-event-date` — Event datetime storage, the `gatherpress_events` DB table, date-based queries, timezone handling, and related blocks (event-date, add-to-calendar)
 - `gatherpress-rsvp` — Comment-based RSVP system, attendee management, waiting list, RSVP blocks (rsvp, rsvp-form, rsvp-response, rsvp-template)
-
-**Planned supports (not yet implemented):**
-
-- `gatherpress-venue` — Venue taxonomy association and venue selector
-- `gatherpress-online-event` — Online event link meta and online-event term
+- `gatherpress-venue` — Venue taxonomy association, venue selector, and venue block rendering
+- `gatherpress-online-event` — Online event link meta, online-event term, and online-event block rendering
 
 **How it works:**
 

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -1,12 +1,14 @@
 # Post Type Supports
 
-GatherPress uses WordPress [post type supports](https://developer.wordpress.org/reference/functions/add_post_type_support/) to allow developers to enable GatherPress features on their own custom post types. This makes it possible to use event dates, venues, RSVPs, and other GatherPress functionality without being limited to the built-in `gatherpress_event` post type.
+GatherPress uses WordPress [post type supports](https://developer.wordpress.org/reference/functions/add_post_type_support/) to allow developers to enable GatherPress features on their own custom post types. This makes it possible to use event dates, venues, RSVPs, and other GatherPress functionality without being limited to the built-in `gatherpress_event` or `gatherpress_venue` post types.
 
-## Available Supports
+## Event Post Type Supports
+
+These supports are declared on post types that act as **events**.
 
 ### `gatherpress-event-date`
 
-Enables event datetime storage and display for a post type. This includes:
+The core identifier for event post types. Enables event datetime storage and display. This includes:
 
 - Registration of datetime meta fields (`gatherpress_datetime`, `gatherpress_datetime_start`, `gatherpress_datetime_end`, `gatherpress_timezone`, etc.)
 - Storage in the `gatherpress_events` database table
@@ -65,15 +67,6 @@ add_action( 'init', function() {
 }, 11 );
 ```
 
-Or include it in your `register_post_type()` call:
-
-```php
-register_post_type( 'my_custom_event', array(
-    'supports' => array( 'title', 'editor', 'gatherpress-event-date', 'gatherpress-rsvp' ),
-    // ... other args
-) );
-```
-
 ### `gatherpress-venue`
 
 Enables physical venue association for a post type. This includes:
@@ -91,14 +84,17 @@ add_action( 'init', function() {
 }, 11 );
 ```
 
-> **Note:** Use priority 11 or later so the `_gatherpress_venue` taxonomy is registered for your post type correctly.
+> **Note:** Register `gatherpress-venue` support at priority 10 (the default for `register_post_type()`) so GatherPress's priority-11 taxonomy registration can discover your post type via `get_post_types_by_support()`. For standalone `add_post_type_support()` calls after registration, use priority 11 or later.
 
-You can also override the venue post type used for lookups via the `gatherpress_venue_post_type` filter:
+You can also override the venue post type used for lookups via the `gatherpress_venue_post_type` filter. The filter receives the event post type as a second argument, enabling per-event-type venue post type overrides:
 
 ```php
-add_filter( 'gatherpress_venue_post_type', function( $post_type ) {
-    return 'my_custom_venue';
-} );
+add_filter( 'gatherpress_venue_post_type', function( $post_type, $event_post_type ) {
+    if ( 'my_custom_event' === $event_post_type ) {
+        return 'my_custom_venue';
+    }
+    return $post_type;
+}, 10, 2 );
 ```
 
 ### `gatherpress-online-event`
@@ -116,6 +112,48 @@ add_action( 'init', function() {
     add_post_type_support( 'my_custom_event', 'gatherpress-online-event' );
 }, 11 );
 ```
+
+---
+
+## Venue Post Type Supports
+
+These supports are declared on post types that act as **venues**. `gatherpress-venue-information` is the core identifier — declaring it is what makes a post type a venue source.
+
+### `gatherpress-venue-information`
+
+The core identifier for venue post types. Enables venue address and contact data. This includes:
+
+- Registration of the `gatherpress_venue_information` meta field (JSON: address, phone, website, lat/lng)
+- Venue detail blocks (address, phone number, website)
+- Automatic creation and management of the corresponding `_gatherpress_venue` taxonomy term
+- `post_type_supports( $type, 'gatherpress-venue-information' )` is the canonical check for "is this a venue?"
+
+#### Usage for gatherpress-venue-information
+
+```php
+register_post_type( 'my_custom_venue', array(
+    'supports' => array( 'title', 'editor', 'gatherpress-venue-information' ),
+    // ... other args
+) );
+```
+
+### `gatherpress-venue-map`
+
+Enables map display for a venue post type. This includes:
+
+- Registration of map meta fields (`gatherpress_venue_map_show`, `gatherpress_venue_map_zoom`, `gatherpress_venue_map_height`)
+- Venue Map block rendering
+
+#### Usage for gatherpress-venue-map
+
+```php
+register_post_type( 'my_custom_venue', array(
+    'supports' => array( 'title', 'editor', 'gatherpress-venue-information', 'gatherpress-venue-map' ),
+    // ... other args
+) );
+```
+
+---
 
 ## How It Works
 
@@ -137,15 +175,41 @@ if ( post_type_supports( get_post_type( $post_id ), 'gatherpress-event-date' ) )
 }
 ```
 
-Similarly, queries that previously targeted only `gatherpress_event` now include all post types with the relevant support:
+The same pattern applies on the venue side:
 
 ```php
-// Before.
-$args = array( 'post_type' => 'gatherpress_event' );
+// Before: only works with gatherpress_venue.
+if ( Venue::POST_TYPE === get_post_type( $post_id ) ) {
+    // Handle venue logic.
+}
 
-// After.
-$args = array( 'post_type' => get_post_types_by_support( 'gatherpress-event-date' ) );
+// After: works with any post type that has gatherpress-venue-information support.
+if ( post_type_supports( get_post_type( $post_id ), 'gatherpress-venue-information' ) ) {
+    // Handle venue logic.
+}
 ```
+
+Similarly, queries that previously targeted only `gatherpress_event` or `gatherpress_venue` now include all post types with the relevant support:
+
+```php
+// Event queries.
+$args = array( 'post_type' => get_post_types_by_support( 'gatherpress-event-date' ) );
+
+// Venue queries.
+$args = array( 'post_type' => get_post_types_by_support( 'gatherpress-venue-information' ) );
+```
+
+In JavaScript, support checks use the WordPress data store:
+
+```js
+// Check if current post type is an event.
+select( 'core' ).getPostType( postType )?.supports?.[ 'gatherpress-event-date' ];
+
+// Check if current post type is a venue.
+select( 'core' ).getPostType( postType )?.supports?.[ 'gatherpress-venue-information' ];
+```
+
+---
 
 ## Naming Convention
 
@@ -157,5 +221,7 @@ All GatherPress supports use the following naming convention:
 ## Important Notes
 
 - The `gatherpress_events` database table stores data by `post_id` and is post-type agnostic. Any post type with `gatherpress-event-date` support can store datetime data in this table.
-- Supports must be registered before or during `init`. Use **priority 10** (the default) for your `register_post_type()` call. GatherPress itself runs its meta registration and taxonomy setup at priority 11 — this ordering ensures your post type is discoverable via `get_post_types_by_support()` when those hooks fire. For `gatherpress-venue`, a priority of 11 or later is required on any additional `add_post_type_support()` calls (not `register_post_type()` itself) because the venue taxonomy registration loop runs at priority 11.
+- Supports must be registered before or during `init`. Use **priority 10** (the default) for your `register_post_type()` call. GatherPress itself runs its meta registration and taxonomy setup at priority 11 — this ordering ensures your post type is discoverable via `get_post_types_by_support()` when those hooks fire.
 - The `Event::POST_TYPE` constant still exists and refers to `gatherpress_event`. It is used for GatherPress's own post type registration but should not be used for feature checks.
+- The `Venue::POST_TYPE` constant still exists and refers to `gatherpress_venue`. It is used for GatherPress's own post type registration but should not be used for feature checks.
+- The `venuePostTypes` map is exposed to the block editor via `block_editor_settings_all` under `settings.gatherpress.venuePostTypes`. It maps event post type slugs to their corresponding venue post type slugs, resolved via the `gatherpress_venue_post_type` filter.

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -74,12 +74,48 @@ register_post_type( 'my_custom_event', array(
 ) );
 ```
 
-### Planned Supports
+### `gatherpress-venue`
 
-The following supports are planned but not yet implemented:
+Enables physical venue association for a post type. This includes:
 
-- **`gatherpress-venue`** - Physical venue association via the `_gatherpress_venue` taxonomy
-- **`gatherpress-online-event`** - Online event link meta field and online-event term
+- Registration of the `_gatherpress_venue` taxonomy for the post type
+- Venue selector in the block editor
+- Venue block rendering (name, address, map, phone, website)
+- Venue detail field visibility (hides empty address/phone/website blocks)
+
+#### Usage for gatherpress-venue
+
+```php
+add_action( 'init', function() {
+    add_post_type_support( 'my_custom_event', 'gatherpress-venue' );
+}, 11 );
+```
+
+> **Note:** Use priority 11 or later so the `_gatherpress_venue` taxonomy is registered for your post type correctly.
+
+You can also override the venue post type used for lookups via the `gatherpress_venue_post_type` filter:
+
+```php
+add_filter( 'gatherpress_venue_post_type', function( $post_type ) {
+    return 'my_custom_venue';
+} );
+```
+
+### `gatherpress-online-event`
+
+Enables online event functionality for a post type. This includes:
+
+- Online event toggle and link field in the block editor inspector
+- Online Event block rendering (icon and link)
+- Association with the `online-event` term in the `_gatherpress_venue` taxonomy
+
+#### Usage for gatherpress-online-event
+
+```php
+add_action( 'init', function() {
+    add_post_type_support( 'my_custom_event', 'gatherpress-online-event' );
+}, 11 );
+```
 
 ## How It Works
 
@@ -121,5 +157,5 @@ All GatherPress supports use the following naming convention:
 ## Important Notes
 
 - The `gatherpress_events` database table stores data by `post_id` and is post-type agnostic. Any post type with `gatherpress-event-date` support can store datetime data in this table.
-- Supports must be registered before or during `init` (priority 10). GatherPress registers post-type-specific hooks inside `register_post_meta()` which loops over all post types with the relevant support.
+- Supports must be registered before or during `init`. Use **priority 10** (the default) for your `register_post_type()` call. GatherPress itself runs its meta registration and taxonomy setup at priority 11 — this ordering ensures your post type is discoverable via `get_post_types_by_support()` when those hooks fire. For `gatherpress-venue`, a priority of 11 or later is required on any additional `add_post_type_support()` calls (not `register_post_type()` itself) because the venue taxonomy registration loop runs at priority 11.
 - The `Event::POST_TYPE` constant still exists and refers to `gatherpress_event`. It is used for GatherPress's own post type registration but should not be used for feature checks.

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -18,7 +18,6 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 use GatherPress\Core\Block;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
-use GatherPress\Core\Venue;
 use WP_HTML_Tag_Processor;
 
 /**
@@ -179,8 +178,8 @@ class General_Block {
 		// First try to get it from block context, then fall back to current post.
 		$venue_post_id = $block['attrs']['postId'] ?? get_the_ID();
 
-		// Verify this is actually a venue post.
-		if ( Venue::POST_TYPE !== get_post_type( $venue_post_id ) ) {
+		// Verify this is actually a venue post type.
+		if ( ! post_type_supports( (string) get_post_type( $venue_post_id ), 'gatherpress-venue-information' ) ) {
 			return $block_content;
 		}
 

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -16,7 +16,6 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
-use GatherPress\Core\Event;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Venue;
@@ -269,10 +268,10 @@ class General_Block {
 		$block_instance = Block::get_instance();
 		$post_id        = $block_instance->get_post_id( $block );
 
-		// Only process if we have a valid event post.
+		// Only process if the post type supports RSVP.
 		// Only check publish status if not in preview mode.
 		if (
-			Event::POST_TYPE !== get_post_type( $post_id ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
 		) {
 			return $block_content;
@@ -317,10 +316,10 @@ class General_Block {
 		$block_instance = Block::get_instance();
 		$post_id        = $block_instance->get_post_id( $block );
 
-		// Only process if we have a valid event post.
+		// Only process if the post type supports RSVP.
 		// Only check publish status if not in preview mode.
 		if (
-			Event::POST_TYPE !== get_post_type( $post_id ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
 		) {
 			return $block_content;

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -116,7 +116,8 @@ class Online_Event {
 		}
 
 		$event_post_type = (string) get_post_type( $post_id );
-		$venue_terms     = get_the_terms( $post_id, Venue::get_taxonomy( Venue::get_venue_post_type( $event_post_type ) ) );
+		$taxonomy        = Venue::get_taxonomy( Venue::get_venue_post_type( $event_post_type ) );
+		$venue_terms     = get_the_terms( $post_id, $taxonomy );
 
 		if ( ! is_array( $venue_terms ) ) {
 			return false;

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -110,9 +110,9 @@ class Online_Event {
 	 * @return bool True if the event has the online-event term, false otherwise.
 	 */
 	private function has_online_event_term( int $post_id ): bool {
-		// Only check for post types that support online events.
+		// Only render for post types that support online events.
 		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-online-event' ) ) {
-			return true;
+			return false;
 		}
 
 		$venue_terms = get_the_terms( $post_id, Venue::TAXONOMY );

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -12,7 +12,6 @@ namespace GatherPress\Core\Blocks;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-use GatherPress\Core\Event;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Venue;
 use WP_Block;
@@ -111,8 +110,8 @@ class Online_Event {
 	 * @return bool True if the event has the online-event term, false otherwise.
 	 */
 	private function has_online_event_term( int $post_id ): bool {
-		// Only check for event post types.
-		if ( Event::POST_TYPE !== get_post_type( $post_id ) ) {
+		// Only check for post types that support online events.
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-online-event' ) ) {
 			return true;
 		}
 

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -115,7 +115,8 @@ class Online_Event {
 			return false;
 		}
 
-		$venue_terms = get_the_terms( $post_id, Venue::TAXONOMY );
+		$event_post_type = (string) get_post_type( $post_id );
+		$venue_terms     = get_the_terms( $post_id, Venue::get_taxonomy( Venue::get_venue_post_type( $event_post_type ) ) );
 
 		if ( ! is_array( $venue_terms ) ) {
 			return false;

--- a/includes/core/classes/blocks/class-venue.php
+++ b/includes/core/classes/blocks/class-venue.php
@@ -15,7 +15,6 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
-use GatherPress\Core\Event;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Venue as Venue_Core;
 use WP_Block;
@@ -123,21 +122,19 @@ class Venue {
 		$post_id   = Block::get_instance()->get_post_id( $block );
 		$post_type = get_post_type( $post_id );
 
-		switch ( $post_type ) {
-			case Venue_Core::POST_TYPE:
-				return get_post( $post_id );
-
-			case Event::POST_TYPE:
-				$venue_post = Venue_Core::get_instance()->get_venue_post_from_event_post_id( $post_id );
-
-				if ( $venue_post instanceof WP_Post && Venue_Core::POST_TYPE === $venue_post->post_type ) {
-					return $venue_post;
-				}
-				// Fall through to default.
-
-			default:
-				return null;
+		if ( Venue_Core::POST_TYPE === $post_type ) {
+			return get_post( $post_id );
 		}
+
+		if ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
+			$venue_post = Venue_Core::get_instance()->get_venue_post_from_event_post_id( $post_id );
+
+			if ( $venue_post instanceof WP_Post && Venue_Core::POST_TYPE === $venue_post->post_type ) {
+				return $venue_post;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/core/classes/class-event-admin-list.php
+++ b/includes/core/classes/class-event-admin-list.php
@@ -471,7 +471,7 @@ class Event_Admin_List {
 			. ' ON venue_tr.term_taxonomy_id = venue_tt.term_taxonomy_id'
 			. ' AND venue_tt.taxonomy = %s',
 			$wpdb->term_taxonomy,
-			Venue::TAXONOMY
+			Venue::get_taxonomy( Venue::get_venue_post_type( Event::POST_TYPE ) )
 		);
 		$join .= $wpdb->prepare(
 			' LEFT JOIN %i AS venue_terms ON venue_tt.term_id = venue_terms.term_id',

--- a/includes/core/classes/class-event-query.php
+++ b/includes/core/classes/class-event-query.php
@@ -139,11 +139,7 @@ class Event_Query {
 					'field'    => 'slug',
 					'terms'    => $topics,
 				),
-				array(
-					'taxonomy' => Venue::TAXONOMY,
-					'field'    => 'slug',
-					'terms'    => $venues,
-				),
+				$this->build_venue_tax_query( $venues ),
 			);
 		} elseif ( ! empty( $topics ) ) {
 			$tax_query[] = array(
@@ -152,11 +148,7 @@ class Event_Query {
 				'terms'    => $topics,
 			);
 		} elseif ( ! empty( $venues ) ) {
-			$tax_query[] = array(
-				'taxonomy' => Venue::TAXONOMY,
-				'field'    => 'slug',
-				'terms'    => $venues,
-			);
+			$tax_query[] = $this->build_venue_tax_query( $venues );
 		}
 
 		$args['tax_query'] = $tax_query; //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
@@ -490,6 +482,31 @@ class Event_Query {
 		}
 
 		return $pieces;
+	}
+
+	/**
+	 * Builds a WP_Query compatible tax_query array for filtering events by venue slugs.
+	 *
+	 * Creates an OR relation across all registered venue post type taxonomies, allowing
+	 * events to be filtered by venue regardless of which venue post type they use.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $venues Array of venue slugs to filter by.
+	 * @return array WP_Query compatible tax_query array.
+	 */
+	private function build_venue_tax_query( array $venues ): array {
+		$venue_tax_query = array( 'relation' => 'OR' );
+
+		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $venue_post_type ) {
+			$venue_tax_query[] = array(
+				'taxonomy' => Venue::get_taxonomy( $venue_post_type ),
+				'field'    => 'slug',
+				'terms'    => $venues,
+			);
+		}
+
+		return $venue_tax_query;
 	}
 
 	/**

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -67,7 +67,8 @@ class Event_Setup {
 	 */
 	protected function setup_hooks(): void {
 		add_action( 'init', array( $this, 'register_post_type' ) );
-		add_action( 'init', array( $this, 'register_post_meta' ) );
+		// Priority 11 ensures third-party CPTs are discoverable via get_post_types_by_support().
+		add_action( 'init', array( $this, 'register_post_meta' ), 11 );
 		add_action( 'init', array( $this, 'register_calendar_rewrite_rule' ) );
 		add_action( 'parse_request', array( $this, 'handle_calendar_ics_request' ) );
 		add_action( 'template_redirect', array( $this, 'handle_event_archive_redirect' ) );

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -181,6 +181,8 @@ class Event_Setup {
 					'custom-fields',
 					'gatherpress-event-date',
 					'gatherpress-rsvp',
+					'gatherpress-venue',
+					'gatherpress-online-event',
 				),
 				'menu_icon'     => 'dashicons-nametag',
 				// Note: has_archive must be true for event feed URLs (/event/feed/) to work.

--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -539,7 +539,8 @@ class Event {
 			'is_online_event' => false,
 		);
 
-		$term  = current( (array) get_the_terms( $this->event, Venue::TAXONOMY ) );
+		$event_post_type = (string) get_post_type( $this->event );
+		$term            = current( (array) get_the_terms( $this->event, Venue::get_taxonomy( Venue::get_venue_post_type( $event_post_type ) ) ) );
 		$venue = null;
 
 		if ( ! empty( $term ) && is_a( $term, 'WP_Term' ) ) {

--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -540,8 +540,9 @@ class Event {
 		);
 
 		$event_post_type = (string) get_post_type( $this->event );
-		$term            = current( (array) get_the_terms( $this->event, Venue::get_taxonomy( Venue::get_venue_post_type( $event_post_type ) ) ) );
-		$venue = null;
+		$taxonomy        = Venue::get_taxonomy( Venue::get_venue_post_type( $event_post_type ) );
+		$term            = current( (array) get_the_terms( $this->event, $taxonomy ) );
+		$venue           = null;
 
 		if ( ! empty( $term ) && is_a( $term, 'WP_Term' ) ) {
 			$venue_information['name'] = $term->name;

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -349,25 +349,30 @@ class Setup {
 
 		$term_name = __( 'Online event', 'gatherpress' );
 		$term_slug = 'online-event';
-		$term      = term_exists( $term_slug, Venue::TAXONOMY );
 
-		if ( ! $term ) {
-			wp_insert_term(
-				$term_name,
-				Venue::TAXONOMY,
-				array(
-					'slug' => $term_slug,
-				)
-			);
-		} else {
-			wp_update_term(
-				intval( $term['term_id'] ),
-				Venue::TAXONOMY,
-				array(
-					'name' => $term_name,
-					'slug' => $term_slug,
-				),
-			);
+		// Ensure the online-event term exists in each registered venue taxonomy.
+		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $venue_post_type ) {
+			$taxonomy = Venue::get_taxonomy( $venue_post_type );
+			$term     = term_exists( $term_slug, $taxonomy );
+
+			if ( ! $term ) {
+				wp_insert_term(
+					$term_name,
+					$taxonomy,
+					array(
+						'slug' => $term_slug,
+					)
+				);
+			} else {
+				wp_update_term(
+					intval( $term['term_id'] ),
+					$taxonomy,
+					array(
+						'name' => $term_name,
+						'slug' => $term_slug,
+					),
+				);
+			}
 		}
 	}
 

--- a/includes/core/classes/class-venue.php
+++ b/includes/core/classes/class-venue.php
@@ -72,12 +72,7 @@ class Venue {
 	 * @return void
 	 */
 	protected function setup_hooks(): void {
-		add_action(
-			sprintf( 'save_post_%s', self::POST_TYPE ),
-			array( $this, 'add_venue_term' ),
-			10,
-			3
-		);
+		add_action( 'save_post', array( $this, 'add_venue_term' ), 10, 3 );
 		add_action(
 			sprintf( 'save_post_%s', self::POST_TYPE ),
 			array( $this, 'maybe_apply_venue_template' ),
@@ -85,32 +80,78 @@ class Venue {
 			2
 		);
 		add_action( 'init', array( $this, 'register_post_type' ) );
-		add_action( 'init', array( $this, 'register_post_meta' ) );
 		// Priority 11 so post types registered at default priority 10 are available for get_post_types_by_support().
+		add_action( 'init', array( $this, 'register_post_meta' ), 11 );
 		add_action( 'init', array( $this, 'register_taxonomy' ), 11 );
 		add_action( 'post_updated', array( $this, 'maybe_update_term_slug' ), 10, 3 );
 		add_action( 'delete_post', array( $this, 'delete_venue_term' ) );
+		add_filter( 'block_editor_settings_all', array( $this, 'add_editor_settings' ) );
 	}
 
 	/**
-	 * Returns the post type used as the venue, applying the gatherpress_venue_post_type filter.
+	 * Returns the post type used as the venue for a given event post type.
 	 *
 	 * Defaults to the built-in gatherpress_venue post type. Developers can override this
-	 * via the filter to designate a custom post type as the venue for a given context.
+	 * via the filter to designate a custom post type as the venue for a given event post type.
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param string $event_post_type The event post type requesting a venue post type. Default empty string.
 	 * @return string The venue post type slug.
 	 */
-	public static function get_venue_post_type(): string {
+	public static function get_venue_post_type( string $event_post_type = '' ): string {
 		/**
 		 * Filters the post type used as the venue.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $post_type The venue post type slug. Default 'gatherpress_venue'.
+		 * @param string $post_type       The venue post type slug. Default 'gatherpress_venue'.
+		 * @param string $event_post_type The event post type requesting a venue post type.
 		 */
-		return (string) apply_filters( 'gatherpress_venue_post_type', self::POST_TYPE );
+		return (string) apply_filters( 'gatherpress_venue_post_type', self::POST_TYPE, $event_post_type );
+	}
+
+	/**
+	 * Returns a map of event post types to their corresponding venue post types.
+	 *
+	 * Iterates over all post types that support 'gatherpress-venue' and resolves
+	 * the venue post type for each via get_venue_post_type(). This map is used
+	 * to expose the per-event-type venue post type to the block editor.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, string> Map of event post type slug to venue post type slug.
+	 */
+	public static function get_venue_post_type_map(): array {
+		$map = array();
+
+		foreach ( get_post_types_by_support( 'gatherpress-venue' ) as $event_post_type ) {
+			$map[ $event_post_type ] = self::get_venue_post_type( $event_post_type );
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Adds GatherPress venue configuration to the block editor settings.
+	 *
+	 * Exposes the venue post type map under settings['gatherpress']['venuePostTypes']
+	 * so that the block editor can resolve the correct venue post type for each
+	 * event post type without relying on window globals.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $settings The block editor settings array.
+	 * @return array The modified block editor settings array.
+	 */
+	public function add_editor_settings( array $settings ): array {
+		if ( ! isset( $settings['gatherpress'] ) ) {
+			$settings['gatherpress'] = array();
+		}
+
+		$settings['gatherpress']['venuePostTypes'] = self::get_venue_post_type_map();
+
+		return $settings;
 	}
 
 	/**
@@ -188,6 +229,8 @@ class Venue {
 					'thumbnail',
 					'revisions',
 					'custom-fields',
+					'gatherpress-venue-information',
+					'gatherpress-venue-map',
 				),
 				'menu_icon'    => 'dashicons-location',
 				'template'     => array(
@@ -239,20 +282,21 @@ class Venue {
 	}
 
 	/**
-	 * Registers custom meta fields for the Venue post type.
+	 * Registers custom meta fields for all venue post types.
 	 *
-	 * Sets up meta fields associated with the Venue post type, such as 'venue_information',
-	 * configuring capabilities, sanitization, and REST API visibility. This method ensures
-	 * that only users with the appropriate permissions can edit these fields, and that
-	 * the data stored is properly sanitized. Each meta field is registered to be
-	 * single and of a string type, optimized for use within the WordPress REST API.
+	 * Meta fields are registered per support:
+	 * - gatherpress-venue-information: venue address, phone, website, and lat/lng as JSON.
+	 * - gatherpress-venue-map: map display settings (show, zoom, height).
+	 *
+	 * Runs at priority 11 so custom venue post types registered at priority 10 are
+	 * discoverable via get_post_types_by_support() when this hook fires.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
 	public function register_post_meta(): void {
-		$post_meta = array(
+		$venue_information_meta = array(
 			// Venue information stored as JSON.
 			'gatherpress_venue_information' => array(
 				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
@@ -262,8 +306,11 @@ class Venue {
 				'type'              => 'string',
 				'default'           => '',
 			),
+		);
+
+		$venue_map_meta = array(
 			// Map display settings.
-			'gatherpress_venue_map_show'    => array(
+			'gatherpress_venue_map_show'   => array(
 				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
 				'show_in_rest'      => true,
@@ -271,7 +318,7 @@ class Venue {
 				'type'              => 'boolean',
 				'default'           => true,
 			),
-			'gatherpress_venue_map_zoom'    => array(
+			'gatherpress_venue_map_zoom'   => array(
 				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
@@ -279,7 +326,7 @@ class Venue {
 				'type'              => 'integer',
 				'default'           => 10,
 			),
-			'gatherpress_venue_map_height'  => array(
+			'gatherpress_venue_map_height' => array(
 				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
@@ -289,12 +336,16 @@ class Venue {
 			),
 		);
 
-		foreach ( $post_meta as $meta_key => $args ) {
-			register_post_meta(
-				self::POST_TYPE,
-				$meta_key,
-				$args
-			);
+		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $post_type ) {
+			foreach ( $venue_information_meta as $meta_key => $args ) {
+				register_post_meta( $post_type, $meta_key, $args );
+			}
+		}
+
+		foreach ( get_post_types_by_support( 'gatherpress-venue-map' ) as $post_type ) {
+			foreach ( $venue_map_meta as $meta_key => $args ) {
+				register_post_meta( $post_type, $meta_key, $args );
+			}
 		}
 	}
 
@@ -356,6 +407,10 @@ class Venue {
 	public function add_venue_term( int $post_id, WP_Post $post, bool $update ): void {
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) { // @codeCoverageIgnore
 			return; // @codeCoverageIgnore
+		}
+
+		if ( ! post_type_supports( $post->post_type, 'gatherpress-venue-information' ) ) {
+			return;
 		}
 
 		if (
@@ -447,8 +502,8 @@ class Venue {
 	 * @return void
 	 */
 	public function maybe_update_term_slug( int $post_id, WP_Post $post_after, WP_Post $post_before ): void {
-		// Check if the post type is Venue.
-		if ( self::POST_TYPE !== get_post_type( $post_id ) ) {
+		// Only process venue post types.
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-venue-information' ) ) {
 			return;
 		}
 
@@ -514,8 +569,8 @@ class Venue {
 	 * @return void
 	 */
 	public function delete_venue_term( int $post_id ): void {
-		// Check if the post type is Venue.
-		if ( get_post_type( $post_id ) === self::POST_TYPE ) {
+		// Only process venue post types.
+		if ( post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-venue-information' ) ) {
 			// Retrieve the post object.
 			$post = get_post( $post_id );
 
@@ -558,12 +613,13 @@ class Venue {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $slug Slug of the Venue taxonomy to retrieve the Venue post.
+	 * @param string $slug            Slug of the Venue taxonomy to retrieve the Venue post.
+	 * @param string $event_post_type The event post type context for venue post type resolution. Default empty string.
 	 * @return null|WP_Post The Venue post object if found; otherwise, null.
 	 */
-	public function get_venue_post_from_term_slug( string $slug ): ?WP_Post {
+	public function get_venue_post_from_term_slug( string $slug, string $event_post_type = '' ): ?WP_Post {
 		// Remove any leading underscores from the slug and retrieve the corresponding Venue post.
-		return get_page_by_path( ltrim( $slug, '_' ), OBJECT, self::POST_TYPE );
+		return get_page_by_path( ltrim( $slug, '_' ), OBJECT, self::get_venue_post_type( $event_post_type ) );
 	}
 
 	/**
@@ -583,8 +639,11 @@ class Venue {
 		if ( ! is_array( $venue_terms ) || empty( $venue_terms ) ) {
 			return null;
 		}
+
+		$event_post_type = (string) get_post_type( $post_id );
+
 		// Assuming that we have only ONE venue related.
-		return $this->get_venue_post_from_term_slug( $venue_terms[0]->slug );
+		return $this->get_venue_post_from_term_slug( $venue_terms[0]->slug, $event_post_type );
 	}
 
 	/**
@@ -616,14 +675,14 @@ class Venue {
 			if ( ! empty( $venue_terms ) && is_array( $venue_terms ) ) {
 				$venue_term = $venue_terms[0];
 				$venue_slug = $venue_term->slug;
-				$venue_post = $this->get_venue_post_from_term_slug( $venue_slug );
+				$venue_post = $this->get_venue_post_from_term_slug( $venue_slug, $post_type );
 			}
 
 			$venue_meta['isOnlineEventTerm'] = ( 'online-event' === $venue_slug );
 			$venue_meta['onlineEventLink']   = $event->maybe_get_online_event_link();
 		}
 
-		if ( self::POST_TYPE === $post_type ) {
+		if ( post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
 			$venue_post = get_post( $post_id );
 		}
 

--- a/includes/core/classes/class-venue.php
+++ b/includes/core/classes/class-venue.php
@@ -99,6 +99,22 @@ class Venue {
 	 * @param string $event_post_type The event post type requesting a venue post type. Default empty string.
 	 * @return string The venue post type slug.
 	 */
+	/**
+	 * Returns the taxonomy slug for a given venue post type.
+	 *
+	 * The taxonomy slug is always derived by prepending an underscore to the venue
+	 * post type slug — for example, 'gatherpress_venue' uses '_gatherpress_venue'.
+	 * Custom venue post types follow the same convention automatically.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $venue_post_type The venue post type slug. Defaults to the built-in venue post type.
+	 * @return string The taxonomy slug for the given venue post type.
+	 */
+	public static function get_taxonomy( string $venue_post_type = '' ): string {
+		return '_' . ( $venue_post_type ?: self::POST_TYPE );
+	}
+
 	public static function get_venue_post_type( string $event_post_type = '' ): string {
 		/**
 		 * Filters the post type used as the venue.
@@ -366,28 +382,30 @@ class Venue {
 	 * @return void
 	 */
 	public function register_taxonomy(): void {
-		register_taxonomy(
-			self::TAXONOMY,
-			array(),
-			array(
-				'labels'             => array(
-					'name'          => _x( 'Venues', 'Admin menu and taxonomy general name', 'gatherpress' ),
-					'singular_name' => _x( 'Venue', 'Admin menu and taxonomy singular name', 'gatherpress' ),
-				),
-				'hierarchical'       => false,
-				'public'             => true,
-				'show_ui'            => false,
-				'show_admin_column'  => false,
-				'query_var'          => true,
-				'publicly_queryable' => true,
-				'rewrite'            => false,
-				'show_in_rest'       => true,
-			)
+		$taxonomy_args = array(
+			'labels'             => array(
+				'name'          => _x( 'Venues', 'Admin menu and taxonomy general name', 'gatherpress' ),
+				'singular_name' => _x( 'Venue', 'Admin menu and taxonomy singular name', 'gatherpress' ),
+			),
+			'hierarchical'       => false,
+			'public'             => true,
+			'show_ui'            => false,
+			'show_admin_column'  => false,
+			'query_var'          => true,
+			'publicly_queryable' => true,
+			'rewrite'            => false,
+			'show_in_rest'       => true,
 		);
 
-		// Register the taxonomy for all post types that support gatherpress-venue.
-		foreach ( get_post_types_by_support( 'gatherpress-venue' ) as $post_type ) {
-			register_taxonomy_for_object_type( self::TAXONOMY, $post_type );
+		// Register one taxonomy per venue post type: '_' . venue_post_type_slug.
+		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $venue_post_type ) {
+			register_taxonomy( self::get_taxonomy( $venue_post_type ), array(), $taxonomy_args );
+		}
+
+		// Register each event post type with the taxonomy of its resolved venue post type.
+		foreach ( get_post_types_by_support( 'gatherpress-venue' ) as $event_post_type ) {
+			$venue_post_type = self::get_venue_post_type( $event_post_type );
+			register_taxonomy_for_object_type( self::get_taxonomy( $venue_post_type ), $event_post_type );
 		}
 	}
 
@@ -420,12 +438,13 @@ class Venue {
 		) {
 			$term_slug = $this->get_venue_term_slug( $post->post_name );
 			$title     = html_entity_decode( get_the_title( $post_id ) );
-			$term      = term_exists( $term_slug, self::TAXONOMY );
+			$taxonomy  = self::get_taxonomy( $post->post_type );
+			$term      = term_exists( $term_slug, $taxonomy );
 
 			if ( empty( $term ) ) {
 				wp_insert_term(
 					$title,
-					self::TAXONOMY,
+					$taxonomy,
 					array(
 						'slug' => $term_slug,
 					)
@@ -531,13 +550,15 @@ class Venue {
 			// Decode the title to ensure special characters are handled correctly.
 			$title = html_entity_decode( get_the_title( $post_id ) );
 
+			$taxonomy = self::get_taxonomy( (string) get_post_type( $post_id ) );
+
 			// Check if the old term exists, and if not, insert the new term.
-			$term = term_exists( $old_term_slug, self::TAXONOMY );
+			$term = term_exists( $old_term_slug, $taxonomy );
 
 			if ( empty( $term ) ) {
 				wp_insert_term(
 					$title,
-					self::TAXONOMY,
+					$taxonomy,
 					array(
 						'slug' => $new_term_slug,
 					)
@@ -546,7 +567,7 @@ class Venue {
 				// Update the existing term with the new name and slug.
 				wp_update_term(
 					intval( $term['term_id'] ),
-					self::TAXONOMY,
+					$taxonomy,
 					array(
 						'name' => $title,
 						'slug' => $new_term_slug,
@@ -578,11 +599,12 @@ class Venue {
 			$term_slug = $this->get_venue_term_slug( $post->post_name );
 
 			// Get the term by slug.
-			$term = get_term_by( 'slug', $term_slug, self::TAXONOMY );
+			$taxonomy = self::get_taxonomy( (string) get_post_type( $post_id ) );
+			$term     = get_term_by( 'slug', $term_slug, $taxonomy );
 
 			// Check if the term exists and delete it.
 			if ( is_a( $term, '\WP_Term' ) ) {
-				wp_delete_term( $term->term_id, self::TAXONOMY );
+				wp_delete_term( $term->term_id, $taxonomy );
 			}
 		}
 	}
@@ -635,12 +657,11 @@ class Venue {
 	 * @return null|WP_Post The Venue post object if found; otherwise, null.
 	 */
 	public function get_venue_post_from_event_post_id( int $post_id ): ?WP_Post {
-		$venue_terms = get_the_terms( $post_id, self::TAXONOMY );
+		$event_post_type = (string) get_post_type( $post_id );
+		$venue_terms     = get_the_terms( $post_id, self::get_taxonomy( self::get_venue_post_type( $event_post_type ) ) );
 		if ( ! is_array( $venue_terms ) || empty( $venue_terms ) ) {
 			return null;
 		}
-
-		$event_post_type = (string) get_post_type( $post_id );
 
 		// Assuming that we have only ONE venue related.
 		return $this->get_venue_post_from_term_slug( $venue_terms[0]->slug, $event_post_type );
@@ -670,7 +691,7 @@ class Venue {
 
 		if ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
 			$event       = new Event( $post_id );
-			$venue_terms = get_the_terms( $post_id, self::TAXONOMY );
+			$venue_terms = get_the_terms( $post_id, self::get_taxonomy( self::get_venue_post_type( $post_type ) ) );
 
 			if ( ! empty( $venue_terms ) && is_array( $venue_terms ) ) {
 				$venue_term = $venue_terms[0];

--- a/includes/core/classes/class-venue.php
+++ b/includes/core/classes/class-venue.php
@@ -86,9 +86,31 @@ class Venue {
 		);
 		add_action( 'init', array( $this, 'register_post_type' ) );
 		add_action( 'init', array( $this, 'register_post_meta' ) );
-		add_action( 'init', array( $this, 'register_taxonomy' ) );
+		// Priority 11 so post types registered at default priority 10 are available for get_post_types_by_support().
+		add_action( 'init', array( $this, 'register_taxonomy' ), 11 );
 		add_action( 'post_updated', array( $this, 'maybe_update_term_slug' ), 10, 3 );
 		add_action( 'delete_post', array( $this, 'delete_venue_term' ) );
+	}
+
+	/**
+	 * Returns the post type used as the venue, applying the gatherpress_venue_post_type filter.
+	 *
+	 * Defaults to the built-in gatherpress_venue post type. Developers can override this
+	 * via the filter to designate a custom post type as the venue for a given context.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string The venue post type slug.
+	 */
+	public static function get_venue_post_type(): string {
+		/**
+		 * Filters the post type used as the venue.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $post_type The venue post type slug. Default 'gatherpress_venue'.
+		 */
+		return (string) apply_filters( 'gatherpress_venue_post_type', self::POST_TYPE );
 	}
 
 	/**
@@ -295,7 +317,7 @@ class Venue {
 	public function register_taxonomy(): void {
 		register_taxonomy(
 			self::TAXONOMY,
-			Event::POST_TYPE,
+			array(),
 			array(
 				'labels'             => array(
 					'name'          => _x( 'Venues', 'Admin menu and taxonomy general name', 'gatherpress' ),
@@ -311,8 +333,11 @@ class Venue {
 				'show_in_rest'       => true,
 			)
 		);
-		// It is necessary to make this taxonomy visible on event posts, within REST responses.
-		register_taxonomy_for_object_type( self::TAXONOMY, Event::POST_TYPE );
+
+		// Register the taxonomy for all post types that support gatherpress-venue.
+		foreach ( get_post_types_by_support( 'gatherpress-venue' ) as $post_type ) {
+			register_taxonomy_for_object_type( self::TAXONOMY, $post_type );
+		}
 	}
 
 	/**
@@ -584,7 +609,7 @@ class Venue {
 		$venue_meta['isOnlineEventTerm'] = false;
 		$venue_meta['onlineEventLink']   = '';
 
-		if ( Event::POST_TYPE === $post_type ) {
+		if ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
 			$event       = new Event( $post_id );
 			$venue_terms = get_the_terms( $post_id, self::TAXONOMY );
 

--- a/includes/core/classes/class-venue.php
+++ b/includes/core/classes/class-venue.php
@@ -136,6 +136,14 @@ class Venue {
 	 * Applies the 'gatherpress_venue_post_type' filter so developers can map
 	 * custom event post types to their own venue post types.
 	 *
+	 * Results are cached in a static array for the lifetime of the request to
+	 * avoid repeated filter invocations. If a plugin adds or removes the
+	 * 'gatherpress_venue_post_type' filter after this method has already been
+	 * called for a given event post type, the cached value will be returned
+	 * rather than the updated filter result. This is an unlikely edge case in
+	 * normal WordPress request flow, where filters are registered before any
+	 * post-type lookups occur.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param string $event_post_type The event post type requesting a venue post type.

--- a/includes/core/classes/class-venue.php
+++ b/includes/core/classes/class-venue.php
@@ -112,9 +112,24 @@ class Venue {
 	 * @return string The taxonomy slug for the given venue post type.
 	 */
 	public static function get_taxonomy( string $venue_post_type = '' ): string {
-		return '_' . ( $venue_post_type ?: self::POST_TYPE );
+		if ( ! $venue_post_type ) {
+			$venue_post_type = self::POST_TYPE;
+		}
+
+		return '_' . $venue_post_type;
 	}
 
+	/**
+	 * Get the venue post type slug for a given event post type.
+	 *
+	 * Applies the 'gatherpress_venue_post_type' filter so developers can map
+	 * custom event post types to their own venue post types.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $event_post_type The event post type requesting a venue post type.
+	 * @return string The venue post type slug.
+	 */
 	public static function get_venue_post_type( string $event_post_type = '' ): string {
 		/**
 		 * Filters the post type used as the venue.
@@ -658,7 +673,8 @@ class Venue {
 	 */
 	public function get_venue_post_from_event_post_id( int $post_id ): ?WP_Post {
 		$event_post_type = (string) get_post_type( $post_id );
-		$venue_terms     = get_the_terms( $post_id, self::get_taxonomy( self::get_venue_post_type( $event_post_type ) ) );
+		$taxonomy        = self::get_taxonomy( self::get_venue_post_type( $event_post_type ) );
+		$venue_terms     = get_the_terms( $post_id, $taxonomy );
 		if ( ! is_array( $venue_terms ) || empty( $venue_terms ) ) {
 			return null;
 		}

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -40,7 +40,6 @@ import DateTimeRange from '../../components/DateTimeRange';
 import { getFromGlobal } from '../../helpers/globals';
 import { isEventPostType, hasValidEventId } from '../../helpers/event';
 import { isInFSETemplate } from '../../helpers/editor';
-import { CPT_EVENT } from '../../helpers/namespace';
 
 const globalDateFormat = getFromGlobal( 'settings.dateFormat' );
 const globalTimeFormat = getFromGlobal( 'settings.timeFormat' );
@@ -234,10 +233,17 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				};
 			}
 
-			// For Query Loop context, fetch from entity record.
+			// Resolve the post type from context or fall back to the editor's current post type.
+			// This ensures custom post types with gatherpress-event-date support work correctly
+			// in Query Loop blocks and postId override scenarios.
+			const postType =
+				context?.postType ||
+				select( 'core/editor' )?.getCurrentPostType();
+
+			// For Query Loop and override contexts, fetch from entity record.
 			const hasResolved = select( 'core' ).hasFinishedResolution(
 				'getEntityRecord',
-				[ 'postType', CPT_EVENT, postId ]
+				[ 'postType', postType, postId ]
 			);
 
 			if ( ! hasResolved ) {
@@ -246,7 +252,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 
 			const meta = select( 'core' ).getEntityRecord(
 				'postType',
-				CPT_EVENT,
+				postType,
 				postId
 			)?.meta;
 
@@ -256,7 +262,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				timezone: meta?.gatherpress_timezone,
 			};
 		},
-		[ postId ]
+		[ postId, context?.postType ]
 	);
 
 	// Show spinner only while loading, not on 404.

--- a/src/blocks/online-event-link/edit.js
+++ b/src/blocks/online-event-link/edit.js
@@ -10,7 +10,7 @@ import { store as editorStore } from '@wordpress/editor';
 /**
  * Internal dependencies.
  */
-import { CPT_EVENT } from '../../helpers/namespace';
+import { isPostTypeSupporting } from '../../helpers/event';
 
 /**
  * Edit component for the GatherPress Online Event block.
@@ -48,26 +48,26 @@ const Edit = ( { context, attributes, setAttributes } ) => {
 		[]
 	);
 
-	// Determine which post and meta field to use (only events have online links).
+	// Determine which post and meta field to use (only online-event-supporting types have online links).
 	const { postId, postType, metaKey } = useSelect(
 		( select ) => {
-			// If we have context, check if it's an event.
+			// If we have context, check if the context post type supports online events.
 			if ( contextPostId ) {
 				const { getEntityRecord } = select( coreStore );
 				const contextPost = getEntityRecord( 'postType', 'any', contextPostId );
 				const contextType = contextPost?.type;
 
-				if ( CPT_EVENT === contextType ) {
+				if ( contextType && isPostTypeSupporting( 'gatherpress-online-event', contextType ) ) {
 					return {
 						postId: contextPostId,
-						postType: CPT_EVENT,
+						postType: contextType,
 						metaKey: 'gatherpress_online_event_link',
 					};
 				}
 			}
 
-			// Fall back to current editor post if it's an event.
-			if ( CPT_EVENT === currentPostType ) {
+			// Fall back to current editor post if it supports online events.
+			if ( isPostTypeSupporting( 'gatherpress-online-event', currentPostType ) ) {
 				return {
 					postId: currentPostId,
 					postType: currentPostType,
@@ -75,7 +75,7 @@ const Edit = ( { context, attributes, setAttributes } ) => {
 				};
 			}
 
-			// Not an event context - no online link.
+			// Not an online-event context - no online link.
 			return {
 				postId: null,
 				postType: null,

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -18,7 +18,7 @@ import { __ } from '@wordpress/i18n';
 import TEMPLATE from './template';
 import { hasValidBlockContext, isInFSETemplate } from '../../helpers/editor';
 import { isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
-import { getVenuePostType, getVenueTaxonomy } from '../../helpers/venue';
+import { getVenuePostType, getVenueTaxonomy, useVenueTaxonomyIds } from '../../helpers/venue';
 
 /**
  * Edit component for the GatherPress Online Event block.
@@ -68,31 +68,10 @@ const Edit = ( { attributes, context } ) => {
 		! isDescendentOfQueryLoop && ! isInFSETemplate() && isEditingEvent;
 
 	// Read venue taxonomy IDs without triggering context=edit REST requests.
-	const venueTaxonomyIds = useSelect(
-		( wpSelect ) => {
-			if ( ! isEditingEvent ) {
-				return undefined;
-			}
-
-			// Try editor in-memory state first (PHP preload data + pending edits).
-			const editorAttr = wpSelect( 'core/editor' )?.getEditedPostAttribute( venueTaxonomy );
-			if ( Array.isArray( editorAttr ) ) {
-				return editorAttr;
-			}
-
-			if ( ! currentPostId ) {
-				return undefined;
-			}
-
-			// Fallback: query taxonomy terms with context=view (no edit permissions needed).
-			const terms = wpSelect( 'core' ).getEntityRecords(
-				'taxonomy',
-				venueTaxonomy,
-				{ post: currentPostId, per_page: 100, context: 'view' }
-			);
-			return terms?.map( ( t ) => t.id );
-		},
-		[ isEditingEvent, venueTaxonomy, currentPostId ]
+	const venueTaxonomyIds = useVenueTaxonomyIds(
+		venueTaxonomy,
+		currentPostId,
+		! isEditingEvent
 	);
 
 	const updateVenueTaxonomyIds = ( newIds ) =>

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -9,7 +9,6 @@ import {
 } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -68,13 +67,36 @@ const Edit = ( { attributes, context } ) => {
 	const showControls =
 		! isDescendentOfQueryLoop && ! isInFSETemplate() && isEditingEvent;
 
-	// Get venue taxonomy IDs for the current event.
-	const [ venueTaxonomyIds, updateVenueTaxonomyIds ] = useEntityProp(
-		'postType',
-		currentPostType,
-		venueTaxonomy,
-		isEditingEvent ? currentPostId : undefined
+	// Read venue taxonomy IDs without triggering context=edit REST requests.
+	const venueTaxonomyIds = useSelect(
+		( wpSelect ) => {
+			if ( ! isEditingEvent ) {
+				return undefined;
+			}
+
+			// Try editor in-memory state first (PHP preload data + pending edits).
+			const editorAttr = wpSelect( 'core/editor' )?.getEditedPostAttribute( venueTaxonomy );
+			if ( Array.isArray( editorAttr ) ) {
+				return editorAttr;
+			}
+
+			if ( ! currentPostId ) {
+				return undefined;
+			}
+
+			// Fallback: query taxonomy terms with context=view (no edit permissions needed).
+			const terms = wpSelect( 'core' ).getEntityRecords(
+				'taxonomy',
+				venueTaxonomy,
+				{ post: currentPostId, per_page: 100, context: 'view' }
+			);
+			return terms?.map( ( t ) => t.id );
+		},
+		[ isEditingEvent, venueTaxonomy, currentPostId ]
 	);
+
+	const updateVenueTaxonomyIds = ( newIds ) =>
+		editPost( { [ venueTaxonomy ]: newIds } );
 
 	// Get online event link from meta.
 	const onlineEventLinkMeta = useSelect(
@@ -155,14 +177,13 @@ const Edit = ( { attributes, context } ) => {
 				venueTermIds =
 					select( 'core/editor' ).getEditedPostAttribute( venueTaxonomy );
 			} else if ( eventId ) {
-				// Fetch from saved post data using context or editor post type.
-				const postType = context?.postType || editorPostType;
-				const post = select( 'core' ).getEntityRecord(
-					'postType',
-					postType,
-					eventId
+				// Query taxonomy terms with context=view to avoid context=edit requests.
+				const terms = select( 'core' ).getEntityRecords(
+					'taxonomy',
+					venueTaxonomy,
+					{ post: eventId, per_page: 100, context: 'view' }
 				);
-				venueTermIds = post?.[ venueTaxonomy ];
+				venueTermIds = terms?.map( ( t ) => t.id );
 			} else {
 				return false;
 			}
@@ -175,7 +196,7 @@ const Edit = ( { attributes, context } ) => {
 				( id ) => String( id ) === String( onlineTermId )
 			);
 		},
-		[ eventId, onlineEventTerm, context?.postType, venueTaxonomy ]
+		[ eventId, onlineEventTerm, venueTaxonomy ]
 	);
 
 	// Dim the block when not an online event or no valid context.

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -18,8 +18,8 @@ import { __ } from '@wordpress/i18n';
  */
 import TEMPLATE from './template';
 import { hasValidBlockContext, isInFSETemplate } from '../../helpers/editor';
-import { DISABLED_FIELD_OPACITY } from '../../helpers/event';
-import { TAX_VENUE, CPT_EVENT } from '../../helpers/namespace';
+import { isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
+import { TAX_VENUE } from '../../helpers/namespace';
 
 /**
  * Edit component for the GatherPress Online Event block.
@@ -59,14 +59,14 @@ const Edit = ( { attributes, context } ) => {
 		[]
 	);
 
-	const isEditingEvent = CPT_EVENT === currentPostType;
+	const isEditingEvent = isPostTypeSupporting( 'gatherpress-online-event', currentPostType );
 	const showControls =
 		! isDescendentOfQueryLoop && ! isInFSETemplate() && isEditingEvent;
 
 	// Get venue taxonomy IDs for the current event.
 	const [ venueTaxonomyIds, updateVenueTaxonomyIds ] = useEntityProp(
 		'postType',
-		CPT_EVENT,
+		currentPostType,
 		TAX_VENUE,
 		isEditingEvent ? currentPostId : undefined
 	);
@@ -139,7 +139,9 @@ const Edit = ( { attributes, context } ) => {
 			const editorPostId = select( 'core/editor' )?.getCurrentPostId();
 			const editorPostType = select( 'core/editor' )?.getCurrentPostType();
 			const isCurrentPost = eventId && editorPostId === eventId;
-			const isEditorEvent = CPT_EVENT === editorPostType;
+			const isEditorEvent =
+				!! select( 'core' ).getPostType( editorPostType )
+					?.supports?.[ 'gatherpress-online-event' ];
 
 			let venueTermIds;
 
@@ -148,10 +150,11 @@ const Edit = ( { attributes, context } ) => {
 				venueTermIds =
 					select( 'core/editor' ).getEditedPostAttribute( TAX_VENUE );
 			} else if ( eventId ) {
-				// Fetch from saved post data.
+				// Fetch from saved post data using context or editor post type.
+				const postType = context?.postType || editorPostType;
 				const post = select( 'core' ).getEntityRecord(
 					'postType',
-					CPT_EVENT,
+					postType,
 					eventId
 				);
 				venueTermIds = post?.[ TAX_VENUE ];
@@ -167,7 +170,7 @@ const Edit = ( { attributes, context } ) => {
 				( id ) => String( id ) === String( onlineTermId )
 			);
 		},
-		[ eventId, onlineEventTerm ]
+		[ eventId, onlineEventTerm, context?.postType ]
 	);
 
 	// Dim the block when not an online event or no valid context.
@@ -176,7 +179,7 @@ const Edit = ( { attributes, context } ) => {
 			opacity: hasValidBlockContext( {
 				isDescendentOfQueryLoop,
 				postType: context?.postType,
-				expectedPostType: CPT_EVENT,
+				support: 'gatherpress-online-event',
 				hasData: isOnlineEvent,
 			} )
 				? 1

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -19,7 +19,7 @@ import { __ } from '@wordpress/i18n';
 import TEMPLATE from './template';
 import { hasValidBlockContext, isInFSETemplate } from '../../helpers/editor';
 import { isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
-import { TAX_VENUE } from '../../helpers/namespace';
+import { getVenuePostType, getVenueTaxonomy } from '../../helpers/venue';
 
 /**
  * Edit component for the GatherPress Online Event block.
@@ -46,16 +46,21 @@ const Edit = ( { attributes, context } ) => {
 	const { editPost, unlockPostSaving } = useDispatch( 'core/editor' );
 
 	// Get the current post info and venue taxonomy.
-	const { currentPostId, currentPostType, onlineEventTerm } = useSelect(
-		( select ) => ( {
-			currentPostId: select( 'core/editor' )?.getCurrentPostId(),
-			currentPostType: select( 'core/editor' )?.getCurrentPostType(),
-			onlineEventTerm:
-				select( 'core' ).getEntityRecords( 'taxonomy', TAX_VENUE, {
-					slug: 'online-event',
-					per_page: 1,
-				} )?.[ 0 ] || null,
-		} ),
+	const { currentPostId, currentPostType, venueTaxonomy, onlineEventTerm } = useSelect(
+		( select ) => {
+			const editorPostType = select( 'core/editor' )?.getCurrentPostType();
+			const tax = getVenueTaxonomy( getVenuePostType( editorPostType ) );
+			return {
+				currentPostId: select( 'core/editor' )?.getCurrentPostId(),
+				currentPostType: editorPostType,
+				venueTaxonomy: tax,
+				onlineEventTerm:
+					select( 'core' ).getEntityRecords( 'taxonomy', tax, {
+						slug: 'online-event',
+						per_page: 1,
+					} )?.[ 0 ] || null,
+			};
+		},
 		[]
 	);
 
@@ -67,7 +72,7 @@ const Edit = ( { attributes, context } ) => {
 	const [ venueTaxonomyIds, updateVenueTaxonomyIds ] = useEntityProp(
 		'postType',
 		currentPostType,
-		TAX_VENUE,
+		venueTaxonomy,
 		isEditingEvent ? currentPostId : undefined
 	);
 
@@ -148,7 +153,7 @@ const Edit = ( { attributes, context } ) => {
 			if ( isCurrentPost || ( ! eventId && isEditorEvent ) ) {
 				// Use live editor data for current post.
 				venueTermIds =
-					select( 'core/editor' ).getEditedPostAttribute( TAX_VENUE );
+					select( 'core/editor' ).getEditedPostAttribute( venueTaxonomy );
 			} else if ( eventId ) {
 				// Fetch from saved post data using context or editor post type.
 				const postType = context?.postType || editorPostType;
@@ -157,7 +162,7 @@ const Edit = ( { attributes, context } ) => {
 					postType,
 					eventId
 				);
-				venueTermIds = post?.[ TAX_VENUE ];
+				venueTermIds = post?.[ venueTaxonomy ];
 			} else {
 				return false;
 			}
@@ -170,7 +175,7 @@ const Edit = ( { attributes, context } ) => {
 				( id ) => String( id ) === String( onlineTermId )
 			);
 		},
-		[ eventId, onlineEventTerm, context?.postType ]
+		[ eventId, onlineEventTerm, context?.postType, venueTaxonomy ]
 	);
 
 	// Dim the block when not an online event or no valid context.

--- a/src/blocks/rsvp-guest-count-display/edit.js
+++ b/src/blocks/rsvp-guest-count-display/edit.js
@@ -10,8 +10,7 @@ import { useEffect } from '@wordpress/element';
  * Internal dependencies.
  */
 import { getEditorDocument } from '../../helpers/editor';
-import { DISABLED_FIELD_OPACITY, isEventPostType } from '../../helpers/event';
-import { CPT_EVENT } from '../../helpers/namespace';
+import { DISABLED_FIELD_OPACITY, isPostTypeSupporting } from '../../helpers/event';
 
 /**
  * Edit function for the RSVP Guest Count Display Block.
@@ -32,8 +31,8 @@ const Edit = ( { context, clientId } ) => {
 	const contextPostId = context?.postId;
 	const rsvpResponses = context?.[ 'gatherpress/rsvpResponses' ] ?? null;
 
-	// Check if context post type is an event.
-	const isEventContext = isEventPostType( context?.postType );
+	// Check if context post type supports RSVP.
+	const isEventContext = isPostTypeSupporting( 'gatherpress-rsvp', context?.postType );
 
 	// Example guest count.
 	let guestCount = 1;
@@ -75,23 +74,26 @@ const Edit = ( { context, clientId } ) => {
 			}
 
 			// If we have a Post ID override, fetch from that post.
+			// Use context post type if available; it corresponds to the same post type as the override.
 			if ( postIdOverride ) {
-				const post = select( 'core' ).getEntityRecord( 'postType', CPT_EVENT, postIdOverride );
+				const overridePostType =
+					context?.postType ||
+					select( 'core/editor' )?.getCurrentPostType();
+				const post = select( 'core' ).getEntityRecord( 'postType', overridePostType, postIdOverride );
 				return post?.meta?.gatherpress_max_guest_limit || 0;
 			}
 
 			// Otherwise check current post.
 			const currentPostType = select( 'core/editor' )?.getCurrentPostType();
-			const isCurrentPostEvent = CPT_EVENT === currentPostType;
 
-			if ( isCurrentPostEvent ) {
+			if ( isPostTypeSupporting( 'gatherpress-rsvp', currentPostType ) ) {
 				return select( 'core/editor' ).getEditedPostAttribute( 'meta' )
 					?.gatherpress_max_guest_limit || 0;
 			}
 
 			return 0;
 		},
-		[ clientId, contextPostId, isEventContext ],
+		[ clientId, contextPostId, isEventContext, context?.postType ],
 	);
 
 	// Apply dimming via CSS when max attendance limit is 0.

--- a/src/blocks/venue-detail/block.json
+++ b/src/blocks/venue-detail/block.json
@@ -8,7 +8,7 @@
 	"icon": "location",
 	"description": "Display venue details like address, phone, or website.",
 	"parent": ["gatherpress/venue"],
-	"usesContext": ["postId", "queryId"],
+	"usesContext": ["postId", "postType", "queryId"],
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/src/blocks/venue-detail/hooks/use-venue-data.js
+++ b/src/blocks/venue-detail/hooks/use-venue-data.js
@@ -10,7 +10,7 @@ import { useCallback } from '@wordpress/element';
 /**
  * Internal dependencies.
  */
-import { CPT_VENUE } from '../../../helpers/namespace';
+import { isPostTypeSupporting } from '../../../helpers/event';
 import { getJsonFieldName } from '../helpers';
 
 /**
@@ -35,24 +35,15 @@ export function useVenueData( context, fieldType ) {
 				selectData( 'core/editor' )?.getCurrentPostType();
 			const contextPostId = context?.postId || 0;
 
-			// Check if the context post is actually a venue.
-			let contextPostIsVenue = false;
-			if ( contextPostId ) {
-				const contextPost = selectData( coreStore ).getEntityRecord(
-					'postType',
-					CPT_VENUE,
-					contextPostId
-				);
-				// If we got a record from the venue post type, it's a venue.
-				contextPostIsVenue = !! contextPost;
-			}
+			// Check if the context post type is a venue via its registered supports.
+			const contextPostIsVenue = !! contextPostId && isPostTypeSupporting( 'gatherpress-venue-information', context?.postType );
 
 			// Only use contextPostId if it's actually a venue post.
 			// Otherwise, check if we're editing a venue directly.
 			let effectiveVenuePostId = 0;
 			if ( contextPostIsVenue ) {
 				effectiveVenuePostId = contextPostId;
-			} else if ( currentPostType === CPT_VENUE ) {
+			} else if ( isPostTypeSupporting( 'gatherpress-venue-information', currentPostType ) ) {
 				effectiveVenuePostId = currentPostId;
 			}
 
@@ -60,10 +51,10 @@ export function useVenueData( context, fieldType ) {
 				venuePostId: effectiveVenuePostId,
 				isEditingCurrentPost:
 					currentPostId === effectiveVenuePostId &&
-					currentPostType === CPT_VENUE,
+					isPostTypeSupporting( 'gatherpress-venue-information', currentPostType ),
 			};
 		},
-		[ context?.postId ]
+		[ context?.postId, context?.postType ]
 	);
 
 	// Map field type to JSON field name.
@@ -92,7 +83,7 @@ export function useVenueData( context, fieldType ) {
 				const { getEditedEntityRecord } = selectData( coreStore );
 				const venuePost = getEditedEntityRecord(
 					'postType',
-					CPT_VENUE,
+					context?.postType,
 					venuePostId
 				);
 				venueInfoJson =
@@ -105,7 +96,7 @@ export function useVenueData( context, fieldType ) {
 				return {};
 			}
 		},
-		[ venuePostId, isEditingCurrentPost ]
+		[ venuePostId, isEditingCurrentPost, context?.postType ]
 	);
 
 	const fieldValue = jsonFieldName ? venueInfo[ jsonFieldName ] || '' : '';
@@ -128,7 +119,7 @@ export function useVenueData( context, fieldType ) {
 			} else {
 				const currentVenueInfo = select(
 					coreStore
-				)?.getEditedEntityRecord( 'postType', CPT_VENUE, venuePostId );
+				)?.getEditedEntityRecord( 'postType', context?.postType, venuePostId );
 				venueInfoJson =
 					currentVenueInfo?.meta?.gatherpress_venue_information ||
 					'{}';
@@ -156,7 +147,7 @@ export function useVenueData( context, fieldType ) {
 					},
 				} );
 			} else {
-				editEntityRecord( 'postType', CPT_VENUE, venuePostId, {
+				editEntityRecord( 'postType', context?.postType, venuePostId, {
 					meta: {
 						gatherpress_venue_information:
 							JSON.stringify( updatedVenueInfo ),
@@ -164,7 +155,7 @@ export function useVenueData( context, fieldType ) {
 				} );
 			}
 		},
-		[ venuePostId, isEditingCurrentPost, editEntityRecord, editPost ]
+		[ venuePostId, isEditingCurrentPost, editEntityRecord, editPost, context?.postType ]
 	);
 
 	// Update the current field value (strips HTML tags).

--- a/src/blocks/venue-map/block.json
+++ b/src/blocks/venue-map/block.json
@@ -8,7 +8,7 @@
 	"icon": "location-alt",
 	"description": "Display a map for the venue location.",
 	"parent": ["gatherpress/venue"],
-	"usesContext": ["postId", "queryId"],
+	"usesContext": ["postId", "postType", "queryId"],
 	"attributes": {
 		"zoom": {
 			"type": "number",

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -36,7 +36,6 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const { isEditingThisVenue, venueInfoJson } = useSelect(
 		( select ) => {
 			const currentPostId = select( 'core/editor' )?.getCurrentPostId();
-			const currentPostType = select( 'core/editor' )?.getCurrentPostType();
 			const contextPostId = context?.postId || 0;
 
 			// If we're editing a venue post directly and context doesn't provide a valid ID,
@@ -67,10 +66,12 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 			}
 
 			// Read from core store for a different venue post.
+			// Use context?.postType (the venue post type from BlockContextProvider),
+			// not currentPostType (the event post type), to avoid requesting the wrong endpoint.
 			const { getEditedEntityRecord } = select( 'core' );
 			const venuePost = getEditedEntityRecord(
 				'postType',
-				currentPostType,
+				context?.postType,
 				effectiveVenuePostId
 			);
 
@@ -79,7 +80,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				venueInfoJson: venuePost?.meta?.gatherpress_venue_information || '{}',
 			};
 		},
-		[ context?.postId ]
+		[ context?.postId, context?.postType ]
 	);
 
 	// For live preview when editing the venue, read lat/long from venue store.

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -13,7 +13,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies.
  */
-import { CPT_VENUE } from '../../helpers/namespace';
+import { isVenuePostType } from '../../helpers/venue';
 import MapEmbed from '../../components/MapEmbed';
 
 /**
@@ -43,7 +43,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 			// use the current post ID.
 			const effectiveVenuePostId =
 				contextPostId ||
-				( currentPostType === CPT_VENUE ? currentPostId : 0 );
+				( isVenuePostType() ? currentPostId : 0 );
 
 			if ( ! effectiveVenuePostId ) {
 				return {
@@ -54,7 +54,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 
 			const isEditing =
 				currentPostId === effectiveVenuePostId &&
-				currentPostType === CPT_VENUE;
+				isVenuePostType();
 
 			if ( isEditing ) {
 				// Read from core/editor store for the current post being edited.
@@ -70,7 +70,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 			const { getEditedEntityRecord } = select( 'core' );
 			const venuePost = getEditedEntityRecord(
 				'postType',
-				CPT_VENUE,
+				currentPostType,
 				effectiveVenuePostId
 			);
 

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -17,9 +17,9 @@ import { useSelect } from '@wordpress/data';
  */
 import { getCurrentContextualPostId, hasValidBlockContext } from '../../helpers/editor';
 import { isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
-import { GetVenuePostFromTermId, GetVenuePostFromEventId } from '../../helpers/venue';
+import { GetVenuePostFromTermId, GetVenuePostFromEventId, getVenuePostType } from '../../helpers/venue';
 import VenueNavigator from '../../components/VenueNavigator';
-import { CPT_VENUE, TAX_VENUE } from '../../helpers/namespace';
+import { TAX_VENUE } from '../../helpers/namespace';
 import { TEMPLATE_WITH_TITLE, TEMPLATE_WITHOUT_TITLE } from './template';
 
 const Edit = ( props ) => {
@@ -27,7 +27,7 @@ const Edit = ( props ) => {
 
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
 	const isEventContext = isPostTypeSupporting( 'gatherpress-venue', context?.postType );
-	const isVenueContext = CPT_VENUE === context?.postType;
+	const isVenueContext = isPostTypeSupporting( 'gatherpress-venue-information', context?.postType );
 
 	// Resolve the effective post type from context or the current editor post type.
 	const currentEditorPostType = useSelect(
@@ -35,6 +35,7 @@ const Edit = ( props ) => {
 		[]
 	);
 	const effectivePostType = context?.postType || currentEditorPostType;
+	const venuePostType = getVenuePostType( effectivePostType );
 
 	const eventId = getCurrentContextualPostId( context?.postId );
 	const [ venueTaxonomyIds ] = useEntityProp(
@@ -123,7 +124,7 @@ const Edit = ( props ) => {
 			<BlockContextProvider
 				value={ {
 					postId: venuePostId,
-					postType: CPT_VENUE,
+					postType: venuePostType,
 				} }
 			>
 				<InnerBlocks template={ template } templateLock={ false } />

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -17,9 +17,8 @@ import { useSelect } from '@wordpress/data';
  */
 import { getCurrentContextualPostId, hasValidBlockContext } from '../../helpers/editor';
 import { isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
-import { GetVenuePostFromTermId, GetVenuePostFromEventId, getVenuePostType } from '../../helpers/venue';
+import { GetVenuePostFromTermId, GetVenuePostFromEventId, getVenuePostType, getVenueTaxonomy } from '../../helpers/venue';
 import VenueNavigator from '../../components/VenueNavigator';
-import { TAX_VENUE } from '../../helpers/namespace';
 import { TEMPLATE_WITH_TITLE, TEMPLATE_WITHOUT_TITLE } from './template';
 
 const Edit = ( props ) => {
@@ -41,7 +40,7 @@ const Edit = ( props ) => {
 	const [ venueTaxonomyIds ] = useEntityProp(
 		'postType',
 		effectivePostType,
-		TAX_VENUE,
+		getVenueTaxonomy( venuePostType ),
 		isVenueContext ? 0 : eventId
 	);
 
@@ -61,13 +60,13 @@ const Edit = ( props ) => {
 				.map( ( termId ) =>
 					wpSelect( 'core' ).getEntityRecord(
 						'taxonomy',
-						TAX_VENUE,
+						getVenueTaxonomy( venuePostType ),
 						termId
 					)
 				)
 				.filter( Boolean );
 		},
-		[ isEditableEventContext, venueTaxonomyIds ]
+		[ isEditableEventContext, venueTaxonomyIds, venuePostType ]
 	);
 
 	// Find venue term ID (excluding online-event).

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -9,7 +9,6 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { PanelBody, PanelRow } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -37,11 +36,34 @@ const Edit = ( props ) => {
 	const venuePostType = getVenuePostType( effectivePostType );
 
 	const eventId = getCurrentContextualPostId( context?.postId );
-	const [ venueTaxonomyIds ] = useEntityProp(
-		'postType',
-		effectivePostType,
-		getVenueTaxonomy( venuePostType ),
-		isVenueContext ? 0 : eventId
+	const venueTaxonomy = getVenueTaxonomy( venuePostType );
+
+	// Read venue taxonomy IDs without triggering context=edit REST requests.
+	const venueTaxonomyIds = useSelect(
+		( wpSelect ) => {
+			if ( isVenueContext || isDescendentOfQueryLoop ) {
+				return undefined;
+			}
+
+			// Try editor in-memory state first (PHP preload data + pending edits).
+			const editorAttr = wpSelect( 'core/editor' )?.getEditedPostAttribute( venueTaxonomy );
+			if ( Array.isArray( editorAttr ) ) {
+				return editorAttr;
+			}
+
+			if ( ! eventId ) {
+				return undefined;
+			}
+
+			// Fallback: query taxonomy terms with context=view (no edit permissions needed).
+			const terms = wpSelect( 'core' ).getEntityRecords(
+				'taxonomy',
+				venueTaxonomy,
+				{ post: eventId, per_page: 100, context: 'view' }
+			);
+			return terms?.map( ( t ) => t.id );
+		},
+		[ isVenueContext, isDescendentOfQueryLoop, eventId, venueTaxonomy ]
 	);
 
 	const isEditableEventContext =
@@ -60,13 +82,13 @@ const Edit = ( props ) => {
 				.map( ( termId ) =>
 					wpSelect( 'core' ).getEntityRecord(
 						'taxonomy',
-						getVenueTaxonomy( venuePostType ),
+						venueTaxonomy,
 						termId
 					)
 				)
 				.filter( Boolean );
 		},
-		[ isEditableEventContext, venueTaxonomyIds, venuePostType ]
+		[ isEditableEventContext, venueTaxonomyIds, venueTaxonomy ]
 	);
 
 	// Find venue term ID (excluding online-event).

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -16,7 +16,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { getCurrentContextualPostId, hasValidBlockContext } from '../../helpers/editor';
-import { isEventPostType, DISABLED_FIELD_OPACITY } from '../../helpers/event';
+import { isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
 import { GetVenuePostFromTermId, GetVenuePostFromEventId } from '../../helpers/venue';
 import VenueNavigator from '../../components/VenueNavigator';
 import { CPT_EVENT, CPT_VENUE, TAX_VENUE } from '../../helpers/namespace';
@@ -26,13 +26,13 @@ const Edit = ( props ) => {
 	const { context } = props;
 
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
-	const isEventContext = isEventPostType( context?.postType );
+	const isEventContext = isPostTypeSupporting( 'gatherpress-venue', context?.postType );
 	const isVenueContext = CPT_VENUE === context?.postType;
 
 	const eventId = getCurrentContextualPostId( context?.postId );
 	const [ venueTaxonomyIds ] = useEntityProp(
 		'postType',
-		CPT_EVENT,
+		context?.postType || CPT_EVENT,
 		TAX_VENUE,
 		isVenueContext ? 0 : eventId
 	);
@@ -99,7 +99,7 @@ const Edit = ( props ) => {
 			opacity: hasValidBlockContext( {
 				isDescendentOfQueryLoop,
 				postType: context?.postType,
-				expectedPostType: CPT_EVENT,
+				support: 'gatherpress-venue',
 				hasData: hasVenue,
 			} )
 				? 1

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -16,7 +16,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { getCurrentContextualPostId, hasValidBlockContext, isInFSETemplate } from '../../helpers/editor';
 import { isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
-import { GetVenuePostFromTermId, GetVenuePostFromEventId, getVenuePostType, getVenueTaxonomy } from '../../helpers/venue';
+import { GetVenuePostFromTermId, GetVenuePostFromEventId, getVenuePostType, getVenueTaxonomy, useVenueTaxonomyIds } from '../../helpers/venue';
 import VenueNavigator from '../../components/VenueNavigator';
 import { TEMPLATE_WITH_TITLE, TEMPLATE_WITHOUT_TITLE } from './template';
 
@@ -39,31 +39,10 @@ const Edit = ( props ) => {
 	const venueTaxonomy = getVenueTaxonomy( venuePostType );
 
 	// Read venue taxonomy IDs without triggering context=edit REST requests.
-	const venueTaxonomyIds = useSelect(
-		( wpSelect ) => {
-			if ( isVenueContext || isDescendentOfQueryLoop ) {
-				return undefined;
-			}
-
-			// Try editor in-memory state first (PHP preload data + pending edits).
-			const editorAttr = wpSelect( 'core/editor' )?.getEditedPostAttribute( venueTaxonomy );
-			if ( Array.isArray( editorAttr ) ) {
-				return editorAttr;
-			}
-
-			if ( ! eventId ) {
-				return undefined;
-			}
-
-			// Fallback: query taxonomy terms with context=view (no edit permissions needed).
-			const terms = wpSelect( 'core' ).getEntityRecords(
-				'taxonomy',
-				venueTaxonomy,
-				{ post: eventId, per_page: 100, context: 'view' }
-			);
-			return terms?.map( ( t ) => t.id );
-		},
-		[ isVenueContext, isDescendentOfQueryLoop, eventId, venueTaxonomy ]
+	const venueTaxonomyIds = useVenueTaxonomyIds(
+		venueTaxonomy,
+		eventId,
+		isVenueContext || isDescendentOfQueryLoop
 	);
 
 	const isEditableEventContext =

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -19,7 +19,7 @@ import { getCurrentContextualPostId, hasValidBlockContext } from '../../helpers/
 import { isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
 import { GetVenuePostFromTermId, GetVenuePostFromEventId } from '../../helpers/venue';
 import VenueNavigator from '../../components/VenueNavigator';
-import { CPT_EVENT, CPT_VENUE, TAX_VENUE } from '../../helpers/namespace';
+import { CPT_VENUE, TAX_VENUE } from '../../helpers/namespace';
 import { TEMPLATE_WITH_TITLE, TEMPLATE_WITHOUT_TITLE } from './template';
 
 const Edit = ( props ) => {
@@ -29,10 +29,17 @@ const Edit = ( props ) => {
 	const isEventContext = isPostTypeSupporting( 'gatherpress-venue', context?.postType );
 	const isVenueContext = CPT_VENUE === context?.postType;
 
+	// Resolve the effective post type from context or the current editor post type.
+	const currentEditorPostType = useSelect(
+		( select ) => select( 'core/editor' )?.getCurrentPostType(),
+		[]
+	);
+	const effectivePostType = context?.postType || currentEditorPostType;
+
 	const eventId = getCurrentContextualPostId( context?.postId );
 	const [ venueTaxonomyIds ] = useEntityProp(
 		'postType',
-		context?.postType || CPT_EVENT,
+		effectivePostType,
 		TAX_VENUE,
 		isVenueContext ? 0 : eventId
 	);
@@ -70,7 +77,8 @@ const Edit = ( props ) => {
 	// Fetch venue post - use different methods for Query Loop vs direct editing.
 	const venuePostFromTerm = GetVenuePostFromTermId( venueTermId );
 	const venuePostFromEvent = GetVenuePostFromEventId(
-		isDescendentOfQueryLoop ? context?.postId : null
+		isDescendentOfQueryLoop ? context?.postId : null,
+		context?.postType
 	);
 
 	// Use Query Loop result if available, otherwise use direct editing result.

--- a/src/blocks/venue/slotfill.js
+++ b/src/blocks/venue/slotfill.js
@@ -4,11 +4,11 @@ import { Fill } from '@wordpress/components';
  * Internal dependencies
  */
 import VenueNavigator from '../../components/VenueNavigator';
-import { isEventPostType } from '../../helpers/event';
+import { isPostTypeSupporting } from '../../helpers/event';
 
 export default function VenueBlockPluginFill() {
 	return (
-		isEventPostType() && (
+		isPostTypeSupporting( 'gatherpress-venue' ) && (
 			<>
 				<Fill name="VenuePluginDocumentSettings">
 					<VenueNavigator />

--- a/src/components/OnlineEvent.js
+++ b/src/components/OnlineEvent.js
@@ -9,7 +9,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies.
  */
-import { TAX_VENUE } from '../helpers/namespace';
+import { getVenuePostType, getVenueTaxonomy } from '../helpers/venue';
 
 /**
  * OnlineEvent component for GatherPress.
@@ -32,19 +32,25 @@ const OnlineEvent = () => {
 				.gatherpress_online_event_link,
 	);
 
+	// Derive the venue taxonomy from the current editor post type.
+	const venueTaxonomy = useSelect( ( select ) => {
+		const editorPostType = select( 'core/editor' )?.getCurrentPostType();
+		return getVenueTaxonomy( getVenuePostType( editorPostType ) );
+	}, [] );
+
 	// Get current venue taxonomy terms.
 	const venueTermIds = useSelect( ( select ) =>
-		select( 'core/editor' ).getEditedPostAttribute( TAX_VENUE ),
+		select( 'core/editor' ).getEditedPostAttribute( venueTaxonomy ),
 	);
 
 	// Get the online-event term to find its ID.
 	const onlineEventTerm = useSelect( ( select ) => {
-		const terms = select( 'core' ).getEntityRecords( 'taxonomy', TAX_VENUE, {
+		const terms = select( 'core' ).getEntityRecords( 'taxonomy', venueTaxonomy, {
 			slug: 'online-event',
 			per_page: 1,
 		} );
 		return terms?.[ 0 ] || null;
-	}, [] );
+	}, [ venueTaxonomy ] );
 
 	// Check if online-event term is currently assigned.
 	// Term IDs may be strings or numbers depending on source, so compare as strings.
@@ -116,7 +122,7 @@ const OnlineEvent = () => {
 			);
 		}
 
-		editPost( { [ TAX_VENUE ]: newTerms } );
+		editPost( { [ venueTaxonomy ]: newTerms } );
 		unlockPostSaving();
 	};
 

--- a/src/components/PopularVenues.js
+++ b/src/components/PopularVenues.js
@@ -18,14 +18,15 @@ import { usePopularVenues, getVenueTitle } from '../helpers/venue';
  *
  * @since 1.0.0
  *
- * @param {Object}   props           Component props.
- * @param {Function} props.onSelect  Callback function when a venue is selected.
- * @param {number}   props.currentId Currently selected venue ID (to highlight/disable it).
+ * @param {Object}   props               Component props.
+ * @param {Function} props.onSelect      Callback function when a venue is selected.
+ * @param {number}   props.currentId     Currently selected venue ID (to highlight/disable it).
+ * @param {string}   props.venuePostType Venue post type slug used to derive the taxonomy.
  *
  * @return {JSX.Element|null} Popular venues list or null if no venues.
  */
-export default function PopularVenues( { onSelect, currentId } ) {
-	const popularVenues = usePopularVenues( 3 );
+export default function PopularVenues( { onSelect, currentId, venuePostType } ) {
+	const popularVenues = usePopularVenues( 3, venuePostType );
 
 	// Don't render if there are no popular venues.
 	if ( ! popularVenues || 0 === popularVenues.length ) {

--- a/src/components/VenueComboboxProvider.js
+++ b/src/components/VenueComboboxProvider.js
@@ -3,10 +3,10 @@
  */
 import { VenueTermsCombobox } from './VenueTermsCombobox';
 import { VenuePostsCombobox } from './VenuePostsCombobox';
-import { isEventPostType } from '../helpers/event';
+import { isPostTypeSupporting } from '../helpers/event';
 
 export const VenueComboboxProvider = ( { search, setSearch, ...props } ) => {
-	const isEventContext = isEventPostType( props?.context?.postType );
+	const isEventContext = isPostTypeSupporting( 'gatherpress-venue', props?.context?.postType );
 	return (
 		<>
 			{ isEventContext && (

--- a/src/components/VenueForm.js
+++ b/src/components/VenueForm.js
@@ -18,7 +18,8 @@ import { useEntityProp, store as coreDataStore } from '@wordpress/core-data';
 /**
  * Internal dependencies.
  */
-import { CPT_VENUE, TAX_VENUE } from '../helpers/namespace';
+import { TAX_VENUE } from '../helpers/namespace';
+import { getVenuePostType } from '../helpers/venue';
 import { isPostTypeSupporting } from '../helpers/event';
 import { getCurrentContextualPostId } from '../helpers/editor';
 import { geocodeAddress } from '../helpers/geocoding';
@@ -132,18 +133,20 @@ function CreateVenueForm( { search, ...props } ) {
 	const [ address, setAddress ] = useState( '' );
 	const [ titleError, setTitleError ] = useState( '' );
 
+	const venuePostType = getVenuePostType( props?.context?.postType );
+
 	const { lastError, isSaving } = useSelect(
 		( select ) => ( {
 			lastError: select( coreDataStore ).getLastEntitySaveError(
 				'postType',
-				CPT_VENUE
+				venuePostType
 			),
 			isSaving: select( coreDataStore ).isSavingEntityRecord(
 				'postType',
-				CPT_VENUE
+				venuePostType
 			),
 		} ),
-		[]
+		[ venuePostType ]
 	);
 
 	/**
@@ -186,6 +189,14 @@ function CreateVenueForm( { search, ...props } ) {
 		[ props?.context?.postType ]
 	);
 
+	const venueRestBase = useSelect(
+		( select ) => {
+			const venuePostTypeObj = select( 'core' ).getPostType( venuePostType );
+			return venuePostTypeObj?.rest_base || venuePostType + 's';
+		},
+		[ venuePostType ]
+	);
+
 	const [ , updateVenueTaxonomyIds ] = useEntityProp(
 		'postType',
 		currentPostType,
@@ -213,7 +224,7 @@ function CreateVenueForm( { search, ...props } ) {
 			const newAttributes = {
 				...blockProps.attributes,
 				selectedPostId: postId,
-				selectedPostType: CPT_VENUE,
+				selectedPostType: venuePostType,
 			};
 			blockProps.setAttributes( newAttributes );
 		}
@@ -239,7 +250,7 @@ function CreateVenueForm( { search, ...props } ) {
 	) => {
 		try {
 			const newPost = await apiFetch( {
-				path: `/wp/v2/${ CPT_VENUE }s`, // !! Watch out & beware of the 's' at the end. // @TODO Make this nicer.
+				path: `/wp/v2/${ venueRestBase }`,
 				method: 'POST',
 				data: {
 					title,

--- a/src/components/VenueForm.js
+++ b/src/components/VenueForm.js
@@ -11,16 +11,15 @@ import {
 	useNavigator,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
-import { useEntityProp, store as coreDataStore } from '@wordpress/core-data';
+import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies.
  */
 import { getVenuePostType, getVenueTaxonomy } from '../helpers/venue';
 import { isPostTypeSupporting } from '../helpers/event';
-import { getCurrentContextualPostId } from '../helpers/editor';
 import { geocodeAddress } from '../helpers/geocoding';
 
 /**
@@ -179,16 +178,6 @@ function CreateVenueForm( { search, ...props } ) {
 		setTitleError( error );
 	};
 
-	const cId = getCurrentContextualPostId( props?.context?.postId );
-
-	// Use context post type if provided, otherwise fall back to the editor's current post type.
-	const currentPostType = useSelect(
-		( select ) =>
-			props?.context?.postType ||
-			select( 'core/editor' )?.getCurrentPostType(),
-		[ props?.context?.postType ]
-	);
-
 	const venueRestBase = useSelect(
 		( select ) => {
 			const venuePostTypeObj = select( 'core' ).getPostType( venuePostType );
@@ -197,12 +186,9 @@ function CreateVenueForm( { search, ...props } ) {
 		[ venuePostType ]
 	);
 
-	const [ , updateVenueTaxonomyIds ] = useEntityProp(
-		'postType',
-		currentPostType,
-		venueTaxonomy,
-		cId
-	);
+	const { editPost } = useDispatch( 'core/editor' );
+	const updateVenueTaxonomyIds = ( newIds ) =>
+		editPost( { [ venueTaxonomy ]: newIds } );
 
 	const { goTo } = useNavigator();
 

--- a/src/components/VenueForm.js
+++ b/src/components/VenueForm.js
@@ -18,8 +18,8 @@ import { useEntityProp, store as coreDataStore } from '@wordpress/core-data';
 /**
  * Internal dependencies.
  */
-import { CPT_EVENT, CPT_VENUE, TAX_VENUE } from '../helpers/namespace';
-import { isEventPostType } from '../helpers/event';
+import { CPT_VENUE, TAX_VENUE } from '../helpers/namespace';
+import { isPostTypeSupporting } from '../helpers/event';
 import { getCurrentContextualPostId } from '../helpers/editor';
 import { geocodeAddress } from '../helpers/geocoding';
 
@@ -178,9 +178,17 @@ function CreateVenueForm( { search, ...props } ) {
 
 	const cId = getCurrentContextualPostId( props?.context?.postId );
 
+	// Use context post type if provided, otherwise fall back to the editor's current post type.
+	const currentPostType = useSelect(
+		( select ) =>
+			props?.context?.postType ||
+			select( 'core/editor' )?.getCurrentPostType(),
+		[ props?.context?.postType ]
+	);
+
 	const [ , updateVenueTaxonomyIds ] = useEntityProp(
 		'postType',
-		CPT_EVENT,
+		currentPostType,
 		TAX_VENUE,
 		cId
 	);
@@ -338,7 +346,7 @@ function CreateVenueForm( { search, ...props } ) {
 	 * This function is called when the save button is clicked.
 	 */
 	const saveBogus = async () => {
-		if ( isEventPostType() ) {
+		if ( isPostTypeSupporting( 'gatherpress-venue' ) ) {
 			// This should only run for the VenueTermsCombobox.
 			await updateVenueTermOnEventPost();
 		} else {

--- a/src/components/VenueForm.js
+++ b/src/components/VenueForm.js
@@ -18,8 +18,7 @@ import { useEntityProp, store as coreDataStore } from '@wordpress/core-data';
 /**
  * Internal dependencies.
  */
-import { TAX_VENUE } from '../helpers/namespace';
-import { getVenuePostType } from '../helpers/venue';
+import { getVenuePostType, getVenueTaxonomy } from '../helpers/venue';
 import { isPostTypeSupporting } from '../helpers/event';
 import { getCurrentContextualPostId } from '../helpers/editor';
 import { geocodeAddress } from '../helpers/geocoding';
@@ -134,6 +133,7 @@ function CreateVenueForm( { search, ...props } ) {
 	const [ titleError, setTitleError ] = useState( '' );
 
 	const venuePostType = getVenuePostType( props?.context?.postType );
+	const venueTaxonomy = getVenueTaxonomy( venuePostType );
 
 	const { lastError, isSaving } = useSelect(
 		( select ) => ( {
@@ -200,7 +200,7 @@ function CreateVenueForm( { search, ...props } ) {
 	const [ , updateVenueTaxonomyIds ] = useEntityProp(
 		'postType',
 		currentPostType,
-		TAX_VENUE,
+		venueTaxonomy,
 		cId
 	);
 
@@ -288,7 +288,7 @@ function CreateVenueForm( { search, ...props } ) {
 	) => {
 		try {
 			const terms = await apiFetch( {
-				path: `/wp/v2/${ TAX_VENUE }?slug=${ newPostSlug }`,
+				path: `/wp/v2/${ venueTaxonomy }?slug=${ newPostSlug }`,
 			} );
 
 			if ( 0 < terms.length ) {

--- a/src/components/VenueForm.js
+++ b/src/components/VenueForm.js
@@ -131,7 +131,15 @@ function CreateVenueForm( { search, ...props } ) {
 	const [ address, setAddress ] = useState( '' );
 	const [ titleError, setTitleError ] = useState( '' );
 
-	const venuePostType = getVenuePostType( props?.context?.postType );
+	// Use context post type if provided, otherwise fall back to the editor's current post type.
+	// This is necessary because CreateVenueForm can be rendered from slotfill.js without any props.
+	const currentPostType = useSelect(
+		( select ) =>
+			props?.context?.postType ||
+			select( 'core/editor' )?.getCurrentPostType(),
+		[ props?.context?.postType ]
+	);
+	const venuePostType = getVenuePostType( currentPostType );
 	const venueTaxonomy = getVenueTaxonomy( venuePostType );
 
 	const { lastError, isSaving } = useSelect(

--- a/src/components/VenueNavigator.js
+++ b/src/components/VenueNavigator.js
@@ -29,7 +29,15 @@ import { getCurrentContextualPostId } from '../helpers/editor';
 export default function VenueNavigator( props = null ) {
 	const addNewItemLabel = __( 'Add New Venue', 'gatherpress' );
 
-	const venuePostType = getVenuePostType( props?.context?.postType );
+	// Use context post type if provided, otherwise fall back to the editor's current post type.
+	// This is necessary because VenueNavigator can be rendered from slotfill.js without any props.
+	const currentPostType = useSelect(
+		( select ) =>
+			props?.context?.postType ||
+			select( 'core/editor' )?.getCurrentPostType(),
+		[ props?.context?.postType ]
+	);
+	const venuePostType = getVenuePostType( currentPostType );
 	const venueTaxonomy = getVenueTaxonomy( venuePostType );
 
 	/**

--- a/src/components/VenueNavigator.js
+++ b/src/components/VenueNavigator.js
@@ -7,8 +7,8 @@ import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	Navigator,
 } from '@wordpress/components';
-import { store as coreDataStore, useEntityProp } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useCallback, useMemo } from '@wordpress/element';
 
 /**
@@ -53,19 +53,35 @@ export default function VenueNavigator( props = null ) {
 	// Get current venue and update function for event context.
 	const cId = getCurrentContextualPostId( props?.context?.postId );
 
-	// Use context post type if provided, otherwise fall back to the editor's current post type.
-	const currentPostType = useSelect(
-		( select ) =>
-			props?.context?.postType ||
-			select( 'core/editor' )?.getCurrentPostType(),
-		[ props?.context?.postType ]
+	const { editPost } = useDispatch( 'core/editor' );
+
+	// Read venue taxonomy IDs without triggering context=edit REST requests.
+	const venueTaxonomyIds = useSelect(
+		( wpSelect ) => {
+			// Try editor in-memory state first (PHP preload data + pending edits).
+			const editorAttr = wpSelect( 'core/editor' )?.getEditedPostAttribute( venueTaxonomy );
+			if ( Array.isArray( editorAttr ) ) {
+				return editorAttr;
+			}
+
+			if ( ! cId ) {
+				return undefined;
+			}
+
+			// Fallback: query taxonomy terms with context=view (no edit permissions needed).
+			const terms = wpSelect( 'core' ).getEntityRecords(
+				'taxonomy',
+				venueTaxonomy,
+				{ post: cId, per_page: 100, context: 'view' }
+			);
+			return terms?.map( ( t ) => t.id );
+		},
+		[ venueTaxonomy, cId ]
 	);
 
-	const [ venueTaxonomyIds, updateVenueTaxonomyIds ] = useEntityProp(
-		'postType',
-		currentPostType,
-		venueTaxonomy,
-		cId
+	const updateVenueTaxonomyIds = useCallback(
+		( newIds ) => editPost( { [ venueTaxonomy ]: newIds } ),
+		[ editPost, venueTaxonomy ]
 	);
 
 	// Get the online-event term to preserve it when selecting a venue.

--- a/src/components/VenueNavigator.js
+++ b/src/components/VenueNavigator.js
@@ -14,7 +14,8 @@ import { useState, useCallback, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { CPT_VENUE, TAX_VENUE } from '../helpers/namespace';
+import { TAX_VENUE } from '../helpers/namespace';
+import { getVenuePostType } from '../helpers/venue';
 import CreateVenueForm from './VenueForm';
 import { VenueComboboxProvider } from './VenueComboboxProvider';
 import PopularVenues from './PopularVenues';
@@ -29,6 +30,8 @@ import { getCurrentContextualPostId } from '../helpers/editor';
 export default function VenueNavigator( props = null ) {
 	const addNewItemLabel = __( 'Add New Venue', 'gatherpress' );
 
+	const venuePostType = getVenuePostType( props?.context?.postType );
+
 	/**
 	 * Check if user can CREATE new venues.
 	 *
@@ -36,8 +39,10 @@ export default function VenueNavigator( props = null ) {
 	 *       https://developer.wordpress.org/block-editor/reference-guides/packages/packages-core-data/#useresourcepermissions
 	 */
 	const userCanEdit = useSelect( ( select ) => {
-		return select( coreDataStore ).canUser( 'create', CPT_VENUE + 's' ); // needs to be plural, because canUser currently only supports resources in the wp/v2 namespace.
-	}, [] );
+		const venuePostTypeObj = select( 'core' ).getPostType( venuePostType );
+		const restBase = venuePostTypeObj?.rest_base || venuePostType + 's';
+		return select( coreDataStore ).canUser( 'create', restBase ); // needs to be plural, because canUser currently only supports resources in the wp/v2 namespace.
+	}, [ venuePostType ] );
 
 	const [ search, setSearch ] = useState( '' );
 

--- a/src/components/VenueNavigator.js
+++ b/src/components/VenueNavigator.js
@@ -14,7 +14,7 @@ import { useState, useCallback, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { getVenuePostType, getVenueTaxonomy } from '../helpers/venue';
+import { getVenuePostType, getVenueTaxonomy, useVenueTaxonomyIds } from '../helpers/venue';
 import CreateVenueForm from './VenueForm';
 import { VenueComboboxProvider } from './VenueComboboxProvider';
 import PopularVenues from './PopularVenues';
@@ -56,28 +56,7 @@ export default function VenueNavigator( props = null ) {
 	const { editPost } = useDispatch( 'core/editor' );
 
 	// Read venue taxonomy IDs without triggering context=edit REST requests.
-	const venueTaxonomyIds = useSelect(
-		( wpSelect ) => {
-			// Try editor in-memory state first (PHP preload data + pending edits).
-			const editorAttr = wpSelect( 'core/editor' )?.getEditedPostAttribute( venueTaxonomy );
-			if ( Array.isArray( editorAttr ) ) {
-				return editorAttr;
-			}
-
-			if ( ! cId ) {
-				return undefined;
-			}
-
-			// Fallback: query taxonomy terms with context=view (no edit permissions needed).
-			const terms = wpSelect( 'core' ).getEntityRecords(
-				'taxonomy',
-				venueTaxonomy,
-				{ post: cId, per_page: 100, context: 'view' }
-			);
-			return terms?.map( ( t ) => t.id );
-		},
-		[ venueTaxonomy, cId ]
-	);
+	const venueTaxonomyIds = useVenueTaxonomyIds( venueTaxonomy, cId );
 
 	const updateVenueTaxonomyIds = useCallback(
 		( newIds ) => editPost( { [ venueTaxonomy ]: newIds } ),

--- a/src/components/VenueNavigator.js
+++ b/src/components/VenueNavigator.js
@@ -14,11 +14,11 @@ import { useState, useCallback, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { CPT_VENUE, CPT_EVENT, TAX_VENUE } from '../helpers/namespace';
+import { CPT_VENUE, TAX_VENUE } from '../helpers/namespace';
 import CreateVenueForm from './VenueForm';
 import { VenueComboboxProvider } from './VenueComboboxProvider';
 import PopularVenues from './PopularVenues';
-import { isEventPostType } from '../helpers/event';
+import { isPostTypeSupporting } from '../helpers/event';
 import { getCurrentContextualPostId } from '../helpers/editor';
 
 /**
@@ -41,17 +41,24 @@ export default function VenueNavigator( props = null ) {
 
 	const [ search, setSearch ] = useState( '' );
 
-	// Check if we're in an event context to show popular venues.
+	// Check if we're in a venue-supporting context to show popular venues.
 	// When used in panel context, props may be null, so check current editor post type.
-	const isEventContext = props?.context?.postType
-		? isEventPostType( props.context.postType )
-		: isEventPostType();
+	const isEventContext = isPostTypeSupporting( 'gatherpress-venue', props?.context?.postType );
 
 	// Get current venue and update function for event context.
 	const cId = getCurrentContextualPostId( props?.context?.postId );
+
+	// Use context post type if provided, otherwise fall back to the editor's current post type.
+	const currentPostType = useSelect(
+		( select ) =>
+			props?.context?.postType ||
+			select( 'core/editor' )?.getCurrentPostType(),
+		[ props?.context?.postType ]
+	);
+
 	const [ venueTaxonomyIds, updateVenueTaxonomyIds ] = useEntityProp(
 		'postType',
-		CPT_EVENT,
+		currentPostType,
 		TAX_VENUE,
 		cId
 	);

--- a/src/components/VenueNavigator.js
+++ b/src/components/VenueNavigator.js
@@ -14,8 +14,7 @@ import { useState, useCallback, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { TAX_VENUE } from '../helpers/namespace';
-import { getVenuePostType } from '../helpers/venue';
+import { getVenuePostType, getVenueTaxonomy } from '../helpers/venue';
 import CreateVenueForm from './VenueForm';
 import { VenueComboboxProvider } from './VenueComboboxProvider';
 import PopularVenues from './PopularVenues';
@@ -31,6 +30,7 @@ export default function VenueNavigator( props = null ) {
 	const addNewItemLabel = __( 'Add New Venue', 'gatherpress' );
 
 	const venuePostType = getVenuePostType( props?.context?.postType );
+	const venueTaxonomy = getVenueTaxonomy( venuePostType );
 
 	/**
 	 * Check if user can CREATE new venues.
@@ -64,18 +64,18 @@ export default function VenueNavigator( props = null ) {
 	const [ venueTaxonomyIds, updateVenueTaxonomyIds ] = useEntityProp(
 		'postType',
 		currentPostType,
-		TAX_VENUE,
+		venueTaxonomy,
 		cId
 	);
 
 	// Get the online-event term to preserve it when selecting a venue.
 	const onlineEventTermId = useSelect( ( wpSelect ) => {
-		const terms = wpSelect( 'core' ).getEntityRecords( 'taxonomy', TAX_VENUE, {
+		const terms = wpSelect( 'core' ).getEntityRecords( 'taxonomy', venueTaxonomy, {
 			slug: 'online-event',
 			per_page: 1,
 		} );
 		return terms?.[ 0 ]?.id || null;
-	}, [] );
+	}, [ venueTaxonomy ] );
 
 	// Check if online-event term is currently assigned.
 	const hasOnlineEventTerm = useMemo( () => {
@@ -123,6 +123,7 @@ export default function VenueNavigator( props = null ) {
 					<PopularVenues
 						onSelect={ handlePopularVenueSelect }
 						currentId={ venueTaxonomyIds?.[ 0 ] }
+						venuePostType={ venuePostType }
 					/>
 				) }
 				{ userCanEdit && (

--- a/src/components/VenuePostsCombobox.js
+++ b/src/components/VenuePostsCombobox.js
@@ -9,8 +9,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { useVenueOptions } from '../helpers/venue';
-import { CPT_VENUE } from '../helpers/namespace';
+import { useVenueOptions, getVenuePostType } from '../helpers/venue';
 
 /**
  * VenuePostsCombobox component.
@@ -31,12 +30,14 @@ export const VenuePostsCombobox = ( { search, setSearch, ...props } ) => {
 	// Get the currently selected venue post ID from block attributes.
 	const venueId = props?.attributes?.selectedPostId;
 
+	const venuePostType = getVenuePostType( props?.context?.postType );
+
 	// Fetch available venue options using a custom query hook.
 	const { venueOptions } = useVenueOptions(
 		search,
 		venueId,
 		'postType',
-		CPT_VENUE
+		venuePostType
 	);
 
 	/**
@@ -51,11 +52,11 @@ export const VenuePostsCombobox = ( { search, setSearch, ...props } ) => {
 			const newAttributes = {
 				...props.attributes,
 				selectedPostId: value,
-				selectedPostType: CPT_VENUE,
+				selectedPostType: venuePostType,
 			};
 			props.setAttributes( newAttributes );
 		},
-		[ props ]
+		[ props, venuePostType ]
 	);
 
 	/**

--- a/src/components/VenueTermsCombobox.js
+++ b/src/components/VenueTermsCombobox.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { getCurrentContextualPostId } from '../helpers/editor';
 import { useVenueOptions } from '../helpers/venue';
-import { CPT_EVENT, TAX_VENUE } from '../helpers/namespace';
+import { TAX_VENUE } from '../helpers/namespace';
 
 /**
  * VenueTermsCombobox component.
@@ -36,9 +36,18 @@ import { CPT_EVENT, TAX_VENUE } from '../helpers/namespace';
 export const VenueTermsCombobox = ( { search, setSearch, ...props } ) => {
 	// Get the current contextual post ID, falling back to editor post ID if not passed.
 	const cId = getCurrentContextualPostId( props?.context?.postId );
+
+	// Use context post type if provided, otherwise fall back to the editor's current post type.
+	const currentPostType = useSelect(
+		( select ) =>
+			props?.context?.postType ||
+			select( 'core/editor' )?.getCurrentPostType(),
+		[ props?.context?.postType ]
+	);
+
 	const [ venueTaxonomyIds, updateVenueTaxonomyIds ] = useEntityProp(
 		'postType',
-		CPT_EVENT,
+		currentPostType,
 		TAX_VENUE,
 		cId
 	);

--- a/src/components/VenueTermsCombobox.js
+++ b/src/components/VenueTermsCombobox.js
@@ -12,8 +12,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import { getCurrentContextualPostId } from '../helpers/editor';
-import { useVenueOptions } from '../helpers/venue';
-import { TAX_VENUE } from '../helpers/namespace';
+import { getVenuePostType, getVenueTaxonomy, useVenueOptions } from '../helpers/venue';
 
 /**
  * VenueTermsCombobox component.
@@ -45,21 +44,24 @@ export const VenueTermsCombobox = ( { search, setSearch, ...props } ) => {
 		[ props?.context?.postType ]
 	);
 
+	// Derive the venue taxonomy from the event post type.
+	const venueTaxonomy = getVenueTaxonomy( getVenuePostType( currentPostType ) );
+
 	const [ venueTaxonomyIds, updateVenueTaxonomyIds ] = useEntityProp(
 		'postType',
 		currentPostType,
-		TAX_VENUE,
+		venueTaxonomy,
 		cId
 	);
 
 	// Get the online-event term to exclude it from venue selection.
 	const onlineEventTermId = useSelect( ( wpSelect ) => {
-		const terms = wpSelect( 'core' ).getEntityRecords( 'taxonomy', TAX_VENUE, {
+		const terms = wpSelect( 'core' ).getEntityRecords( 'taxonomy', venueTaxonomy, {
 			slug: 'online-event',
 			per_page: 1,
 		} );
 		return terms?.[ 0 ]?.id || null;
-	}, [] );
+	}, [ venueTaxonomy ] );
 
 	// Filter out the online-event term to get only physical venue IDs.
 	const physicalVenueIds = useMemo( () => {
@@ -72,7 +74,7 @@ export const VenueTermsCombobox = ( { search, setSearch, ...props } ) => {
 
 	// The currently selected physical venue term ID (if any).
 	const venueId = physicalVenueIds?.[ 0 ];
-	const { venueOptions } = useVenueOptions( search, venueId );
+	const { venueOptions } = useVenueOptions( search, venueId, 'taxonomy', venueTaxonomy );
 
 	/**
 	 * Debounced setter for the search input to avoid excessive queries.

--- a/src/components/VenueTermsCombobox.js
+++ b/src/components/VenueTermsCombobox.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import { getCurrentContextualPostId } from '../helpers/editor';
-import { getVenuePostType, getVenueTaxonomy, useVenueOptions } from '../helpers/venue';
+import { getVenuePostType, getVenueTaxonomy, useVenueOptions, useVenueTaxonomyIds } from '../helpers/venue';
 
 /**
  * VenueTermsCombobox component.
@@ -49,28 +49,7 @@ export const VenueTermsCombobox = ( { search, setSearch, ...props } ) => {
 	const { editPost } = useDispatch( 'core/editor' );
 
 	// Read venue taxonomy IDs without triggering context=edit REST requests.
-	const venueTaxonomyIds = useSelect(
-		( wpSelect ) => {
-			// Try editor in-memory state first (PHP preload data + pending edits).
-			const editorAttr = wpSelect( 'core/editor' )?.getEditedPostAttribute( venueTaxonomy );
-			if ( Array.isArray( editorAttr ) ) {
-				return editorAttr;
-			}
-
-			if ( ! cId ) {
-				return undefined;
-			}
-
-			// Fallback: query taxonomy terms with context=view (no edit permissions needed).
-			const terms = wpSelect( 'core' ).getEntityRecords(
-				'taxonomy',
-				venueTaxonomy,
-				{ post: cId, per_page: 100, context: 'view' }
-			);
-			return terms?.map( ( t ) => t.id );
-		},
-		[ venueTaxonomy, cId ]
-	);
+	const venueTaxonomyIds = useVenueTaxonomyIds( venueTaxonomy, cId );
 
 	const updateVenueTaxonomyIds = useCallback(
 		( newIds ) => editPost( { [ venueTaxonomy ]: newIds } ),

--- a/src/components/VenueTermsCombobox.js
+++ b/src/components/VenueTermsCombobox.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { ComboboxControl } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -47,11 +46,35 @@ export const VenueTermsCombobox = ( { search, setSearch, ...props } ) => {
 	// Derive the venue taxonomy from the event post type.
 	const venueTaxonomy = getVenueTaxonomy( getVenuePostType( currentPostType ) );
 
-	const [ venueTaxonomyIds, updateVenueTaxonomyIds ] = useEntityProp(
-		'postType',
-		currentPostType,
-		venueTaxonomy,
-		cId
+	const { editPost } = useDispatch( 'core/editor' );
+
+	// Read venue taxonomy IDs without triggering context=edit REST requests.
+	const venueTaxonomyIds = useSelect(
+		( wpSelect ) => {
+			// Try editor in-memory state first (PHP preload data + pending edits).
+			const editorAttr = wpSelect( 'core/editor' )?.getEditedPostAttribute( venueTaxonomy );
+			if ( Array.isArray( editorAttr ) ) {
+				return editorAttr;
+			}
+
+			if ( ! cId ) {
+				return undefined;
+			}
+
+			// Fallback: query taxonomy terms with context=view (no edit permissions needed).
+			const terms = wpSelect( 'core' ).getEntityRecords(
+				'taxonomy',
+				venueTaxonomy,
+				{ post: cId, per_page: 100, context: 'view' }
+			);
+			return terms?.map( ( t ) => t.id );
+		},
+		[ venueTaxonomy, cId ]
+	);
+
+	const updateVenueTaxonomyIds = useCallback(
+		( newIds ) => editPost( { [ venueTaxonomy ]: newIds } ),
+		[ editPost, venueTaxonomy ]
 	);
 
 	// Get the online-event term to exclude it from venue selection.

--- a/src/helpers/editor.js
+++ b/src/helpers/editor.js
@@ -5,6 +5,11 @@ import { dispatch, select } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
+ * Internal dependencies.
+ */
+import { isPostTypeSupporting } from './event';
+
+/**
  * Enable the Save buttons after making an update.
  *
  * This function uses a hacky approach to trigger a change in the post's meta, which prompts
@@ -87,14 +92,14 @@ export function isInFSETemplate() {
  * @param {Object}  options                         Options for determining visibility.
  * @param {boolean} options.isDescendentOfQueryLoop Whether the block is inside a Query Loop.
  * @param {string}  options.postType                The post type from block context.
- * @param {string}  options.expectedPostType        The expected post type for this block.
+ * @param {string}  options.support                 The post type support to check (e.g. 'gatherpress-venue').
  * @param {boolean} [options.hasData=false]         Whether the block has its specific data.
  * @return {boolean} True if the block should be fully visible, false if it should be dimmed.
  */
 export function hasValidBlockContext( {
 	isDescendentOfQueryLoop,
 	postType,
-	expectedPostType,
+	support,
 	hasData = false,
 } ) {
 	// Always visible in FSE templates for design/preview purposes.
@@ -102,9 +107,9 @@ export function hasValidBlockContext( {
 		return true;
 	}
 
-	// In Query Loop, require both valid post type context AND data.
+	// In Query Loop, require both valid post type support AND data.
 	if ( isDescendentOfQueryLoop ) {
-		return postType === expectedPostType && hasData;
+		return isPostTypeSupporting( support, postType ) && hasData;
 	}
 
 	// When editing directly, just check if we have data.

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -14,7 +14,6 @@ import { __ } from '@wordpress/i18n';
  */
 import { createMomentWithTimezone, getTimezone } from './datetime';
 import { getFromGlobal } from './globals';
-import { CPT_EVENT } from './namespace';
 
 /**
  * Opacity value for disabled form fields and elements.
@@ -107,8 +106,8 @@ export function hasValidEventId( postId = null, postType = null ) {
 			return false;
 		}
 
-		// Use the provided postType or fall back to CPT_EVENT for entity lookup.
-		const lookupType = postType || CPT_EVENT;
+		// Use the provided postType or fall back to the current editor post type.
+		const lookupType = postType || select( 'core/editor' )?.getCurrentPostType();
 		const post = select( 'core' ).getEntityRecord(
 			'postType',
 			lookupType,

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { createMomentWithTimezone, getTimezone } from './datetime';
 import { getFromGlobal } from './globals';
+import { getVenueTaxonomy, getVenuePostType } from './venue';
 
 /**
  * Opacity value for disabled form fields and elements.
@@ -187,12 +188,14 @@ export function hasEventPastNotice() {
  * @return {boolean} True if the event has the online-event term, false otherwise.
  */
 export function hasOnlineEventTerm( postId = null ) {
-	const TAX_VENUE = '_gatherpress_venue';
+	// Derive the venue taxonomy from the current editor post type.
+	const currentPostType = select( 'core/editor' )?.getCurrentPostType?.();
+	const venueTaxonomy = getVenueTaxonomy( getVenuePostType( currentPostType ) );
 
 	// Get the online-event term ID.
 	const onlineEventTerms = select( 'core' ).getEntityRecords(
 		'taxonomy',
-		TAX_VENUE,
+		venueTaxonomy,
 		{ slug: 'online-event', per_page: 1 }
 	);
 	const onlineEventTermId = onlineEventTerms?.[ 0 ]?.id;
@@ -205,10 +208,10 @@ export function hasOnlineEventTerm( postId = null ) {
 	if ( postId ) {
 		const post = select( 'core' ).getEntityRecord(
 			'postType',
-			'gatherpress_event',
+			currentPostType || 'gatherpress_event',
 			postId
 		);
-		const venueTaxonomyIds = post?.[ TAX_VENUE ];
+		const venueTaxonomyIds = post?.[ venueTaxonomy ];
 
 		if ( ! venueTaxonomyIds?.length ) {
 			return false;
@@ -225,7 +228,7 @@ export function hasOnlineEventTerm( postId = null ) {
 	}
 
 	const venueTaxonomyIds =
-		select( 'core/editor' ).getEditedPostAttribute( TAX_VENUE );
+		select( 'core/editor' ).getEditedPostAttribute( venueTaxonomy );
 
 	if ( ! venueTaxonomyIds?.length ) {
 		return false;

--- a/src/helpers/namespace.js
+++ b/src/helpers/namespace.js
@@ -1,2 +1,1 @@
-export const TAX_VENUE = '_gatherpress_venue';
 export const REST_NAMESPACE = 'gatherpress/v1';

--- a/src/helpers/namespace.js
+++ b/src/helpers/namespace.js
@@ -3,7 +3,7 @@
  *
  * Note: earlier versions of this file also exported post type and taxonomy
  * constants such as CPT_EVENT and TAX_VENUE. Those were intentionally removed
- * in favour of post-type-support checks (post_type_supports / isPostTypeSupporting),
+ * in favor of post-type-support checks (post_type_supports / isPostTypeSupporting),
  * which allow third-party post types to participate in GatherPress features
  * without relying on hardcoded slug comparisons.
  *

--- a/src/helpers/namespace.js
+++ b/src/helpers/namespace.js
@@ -1,4 +1,2 @@
-export const CPT_EVENT = 'gatherpress_event';
-export const CPT_VENUE = 'gatherpress_venue';
 export const TAX_VENUE = '_gatherpress_venue';
 export const REST_NAMESPACE = 'gatherpress/v1';

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -328,6 +328,54 @@ export function useVenueOptions(
 }
 
 /**
+ * Reads the venue taxonomy term IDs for a given post.
+ *
+ * Tries the editor in-memory state first (PHP preload data + pending edits via
+ * getEditedPostAttribute), then falls back to a REST context=view query when
+ * the in-memory state is not yet an array. This avoids triggering context=edit
+ * REST requests that would fail for custom post types without edit permissions.
+ *
+ * Returns undefined when skipped or when postId is absent and the editor
+ * attribute has not yet loaded.
+ *
+ * @since 1.0.0
+ *
+ * @param {string}      venueTaxonomy Taxonomy slug (e.g. '_gatherpress_venue').
+ * @param {number|null} postId        The event post whose terms should be fetched.
+ * @param {boolean}     skip          When true, skip all lookups and return undefined.
+ * @return {number[]|undefined} Array of term IDs, or undefined when not yet resolved.
+ */
+export function useVenueTaxonomyIds( venueTaxonomy, postId, skip = false ) {
+	return useSelect(
+		( wpSelect ) => {
+			if ( skip ) {
+				return undefined;
+			}
+
+			// Try editor in-memory state first (PHP preload data + pending edits).
+			const editorAttr =
+				wpSelect( 'core/editor' )?.getEditedPostAttribute( venueTaxonomy );
+			if ( Array.isArray( editorAttr ) ) {
+				return editorAttr;
+			}
+
+			if ( ! postId ) {
+				return undefined;
+			}
+
+			// Fallback: query taxonomy terms with context=view (no edit permissions needed).
+			const terms = wpSelect( 'core' ).getEntityRecords(
+				'taxonomy',
+				venueTaxonomy,
+				{ post: postId, per_page: 100, context: 'view' }
+			);
+			return terms?.map( ( t ) => t.id );
+		},
+		[ skip, venueTaxonomy, postId ]
+	);
+}
+
+/**
  * Hook to fetch the most popular venues (based on usage count).
  *
  * Retrieves venue taxonomy terms ordered by count (number of events using that venue)

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -9,7 +9,16 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { CPT_VENUE, TAX_VENUE } from './namespace';
+import { TAX_VENUE } from './namespace';
+
+/**
+ * Default venue post type slug used as a fallback when no override is configured.
+ *
+ * @since 1.0.0
+ *
+ * @type {string}
+ */
+const DEFAULT_VENUE_POST_TYPE = 'gatherpress_venue';
 
 /**
  * Retrieves the venue post type slug for a given event post type.
@@ -27,7 +36,7 @@ export function getVenuePostType( eventPostType = '' ) {
 	const map =
 		select( 'core/editor' )?.getEditorSettings()?.gatherpress
 			?.venuePostTypes ?? {};
-	return map[ eventPostType ] ?? CPT_VENUE;
+	return map[ eventPostType ] ?? DEFAULT_VENUE_POST_TYPE;
 }
 
 /**
@@ -61,7 +70,7 @@ export function isVenuePostType() {
  * @param {string}      venuePostType The post type to query for the venue post. Defaults to 'gatherpress_venue'.
  * @return {Object[]|Array}           An array of matching venue post objects, or an empty array if none is found.
  */
-export function GetVenuePostFromTermId( termId, venuePostType = CPT_VENUE ) {
+export function GetVenuePostFromTermId( termId, venuePostType = DEFAULT_VENUE_POST_TYPE ) {
 	const { venuePost } = useSelect(
 		( wpSelect ) => {
 			if ( null === termId ) {
@@ -114,7 +123,7 @@ export function GetVenueTermFromPostId( postId = null ) {
 			// Retrieve the venue post entity from the WordPress data store.
 			const venuePost = wpSelect( 'core' ).getEntityRecord(
 				'postType',
-				CPT_VENUE,
+				DEFAULT_VENUE_POST_TYPE,
 				postId
 			);
 			// Prefix the slug with an underscore to match taxonomy term format.
@@ -158,7 +167,7 @@ export function GetVenuePostFromEventId( eventId, postType = null ) {
 				postType || wpSelect( 'core/editor' )?.getCurrentPostType();
 
 			if ( ! resolvedPostType ) {
-				return { termId: null, venuePostType: CPT_VENUE };
+				return { termId: null, venuePostType: DEFAULT_VENUE_POST_TYPE };
 			}
 
 			// Retrieve the event post entity from the core store.
@@ -179,7 +188,7 @@ export function GetVenuePostFromEventId( eventId, postType = null ) {
 					eventPost && 1 <= eventPost._gatherpress_venue.length
 						? eventPost?._gatherpress_venue?.[ 0 ]
 						: null,
-				venuePostType: venuePostTypeMap[ resolvedPostType ] ?? CPT_VENUE,
+				venuePostType: venuePostTypeMap[ resolvedPostType ] ?? DEFAULT_VENUE_POST_TYPE,
 			};
 		},
 		[ eventId, postType ]

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -163,17 +163,18 @@ export function GetVenueTermFromPostId( postId = null, venuePostType = DEFAULT_V
 }
 
 /**
- * Retrieves a 'gatherpress_venue' post object from a given event post ID.
+ * Retrieves a venue post object from a given event post ID.
  *
- * Uses the WordPress data store to get the event post entity from the REST API,
- * extracts the related Venue term ID from its `_gatherpress_venue` taxonomy field,
- * and fetches the corresponding Venue post via `GetVenuePostFromTermId()`.
+ * Queries the venue taxonomy terms associated with the event post directly
+ * via the REST API (using the `post` parameter on the terms endpoint), avoiding
+ * a separate context=edit fetch of the event post itself. Falls back to the
+ * first non-online-event term and fetches the corresponding venue post.
  *
  * @since 1.0.0
  *
  * @param {number} eventId  The ID of the event post.
  * @param {string} postType The post type of the event (defaults to the current editor post type).
- * @return {Object|null} The related Venue post object, or null if none is found.
+ * @return {Object|null} The related venue post object, or null if none is found.
  */
 export function GetVenuePostFromEventId( eventId, postType = null ) {
 	const { termId, venuePostType } = useSelect(
@@ -182,16 +183,9 @@ export function GetVenuePostFromEventId( eventId, postType = null ) {
 			const resolvedPostType =
 				postType || wpSelect( 'core/editor' )?.getCurrentPostType();
 
-			if ( ! resolvedPostType ) {
+			if ( ! resolvedPostType || ! eventId ) {
 				return { termId: null, venuePostType: DEFAULT_VENUE_POST_TYPE };
 			}
-
-			// Retrieve the event post entity from the core store.
-			const eventPost = wpSelect( 'core' ).getEntityRecord(
-				'postType',
-				resolvedPostType,
-				eventId
-			);
 
 			// Resolve the venue post type for this event post type from editor settings.
 			const venuePostTypeMap =
@@ -201,16 +195,23 @@ export function GetVenuePostFromEventId( eventId, postType = null ) {
 			const resolvedVenuePostType =
 				venuePostTypeMap[ resolvedPostType ] ?? DEFAULT_VENUE_POST_TYPE;
 
-			// Derive the taxonomy key from the venue post type and extract the venue term ID.
+			// Query venue taxonomy terms associated with this event post directly.
+			// This avoids fetching the event post with context=edit, which would fail
+			// for custom post types in query loop contexts.
 			const venueTax = getVenueTaxonomy( resolvedVenuePostType );
-			const venueTaxonomyIds = eventPost?.[ venueTax ];
+			const venueTerms = wpSelect( 'core' ).getEntityRecords(
+				'taxonomy',
+				venueTax,
+				{ post: eventId, per_page: 10, context: 'view' }
+			);
 
-			// Extract the venue term ID if available; otherwise return null.
+			// Find the first non-online-event term.
+			const venueTerm = venueTerms?.find(
+				( term ) => 'online-event' !== term.slug
+			);
+
 			return {
-				termId:
-					eventPost && 1 <= venueTaxonomyIds?.length
-						? venueTaxonomyIds?.[ 0 ]
-						: null,
+				termId: venueTerm?.id ?? null,
 				venuePostType: resolvedVenuePostType,
 			};
 		},

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -12,32 +12,56 @@ import { store as coreStore } from '@wordpress/core-data';
 import { CPT_VENUE, TAX_VENUE } from './namespace';
 
 /**
+ * Retrieves the venue post type slug for a given event post type.
+ *
+ * Reads the venuePostTypes map from the block editor settings exposed by PHP
+ * via the block_editor_settings_all filter. Falls back to 'gatherpress_venue'
+ * if the map is unavailable or the event post type is not found.
+ *
+ * @since 1.0.0
+ *
+ * @param {string} [eventPostType=''] The event post type slug to look up.
+ * @return {string} The venue post type slug for the given event post type.
+ */
+export function getVenuePostType( eventPostType = '' ) {
+	const map =
+		select( 'core/editor' )?.getEditorSettings()?.gatherpress
+			?.venuePostTypes ?? {};
+	return map[ eventPostType ] ?? CPT_VENUE;
+}
+
+/**
  * Check if the current post type is a venue.
  *
- * This function determines whether the current post type in the WordPress editor
- * is associated with venue content.
+ * Uses the WordPress data store to check whether the current editor post type
+ * declares the 'gatherpress-venue-information' support, which is the identifier
+ * for all venue post types.
  *
  * @since 1.0.0
  *
  * @return {boolean} True if the current post type is a venue; false otherwise.
  */
 export function isVenuePostType() {
-	return 'gatherpress_venue' === select( 'core/editor' )?.getCurrentPostType();
+	const postType = select( 'core/editor' )?.getCurrentPostType();
+	return !! select( 'core' )
+		?.getPostType( postType )
+		?.supports?.[ 'gatherpress-venue-information' ];
 }
 
 /**
- * Retrieves a 'gatherpress_venue' post object from a given '_gatherpress_venue' term ID.
+ * Retrieves a venue post object from a given '_gatherpress_venue' term ID.
  *
  * Uses the taxonomy term ID to find the corresponding term object,
  * strips any leading underscore from the slug, and fetches the related
- * Venue post whose slug matches the term. Returns the first matching post.
+ * venue post whose slug matches the term. Returns the first matching post.
  *
  * @since 1.0.0
  *
- * @param {number|null} termId The ID of the '_gatherpress_venue' term. If null, no post is retrieved.
- * @return {Object[]|Array}     An array of matching Venue post objects, or an empty array if none is found.
+ * @param {number|null} termId        The ID of the '_gatherpress_venue' term. If null, no post is retrieved.
+ * @param {string}      venuePostType The post type to query for the venue post. Defaults to 'gatherpress_venue'.
+ * @return {Object[]|Array}           An array of matching venue post objects, or an empty array if none is found.
  */
-export function GetVenuePostFromTermId( termId ) {
+export function GetVenuePostFromTermId( termId, venuePostType = CPT_VENUE ) {
 	const { venuePost } = useSelect(
 		( wpSelect ) => {
 			if ( null === termId ) {
@@ -51,11 +75,11 @@ export function GetVenuePostFromTermId( termId ) {
 			);
 			// If term object exists, strip any leading underscore from its slug.
 			const venueSlug = venueTerm?.slug.replace( /^_/, '' );
-			// Query for one Venue post with the matching slug.
+			// Query for one venue post with the matching slug.
 			return {
 				venuePost: wpSelect( 'core' ).getEntityRecords(
 					'postType',
-					CPT_VENUE,
+					venuePostType,
 					{
 						per_page: 1,
 						slug: venueSlug,
@@ -63,7 +87,7 @@ export function GetVenuePostFromTermId( termId ) {
 				),
 			};
 		},
-		[ termId ]
+		[ termId, venuePostType ]
 	);
 
 	return venuePost;
@@ -127,14 +151,14 @@ export function GetVenueTermFromPostId( postId = null ) {
  * @return {Object|null} The related Venue post object, or null if none is found.
  */
 export function GetVenuePostFromEventId( eventId, postType = null ) {
-	const { termId } = useSelect(
+	const { termId, venuePostType } = useSelect(
 		( wpSelect ) => {
 			// Resolve the post type: use provided value or fall back to the current editor post type.
 			const resolvedPostType =
 				postType || wpSelect( 'core/editor' )?.getCurrentPostType();
 
 			if ( ! resolvedPostType ) {
-				return { termId: null };
+				return { termId: null, venuePostType: CPT_VENUE };
 			}
 
 			// Retrieve the event post entity from the core store.
@@ -143,19 +167,26 @@ export function GetVenuePostFromEventId( eventId, postType = null ) {
 				resolvedPostType,
 				eventId
 			);
+
+			// Resolve the venue post type for this event post type from editor settings.
+			const venuePostTypeMap =
+				wpSelect( 'core/editor' )?.getEditorSettings()?.gatherpress
+					?.venuePostTypes ?? {};
+
 			// Extract the venue term ID if available; otherwise return null.
 			return {
 				termId:
 					eventPost && 1 <= eventPost._gatherpress_venue.length
 						? eventPost?._gatherpress_venue?.[ 0 ]
 						: null,
+				venuePostType: venuePostTypeMap[ resolvedPostType ] ?? CPT_VENUE,
 			};
 		},
 		[ eventId, postType ]
 	);
 
-	// Fetch and return the related Venue post using the term ID.
-	return GetVenuePostFromTermId( termId );
+	// Fetch and return the related venue post using the term ID and resolved venue post type.
+	return GetVenuePostFromTermId( termId, venuePostType );
 }
 
 /**

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -9,7 +9,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { CPT_EVENT, CPT_VENUE, TAX_VENUE } from './namespace';
+import { CPT_VENUE, TAX_VENUE } from './namespace';
 
 /**
  * Check if the current post type is a venue.
@@ -114,24 +114,33 @@ export function GetVenueTermFromPostId( postId = null ) {
 }
 
 /**
- * Retrieves a 'gatherpress_venue' post object from a given 'gatherpress_event' post ID.
+ * Retrieves a 'gatherpress_venue' post object from a given event post ID.
  *
- * Uses the WordPress data store to get the Event post entity from the REST API,
+ * Uses the WordPress data store to get the event post entity from the REST API,
  * extracts the related Venue term ID from its `_gatherpress_venue` taxonomy field,
  * and fetches the corresponding Venue post via `GetVenuePostFromTermId()`.
  *
  * @since 1.0.0
  *
- * @param {number} eventId The ID of the GatherPress event post.
+ * @param {number} eventId  The ID of the event post.
+ * @param {string} postType The post type of the event (defaults to the current editor post type).
  * @return {Object|null} The related Venue post object, or null if none is found.
  */
-export function GetVenuePostFromEventId( eventId ) {
+export function GetVenuePostFromEventId( eventId, postType = null ) {
 	const { termId } = useSelect(
 		( wpSelect ) => {
+			// Resolve the post type: use provided value or fall back to the current editor post type.
+			const resolvedPostType =
+				postType || wpSelect( 'core/editor' )?.getCurrentPostType();
+
+			if ( ! resolvedPostType ) {
+				return { termId: null };
+			}
+
 			// Retrieve the event post entity from the core store.
 			const eventPost = wpSelect( 'core' ).getEntityRecord(
 				'postType',
-				CPT_EVENT,
+				resolvedPostType,
 				eventId
 			);
 			// Extract the venue term ID if available; otherwise return null.
@@ -142,7 +151,7 @@ export function GetVenuePostFromEventId( eventId ) {
 						: null,
 			};
 		},
-		[ eventId ]
+		[ eventId, postType ]
 	);
 
 	// Fetch and return the related Venue post using the term ID.

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -9,7 +9,6 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { TAX_VENUE } from './namespace';
 
 /**
  * Default venue post type slug used as a fallback when no override is configured.
@@ -19,6 +18,22 @@ import { TAX_VENUE } from './namespace';
  * @type {string}
  */
 const DEFAULT_VENUE_POST_TYPE = 'gatherpress_venue';
+
+/**
+ * Returns the venue taxonomy slug for a given venue post type.
+ *
+ * The taxonomy is derived by prepending an underscore to the venue post type slug,
+ * following the convention established in PHP via Venue::get_taxonomy().
+ * For example, 'gatherpress_venue' becomes '_gatherpress_venue'.
+ *
+ * @since 1.0.0
+ *
+ * @param {string} [venuePostType='gatherpress_venue'] The venue post type slug.
+ * @return {string} The taxonomy slug for the given venue post type.
+ */
+export function getVenueTaxonomy( venuePostType = DEFAULT_VENUE_POST_TYPE ) {
+	return '_' + venuePostType;
+}
 
 /**
  * Retrieves the venue post type slug for a given event post type.
@@ -34,7 +49,7 @@ const DEFAULT_VENUE_POST_TYPE = 'gatherpress_venue';
  */
 export function getVenuePostType( eventPostType = '' ) {
 	const map =
-		select( 'core/editor' )?.getEditorSettings()?.gatherpress
+		select( 'core/editor' )?.getEditorSettings?.()?.gatherpress
 			?.venuePostTypes ?? {};
 	return map[ eventPostType ] ?? DEFAULT_VENUE_POST_TYPE;
 }
@@ -76,10 +91,10 @@ export function GetVenuePostFromTermId( termId, venuePostType = DEFAULT_VENUE_PO
 			if ( null === termId ) {
 				return [];
 			}
-			// Get the term object from the '_gatherpress_venue' taxonomy.
+			// Get the term object from the venue taxonomy derived from the venue post type.
 			const venueTerm = wpSelect( 'core' ).getEntityRecord(
 				'taxonomy',
-				TAX_VENUE,
+				getVenueTaxonomy( venuePostType ),
 				termId
 			);
 			// If term object exists, strip any leading underscore from its slug.
@@ -103,18 +118,19 @@ export function GetVenuePostFromTermId( termId, venuePostType = DEFAULT_VENUE_PO
 }
 
 /**
- * Retrieves the '_gatherpress_venue' term object associated with a given 'gatherpress_venue' post ID.
+ * Retrieves the venue taxonomy term object associated with a given venue post ID.
  *
- * Looks up the Venue post by ID from the `core` data store, prefixes its slug with an underscore
- * (to match the related taxonomy term format), and retrieves the term object from the '_gatherpress_venue' taxonomy.
+ * Looks up the venue post by ID from the `core` data store, prefixes its slug with an underscore
+ * (to match the related taxonomy term format), and retrieves the term object from the derived
+ * venue taxonomy.
  *
  * @since 1.0.0
  *
- * @param {number|null} postId The ID of the GatherPress venue post.
- *                             Defaults to null, in which case no term is retrieved.
- * @return {Object[]|Array}    An array of matching term objects, or an empty array if no matching term is found.
+ * @param {number|null} postId        The ID of the venue post. Defaults to null, in which case no term is retrieved.
+ * @param {string}      venuePostType The venue post type slug. Defaults to 'gatherpress_venue'.
+ * @return {Object[]|Array}           An array of matching term objects, or an empty array if no matching term is found.
  */
-export function GetVenueTermFromPostId( postId = null ) {
+export function GetVenueTermFromPostId( postId = null, venuePostType = DEFAULT_VENUE_POST_TYPE ) {
 	const { venueTerm } = useSelect(
 		( wpSelect ) => {
 			if ( null === postId ) {
@@ -123,16 +139,16 @@ export function GetVenueTermFromPostId( postId = null ) {
 			// Retrieve the venue post entity from the WordPress data store.
 			const venuePost = wpSelect( 'core' ).getEntityRecord(
 				'postType',
-				DEFAULT_VENUE_POST_TYPE,
+				venuePostType,
 				postId
 			);
 			// Prefix the slug with an underscore to match taxonomy term format.
 			const venueSlug = '_' + venuePost.slug;
-			// Fetch the '_gatherpress_venue' taxonomy term matching this slug.
+			// Fetch the venue taxonomy term matching this slug.
 			return {
 				venueTerm: wpSelect( 'core' ).getEntityRecords(
 					'taxonomy',
-					TAX_VENUE,
+					getVenueTaxonomy( venuePostType ),
 					{
 						per_page: 1,
 						slug: venueSlug,
@@ -140,7 +156,7 @@ export function GetVenueTermFromPostId( postId = null ) {
 				),
 			};
 		},
-		[ postId ]
+		[ postId, venuePostType ]
 	);
 
 	return venueTerm;
@@ -179,16 +195,23 @@ export function GetVenuePostFromEventId( eventId, postType = null ) {
 
 			// Resolve the venue post type for this event post type from editor settings.
 			const venuePostTypeMap =
-				wpSelect( 'core/editor' )?.getEditorSettings()?.gatherpress
+				wpSelect( 'core/editor' )?.getEditorSettings?.()?.gatherpress
 					?.venuePostTypes ?? {};
+
+			const resolvedVenuePostType =
+				venuePostTypeMap[ resolvedPostType ] ?? DEFAULT_VENUE_POST_TYPE;
+
+			// Derive the taxonomy key from the venue post type and extract the venue term ID.
+			const venueTax = getVenueTaxonomy( resolvedVenuePostType );
+			const venueTaxonomyIds = eventPost?.[ venueTax ];
 
 			// Extract the venue term ID if available; otherwise return null.
 			return {
 				termId:
-					eventPost && 1 <= eventPost._gatherpress_venue.length
-						? eventPost?._gatherpress_venue?.[ 0 ]
+					eventPost && 1 <= venueTaxonomyIds?.length
+						? venueTaxonomyIds?.[ 0 ]
 						: null,
-				venuePostType: venuePostTypeMap[ resolvedPostType ] ?? DEFAULT_VENUE_POST_TYPE,
+				venuePostType: resolvedVenuePostType,
 			};
 		},
 		[ eventId, postType ]
@@ -236,7 +259,7 @@ export function useVenueOptions(
 	search,
 	venueId,
 	kind = 'taxonomy',
-	name = TAX_VENUE
+	name = getVenueTaxonomy( DEFAULT_VENUE_POST_TYPE )
 ) {
 	const { venue, venues } = useSelect(
 		( wpSelect ) => {
@@ -311,11 +334,12 @@ export function useVenueOptions(
  *
  * @since 1.0.0
  *
- * @param {number} limit Maximum number of popular venues to fetch (default: 3).
+ * @param {number} limit         Maximum number of popular venues to fetch (default: 3).
+ * @param {string} venuePostType Venue post type slug used to derive the taxonomy (default: 'gatherpress_venue').
  *
  * @return {Array} Array of popular venue terms with id, name, and count properties.
  */
-export function usePopularVenues( limit = 3 ) {
+export function usePopularVenues( limit = 3, venuePostType = DEFAULT_VENUE_POST_TYPE ) {
 	const popularVenues = useSelect(
 		( wpSelect ) => {
 			const { getEntityRecords } = wpSelect( coreStore );
@@ -328,13 +352,17 @@ export function usePopularVenues( limit = 3 ) {
 				hide_empty: true, // Only show venues that are actually used.
 			};
 
-			const venues = getEntityRecords( 'taxonomy', TAX_VENUE, query );
+			const venues = getEntityRecords(
+				'taxonomy',
+				getVenueTaxonomy( venuePostType ),
+				query
+			);
 			// Filter out the online-event term since it's controlled by a separate toggle.
 			return venues
 				?.filter( ( venue ) => 'online-event' !== venue.slug )
 				.slice( 0, limit );
 		},
-		[ limit ]
+		[ limit, venuePostType ]
 	);
 
 	return popularVenues ?? [];

--- a/src/integrations/aql/index.js
+++ b/src/integrations/aql/index.js
@@ -15,7 +15,7 @@ import {
 	EventIncludeUnfinishedControls,
 	EventOrderControls,
 } from '../../variations/core/query/components';
-import { CPT_EVENT } from '../../helpers/namespace';
+import { isPostTypeSupporting } from '../../helpers/event';
 
 /**
  * Component that auto-sets GatherPress event defaults when the post type
@@ -30,9 +30,9 @@ const AQLEventDefaults = ( { attributes, setAttributes } ) => {
 	const { postType, gatherpress_event_query: eventQuery } = attributes.query;
 
 	useEffect( () => {
-		// Set GatherPress defaults when post type is gatherpress_event
+		// Set GatherPress defaults when post type supports event-date
 		// but event query params haven't been set yet.
-		if ( CPT_EVENT === postType && ! eventQuery ) {
+		if ( isPostTypeSupporting( 'gatherpress-event-date', postType ) && ! eventQuery ) {
 			setAttributes( {
 				query: {
 					...attributes.query,
@@ -68,8 +68,10 @@ const withAQLEventControls = ( BlockEdit ) => ( props ) => {
 		return <BlockEdit { ...props } />;
 	}
 
-	const isEvent =
-		CPT_EVENT === props.attributes.query?.postType;
+	const isEvent = isPostTypeSupporting(
+		'gatherpress-event-date',
+		props.attributes.query?.postType
+	);
 
 	// For AQL blocks with gatherpress_event post type, add the controls panel.
 	if ( isEvent ) {

--- a/src/panels/venue-settings/fill.js
+++ b/src/panels/venue-settings/fill.js
@@ -17,20 +17,24 @@ import { PluginDocumentSettingPanel } from '@wordpress/editor';
  * Internal dependencies
  */
 import { VenuePluginDocumentSettings } from './slot';
-import { isEventPostType } from '../../helpers/event';
+import { isPostTypeSupporting } from '../../helpers/event';
 import OnlineEventPanel from './online-event';
 
 export default function VenuePluginFill() {
+	const showVenueSection = isPostTypeSupporting( 'gatherpress-venue' );
+	const showOnlineEventSection = isPostTypeSupporting( 'gatherpress-online-event' );
+	const showPanel = showVenueSection || showOnlineEventSection;
+
 	return (
-		isEventPostType() && (
+		showPanel && (
 			<PluginDocumentSettingPanel
 				name="gatherpress-venue-settings-at-events"
 				title={ __( 'Venue settings', 'gatherpress' ) }
 				className="gatherpress-venue-settings"
 			>
 				<VStack spacing={ 6 }>
-					<VenuePluginDocumentSettings.Slot />
-					<OnlineEventPanel />
+					{ showVenueSection && <VenuePluginDocumentSettings.Slot /> }
+					{ showOnlineEventSection && <OnlineEventPanel /> }
 				</VStack>
 			</PluginDocumentSettingPanel>
 		)

--- a/test/unit/js/src/blocks/venue/slotfill.test.js
+++ b/test/unit/js/src/blocks/venue/slotfill.test.js
@@ -26,22 +26,22 @@ jest.mock( '@src/components/VenueNavigator', () => {
 } );
 
 jest.mock( '@src/helpers/event', () => ( {
-	isEventPostType: jest.fn(),
+	isPostTypeSupporting: jest.fn(),
 } ) );
 
 /**
  * Internal dependencies.
  */
 import VenueBlockPluginFill from '@src/blocks/venue/slotfill';
-import { isEventPostType } from '@src/helpers/event';
+import { isPostTypeSupporting } from '@src/helpers/event';
 
 describe( 'VenueBlockPluginFill', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'should render Fill with VenueNavigator when isEventPostType returns true', () => {
-		isEventPostType.mockReturnValue( true );
+	it( 'should render Fill with VenueNavigator when isPostTypeSupporting returns true', () => {
+		isPostTypeSupporting.mockReturnValue( true );
 
 		const { getByTestId } = render( <VenueBlockPluginFill /> );
 
@@ -56,8 +56,8 @@ describe( 'VenueBlockPluginFill', () => {
 		expect( fill ).toContainElement( venueNavigator );
 	} );
 
-	it( 'should return null when isEventPostType returns false', () => {
-		isEventPostType.mockReturnValue( false );
+	it( 'should return null when isPostTypeSupporting returns false', () => {
+		isPostTypeSupporting.mockReturnValue( false );
 
 		const { container } = render( <VenueBlockPluginFill /> );
 
@@ -65,11 +65,11 @@ describe( 'VenueBlockPluginFill', () => {
 		expect( container.firstChild ).toBeNull();
 	} );
 
-	it( 'should call isEventPostType on render', () => {
-		isEventPostType.mockReturnValue( true );
+	it( 'should call isPostTypeSupporting with gatherpress-venue on render', () => {
+		isPostTypeSupporting.mockReturnValue( true );
 
 		render( <VenueBlockPluginFill /> );
 
-		expect( isEventPostType ).toHaveBeenCalled();
+		expect( isPostTypeSupporting ).toHaveBeenCalledWith( 'gatherpress-venue' );
 	} );
 } );

--- a/test/unit/js/src/helpers/editor.test.js
+++ b/test/unit/js/src/helpers/editor.test.js
@@ -306,7 +306,7 @@ describe( 'Editor helper functions', () => {
 			const result = hasValidBlockContext( {
 				isDescendentOfQueryLoop: false,
 				postType: 'post',
-				expectedPostType: 'gatherpress_event',
+				support: 'gatherpress-event-date',
 				hasData: false,
 			} );
 
@@ -321,7 +321,7 @@ describe( 'Editor helper functions', () => {
 			const result = hasValidBlockContext( {
 				isDescendentOfQueryLoop: false,
 				postType: 'post',
-				expectedPostType: 'gatherpress_event',
+				support: 'gatherpress-event-date',
 				hasData: false,
 			} );
 
@@ -329,14 +329,25 @@ describe( 'Editor helper functions', () => {
 		} );
 
 		it( 'returns true when in Query Loop with matching post type and hasData', () => {
-			select.mockReturnValue( {
-				getCurrentPostType: jest.fn().mockReturnValue( 'post' ),
+			select.mockImplementation( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getCurrentPostType: jest.fn().mockReturnValue( 'post' ) };
+				}
+				if ( 'core' === store ) {
+					return {
+						getPostType: ( slug ) =>
+							'gatherpress_event' === slug
+								? { supports: { 'gatherpress-event-date': true } }
+								: { supports: {} },
+					};
+				}
+				return {};
 			} );
 
 			const result = hasValidBlockContext( {
 				isDescendentOfQueryLoop: true,
 				postType: 'gatherpress_event',
-				expectedPostType: 'gatherpress_event',
+				support: 'gatherpress-event-date',
 				hasData: true,
 			} );
 
@@ -344,14 +355,25 @@ describe( 'Editor helper functions', () => {
 		} );
 
 		it( 'returns false when in Query Loop with matching post type but no hasData', () => {
-			select.mockReturnValue( {
-				getCurrentPostType: jest.fn().mockReturnValue( 'post' ),
+			select.mockImplementation( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getCurrentPostType: jest.fn().mockReturnValue( 'post' ) };
+				}
+				if ( 'core' === store ) {
+					return {
+						getPostType: ( slug ) =>
+							'gatherpress_event' === slug
+								? { supports: { 'gatherpress-event-date': true } }
+								: { supports: {} },
+					};
+				}
+				return {};
 			} );
 
 			const result = hasValidBlockContext( {
 				isDescendentOfQueryLoop: true,
 				postType: 'gatherpress_event',
-				expectedPostType: 'gatherpress_event',
+				support: 'gatherpress-event-date',
 				hasData: false,
 			} );
 
@@ -359,14 +381,25 @@ describe( 'Editor helper functions', () => {
 		} );
 
 		it( 'returns false when in Query Loop with non-matching post type', () => {
-			select.mockReturnValue( {
-				getCurrentPostType: jest.fn().mockReturnValue( 'post' ),
+			select.mockImplementation( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getCurrentPostType: jest.fn().mockReturnValue( 'post' ) };
+				}
+				if ( 'core' === store ) {
+					return {
+						getPostType: ( slug ) =>
+							'gatherpress_event' === slug
+								? { supports: { 'gatherpress-event-date': true } }
+								: { supports: {} },
+					};
+				}
+				return {};
 			} );
 
 			const result = hasValidBlockContext( {
 				isDescendentOfQueryLoop: true,
 				postType: 'post',
-				expectedPostType: 'gatherpress_event',
+				support: 'gatherpress-event-date',
 				hasData: true,
 			} );
 
@@ -381,7 +414,7 @@ describe( 'Editor helper functions', () => {
 			const result = hasValidBlockContext( {
 				isDescendentOfQueryLoop: false,
 				postType: 'gatherpress_event',
-				expectedPostType: 'gatherpress_event',
+				support: 'gatherpress-event-date',
 				hasData: true,
 			} );
 
@@ -396,7 +429,7 @@ describe( 'Editor helper functions', () => {
 			const result = hasValidBlockContext( {
 				isDescendentOfQueryLoop: false,
 				postType: 'gatherpress_event',
-				expectedPostType: 'gatherpress_event',
+				support: 'gatherpress-event-date',
 				hasData: false,
 			} );
 
@@ -411,21 +444,32 @@ describe( 'Editor helper functions', () => {
 			const result = hasValidBlockContext( {
 				isDescendentOfQueryLoop: false,
 				postType: 'gatherpress_event',
-				expectedPostType: 'gatherpress_event',
+				support: 'gatherpress-event-date',
 			} );
 
 			expect( result ).toBe( false );
 		} );
 
-		it( 'works with venue post type', () => {
-			select.mockReturnValue( {
-				getCurrentPostType: jest.fn().mockReturnValue( 'post' ),
+		it( 'works with venue support', () => {
+			select.mockImplementation( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getCurrentPostType: jest.fn().mockReturnValue( 'post' ) };
+				}
+				if ( 'core' === store ) {
+					return {
+						getPostType: ( slug ) =>
+							'gatherpress_event' === slug
+								? { supports: { 'gatherpress-venue': true } }
+								: { supports: {} },
+					};
+				}
+				return {};
 			} );
 
 			const result = hasValidBlockContext( {
 				isDescendentOfQueryLoop: true,
-				postType: 'gatherpress_venue',
-				expectedPostType: 'gatherpress_venue',
+				postType: 'gatherpress_event',
+				support: 'gatherpress-venue',
 				hasData: true,
 			} );
 

--- a/test/unit/js/src/helpers/namespace.test.js
+++ b/test/unit/js/src/helpers/namespace.test.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies.
+ */
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * Internal dependencies.
+ */
+import { REST_NAMESPACE } from '@src/helpers/namespace';
+
+/**
+ * Coverage for namespace constants.
+ */
+describe( 'namespace', () => {
+	it( 'exports the correct REST namespace', () => {
+		expect( REST_NAMESPACE ).toBe( 'gatherpress/v1' );
+	} );
+} );

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -34,6 +34,7 @@ import { select, useSelect } from '@wordpress/data';
  */
 import {
 	isVenuePostType,
+	getVenueTaxonomy,
 	GetVenuePostFromTermId,
 	GetVenueTermFromPostId,
 	GetVenuePostFromEventId,
@@ -41,6 +42,27 @@ import {
 	useVenueOptions,
 	usePopularVenues,
 } from '@src/helpers/venue';
+
+/**
+ * Coverage for getVenueTaxonomy.
+ */
+describe( 'getVenueTaxonomy', () => {
+	it( 'returns _gatherpress_venue for default venue post type', () => {
+		expect( getVenueTaxonomy() ).toBe( '_gatherpress_venue' );
+	} );
+
+	it( 'returns _gatherpress_venue when passed gatherpress_venue', () => {
+		expect( getVenueTaxonomy( 'gatherpress_venue' ) ).toBe( '_gatherpress_venue' );
+	} );
+
+	it( 'returns _my_custom_venue for a custom venue post type', () => {
+		expect( getVenueTaxonomy( 'my_custom_venue' ) ).toBe( '_my_custom_venue' );
+	} );
+
+	it( 'prepends underscore to any given post type slug', () => {
+		expect( getVenueTaxonomy( 'gp_location' ) ).toBe( '_gp_location' );
+	} );
+} );
 
 /**
  * Coverage for isVenuePostType.
@@ -349,7 +371,7 @@ describe( 'GetVenuePostFromEventId', () => {
 	} );
 
 	it( 'works with custom post type that uses a custom venue post type', () => {
-		const mockEventPost = { id: 200, _gatherpress_venue: [ 9 ] };
+		const mockEventPost = { id: 200, _gp_location: [ 9 ] };
 		const mockVenueTerm = { id: 9, slug: '_custom-venue' };
 		const mockVenuePost = [ { id: 90, title: 'Custom Venue' } ];
 

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -41,6 +41,7 @@ import {
 	getVenueTitle,
 	useVenueOptions,
 	usePopularVenues,
+	useVenueTaxonomyIds,
 } from '@src/helpers/venue';
 
 /**
@@ -794,5 +795,124 @@ describe( 'usePopularVenues', () => {
 		renderHook( () => usePopularVenues() );
 
 		expect( capturedTaxonomy ).toBe( '_gatherpress_venue' );
+	} );
+} );
+
+/**
+ * Coverage for useVenueTaxonomyIds.
+ */
+describe( 'useVenueTaxonomyIds', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns undefined when skip is true', () => {
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( () => ( {
+				getEditedPostAttribute: jest.fn(),
+				getEntityRecords: jest.fn(),
+			} ) );
+			return callback( wpSelect );
+		} );
+
+		const { result } = renderHook( () =>
+			useVenueTaxonomyIds( '_gatherpress_venue', 42, true )
+		);
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'returns editor attribute when it is an array', () => {
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getEditedPostAttribute: jest.fn( () => [ 1, 2, 3 ] ) };
+				}
+				return { getEntityRecords: jest.fn() };
+			} );
+			return callback( wpSelect );
+		} );
+
+		const { result } = renderHook( () =>
+			useVenueTaxonomyIds( '_gatherpress_venue', 42 )
+		);
+		expect( result.current ).toEqual( [ 1, 2, 3 ] );
+	} );
+
+	it( 'returns undefined when editor attribute is not an array and postId is absent', () => {
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getEditedPostAttribute: jest.fn( () => undefined ) };
+				}
+				return { getEntityRecords: jest.fn() };
+			} );
+			return callback( wpSelect );
+		} );
+
+		const { result } = renderHook( () =>
+			useVenueTaxonomyIds( '_gatherpress_venue', null )
+		);
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'falls back to getEntityRecords and maps term IDs when editor attribute is missing', () => {
+		const mockTerms = [ { id: 10 }, { id: 20 } ];
+
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getEditedPostAttribute: jest.fn( () => undefined ) };
+				}
+				return {
+					getEntityRecords: jest.fn( () => mockTerms ),
+				};
+			} );
+			return callback( wpSelect );
+		} );
+
+		const { result } = renderHook( () =>
+			useVenueTaxonomyIds( '_gatherpress_venue', 42 )
+		);
+		expect( result.current ).toEqual( [ 10, 20 ] );
+	} );
+
+	it( 'returns undefined when getEntityRecords has not resolved yet', () => {
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getEditedPostAttribute: jest.fn( () => undefined ) };
+				}
+				return { getEntityRecords: jest.fn( () => null ) };
+			} );
+			return callback( wpSelect );
+		} );
+
+		const { result } = renderHook( () =>
+			useVenueTaxonomyIds( '_gatherpress_venue', 42 )
+		);
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'uses context=view in the fallback query', () => {
+		let capturedQuery = null;
+
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getEditedPostAttribute: jest.fn( () => undefined ) };
+				}
+				return {
+					getEntityRecords: jest.fn( ( kind, taxonomy, query ) => {
+						capturedQuery = query;
+						return [];
+					} ),
+				};
+			} );
+			return callback( wpSelect );
+		} );
+
+		renderHook( () => useVenueTaxonomyIds( '_gatherpress_venue', 42 ) );
+
+		expect( capturedQuery ).toMatchObject( { context: 'view', post: 42 } );
 	} );
 } );

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -304,9 +304,7 @@ describe( 'GetVenuePostFromEventId', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'returns null when event has no venue term', () => {
-		const mockEventPost = { id: 100, _gatherpress_venue: [] };
-
+	it( 'returns null when event has no venue terms', () => {
 		useSelect.mockImplementation( ( callback ) => {
 			const wpSelect = jest.fn( ( store ) => {
 				if ( 'core/editor' === store ) {
@@ -320,7 +318,6 @@ describe( 'GetVenuePostFromEventId', () => {
 					};
 				}
 				return {
-					getEntityRecord: jest.fn( () => mockEventPost ),
 					getEntityRecords: jest.fn( () => [] ),
 				};
 			} );
@@ -332,17 +329,15 @@ describe( 'GetVenuePostFromEventId', () => {
 		expect( result.current ).toEqual( undefined );
 	} );
 
-	it( 'returns venue post when event has venue term', () => {
-		const mockEventPost = { id: 100, _gatherpress_venue: [ 5 ] };
+	it( 'returns venue post when event has a venue term', () => {
 		const mockVenueTerm = { id: 5, slug: '_event-venue' };
 		const mockVenuePost = [ { id: 20, title: 'Event Venue' } ];
 
-		// First call for GetVenuePostFromEventId.
 		let callCount = 0;
 		useSelect.mockImplementation( ( callback ) => {
 			callCount++;
 			if ( 1 === callCount ) {
-				// First call: GetVenuePostFromEventId.
+				// First call: GetVenuePostFromEventId queries taxonomy terms directly.
 				const wpSelect = jest.fn( ( store ) => {
 					if ( 'core/editor' === store ) {
 						return {
@@ -354,11 +349,11 @@ describe( 'GetVenuePostFromEventId', () => {
 							} ),
 						};
 					}
-					return { getEntityRecord: jest.fn( () => mockEventPost ) };
+					return { getEntityRecords: jest.fn( () => [ mockVenueTerm ] ) };
 				} );
 				return callback( wpSelect );
 			}
-			// Second call: GetVenuePostFromTermId.
+			// Second call: GetVenuePostFromTermId fetches the venue post.
 			const wpSelect = jest.fn( () => ( {
 				getEntityRecord: jest.fn( () => mockVenueTerm ),
 				getEntityRecords: jest.fn( () => mockVenuePost ),
@@ -370,8 +365,7 @@ describe( 'GetVenuePostFromEventId', () => {
 		expect( result.current ).toEqual( mockVenuePost );
 	} );
 
-	it( 'works with custom post type that uses a custom venue post type', () => {
-		const mockEventPost = { id: 200, _gatherpress_location: [ 9 ] };
+	it( 'works with a custom event post type mapped to a custom venue post type', () => {
 		const mockVenueTerm = { id: 9, slug: '_custom-venue' };
 		const mockVenuePost = [ { id: 90, title: 'Custom Venue' } ];
 
@@ -379,7 +373,7 @@ describe( 'GetVenuePostFromEventId', () => {
 		useSelect.mockImplementation( ( callback ) => {
 			callCount++;
 			if ( 1 === callCount ) {
-				// First call: GetVenuePostFromEventId fetches by gatherpress_shindig post type.
+				// First call: GetVenuePostFromEventId queries _gatherpress_location taxonomy.
 				const wpSelect = jest.fn( ( store ) => {
 					if ( 'core/editor' === store ) {
 						return {
@@ -391,7 +385,7 @@ describe( 'GetVenuePostFromEventId', () => {
 							} ),
 						};
 					}
-					return { getEntityRecord: jest.fn( () => mockEventPost ) };
+					return { getEntityRecords: jest.fn( () => [ mockVenueTerm ] ) };
 				} );
 				return callback( wpSelect );
 			}
@@ -407,16 +401,16 @@ describe( 'GetVenuePostFromEventId', () => {
 		expect( result.current ).toEqual( mockVenuePost );
 	} );
 
-	it( 'extracts first venue term ID from event with multiple venues', () => {
-		const mockEventPost = { id: 100, _gatherpress_venue: [ 7, 8, 9 ] };
-		const mockVenueTerm = { id: 7, slug: '_venue-seven' };
+	it( 'skips the online-event term and uses the physical venue term', () => {
+		const onlineTerm = { id: 1, slug: 'online-event' };
+		const venueTerm = { id: 7, slug: '_venue-seven' };
 		const mockVenuePost = [ { id: 70, title: 'Venue Seven' } ];
 
 		let callCount = 0;
 		useSelect.mockImplementation( ( callback ) => {
 			callCount++;
 			if ( 1 === callCount ) {
-				// First call: GetVenuePostFromEventId extracts term ID.
+				// First call: returns both online-event and a physical venue term.
 				const wpSelect = jest.fn( ( store ) => {
 					if ( 'core/editor' === store ) {
 						return {
@@ -428,24 +422,24 @@ describe( 'GetVenuePostFromEventId', () => {
 							} ),
 						};
 					}
-					return { getEntityRecord: jest.fn( () => mockEventPost ) };
+					return { getEntityRecords: jest.fn( () => [ onlineTerm, venueTerm ] ) };
 				} );
 				return callback( wpSelect );
 			}
-			// Second call: GetVenuePostFromTermId uses term ID 7.
+			// Second call: GetVenuePostFromTermId uses term ID 7 (skipping online-event).
 			const wpSelect = jest.fn( () => ( {
-				getEntityRecord: jest.fn( () => mockVenueTerm ),
+				getEntityRecord: jest.fn( () => venueTerm ),
 				getEntityRecords: jest.fn( () => mockVenuePost ),
 			} ) );
 			return callback( wpSelect );
 		} );
 
 		const { result } = renderHook( () => GetVenuePostFromEventId( 100, 'gatherpress_event' ) );
-		// Should return venue post for the first term ID (7).
+		// Should return venue post for the physical venue term (7), not online-event (1).
 		expect( result.current ).toEqual( mockVenuePost );
 	} );
 
-	it( 'returns null when eventPost is undefined', () => {
+	it( 'returns null when venue terms are null', () => {
 		useSelect.mockImplementation( ( callback ) => {
 			const wpSelect = jest.fn( ( store ) => {
 				if ( 'core/editor' === store ) {
@@ -459,8 +453,7 @@ describe( 'GetVenuePostFromEventId', () => {
 					};
 				}
 				return {
-					getEntityRecord: jest.fn( () => undefined ),
-					getEntityRecords: jest.fn( () => [] ),
+					getEntityRecords: jest.fn( () => null ),
 				};
 			} );
 			return callback( wpSelect );
@@ -479,13 +472,36 @@ describe( 'GetVenuePostFromEventId', () => {
 						getEditorSettings: () => ( {} ),
 					};
 				}
-				return { getEntityRecord: jest.fn(), getEntityRecords: jest.fn( () => [] ) };
+				return { getEntityRecords: jest.fn( () => [] ) };
 			} );
 			return callback( wpSelect );
 		} );
 
 		const { result } = renderHook( () => GetVenuePostFromEventId( 100 ) );
 		// Returns undefined because resolvedPostType is null — early return.
+		expect( result.current ).toEqual( undefined );
+	} );
+
+	it( 'returns null when eventId is null', () => {
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return {
+						getCurrentPostType: () => 'gatherpress_event',
+						getEditorSettings: () => ( {
+							gatherpress: {
+								venuePostTypes: { gatherpress_event: 'gatherpress_venue' },
+							},
+						} ),
+					};
+				}
+				return { getEntityRecords: jest.fn( () => [] ) };
+			} );
+			return callback( wpSelect );
+		} );
+
+		const { result } = renderHook( () => GetVenuePostFromEventId( null, 'gatherpress_event' ) );
+		// Returns undefined because eventId is null — early return.
 		expect( result.current ).toEqual( undefined );
 	} );
 } );

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -50,24 +50,59 @@ describe( 'isVenuePostType', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'returns false when there is no current post type', () => {
+	it( 'returns false when select returns undefined', () => {
 		select.mockReturnValue( undefined );
 		expect( isVenuePostType() ).toBe( false );
 	} );
 
-	it( 'returns false when current post type is gatherpress_event', () => {
-		select.mockImplementation( ( store ) => ( {
-			getCurrentPostType: () =>
-				'core/editor' === store ? 'gatherpress_event' : null,
-		} ) );
+	it( 'returns false when post type does not have gatherpress-venue-information support', () => {
+		select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'gatherpress_event' };
+			}
+			if ( 'core' === store ) {
+				return {
+					getPostType: () => ( {
+						supports: { 'gatherpress-event-date': true },
+					} ),
+				};
+			}
+			return {};
+		} );
 		expect( isVenuePostType() ).toBe( false );
 	} );
 
-	it( 'returns true when current post type is gatherpress_venue', () => {
-		select.mockImplementation( ( store ) => ( {
-			getCurrentPostType: () =>
-				'core/editor' === store ? 'gatherpress_venue' : null,
-		} ) );
+	it( 'returns true when post type has gatherpress-venue-information support', () => {
+		select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'gatherpress_venue' };
+			}
+			if ( 'core' === store ) {
+				return {
+					getPostType: () => ( {
+						supports: { 'gatherpress-venue-information': true },
+					} ),
+				};
+			}
+			return {};
+		} );
+		expect( isVenuePostType() ).toBe( true );
+	} );
+
+	it( 'returns true for a custom venue post type with gatherpress-venue-information support', () => {
+		select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'my_custom_venue' };
+			}
+			if ( 'core' === store ) {
+				return {
+					getPostType: () => ( {
+						supports: { 'gatherpress-venue-information': true },
+					} ),
+				};
+			}
+			return {};
+		} );
 		expect( isVenuePostType() ).toBe( true );
 	} );
 } );
@@ -253,7 +288,14 @@ describe( 'GetVenuePostFromEventId', () => {
 		useSelect.mockImplementation( ( callback ) => {
 			const wpSelect = jest.fn( ( store ) => {
 				if ( 'core/editor' === store ) {
-					return { getCurrentPostType: () => 'gatherpress_event' };
+					return {
+						getCurrentPostType: () => 'gatherpress_event',
+						getEditorSettings: () => ( {
+							gatherpress: {
+								venuePostTypes: { gatherpress_event: 'gatherpress_venue' },
+							},
+						} ),
+					};
 				}
 				return {
 					getEntityRecord: jest.fn( () => mockEventPost ),
@@ -279,9 +321,19 @@ describe( 'GetVenuePostFromEventId', () => {
 			callCount++;
 			if ( 1 === callCount ) {
 				// First call: GetVenuePostFromEventId.
-				const wpSelect = jest.fn( () => ( {
-					getEntityRecord: jest.fn( () => mockEventPost ),
-				} ) );
+				const wpSelect = jest.fn( ( store ) => {
+					if ( 'core/editor' === store ) {
+						return {
+							getCurrentPostType: () => 'gatherpress_event',
+							getEditorSettings: () => ( {
+								gatherpress: {
+									venuePostTypes: { gatherpress_event: 'gatherpress_venue' },
+								},
+							} ),
+						};
+					}
+					return { getEntityRecord: jest.fn( () => mockEventPost ) };
+				} );
 				return callback( wpSelect );
 			}
 			// Second call: GetVenuePostFromTermId.
@@ -296,7 +348,7 @@ describe( 'GetVenuePostFromEventId', () => {
 		expect( result.current ).toEqual( mockVenuePost );
 	} );
 
-	it( 'works with custom post type that supports event-date', () => {
+	it( 'works with custom post type that uses a custom venue post type', () => {
 		const mockEventPost = { id: 200, _gatherpress_venue: [ 9 ] };
 		const mockVenueTerm = { id: 9, slug: '_custom-venue' };
 		const mockVenuePost = [ { id: 90, title: 'Custom Venue' } ];
@@ -306,9 +358,19 @@ describe( 'GetVenuePostFromEventId', () => {
 			callCount++;
 			if ( 1 === callCount ) {
 				// First call: GetVenuePostFromEventId fetches by gp_shindig post type.
-				const wpSelect = jest.fn( () => ( {
-					getEntityRecord: jest.fn( () => mockEventPost ),
-				} ) );
+				const wpSelect = jest.fn( ( store ) => {
+					if ( 'core/editor' === store ) {
+						return {
+							getCurrentPostType: () => 'gp_shindig',
+							getEditorSettings: () => ( {
+								gatherpress: {
+									venuePostTypes: { gp_shindig: 'gp_location' },
+								},
+							} ),
+						};
+					}
+					return { getEntityRecord: jest.fn( () => mockEventPost ) };
+				} );
 				return callback( wpSelect );
 			}
 			// Second call: GetVenuePostFromTermId.
@@ -333,9 +395,19 @@ describe( 'GetVenuePostFromEventId', () => {
 			callCount++;
 			if ( 1 === callCount ) {
 				// First call: GetVenuePostFromEventId extracts term ID.
-				const wpSelect = jest.fn( () => ( {
-					getEntityRecord: jest.fn( () => mockEventPost ),
-				} ) );
+				const wpSelect = jest.fn( ( store ) => {
+					if ( 'core/editor' === store ) {
+						return {
+							getCurrentPostType: () => 'gatherpress_event',
+							getEditorSettings: () => ( {
+								gatherpress: {
+									venuePostTypes: { gatherpress_event: 'gatherpress_venue' },
+								},
+							} ),
+						};
+					}
+					return { getEntityRecord: jest.fn( () => mockEventPost ) };
+				} );
 				return callback( wpSelect );
 			}
 			// Second call: GetVenuePostFromTermId uses term ID 7.
@@ -355,7 +427,14 @@ describe( 'GetVenuePostFromEventId', () => {
 		useSelect.mockImplementation( ( callback ) => {
 			const wpSelect = jest.fn( ( store ) => {
 				if ( 'core/editor' === store ) {
-					return { getCurrentPostType: () => 'gatherpress_event' };
+					return {
+						getCurrentPostType: () => 'gatherpress_event',
+						getEditorSettings: () => ( {
+							gatherpress: {
+								venuePostTypes: { gatherpress_event: 'gatherpress_venue' },
+							},
+						} ),
+					};
 				}
 				return {
 					getEntityRecord: jest.fn( () => undefined ),
@@ -373,7 +452,10 @@ describe( 'GetVenuePostFromEventId', () => {
 		useSelect.mockImplementation( ( callback ) => {
 			const wpSelect = jest.fn( ( store ) => {
 				if ( 'core/editor' === store ) {
-					return { getCurrentPostType: () => null };
+					return {
+						getCurrentPostType: () => null,
+						getEditorSettings: () => ( {} ),
+					};
 				}
 				return { getEntityRecord: jest.fn(), getEntityRecords: jest.fn( () => [] ) };
 			} );

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -60,7 +60,7 @@ describe( 'getVenueTaxonomy', () => {
 	} );
 
 	it( 'prepends underscore to any given post type slug', () => {
-		expect( getVenueTaxonomy( 'gp_location' ) ).toBe( '_gp_location' );
+		expect( getVenueTaxonomy( 'gatherpress_location' ) ).toBe( '_gatherpress_location' );
 	} );
 } );
 
@@ -371,7 +371,7 @@ describe( 'GetVenuePostFromEventId', () => {
 	} );
 
 	it( 'works with custom post type that uses a custom venue post type', () => {
-		const mockEventPost = { id: 200, _gp_location: [ 9 ] };
+		const mockEventPost = { id: 200, _gatherpress_location: [ 9 ] };
 		const mockVenueTerm = { id: 9, slug: '_custom-venue' };
 		const mockVenuePost = [ { id: 90, title: 'Custom Venue' } ];
 
@@ -379,14 +379,14 @@ describe( 'GetVenuePostFromEventId', () => {
 		useSelect.mockImplementation( ( callback ) => {
 			callCount++;
 			if ( 1 === callCount ) {
-				// First call: GetVenuePostFromEventId fetches by gp_shindig post type.
+				// First call: GetVenuePostFromEventId fetches by gatherpress_shindig post type.
 				const wpSelect = jest.fn( ( store ) => {
 					if ( 'core/editor' === store ) {
 						return {
-							getCurrentPostType: () => 'gp_shindig',
+							getCurrentPostType: () => 'gatherpress_shindig',
 							getEditorSettings: () => ( {
 								gatherpress: {
-									venuePostTypes: { gp_shindig: 'gp_location' },
+									venuePostTypes: { gatherpress_shindig: 'gatherpress_location' },
 								},
 							} ),
 						};
@@ -403,7 +403,7 @@ describe( 'GetVenuePostFromEventId', () => {
 			return callback( wpSelect );
 		} );
 
-		const { result } = renderHook( () => GetVenuePostFromEventId( 200, 'gp_shindig' ) );
+		const { result } = renderHook( () => GetVenuePostFromEventId( 200, 'gatherpress_shindig' ) );
 		expect( result.current ).toEqual( mockVenuePost );
 	} );
 

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -251,14 +251,19 @@ describe( 'GetVenuePostFromEventId', () => {
 		const mockEventPost = { id: 100, _gatherpress_venue: [] };
 
 		useSelect.mockImplementation( ( callback ) => {
-			const wpSelect = jest.fn( () => ( {
-				getEntityRecord: jest.fn( () => mockEventPost ),
-				getEntityRecords: jest.fn( () => [] ),
-			} ) );
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getCurrentPostType: () => 'gatherpress_event' };
+				}
+				return {
+					getEntityRecord: jest.fn( () => mockEventPost ),
+					getEntityRecords: jest.fn( () => [] ),
+				};
+			} );
 			return callback( wpSelect );
 		} );
 
-		const { result } = renderHook( () => GetVenuePostFromEventId( 100 ) );
+		const { result } = renderHook( () => GetVenuePostFromEventId( 100, 'gatherpress_event' ) );
 		// Returns undefined because termId is null.
 		expect( result.current ).toEqual( undefined );
 	} );
@@ -287,7 +292,34 @@ describe( 'GetVenuePostFromEventId', () => {
 			return callback( wpSelect );
 		} );
 
-		const { result } = renderHook( () => GetVenuePostFromEventId( 100 ) );
+		const { result } = renderHook( () => GetVenuePostFromEventId( 100, 'gatherpress_event' ) );
+		expect( result.current ).toEqual( mockVenuePost );
+	} );
+
+	it( 'works with custom post type that supports event-date', () => {
+		const mockEventPost = { id: 200, _gatherpress_venue: [ 9 ] };
+		const mockVenueTerm = { id: 9, slug: '_custom-venue' };
+		const mockVenuePost = [ { id: 90, title: 'Custom Venue' } ];
+
+		let callCount = 0;
+		useSelect.mockImplementation( ( callback ) => {
+			callCount++;
+			if ( 1 === callCount ) {
+				// First call: GetVenuePostFromEventId fetches by gp_shindig post type.
+				const wpSelect = jest.fn( () => ( {
+					getEntityRecord: jest.fn( () => mockEventPost ),
+				} ) );
+				return callback( wpSelect );
+			}
+			// Second call: GetVenuePostFromTermId.
+			const wpSelect = jest.fn( () => ( {
+				getEntityRecord: jest.fn( () => mockVenueTerm ),
+				getEntityRecords: jest.fn( () => mockVenuePost ),
+			} ) );
+			return callback( wpSelect );
+		} );
+
+		const { result } = renderHook( () => GetVenuePostFromEventId( 200, 'gp_shindig' ) );
 		expect( result.current ).toEqual( mockVenuePost );
 	} );
 
@@ -314,21 +346,42 @@ describe( 'GetVenuePostFromEventId', () => {
 			return callback( wpSelect );
 		} );
 
-		const { result } = renderHook( () => GetVenuePostFromEventId( 100 ) );
+		const { result } = renderHook( () => GetVenuePostFromEventId( 100, 'gatherpress_event' ) );
 		// Should return venue post for the first term ID (7).
 		expect( result.current ).toEqual( mockVenuePost );
 	} );
 
 	it( 'returns null when eventPost is undefined', () => {
 		useSelect.mockImplementation( ( callback ) => {
-			const wpSelect = jest.fn( () => ( {
-				getEntityRecord: jest.fn( () => undefined ),
-				getEntityRecords: jest.fn( () => [] ),
-			} ) );
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getCurrentPostType: () => 'gatherpress_event' };
+				}
+				return {
+					getEntityRecord: jest.fn( () => undefined ),
+					getEntityRecords: jest.fn( () => [] ),
+				};
+			} );
 			return callback( wpSelect );
 		} );
 
-		const { result } = renderHook( () => GetVenuePostFromEventId( 999 ) );
+		const { result } = renderHook( () => GetVenuePostFromEventId( 999, 'gatherpress_event' ) );
+		expect( result.current ).toEqual( undefined );
+	} );
+
+	it( 'returns null when no postType and no editor post type available', () => {
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return { getCurrentPostType: () => null };
+				}
+				return { getEntityRecord: jest.fn(), getEntityRecords: jest.fn( () => [] ) };
+			} );
+			return callback( wpSelect );
+		} );
+
+		const { result } = renderHook( () => GetVenuePostFromEventId( 100 ) );
+		// Returns undefined because resolvedPostType is null — early return.
 		expect( result.current ).toEqual( undefined );
 	} );
 } );

--- a/test/unit/js/src/integrations/aql/index.test.js
+++ b/test/unit/js/src/integrations/aql/index.test.js
@@ -44,6 +44,10 @@ jest.mock( '@wordpress/i18n', () => ( {
 /**
  * Mock internal dependencies.
  */
+jest.mock( '@src/helpers/event', () => ( {
+	isPostTypeSupporting: jest.fn(),
+} ) );
+
 jest.mock( '@src/variations/core/query/components', () => ( {
 	EventListTypeControls: () => (
 		<div data-testid="event-list-type-controls" />
@@ -59,6 +63,7 @@ jest.mock( '@src/variations/core/query/components', () => ( {
  */
 import { addFilter } from '@wordpress/hooks';
 import { useEffect } from '@wordpress/element';
+import { isPostTypeSupporting } from '@src/helpers/event';
 
 // Import the module to trigger the addFilter side effect.
 import '@src/integrations/aql/index';
@@ -75,6 +80,12 @@ describe( 'AQL Integration', () => {
 		useEffect.mockClear();
 		// Restore default useEffect behavior for each test.
 		useEffect.mockImplementation( ( fn ) => fn() );
+		// Default: return true only for gatherpress_event post type.
+		isPostTypeSupporting.mockImplementation(
+			( support, postType ) =>
+				'gatherpress-event-date' === support &&
+				'gatherpress_event' === postType
+		);
 	} );
 
 	describe( 'addFilter registration', () => {
@@ -165,6 +176,35 @@ describe( 'AQL Integration', () => {
 			).toBeInTheDocument();
 		} );
 
+		it( 'renders event controls panel for AQL blocks with custom event-date-supporting post type', () => {
+			// Mock gp_shindig as a post type that supports gatherpress-event-date.
+			isPostTypeSupporting.mockImplementation(
+				( support, postType ) =>
+					'gatherpress-event-date' === support &&
+					'gp_shindig' === postType
+			);
+
+			const MockBlockEdit = () => (
+				<div data-testid="block-edit">Original</div>
+			);
+			const Enhanced = withAQLEventControls( MockBlockEdit );
+
+			const { getByTestId } = render(
+				<Enhanced
+					name="core/query"
+					attributes={ {
+						namespace: 'advanced-query-loop',
+						query: { postType: 'gp_shindig' },
+					} }
+					setAttributes={ jest.fn() }
+				/>
+			);
+
+			expect( getByTestId( 'block-edit' ) ).toBeInTheDocument();
+			expect( getByTestId( 'inspector-controls' ) ).toBeInTheDocument();
+			expect( getByTestId( 'event-list-type-controls' ) ).toBeInTheDocument();
+		} );
+
 		it( 'renders BlockEdit without controls for AQL blocks with non-event post type', () => {
 			const MockBlockEdit = () => (
 				<div data-testid="block-edit">Original</div>
@@ -190,7 +230,7 @@ describe( 'AQL Integration', () => {
 	} );
 
 	describe( 'AQLEventDefaults auto-defaults', () => {
-		it( 'sets GatherPress defaults when post type is gatherpress_event and event query is not set', () => {
+		it( 'sets GatherPress defaults when post type supports event-date and event query is not set', () => {
 			const mockSetAttributes = jest.fn();
 			const MockBlockEdit = () => (
 				<div data-testid="block-edit">Original</div>

--- a/test/unit/js/src/integrations/aql/index.test.js
+++ b/test/unit/js/src/integrations/aql/index.test.js
@@ -177,11 +177,11 @@ describe( 'AQL Integration', () => {
 		} );
 
 		it( 'renders event controls panel for AQL blocks with custom event-date-supporting post type', () => {
-			// Mock gp_shindig as a post type that supports gatherpress-event-date.
+			// Mock gatherpress_shindig as a post type that supports gatherpress-event-date.
 			isPostTypeSupporting.mockImplementation(
 				( support, postType ) =>
 					'gatherpress-event-date' === support &&
-					'gp_shindig' === postType
+					'gatherpress_shindig' === postType
 			);
 
 			const MockBlockEdit = () => (
@@ -194,7 +194,7 @@ describe( 'AQL Integration', () => {
 					name="core/query"
 					attributes={ {
 						namespace: 'advanced-query-loop',
-						query: { postType: 'gp_shindig' },
+						query: { postType: 'gatherpress_shindig' },
 					} }
 					setAttributes={ jest.fn() }
 				/>

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-general-block.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-general-block.php
@@ -280,6 +280,33 @@ class Test_General_Block extends Base {
 	}
 
 	/**
+	 * Test registration URL placeholder is replaced in anchor tag href.
+	 *
+	 * @since  1.0.0
+	 * @covers ::process_registration_block
+	 *
+	 * @return void
+	 */
+	public function test_registration_url_replaced_in_anchor_href(): void {
+		$general_block = General_Block::get_instance();
+
+		// Enable user registration.
+		update_option( 'users_can_register', 1 );
+
+		// Block without the registration URL class so early return is bypassed.
+		$block_content = '<a href="#gatherpress-registration-url">Register</a>';
+		$block         = array( 'attrs' => array() );
+
+		$result = $general_block->process_registration_block( $block_content, $block );
+
+		$this->assertStringNotContainsString(
+			'#gatherpress-registration-url',
+			$result,
+			'Registration URL placeholder should be replaced in anchor href.'
+		);
+	}
+
+	/**
 	 * Test block content remains when registration is disabled but block doesn't have registration URL class.
 	 *
 	 * @since  1.0.0

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-general-block.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-general-block.php
@@ -15,6 +15,7 @@ use GatherPress\Tests\Base;
 /**
  * Class Test_General_Block.
  *
+ * @group multisite
  * @coversDefaultClass \GatherPress\Core\Blocks\General_Block
  */
 class Test_General_Block extends Base {

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-online-event.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-online-event.php
@@ -200,10 +200,10 @@ class Test_Online_Event extends Base {
 	 *
 	 * @return void
 	 */
-	public function test_render_block_returns_content_for_non_event_post(): void {
+	public function test_render_block_returns_empty_for_non_supporting_post_type(): void {
 		$instance = Online_Event::get_instance();
 
-		// Create a regular page (not an event).
+		// Create a regular page (does not support gatherpress-online-event).
 		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
 		$this->go_to( get_permalink( $post_id ) );
 
@@ -223,9 +223,9 @@ class Test_Online_Event extends Base {
 		$result = $instance->render_block( $block_content, $block, $block_instance );
 
 		$this->assertSame(
-			$block_content,
+			'',
 			$result,
-			'Should return block content unchanged for non-event post types.'
+			'Should return empty string for post types that do not support gatherpress-online-event.'
 		);
 	}
 
@@ -508,22 +508,21 @@ class Test_Online_Event extends Base {
 	}
 
 	/**
-	 * Tests render_block returns content for override with non-event post type.
+	 * Tests render_block returns empty for override with non-supporting post type.
 	 *
-	 * When the postId attribute points to a non-event post type,
-	 * has_online_event_term returns true, so it should render with context.
+	 * When the postId attribute points to a post type that does not support
+	 * gatherpress-online-event, the block should not render.
 	 *
 	 * @since 1.0.0
 	 * @covers ::render_block
 	 * @covers ::has_online_event_term
-	 * @covers ::render_with_post_context
 	 *
 	 * @return void
 	 */
-	public function test_render_block_with_non_event_override_renders_content(): void {
+	public function test_render_block_with_non_supporting_override_returns_empty(): void {
 		$instance = Online_Event::get_instance();
 
-		// Create a page (not an event).
+		// Create a page (does not support gatherpress-online-event).
 		$page_id = $this->factory->post->create(
 			array(
 				'post_type'  => 'page',
@@ -535,17 +534,9 @@ class Test_Online_Event extends Base {
 			array(
 				'blockName'    => 'gatherpress/online-event',
 				'attrs'        => array( 'postId' => $page_id ),
-				'innerBlocks'  => array(
-					array(
-						'blockName'    => 'core/paragraph',
-						'attrs'        => array(),
-						'innerBlocks'  => array(),
-						'innerHTML'    => '<p>Page inner content</p>',
-						'innerContent' => array( '<p>Page inner content</p>' ),
-					),
-				),
+				'innerBlocks'  => array(),
 				'innerHTML'    => '',
-				'innerContent' => array( null ),
+				'innerContent' => array(),
 			)
 		);
 
@@ -554,10 +545,10 @@ class Test_Online_Event extends Base {
 
 		$result = $instance->render_block( $block_content, $block, $block_instance );
 
-		$this->assertStringContainsString(
-			'Page inner content',
+		$this->assertSame(
+			'',
 			$result,
-			'Should render inner blocks for non-event post type override.'
+			'Should return empty string for post types that do not support gatherpress-online-event.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-online-event.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-online-event.php
@@ -17,6 +17,7 @@ use WP_Block;
 /**
  * Class Test_Online_Event.
  *
+ * @group multisite
  * @coversDefaultClass \GatherPress\Core\Blocks\Online_Event
  */
 class Test_Online_Event extends Base {

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-venue.php
@@ -17,6 +17,7 @@ use WP_Block;
 /**
  * Class Test_Venue.
  *
+ * @group multisite
  * @coversDefaultClass \GatherPress\Core\Blocks\Venue
  */
 class Test_Venue extends Base {

--- a/test/unit/php/includes/tests/core/classes/class-test-event-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-admin-list.php
@@ -1078,6 +1078,36 @@ class Test_Event_Admin_List extends Base {
 	}
 
 	/**
+	 * Coverage for venue_sorting_join_paged when the venue taxonomy is not registered.
+	 *
+	 * Verifies that the method returns the original $join string unchanged when
+	 * taxonomy_exists() returns false for the derived taxonomy slug, avoiding
+	 * invalid SQL from being appended.
+	 *
+	 * @covers ::venue_sorting_join_paged
+	 *
+	 * @return void
+	 */
+	public function test_venue_sorting_join_paged_unregistered_taxonomy(): void {
+		$instance      = Event_Admin_List::get_instance();
+		$original_join = 'ORIGINAL_JOIN';
+
+		// Temporarily unregister the venue taxonomy so taxonomy_exists() returns false.
+		unregister_taxonomy( Venue::TAXONOMY );
+
+		$result = $instance->venue_sorting_join_paged( $original_join );
+
+		// Re-register the taxonomy so subsequent tests are not affected.
+		Venue::get_instance()->register_taxonomy();
+
+		$this->assertSame(
+			$original_join,
+			$result,
+			'Failed to assert that venue_sorting_join_paged returns the original join.'
+		);
+	}
+
+	/**
 	 * Coverage for venue_sorting_orderby method.
 	 *
 	 * Note: This method relies on the global $wp_query, so we test the method's structure

--- a/test/unit/php/includes/tests/core/classes/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-query.php
@@ -805,6 +805,57 @@ class Test_Event_Query extends Base {
 	}
 
 	/**
+	 * Coverage for build_venue_tax_query method.
+	 *
+	 * @covers ::build_venue_tax_query
+	 *
+	 * @return void
+	 */
+	public function test_build_venue_tax_query(): void {
+		$instance = Event_Query::get_instance();
+		$venues   = array( '_unit-test-venue', '_another-venue' );
+
+		$tax_query = Utility::invoke_hidden_method( $instance, 'build_venue_tax_query', array( $venues ) );
+
+		$this->assertIsArray(
+			$tax_query,
+			'Failed to assert that tax query is an array.'
+		);
+		$this->assertSame(
+			'OR',
+			$tax_query['relation'],
+			'Failed to assert OR relation in venue tax query.'
+		);
+
+		// Expect one entry per registered venue post type (plus the relation key).
+		$venue_post_types = get_post_types_by_support( 'gatherpress-venue-information' );
+		$expected_count   = count( $venue_post_types ) + 1;
+		$this->assertCount(
+			$expected_count,
+			$tax_query,
+			'Failed to assert the correct count of entries in the venue tax query.'
+		);
+
+		// Verify the first condition uses the correct taxonomy, field, and terms.
+		$first_condition = $tax_query[0];
+		$this->assertSame(
+			'slug',
+			$first_condition['field'],
+			'Failed to assert that the field is slug.'
+		);
+		$this->assertSame(
+			$venues,
+			$first_condition['terms'],
+			'Failed to assert that terms match the provided venues.'
+		);
+		$this->assertSame(
+			Venue::get_taxonomy( Venue::POST_TYPE ),
+			$first_condition['taxonomy'],
+			'Failed to assert the taxonomy matches the built-in venue taxonomy.'
+		);
+	}
+
+	/**
 	 * Coverage for get_datetime_comparison_column method.
 	 *
 	 * @covers ::get_datetime_comparison_column

--- a/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
@@ -442,6 +442,22 @@ class Test_Event_Setup extends Base {
 	}
 
 	/**
+	 * Coverage for check_waiting_list method with non-rsvp post type.
+	 *
+	 * @covers ::check_waiting_list
+	 *
+	 * @return void
+	 */
+	public function test_check_waiting_list_skips_non_rsvp_post_type(): void {
+		$instance = Event_Setup::get_instance();
+		$post_id  = $this->mock->post()->get()->ID;
+
+		// A plain post does not support gatherpress-rsvp so the method returns early.
+		$instance->check_waiting_list( $post_id );
+		$this->assertTrue( true, 'check_waiting_list returned early for non-rsvp post type without error.' );
+	}
+
+	/**
 	 * Coverage for delete_event method with non-event post.
 	 *
 	 * @covers ::delete_event

--- a/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-setup.php
@@ -45,7 +45,7 @@ class Test_Event_Setup extends Base {
 			array(
 				'type'     => 'action',
 				'name'     => 'init',
-				'priority' => 10,
+				'priority' => 11,
 				'callback' => array( $instance, 'register_post_meta' ),
 			),
 			array(

--- a/test/unit/php/includes/tests/core/classes/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue.php
@@ -33,7 +33,7 @@ class Test_Venue extends Base {
 		$hooks    = array(
 			array(
 				'type'     => 'action',
-				'name'     => sprintf( 'save_post_%s', Venue::POST_TYPE ),
+				'name'     => 'save_post',
 				'priority' => 10,
 				'callback' => array( $instance, 'add_venue_term' ),
 			),
@@ -52,7 +52,8 @@ class Test_Venue extends Base {
 			array(
 				'type'     => 'action',
 				'name'     => 'init',
-				'priority' => 10,
+				// Priority 11 ensures custom venue post types are discoverable via get_post_types_by_support().
+				'priority' => 11,
 				'callback' => array( $instance, 'register_post_meta' ),
 			),
 			array(
@@ -72,6 +73,12 @@ class Test_Venue extends Base {
 				'name'     => 'delete_post',
 				'priority' => 10,
 				'callback' => array( $instance, 'delete_venue_term' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'block_editor_settings_all',
+				'priority' => 10,
+				'callback' => array( $instance, 'add_editor_settings' ),
 			),
 		);
 
@@ -233,6 +240,7 @@ class Test_Venue extends Base {
 		$instance = Venue::get_instance();
 
 		unregister_post_meta( Venue::POST_TYPE, 'gatherpress_venue_information' );
+		unregister_post_meta( Venue::POST_TYPE, 'gatherpress_venue_map_show' );
 
 		$meta = get_registered_meta_keys( 'post', Venue::POST_TYPE );
 
@@ -242,6 +250,12 @@ class Test_Venue extends Base {
 			'Failed to assert that gatherpress_venue_information does not exist.'
 		);
 
+		$this->assertArrayNotHasKey(
+			'gatherpress_venue_map_show',
+			$meta,
+			'Failed to assert that gatherpress_venue_map_show does not exist.'
+		);
+
 		$instance->register_post_meta();
 
 		$meta = get_registered_meta_keys( 'post', Venue::POST_TYPE );
@@ -249,7 +263,13 @@ class Test_Venue extends Base {
 		$this->assertArrayHasKey(
 			'gatherpress_venue_information',
 			$meta,
-			'Failed to assert that gatherpress_venue_information does exist.'
+			'Failed to assert that gatherpress_venue_information exists for gatherpress-venue-information support.'
+		);
+
+		$this->assertArrayHasKey(
+			'gatherpress_venue_map_show',
+			$meta,
+			'Failed to assert that gatherpress_venue_map_show exists for gatherpress-venue-map support.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue.php
@@ -16,6 +16,7 @@ use WP_Block_Patterns_Registry;
 /**
  * Class Test_Venue.
  *
+ * @group multisite
  * @coversDefaultClass \GatherPress\Core\Venue
  */
 class Test_Venue extends Base {
@@ -57,7 +58,7 @@ class Test_Venue extends Base {
 			array(
 				'type'     => 'action',
 				'name'     => 'init',
-				'priority' => 10,
+				'priority' => 11,
 				'callback' => array( $instance, 'register_taxonomy' ),
 			),
 			array(
@@ -881,5 +882,40 @@ class Test_Venue extends Base {
 				'source'   => 'plugin',
 			)
 		);
+	}
+
+	/**
+	 * Coverage for get_venue_post_type method.
+	 *
+	 * @covers ::get_venue_post_type
+	 *
+	 * @return void
+	 */
+	public function test_get_venue_post_type(): void {
+		// Default returns the built-in venue post type.
+		$this->assertSame(
+			Venue::POST_TYPE,
+			Venue::get_venue_post_type(),
+			'Failed to assert that get_venue_post_type returns the default venue post type.'
+		);
+	}
+
+	/**
+	 * Coverage for get_venue_post_type method with filter override.
+	 *
+	 * @covers ::get_venue_post_type
+	 *
+	 * @return void
+	 */
+	public function test_get_venue_post_type_with_filter(): void {
+		add_filter( 'gatherpress_venue_post_type', fn() => 'custom_venue_type' );
+
+		$this->assertSame(
+			'custom_venue_type',
+			Venue::get_venue_post_type(),
+			'Failed to assert that get_venue_post_type returns the filtered post type.'
+		);
+
+		remove_all_filters( 'gatherpress_venue_post_type' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue.php
@@ -33,12 +33,6 @@ class Test_Venue extends Base {
 		$hooks    = array(
 			array(
 				'type'     => 'action',
-				'name'     => 'save_post',
-				'priority' => 10,
-				'callback' => array( $instance, 'add_venue_term' ),
-			),
-			array(
-				'type'     => 'action',
 				'name'     => sprintf( 'save_post_%s', Venue::POST_TYPE ),
 				'priority' => 10,
 				'callback' => array( $instance, 'maybe_apply_venue_template' ),
@@ -48,6 +42,13 @@ class Test_Venue extends Base {
 				'name'     => 'init',
 				'priority' => 10,
 				'callback' => array( $instance, 'register_post_type' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'init',
+				// Priority 11: post types at priority 10 are available via get_post_types_by_support().
+				'priority' => 11,
+				'callback' => array( $instance, 'register_post_save_hooks' ),
 			),
 			array(
 				'type'     => 'action',
@@ -83,6 +84,32 @@ class Test_Venue extends Base {
 		);
 
 		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * Coverage for register_post_save_hooks method.
+	 *
+	 * Verifies that a save_post_{$type} action is registered for each post type
+	 * that declares the 'gatherpress-venue-information' support.
+	 *
+	 * @covers ::register_post_save_hooks
+	 *
+	 * @return void
+	 */
+	public function test_register_post_save_hooks(): void {
+		$instance = Venue::get_instance();
+		$instance->register_post_save_hooks();
+
+		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $post_type ) {
+			$this->assertSame(
+				10,
+				has_action(
+					sprintf( 'save_post_%s', $post_type ),
+					array( $instance, 'add_venue_term' )
+				),
+				sprintf( 'Failed to assert that save_post_%s has the add_venue_term action.', $post_type )
+			);
+		}
 	}
 
 	/**
@@ -1052,9 +1079,11 @@ class Test_Venue extends Base {
 	public function test_get_venue_post_type_with_filter(): void {
 		add_filter( 'gatherpress_venue_post_type', fn() => 'custom_venue_type' );
 
+		// Pass a unique event post type to avoid returning a cached result from a prior
+		// test run that used the default (empty-string) key.
 		$this->assertSame(
 			'custom_venue_type',
-			Venue::get_venue_post_type(),
+			Venue::get_venue_post_type( 'test_custom_event_type' ),
 			'Failed to assert that get_venue_post_type returns the filtered post type.'
 		);
 

--- a/test/unit/php/includes/tests/core/classes/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue.php
@@ -905,6 +905,128 @@ class Test_Venue extends Base {
 	}
 
 	/**
+	 * Coverage for get_taxonomy method with empty string argument.
+	 *
+	 * @covers ::get_taxonomy
+	 *
+	 * @return void
+	 */
+	public function test_get_taxonomy(): void {
+		// No argument falls back to the default venue post type.
+		$this->assertSame(
+			'_' . Venue::POST_TYPE,
+			Venue::get_taxonomy(),
+			'Failed to assert that get_taxonomy defaults to the built-in venue taxonomy.'
+		);
+
+		// Empty string also falls back to the default venue post type.
+		$this->assertSame(
+			'_' . Venue::POST_TYPE,
+			Venue::get_taxonomy( '' ),
+			'Failed to assert that get_taxonomy with empty string defaults to the built-in venue taxonomy.'
+		);
+
+		// Custom venue post type returns the correctly prefixed taxonomy.
+		$this->assertSame(
+			'_custom_venue_type',
+			Venue::get_taxonomy( 'custom_venue_type' ),
+			'Failed to assert that get_taxonomy prepends an underscore for a custom venue post type.'
+		);
+	}
+
+	/**
+	 * Coverage for get_venue_post_type_map method.
+	 *
+	 * @covers ::get_venue_post_type_map
+	 *
+	 * @return void
+	 */
+	public function test_get_venue_post_type_map(): void {
+		$map = Venue::get_venue_post_type_map();
+
+		$this->assertIsArray(
+			$map,
+			'Failed to assert that the venue post type map is an array.'
+		);
+		$this->assertArrayHasKey(
+			Event::POST_TYPE,
+			$map,
+			'Failed to assert that the map contains the default event post type.'
+		);
+		$this->assertSame(
+			Venue::POST_TYPE,
+			$map[ Event::POST_TYPE ],
+			'Failed to assert that the default event post type maps to the default venue post type.'
+		);
+	}
+
+	/**
+	 * Coverage for add_editor_settings method.
+	 *
+	 * @covers ::add_editor_settings
+	 *
+	 * @return void
+	 */
+	public function test_add_editor_settings(): void {
+		$instance = Venue::get_instance();
+
+		// Test with an empty settings array.
+		$result = $instance->add_editor_settings( array() );
+
+		$this->assertArrayHasKey(
+			'gatherpress',
+			$result,
+			'Failed to assert that the gatherpress key is added to an empty settings array.'
+		);
+		$this->assertArrayHasKey(
+			'venuePostTypes',
+			$result['gatherpress'],
+			'Failed to assert that venuePostTypes is present in gatherpress settings.'
+		);
+		$this->assertIsArray(
+			$result['gatherpress']['venuePostTypes'],
+			'Failed to assert that venuePostTypes is an array.'
+		);
+
+		// Test that existing gatherpress settings are preserved and venuePostTypes is appended.
+		$settings = array(
+			'gatherpress' => array( 'existingKey' => 'existingValue' ),
+		);
+		$result   = $instance->add_editor_settings( $settings );
+
+		$this->assertSame(
+			'existingValue',
+			$result['gatherpress']['existingKey'],
+			'Failed to assert that existing gatherpress settings are preserved.'
+		);
+		$this->assertArrayHasKey(
+			'venuePostTypes',
+			$result['gatherpress'],
+			'Failed to assert that venuePostTypes is added alongside existing gatherpress settings.'
+		);
+	}
+
+	/**
+	 * Coverage for add_venue_term when post type does not support gatherpress-venue-information.
+	 *
+	 * @covers ::add_venue_term
+	 *
+	 * @return void
+	 */
+	public function test_add_venue_term_unsupported_post_type(): void {
+		$instance = Venue::get_instance();
+		$post     = $this->mock->post( array( 'post_type' => 'post' ) )->get();
+
+		// Calling add_venue_term on a standard 'post' should return early and create no term.
+		$instance->add_venue_term( $post->ID, $post, false );
+
+		$this->assertNull(
+			term_exists( $instance->get_venue_term_slug( $post->post_name ), Venue::TAXONOMY ),
+			'Failed to assert that no venue term was created for a post type without venue-information support.'
+		);
+	}
+
+	/**
 	 * Coverage for get_venue_post_type method.
 	 *
 	 * @covers ::get_venue_post_type


### PR DESCRIPTION
### Description of the Change

This PR decouples venue and online-event features from hardcoded post type checks, replacing them with WordPress-native `post_type_supports()` throughout the codebase (~37 files). This enables third-party developers to register custom event and venue post types that participate in GatherPress features without being limited to `gatherpress_event` and `gatherpress_venue`.

**What changed:**

- All `Event::POST_TYPE === get_post_type()` checks replaced with `post_type_supports( $type, 'gatherpress-event-date' )` (or the relevant support key)
- All `Venue::POST_TYPE === get_post_type()` checks replaced with `post_type_supports( $type, 'gatherpress-venue-information' )`
- Hardcoded JS constants (`CPT_EVENT`, `CPT_VENUE`, `TAX_VENUE`) removed in favor of dynamic support checks via `isPostTypeSupporting()` and editor settings
- Taxonomy registration is now dynamic — each venue post type gets its own taxonomy (`_` + post type slug)
- New `Venue::get_venue_post_type()` static method with `gatherpress_venue_post_type` filter for custom event→venue mappings
- Venue post type map exposed to the block editor via `block_editor_settings_all`
- Meta and taxonomy registration moved to `init` priority 11 so custom post types registered at priority 10 are discoverable
- `save_post` hooks registered per post type via `register_post_save_hooks()` instead of globally

**New post type supports introduced:**

- `gatherpress-venue` — Physical venue association (declared on event post types)
- `gatherpress-online-event` — Online event link and toggle (declared on event post types)
- `gatherpress-venue-information` — Core venue identifier with address/contact data (declared on venue post types)
- `gatherpress-venue-map` — Map display settings (declared on venue post types)

**Developer usage example:**

```php
// Enable venue support on a custom event post type.
add_post_type_support( 'my_custom_event', 'gatherpress-venue' );

// Create a custom venue post type.
register_post_type( 'my_custom_venue', array(
    'supports' => array( 'title', 'editor', 'gatherpress-venue-information', 'gatherpress-venue-map' ),
) );

// Map a custom event post type to a custom venue post type.
add_filter( 'gatherpress_venue_post_type', function( $post_type, $event_post_type ) {
    if ( 'my_custom_event' === $event_post_type ) {
        return 'my_custom_venue';
    }
    return $post_type;
}, 10, 2 );
```

**Benefits:**

- Third-party plugins can now use GatherPress event/venue features on their own post types
- Follows established WordPress patterns (`post_type_supports`, `get_post_types_by_support`)
- No breaking changes — existing `gatherpress_event` and `gatherpress_venue` post types work exactly as before
- JS block editor components no longer make `context=edit` REST requests for taxonomy data, improving compatibility with custom post types that lack edit permissions in query loop contexts

Closes #688

### How to test the Change

1. Confirm existing functionality works unchanged: create an event, assign a venue, toggle online event, verify RSVP — all should behave as before.
2. Register a custom event post type with `'supports' => array( 'title', 'editor', 'gatherpress-event-date', 'gatherpress-rsvp', 'gatherpress-venue', 'gatherpress-online-event' )` and verify that the venue selector, online event toggle, and RSVP blocks all function in the editor.
3. Register a custom venue post type with `gatherpress-venue-information` and `gatherpress-venue-map` supports — verify venue detail blocks render correctly.
4. Use the `gatherpress_venue_post_type` filter to map a custom event type to a custom venue type and confirm the correct taxonomy and venue posts are resolved.
5. Verify the admin event list venue sorting column still works.
6. Run the full test suite — PHP and JS should both pass at 100% coverage on changed files.

### Changelog Entry

> Changed - Replaced hardcoded post type checks with `post_type_supports()` across all PHP and JS files, enabling custom post types to use GatherPress venue and online-event features.
> Added - New post type supports: `gatherpress-venue`, `gatherpress-online-event`, `gatherpress-venue-information`, and `gatherpress-venue-map`.
> Added - `gatherpress_venue_post_type` filter for mapping custom event post types to custom venue post types.
> Added - `Venue::get_taxonomy()`, `Venue::get_venue_post_type()`, and `Venue::get_venue_post_type_map()` static methods.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.