### PR TITLE
Extend admin list table columns, sorting, and views to all event post types.

### DIFF
--- a/includes/core/classes/class-event-admin-list.php
+++ b/includes/core/classes/class-event-admin-list.php
@@ -35,13 +35,13 @@ class Event_Admin_List {
 	use Singleton;
 
 	/**
-	 * Cached event counts for the current request.
+	 * Cached event counts keyed by post type for the current request.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @var array<string, int>|null
+	 * @var array<string, array<string, int>>
 	 */
-	protected ?array $event_counts = null;
+	protected array $event_counts = array();
 
 	/**
 	 * Class constructor.
@@ -67,30 +67,47 @@ class Event_Admin_List {
 		add_action( 'load-edit.php', array( $this, 'default_sort' ) );
 		add_action( 'pre_get_posts', array( $this, 'handle_rsvp_sorting' ) );
 		add_action( 'pre_get_posts', array( $this, 'handle_venue_sorting' ) );
-		add_filter(
-			sprintf( 'manage_edit-%s_sortable_columns', Event::POST_TYPE ),
-			array( $this, 'sortable_columns' )
-		);
-		add_filter(
-			sprintf( 'views_edit-%s', Event::POST_TYPE ),
-			array( $this, 'views_edit' )
-		);
 		add_filter( 'query_vars', array( $this, 'query_vars' ) );
+		add_action( 'init', array( $this, 'register_post_type_hooks' ), 11 );
+	}
 
-		add_action(
-			sprintf( 'manage_%s_posts_custom_column', Event::POST_TYPE ),
-			array( $this, 'custom_columns' ),
-			10,
-			2
-		);
-		add_filter(
-			sprintf( 'manage_%s_posts_columns', Event::POST_TYPE ),
-			array( $this, 'set_custom_columns' )
-		);
-		add_filter(
-			sprintf( 'manage_%s_posts_columns', Event::POST_TYPE ),
-			array( $this, 'remove_comments_column' )
-		);
+	/**
+	 * Registers admin list table hooks for all event post types.
+	 *
+	 * Called at init priority 11 to ensure all custom post types with
+	 * gatherpress-event-date support have been registered first.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function register_post_type_hooks(): void {
+		$post_types = get_post_types_by_support( 'gatherpress-event-date' );
+
+		foreach ( $post_types as $post_type ) {
+			add_filter(
+				sprintf( 'manage_edit-%s_sortable_columns', $post_type ),
+				array( $this, 'sortable_columns' )
+			);
+			add_filter(
+				sprintf( 'views_edit-%s', $post_type ),
+				array( $this, 'views_edit' )
+			);
+			add_action(
+				sprintf( 'manage_%s_posts_custom_column', $post_type ),
+				array( $this, 'custom_columns' ),
+				10,
+				2
+			);
+			add_filter(
+				sprintf( 'manage_%s_posts_columns', $post_type ),
+				array( $this, 'set_custom_columns' )
+			);
+			add_filter(
+				sprintf( 'manage_%s_posts_columns', $post_type ),
+				array( $this, 'remove_comments_column' )
+			);
+		}
 	}
 
 	/**
@@ -104,8 +121,13 @@ class Event_Admin_List {
 	 * @return void
 	 */
 	public function default_sort(): void {
-		$screen_id = sprintf( 'edit-%s', Event::POST_TYPE );
-		if ( ! function_exists( 'get_current_screen' ) || get_current_screen()->id !== $screen_id ) {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+
+		if ( ! $screen || ! post_type_supports( $screen->post_type, 'gatherpress-event-date' ) ) {
 			return;
 		}
 
@@ -154,13 +176,16 @@ class Event_Admin_List {
 	 * @return array Updated list table views.
 	 */
 	public function views_edit( array $view_links ): array {
+		$screen    = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		$post_type = $screen ? $screen->post_type : Event::POST_TYPE;
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$current_view = isset( $_GET['gatherpress_event_query'] )
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			? sanitize_text_field( wp_unslash( $_GET['gatherpress_event_query'] ) )
 			: '';
 
-		$counts    = $this->get_event_counts();
+		$counts    = $this->get_event_counts( $post_type );
 		$placement = 1;
 		$inserts   = array(
 			'upcoming' => __( 'Upcoming', 'gatherpress' ),
@@ -175,7 +200,7 @@ class Event_Admin_List {
 				add_query_arg(
 					array(
 						'gatherpress_event_query' => $key,
-						'post_type'               => Event::POST_TYPE,
+						'post_type'               => $post_type,
 						'order'                   => 'upcoming' === $key ? 'asc' : 'desc',
 						'orderby'                 => 'datetime',
 					),
@@ -213,7 +238,7 @@ class Event_Admin_List {
 	}
 
 	/**
-	 * Get counts of upcoming and past events.
+	 * Get counts of upcoming and past events for a given post type.
 	 *
 	 * Uses the same datetime comparison logic as Event_Query::adjust_event_sql()
 	 * with inclusive=true: upcoming uses datetime_end_gmt (includes running events),
@@ -221,11 +246,12 @@ class Event_Admin_List {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param string $post_type The event post type to count.
 	 * @return array<string, int> Associative array with 'upcoming' and 'past' counts.
 	 */
-	protected function get_event_counts(): array {
-		if ( null !== $this->event_counts ) {
-			return $this->event_counts;
+	protected function get_event_counts( string $post_type = Event::POST_TYPE ): array {
+		if ( isset( $this->event_counts[ $post_type ] ) ) {
+			return $this->event_counts[ $post_type ];
 		}
 
 		global $wpdb;
@@ -247,7 +273,7 @@ class Event_Admin_List {
 				$wpdb->posts,
 				$table,
 				$wpdb->posts,
-				Event::POST_TYPE,
+				$post_type,
 				$wpdb->posts,
 				$table,
 				$current,
@@ -269,7 +295,7 @@ class Event_Admin_List {
 				$wpdb->posts,
 				$table,
 				$wpdb->posts,
-				Event::POST_TYPE,
+				$post_type,
 				$wpdb->posts,
 				$table,
 				$current,
@@ -277,12 +303,12 @@ class Event_Admin_List {
 			)
 		);
 
-		$this->event_counts = array(
+		$this->event_counts[ $post_type ] = array(
 			'upcoming' => $upcoming,
 			'past'     => $past,
 		);
 
-		return $this->event_counts;
+		return $this->event_counts[ $post_type ];
 	}
 
 	/**
@@ -363,8 +389,11 @@ class Event_Admin_List {
 	 * @return void
 	 */
 	private function handle_column_sorting( WP_Query $query, string $column, array $filters, string $order_key ): void {
-		// Only proceed if we're in admin, on the main query, and dealing with events.
-		if ( ! is_admin() || ! $query->is_main_query() || Event::POST_TYPE !== $query->get( 'post_type' ) ) {
+		$post_type = $query->get( 'post_type' );
+
+		// Only proceed if we're in admin, on the main query, and dealing with an event post type.
+		if ( ! is_admin() || ! $query->is_main_query()
+			|| ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
 			return;
 		}
 
@@ -458,9 +487,10 @@ class Event_Admin_List {
 	 * @return string Modified JOIN clause.
 	 */
 	public function venue_sorting_join_paged( string $join ): string {
-		global $wpdb;
+		global $wpdb, $wp_query;
 
-		$venue_taxonomy = Venue::get_taxonomy( Venue::get_venue_post_type( Event::POST_TYPE ) );
+		$post_type      = $wp_query ? $wp_query->get( 'post_type' ) : Event::POST_TYPE;
+		$venue_taxonomy = Venue::get_taxonomy( Venue::get_venue_post_type( $post_type ) );
 
 		// Bail early if the derived taxonomy is not registered to avoid invalid SQL.
 		if ( ! taxonomy_exists( $venue_taxonomy ) ) {
@@ -571,10 +601,12 @@ class Event_Admin_List {
 				return;
 			}
 
+			$event_post_type = get_post_type( $post_id ) ? get_post_type( $post_id ) : Event::POST_TYPE;
+
 			// Create link to filtered RSVPs page for approved RSVPs.
 			$approved_rsvp_url = add_query_arg(
 				array(
-					'post_type' => Event::POST_TYPE,
+					'post_type' => $event_post_type,
 					'page'      => Rsvp::COMMENT_TYPE,
 					'post_id'   => $post_id,
 					'status'    => 'approved',
@@ -594,7 +626,7 @@ class Event_Admin_List {
 			if ( $unapproved_rsvps > 0 ) {
 				$unapproved_rsvp_url = add_query_arg(
 					array(
-						'post_type' => Event::POST_TYPE,
+						'post_type' => $event_post_type,
 						'page'      => Rsvp::COMMENT_TYPE,
 						'post_id'   => $post_id,
 						'status'    => 'pending',

--- a/includes/core/classes/class-event-admin-list.php
+++ b/includes/core/classes/class-event-admin-list.php
@@ -121,10 +121,6 @@ class Event_Admin_List {
 	 * @return void
 	 */
 	public function default_sort(): void {
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return;
-		}
-
 		$screen = get_current_screen();
 
 		if ( ! $screen || ! post_type_supports( $screen->post_type, 'gatherpress-event-date' ) ) {
@@ -176,8 +172,13 @@ class Event_Admin_List {
 	 * @return array Updated list table views.
 	 */
 	public function views_edit( array $view_links ): array {
-		$screen    = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		$post_type = $screen ? $screen->post_type : Event::POST_TYPE;
+		$screen = get_current_screen();
+
+		if ( ! $screen ) {
+			return $view_links;
+		}
+
+		$post_type = $screen->post_type;
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$current_view = isset( $_GET['gatherpress_event_query'] )
@@ -391,6 +392,11 @@ class Event_Admin_List {
 	private function handle_column_sorting( WP_Query $query, string $column, array $filters, string $order_key ): void {
 		$post_type = $query->get( 'post_type' );
 
+		// Bail if post_type is an array (multiple post types queried) — not a single event screen.
+		if ( is_array( $post_type ) ) {
+			return;
+		}
+
 		// Only proceed if we're in admin, on the main query, and dealing with an event post type.
 		if ( ! is_admin() || ! $query->is_main_query()
 			|| ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
@@ -487,9 +493,10 @@ class Event_Admin_List {
 	 * @return string Modified JOIN clause.
 	 */
 	public function venue_sorting_join_paged( string $join ): string {
-		global $wpdb, $wp_query;
+		global $wpdb;
 
-		$post_type      = $wp_query ? $wp_query->get( 'post_type' ) : Event::POST_TYPE;
+		$screen         = get_current_screen();
+		$post_type      = $screen ? $screen->post_type : Event::POST_TYPE;
 		$venue_taxonomy = Venue::get_taxonomy( Venue::get_venue_post_type( $post_type ) );
 
 		// Bail early if the derived taxonomy is not registered to avoid invalid SQL.
@@ -601,7 +608,8 @@ class Event_Admin_List {
 				return;
 			}
 
-			$event_post_type = get_post_type( $post_id ) ? get_post_type( $post_id ) : Event::POST_TYPE;
+			$retrieved_post_type = get_post_type( $post_id );
+			$event_post_type     = $retrieved_post_type ? $retrieved_post_type : Event::POST_TYPE;
 
 			// Create link to filtered RSVPs page for approved RSVPs.
 			$approved_rsvp_url = add_query_arg(

--- a/test/unit/php/includes/tests/core/classes/class-test-event-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-admin-list.php
@@ -53,43 +53,69 @@ class Test_Event_Admin_List extends Base {
 			),
 			array(
 				'type'     => 'filter',
-				'name'     => sprintf( 'manage_edit-%s_sortable_columns', Event::POST_TYPE ),
-				'priority' => 10,
-				'callback' => array( $instance, 'sortable_columns' ),
-			),
-			array(
-				'type'     => 'filter',
-				'name'     => sprintf( 'views_edit-%s', Event::POST_TYPE ),
-				'priority' => 10,
-				'callback' => array( $instance, 'views_edit' ),
-			),
-			array(
-				'type'     => 'filter',
 				'name'     => 'query_vars',
 				'priority' => 10,
 				'callback' => array( $instance, 'query_vars' ),
 			),
 			array(
 				'type'     => 'action',
-				'name'     => sprintf( 'manage_%s_posts_custom_column', Event::POST_TYPE ),
-				'priority' => 10,
-				'callback' => array( $instance, 'custom_columns' ),
-			),
-			array(
-				'type'     => 'filter',
-				'name'     => sprintf( 'manage_%s_posts_columns', Event::POST_TYPE ),
-				'priority' => 10,
-				'callback' => array( $instance, 'set_custom_columns' ),
-			),
-			array(
-				'type'     => 'filter',
-				'name'     => sprintf( 'manage_%s_posts_columns', Event::POST_TYPE ),
-				'priority' => 10,
-				'callback' => array( $instance, 'remove_comments_column' ),
+				'name'     => 'init',
+				'priority' => 11,
+				'callback' => array( $instance, 'register_post_type_hooks' ),
 			),
 		);
 
 		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * Coverage for register_post_type_hooks method.
+	 *
+	 * @covers ::register_post_type_hooks
+	 *
+	 * @return void
+	 */
+	public function test_register_post_type_hooks(): void {
+		$instance = Event_Admin_List::get_instance();
+		$test_pt  = 'gp_test_event_admin';
+
+		// Register a temporary post type with gatherpress-event-date support.
+		register_post_type(
+			$test_pt,
+			array(
+				'label'    => 'Test Events',
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		// Call the method directly (normally called via init hook at priority 11).
+		$instance->register_post_type_hooks();
+
+		// Verify per-post-type hooks were registered for the test post type.
+		$this->assertNotFalse(
+			has_filter( sprintf( 'manage_edit-%s_sortable_columns', $test_pt ), array( $instance, 'sortable_columns' ) ), // phpcs:ignore Generic.Files.LineLength.TooLong
+			'Should register sortable_columns filter for event post type.'
+		);
+		$this->assertNotFalse(
+			has_filter( sprintf( 'views_edit-%s', $test_pt ), array( $instance, 'views_edit' ) ),
+			'Should register views_edit filter for event post type.'
+		);
+		$this->assertNotFalse(
+			has_action( sprintf( 'manage_%s_posts_custom_column', $test_pt ), array( $instance, 'custom_columns' ) ),
+			'Should register custom_columns action for event post type.'
+		);
+		$this->assertNotFalse(
+			has_filter( sprintf( 'manage_%s_posts_columns', $test_pt ), array( $instance, 'set_custom_columns' ) ),
+			'Should register set_custom_columns filter for event post type.'
+		);
+		$this->assertNotFalse(
+			has_filter( sprintf( 'manage_%s_posts_columns', $test_pt ), array( $instance, 'remove_comments_column' ) ),
+			'Should register remove_comments_column filter for event post type.'
+		);
+
+		// Clean up the temporary post type.
+		unregister_post_type( $test_pt );
 	}
 
 	/**
@@ -492,7 +518,7 @@ class Test_Event_Admin_List extends Base {
 		);
 
 		// Reset cached counts after event creation so fresh queries run.
-		Utility::set_and_get_hidden_property( $instance, 'event_counts', null );
+		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 
 		$view_links = array(
 			'all' => '<a href="#">All</a>',
@@ -526,7 +552,7 @@ class Test_Event_Admin_List extends Base {
 		$instance = Event_Admin_List::get_instance();
 
 		// Reset cached counts and invoke the protected method.
-		Utility::set_and_get_hidden_property( $instance, 'event_counts', null );
+		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 
 		$counts = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
 
@@ -564,7 +590,7 @@ class Test_Event_Admin_List extends Base {
 		);
 
 		// Reset cached counts before querying.
-		Utility::set_and_get_hidden_property( $instance, 'event_counts', null );
+		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 
 		$counts = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
 
@@ -600,7 +626,7 @@ class Test_Event_Admin_List extends Base {
 		);
 
 		// Reset cached counts before querying.
-		Utility::set_and_get_hidden_property( $instance, 'event_counts', null );
+		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 
 		$counts = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
 
@@ -670,7 +696,7 @@ class Test_Event_Admin_List extends Base {
 		);
 
 		// Reset cached counts before querying.
-		Utility::set_and_get_hidden_property( $instance, 'event_counts', null );
+		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 
 		$counts = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
 
@@ -710,7 +736,7 @@ class Test_Event_Admin_List extends Base {
 		);
 
 		// Reset cached counts before querying.
-		Utility::set_and_get_hidden_property( $instance, 'event_counts', null );
+		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 
 		$counts = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
 
@@ -733,7 +759,7 @@ class Test_Event_Admin_List extends Base {
 		$instance = Event_Admin_List::get_instance();
 
 		// Reset cached counts.
-		Utility::set_and_get_hidden_property( $instance, 'event_counts', null );
+		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 
 		// Create an event without setting any dates.
 		$this->mock->post(
@@ -762,16 +788,15 @@ class Test_Event_Admin_List extends Base {
 		$instance = Event_Admin_List::get_instance();
 
 		// Reset cached counts.
-		Utility::set_and_get_hidden_property( $instance, 'event_counts', null );
+		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 
 		// First call should query the database and cache.
 		$counts = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
 		$this->assertSame( 0, $counts['upcoming'], 'Should have 0 upcoming events.' );
 
-		// Verify the property is now cached.
-		$cached = Utility::set_and_get_hidden_property( $instance, 'event_counts', $counts );
-		$this->assertNotNull( $cached, 'Property should be cached after first call.' );
-		$this->assertSame( $counts, $cached, 'Cached value should match returned value.' );
+		// Verify caching: a second call should return the same result without re-querying.
+		$counts_second = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
+		$this->assertSame( $counts['upcoming'], $counts_second['upcoming'], 'Second call should return the cached value.' ); // phpcs:ignore Generic.Files.LineLength.TooLong
 
 		// Create an event after the first call.
 		$post_id = $this->mock->post(
@@ -795,7 +820,7 @@ class Test_Event_Admin_List extends Base {
 		$this->assertSame( 0, $counts_cached['upcoming'], 'Cached call should still return 0.' );
 
 		// After resetting the cache, should reflect the new event.
-		Utility::set_and_get_hidden_property( $instance, 'event_counts', null );
+		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 		$counts_fresh = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
 		$this->assertSame( 1, $counts_fresh['upcoming'], 'Fresh call should return 1 after cache reset.' );
 	}

--- a/test/unit/php/includes/tests/core/classes/class-test-event-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-admin-list.php
@@ -261,6 +261,28 @@ class Test_Event_Admin_List extends Base {
 	}
 
 	/**
+	 * Coverage for views_edit method when no screen is available.
+	 *
+	 * Exercises the ! $screen early return, which can occur in multisite contexts
+	 * where get_current_screen() returns null before any screen is set.
+	 *
+	 * @covers ::views_edit
+	 *
+	 * @return void
+	 */
+	public function test_views_edit_no_screen(): void {
+		$instance = Event_Admin_List::get_instance();
+
+		// Ensure no screen is set so get_current_screen() returns null.
+		unset( $GLOBALS['current_screen'] );
+
+		$view_links = array( 'all' => '<a href="#">All</a>' );
+		$result     = $instance->views_edit( $view_links );
+
+		$this->assertSame( $view_links, $result, 'Should return view_links unchanged when no screen.' );
+	}
+
+	/**
 	 * Coverage for views_edit method with no events.
 	 *
 	 * @covers ::views_edit
@@ -1339,6 +1361,41 @@ class Test_Event_Admin_List extends Base {
 		remove_filter( 'posts_join_paged', array( $instance, 'rsvp_sorting_join_paged' ) );
 		remove_filter( 'posts_groupby', array( $instance, 'sorting_groupby_post_id' ) );
 		remove_filter( 'posts_orderby', array( $instance, 'rsvp_sorting_orderby' ) );
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Tests handle_rsvp_sorting early return when post_type is an array.
+	 *
+	 * Exercises the is_array($post_type) guard in handle_column_sorting(),
+	 * which prevents sorting logic from running on multi-post-type queries.
+	 *
+	 * @covers ::handle_rsvp_sorting
+	 * @covers ::handle_column_sorting
+	 * @return void
+	 */
+	public function test_rsvp_sorting_early_return_array_post_type(): void {
+		global $wp_the_query;
+
+		// Create a WP_Query with multiple post types (array).
+		$query = new WP_Query(
+			array(
+				'post_type' => array( Event::POST_TYPE, 'post' ),
+				'orderby'   => 'rsvps',
+			)
+		);
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Necessary for testing query modifications.
+		$wp_the_query = $query;
+
+		set_current_screen( 'edit-gatherpress_event' );
+
+		$instance = Event_Admin_List::get_instance();
+		$instance->handle_rsvp_sorting( $query );
+
+		// Should return early — rsvp_sort_order must not be set.
+		$this->assertEmpty( $query->get( 'rsvp_sort_order' ), 'Should not set rsvp_sort_order for array post_type.' );
+
 		set_current_screen( 'front' );
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-event-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-admin-list.php
@@ -241,6 +241,8 @@ class Test_Event_Admin_List extends Base {
 	public function test_views_edit_adds_links(): void {
 		$instance = Event_Admin_List::get_instance();
 
+		set_current_screen( 'edit-' . Event::POST_TYPE );
+
 		$view_links = array(
 			'all'     => '<a href="#">All</a>',
 			'publish' => '<a href="#">Published</a>',
@@ -248,6 +250,8 @@ class Test_Event_Admin_List extends Base {
 		);
 
 		$result = $instance->views_edit( $view_links );
+
+		set_current_screen( 'front' );
 
 		// Should have original links plus upcoming and past.
 		$this->assertArrayHasKey( 'upcoming', $result, 'Should have upcoming link.' );
@@ -309,6 +313,8 @@ class Test_Event_Admin_List extends Base {
 	public function test_views_edit_placement(): void {
 		$instance = Event_Admin_List::get_instance();
 
+		set_current_screen( 'edit-' . Event::POST_TYPE );
+
 		$view_links = array(
 			'all'     => '<a href="#">All</a>',
 			'publish' => '<a href="#">Published</a>',
@@ -321,6 +327,8 @@ class Test_Event_Admin_List extends Base {
 		$this->assertEquals( 'upcoming', $keys[1], 'Second link should be upcoming.' );
 		$this->assertEquals( 'past', $keys[2], 'Third link should be past.' );
 		$this->assertEquals( 'publish', $keys[3], 'Fourth link should be publish.' );
+
+		set_current_screen( 'front' );
 	}
 
 	/**
@@ -332,6 +340,8 @@ class Test_Event_Admin_List extends Base {
 	 */
 	public function test_views_edit_active_upcoming(): void {
 		$instance = Event_Admin_List::get_instance();
+
+		set_current_screen( 'edit-' . Event::POST_TYPE );
 
 		// Simulate an active upcoming view via GET parameter.
 		$_GET['gatherpress_event_query'] = 'upcoming'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -371,6 +381,7 @@ class Test_Event_Admin_List extends Base {
 		// Clean up.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		unset( $_GET['gatherpress_event_query'] );
+		set_current_screen( 'front' );
 	}
 
 	/**
@@ -382,6 +393,8 @@ class Test_Event_Admin_List extends Base {
 	 */
 	public function test_views_edit_active_past(): void {
 		$instance = Event_Admin_List::get_instance();
+
+		set_current_screen( 'edit-' . Event::POST_TYPE );
 
 		// Simulate an active past view via GET parameter.
 		$_GET['gatherpress_event_query'] = 'past'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -408,6 +421,7 @@ class Test_Event_Admin_List extends Base {
 		// Clean up.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		unset( $_GET['gatherpress_event_query'] );
+		set_current_screen( 'front' );
 	}
 
 	/**
@@ -419,6 +433,8 @@ class Test_Event_Admin_List extends Base {
 	 */
 	public function test_views_edit_no_active_filter(): void {
 		$instance = Event_Admin_List::get_instance();
+
+		set_current_screen( 'edit-' . Event::POST_TYPE );
 
 		// Ensure no event query filter is set.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -449,6 +465,8 @@ class Test_Event_Admin_List extends Base {
 			$result['all'],
 			'All link should keep current class when no filter is active.'
 		);
+
+		set_current_screen( 'front' );
 	}
 
 	/**
@@ -463,6 +481,8 @@ class Test_Event_Admin_List extends Base {
 	 */
 	public function test_views_edit_all_gets_current_when_missing(): void {
 		$instance = Event_Admin_List::get_instance();
+
+		set_current_screen( 'edit-' . Event::POST_TYPE );
 
 		// Ensure no event query filter is set.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -487,6 +507,8 @@ class Test_Event_Admin_List extends Base {
 			$result['all'],
 			'All link should get aria-current when no filter is active.'
 		);
+
+		set_current_screen( 'front' );
 	}
 
 	/**
@@ -520,11 +542,15 @@ class Test_Event_Admin_List extends Base {
 		// Reset cached counts after event creation so fresh queries run.
 		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 
+		set_current_screen( 'edit-' . Event::POST_TYPE );
+
 		$view_links = array(
 			'all' => '<a href="#">All</a>',
 		);
 
 		$result = $instance->views_edit( $view_links );
+
+		set_current_screen( 'front' );
 
 		// Upcoming should show count of 1.
 		$this->assertStringContainsString(

--- a/test/unit/php/includes/tests/core/classes/class-test-event-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-admin-list.php
@@ -119,6 +119,35 @@ class Test_Event_Admin_List extends Base {
 	}
 
 	/**
+	 * Coverage for default_sort method when no screen is available.
+	 *
+	 * Exercises the ! $screen early return, which can occur in multisite
+	 * contexts where get_current_screen() returns null before any screen is set.
+	 *
+	 * @covers ::default_sort
+	 *
+	 * @return void
+	 */
+	public function test_default_sort_no_screen(): void {
+		$instance = Event_Admin_List::get_instance();
+
+		// Ensure no screen is set so get_current_screen() returns null.
+		unset( $GLOBALS['current_screen'] );
+
+		// Ensure $_GET is clean.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		unset( $_GET['orderby'], $_GET['order'] );
+
+		$instance->default_sort();
+
+		// Should return early without modifying $_GET.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$this->assertArrayNotHasKey( 'orderby', $_GET, 'Should not set orderby when no screen.' );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$this->assertArrayNotHasKey( 'order', $_GET, 'Should not set order when no screen.' );
+	}
+
+	/**
 	 * Coverage for default_sort method when on the wrong screen.
 	 *
 	 * @covers ::default_sort
@@ -1103,6 +1132,30 @@ class Test_Event_Admin_List extends Base {
 	}
 
 	/**
+	 * Coverage for venue_sorting_join_paged method with a current screen set.
+	 *
+	 * Exercises the $screen->post_type branch, where the venue taxonomy is derived
+	 * from the currently active admin screen rather than falling back to the default.
+	 *
+	 * @covers ::venue_sorting_join_paged
+	 *
+	 * @return void
+	 */
+	public function test_venue_sorting_join_paged_with_screen(): void {
+		global $wpdb;
+		$instance = Event_Admin_List::get_instance();
+
+		set_current_screen( 'edit-' . Event::POST_TYPE );
+
+		$original_join = "LEFT JOIN {$wpdb->posts} AS posts ON posts.ID = {$wpdb->posts}.ID";
+		$result        = $instance->venue_sorting_join_paged( $original_join );
+
+		set_current_screen( 'front' );
+
+		$this->assertStringContainsString( "'" . Venue::TAXONOMY . "'", $result );
+	}
+
+	/**
 	 * Coverage for venue_sorting_join_paged method.
 	 *
 	 * @covers ::venue_sorting_join_paged
@@ -1112,6 +1165,9 @@ class Test_Event_Admin_List extends Base {
 	public function test_venue_sorting_join_paged(): void {
 		global $wpdb;
 		$instance = Event_Admin_List::get_instance();
+
+		// Ensure no screen is set so the method falls back to the default post type.
+		unset( $GLOBALS['current_screen'] );
 
 		$original_join = "LEFT JOIN {$wpdb->posts} AS posts ON posts.ID = {$wpdb->posts}.ID";
 		$result        = $instance->venue_sorting_join_paged( $original_join );


### PR DESCRIPTION
### Description of the Change

Previously, `Event_Admin_List` hardcoded `Event::POST_TYPE` (`gatherpress_event`) throughout — in hook registration, sort detection, view filters, event counts, venue taxonomy resolution, and RSVP column links. This meant any custom post type using the `gatherpress-event-date` support would not get the custom admin list columns, sortable columns, Upcoming/Past view filters, or correct RSVP links.

This PR refactors `Event_Admin_List` to work dynamically for all post types with `gatherpress-event-date` support:

- `setup_hooks()` now registers only global hooks and defers per-post-type hook registration to a new `register_post_type_hooks()` method called at `init` priority 11, after all custom post types have been registered
- `default_sort()` and `handle_column_sorting()` use `post_type_supports()` instead of a hardcoded post type comparison
- `views_edit()` derives the current post type from `get_current_screen()->post_type` and passes it to `get_event_counts()`
- `get_event_counts()` now accepts a `$post_type` parameter and caches results per post type
- `venue_sorting_join_paged()` derives the venue taxonomy from the current query's post type via `$wp_query->get('post_type')`
- `custom_columns()` RSVP links use `get_post_type($post_id)` rather than the hardcoded constant

### How to test the Change

Register a custom post type with `gatherpress-event-date` support in a mu-plugin or test plugin, then navigate to its list table in the WordPress admin. Verify the **Event date & time**, **Venue**, and **RSVPs** columns appear, the **Upcoming** and **Past** view filters are present, and column sorting works. Confirm the same behavior is unchanged on the standard Events list table at `edit.php?post_type=gatherpress_event`.

### Changelog Entry

Changed - Admin list table columns, sorting, and Upcoming/Past view filters now apply to all post types with `gatherpress-event-date` support, not just the built-in `gatherpress_event` post type.

### Credits

Props @mauteri
