### PR TITLE
Add configurable RSVP mode with per-event control and sitewide disable support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Language
 
-Always use **US English** spelling in all code, comments, and documentation. Examples: "initialization" not "initialisation", "color" not "colour", "customize" not "customise".
+Always use **US English** spelling in all code, comments, and documentation. When in doubt, use the spelling WordPress core uses.
 
 ## Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Language
+
+Always use **US English** spelling in all code, comments, and documentation. Examples: "initialization" not "initialisation", "color" not "colour", "customize" not "customise".
+
 ## Development Commands
 
 ### PHP Development

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@ Once activated, GatherPress can be configured from your WordPress dashboard unde
 Customize how GatherPress behaves across your site:
 
 - Use publish date as event date (optional)
+- **RSVP Mode** — choose between All events, Per event (default on), Per event (default off), or Disabled (see [RSVP system](user/rsvp-system.md#rsvp-mode))
 - Default RSVP limit
 - Enable or disable anonymous RSVPs
 - Date and time formats

--- a/docs/developer/settings/README.md
+++ b/docs/developer/settings/README.md
@@ -47,12 +47,36 @@ The settings page is organized into tabs, each managed by its own class:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| `rsvp_mode` | select | `'all_on'` | Controls sitewide RSVP availability. See [RSVP Mode](#rsvp-mode) below. |
 | `max_attendance_limit` | number | `50` | Maximum attendees per event (0 = unlimited) |
 | `max_guest_limit` | number | `0` | Maximum guests per attendee (0-5) |
 | `enable_anonymous_rsvp` | checkbox | `false` | Allow anonymous RSVPs |
 | `rsvp_cleanup_switch` | select | `'off'` | Enable/disable RSVP cleanup |
 | `rsvp_cleanup_frequency` | select | `'daily'` | Cleanup frequency (hourly, daily, weekly, monthly, yearly) |
 | `rsvp_cleanup_interval` | number | `1` | Interval multiplier for cleanup frequency |
+
+#### RSVP Mode
+
+The `rsvp_mode` setting controls how RSVP availability is determined across the site.
+
+| Value | Label | Behavior |
+|-------|-------|----------|
+| `all_on` | All events | RSVP is enabled for every event. No per-event toggle is shown. This is the default. |
+| `per_event_on` | Per event (default on) | A per-event toggle appears in the block editor. New events default to RSVP enabled. |
+| `per_event_off` | Per event (default off) | A per-event toggle appears in the block editor. New events default to RSVP disabled. |
+| `disabled` | Disabled | RSVP is turned off sitewide. RSVP blocks are hidden from the inserter, the RSVPs admin submenu is removed, and the RSVP Settings editor panel is hidden. |
+
+**Per-event meta convention:** the `gatherpress_enable_rsvp` post meta stores the per-event state as an integer (`1` = enabled, `0` = disabled). An unset meta value (empty string) is treated as enabled — only an explicit `0` disables RSVP for an individual event. When mode is `all_on`, this meta is explicitly written as `1` on save so that switching to a per-event mode later produces predictable results.
+
+```php
+use GatherPress\Core\Settings;
+
+// Read the current RSVP mode.
+$mode = Settings::get_instance()->get( 'rsvp_mode' ); // 'all_on'
+
+// Check whether RSVP is enabled for a specific event post.
+$enabled = ( new \GatherPress\Core\Rsvp( $post_id ) )->is_enabled();
+```
 
 ### Formatting Tab
 

--- a/docs/user/rsvp-system.md
+++ b/docs/user/rsvp-system.md
@@ -17,9 +17,9 @@ RSVPs are configured per event when using a per-event mode.
 
 What is known and visible in the UI:
 
-* The presence of the RSVP block allows users to RSVP  
-* Default RSVP behavior comes from GatherPress settings.  
-* Event-level settings override global defaults when a per-event mode is active.
+- The presence of the RSVP block allows users to RSVP  
+- Default RSVP behavior comes from GatherPress settings.  
+- Event-level settings override global defaults when a per-event mode is active.
 
 ## RSVP without an account
 
@@ -31,10 +31,10 @@ Event organizers can manage RSVPs from the WordPress admin.
 
 What is visible:
 
-* A list of RSVPs per event.  
-* Attendee status (yes / no / waiting list, if applicable).  
-* Ability to approve, unapprove, delete or mark as spam manually when hovering, same as comments.
-* if a red dot appears in the RSVP column, it means the RSVP is pending.
+- A list of RSVPs per event.  
+- Attendee status (yes / no / waiting list, if applicable).  
+- Ability to approve, unapprove, delete or mark as spam manually when hovering, same as comments.
+- if a red dot appears in the RSVP column, it means the RSVP is pending.
 
 ![Screenshot of the RSVPs admin page](./user-doc-media/20260110151948.png)
 
@@ -44,14 +44,14 @@ Events can define attendance limits.
 
 What is confirmed:
 
-* Total number of people allowed at the event. A value of 0 indicates no limit.  
-* A maximum number of guests per attendee can be set.  
-* Defaults come from global settings.
+- Total number of people allowed at the event. A value of 0 indicates no limit.  
+- A maximum number of guests per attendee can be set.  
+- Defaults come from global settings.
 
 What happens when an event is full:
 
-* New RSVPs are prevented once the limit is reached.  
-* A waiting list may be used if enabled. If enabled and someone is on a waiting list and a spot opens up, they are moved to attending. For now, no email is sent.
+- New RSVPs are prevented once the limit is reached.  
+- A waiting list may be used if enabled. If enabled and someone is on a waiting list and a spot opens up, they are moved to attending. For now, no email is sent.
 
 ![Screenshot of the settings panel for guest and limit options](./user-doc-media/20260110152233.png)
 

--- a/docs/user/rsvp-system.md
+++ b/docs/user/rsvp-system.md
@@ -2,15 +2,24 @@
 
 This section explains how RSVPs work from both the visitor and organizer perspectives.
 
+## RSVP Mode
+
+Site administrators can control how RSVP works across the entire site from **Events → Settings → RSVP**. Four modes are available:
+
+- **All events** — RSVP is enabled for every event. No per-event toggle is shown in the editor. This is the default behavior.
+- **Per event (default on)** — A toggle appears in the block editor sidebar for each event. New events default to RSVP enabled; editors can disable it per event.
+- **Per event (default off)** — Same as above, but new events default to RSVP disabled. Editors must explicitly enable RSVP for each event.
+- **Disabled** — RSVP is turned off sitewide. RSVP blocks are removed from the block inserter, the RSVPs admin menu is hidden, and the RSVP Settings panel no longer appears in the editor.
+
 ## RSVP functionality
 
-RSVPs are configured per event.
+RSVPs are configured per event when using a per-event mode.
 
 What is known and visible in the UI:
 
 * The presence of the RSVP block allows users to RSVP  
 * Default RSVP behavior comes from GatherPress settings.  
-* Event-level settings override global defaults.
+* Event-level settings override global defaults when a per-event mode is active.
 
 ## RSVP without an account
 

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -16,6 +16,7 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -276,6 +277,15 @@ class General_Block {
 			return $block_content;
 		}
 
+		// Only process if RSVP is enabled for this event.
+		// Empty string means meta was never set; only '0' means explicitly disabled.
+		if (
+			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
+			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
+		) {
+			return '';
+		}
+
 		// Get max guest limit from event settings.
 		$max_guest_limit = (int) get_post_meta( $post_id, 'gatherpress_max_guest_limit', true );
 
@@ -322,6 +332,15 @@ class General_Block {
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
 		) {
 			return $block_content;
+		}
+
+		// Only process if RSVP is enabled for this event.
+		// Empty string means meta was never set; only '0' means explicitly disabled.
+		if (
+			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
+			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
+		) {
+			return '';
 		}
 
 		// Get anonymous RSVP setting from event.

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -16,7 +16,7 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
-use GatherPress\Core\Rsvp_Setup;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -277,7 +277,7 @@ class General_Block {
 			return $block_content;
 		}
 
-		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
 			return '';
 		}
 
@@ -329,7 +329,7 @@ class General_Block {
 			return $block_content;
 		}
 
-		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -277,7 +277,7 @@ class General_Block {
 			return $block_content;
 		}
 
-		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_enabled() ) {
 			return '';
 		}
 
@@ -329,7 +329,7 @@ class General_Block {
 			return $block_content;
 		}
 
-		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_enabled() ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -16,7 +16,7 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
-use GatherPress\Core\Settings;
+use GatherPress\Core\Rsvp_Setup;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -277,12 +277,7 @@ class General_Block {
 			return $block_content;
 		}
 
-		// Only process if RSVP is enabled for this event.
-		// Empty string means meta was never set; only '0' means explicitly disabled.
-		if (
-			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
-			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
-		) {
+		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
 			return '';
 		}
 
@@ -334,12 +329,7 @@ class General_Block {
 			return $block_content;
 		}
 
-		// Only process if RSVP is enabled for this event.
-		// Empty string means meta was never set; only '0' means explicitly disabled.
-		if (
-			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
-			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
-		) {
+		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -21,7 +21,7 @@ use GatherPress\Core\Blocks\Form_Field;
 use GatherPress\Core\Blocks\General_Block;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
-use GatherPress\Core\Settings;
+use GatherPress\Core\Rsvp_Setup;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -124,12 +124,7 @@ class Rsvp_Form {
 			return '';
 		}
 
-		// Validate that RSVP is enabled for this event.
-		// Empty string means meta was never set; only '0' means explicitly disabled.
-		if (
-			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
-			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
-		) {
+		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -123,7 +123,7 @@ class Rsvp_Form {
 			return '';
 		}
 
-		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_enabled() ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -21,7 +21,6 @@ use GatherPress\Core\Blocks\Form_Field;
 use GatherPress\Core\Blocks\General_Block;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
-use GatherPress\Core\Rsvp_Setup;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -124,7 +123,7 @@ class Rsvp_Form {
 			return '';
 		}
 
-		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -21,6 +21,7 @@ use GatherPress\Core\Blocks\Form_Field;
 use GatherPress\Core\Blocks\General_Block;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -119,6 +120,15 @@ class Rsvp_Form {
 		if (
 			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
+		) {
+			return '';
+		}
+
+		// Validate that RSVP is enabled for this event.
+		// Empty string means meta was never set; only '0' means explicitly disabled.
+		if (
+			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
+			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
 		) {
 			return '';
 		}

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -14,7 +14,6 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
 use GatherPress\Core\Rsvp;
-use GatherPress\Core\Rsvp_Setup;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -101,7 +100,7 @@ class Rsvp_Response {
 			return '';
 		}
 
-		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -100,7 +100,7 @@ class Rsvp_Response {
 			return '';
 		}
 
-		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_enabled() ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
 use GatherPress\Core\Rsvp;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -96,6 +97,15 @@ class Rsvp_Response {
 		if (
 			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
+		) {
+			return '';
+		}
+
+		// Validate that RSVP is enabled for this event.
+		// Empty string means meta was never set; only '0' means explicitly disabled.
+		if (
+			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
+			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
 		) {
 			return '';
 		}

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
 use GatherPress\Core\Rsvp;
-use GatherPress\Core\Settings;
+use GatherPress\Core\Rsvp_Setup;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -101,12 +101,7 @@ class Rsvp_Response {
 			return '';
 		}
 
-		// Validate that RSVP is enabled for this event.
-		// Empty string means meta was never set; only '0' means explicitly disabled.
-		if (
-			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
-			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
-		) {
+		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -134,7 +134,7 @@ class Rsvp_Template {
 			return $block_content;
 		}
 
-		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_enabled() ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
 use GatherPress\Core\Event;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_Block;
@@ -131,6 +132,15 @@ class Rsvp_Template {
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
 		) {
 			return $block_content;
+		}
+
+		// Only process if RSVP is enabled for this event.
+		// Empty string means meta was never set; only '0' means explicitly disabled.
+		if (
+			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
+			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
+		) {
+			return '';
 		}
 
 		$responses     = $event->rsvp->responses()['attending']['records'];

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
 use GatherPress\Core\Event;
-use GatherPress\Core\Settings;
+use GatherPress\Core\Rsvp_Setup;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_Block;
@@ -134,12 +134,7 @@ class Rsvp_Template {
 			return $block_content;
 		}
 
-		// Only process if RSVP is enabled for this event.
-		// Empty string means meta was never set; only '0' means explicitly disabled.
-		if (
-			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
-			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
-		) {
+		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
 use GatherPress\Core\Event;
-use GatherPress\Core\Rsvp_Setup;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_Block;
@@ -134,7 +134,7 @@ class Rsvp_Template {
 			return $block_content;
 		}
 
-		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -111,7 +111,7 @@ class Rsvp {
 			return '';
 		}
 
-		if ( ! ( new Core_Rsvp( $post_id ) )->is_rsvp_enabled() ) {
+		if ( ! ( new Core_Rsvp( $post_id ) )->is_enabled() ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -17,6 +17,7 @@ use GatherPress\Core\Blocks\Form_Field;
 use GatherPress\Core\Blocks\General_Block;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp_Setup;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -106,6 +107,15 @@ class Rsvp {
 		if (
 			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
 			( ! is_preview() && 'publish' !== get_post_status( $post_id ) )
+		) {
+			return '';
+		}
+
+		// Validate that RSVP is enabled for this event.
+		// Empty string means meta was never set; only '0' means explicitly disabled.
+		if (
+			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
+			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
 		) {
 			return '';
 		}

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -17,7 +17,6 @@ use GatherPress\Core\Blocks\Form_Field;
 use GatherPress\Core\Blocks\General_Block;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp_Setup;
-use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;
@@ -111,12 +110,7 @@ class Rsvp {
 			return '';
 		}
 
-		// Validate that RSVP is enabled for this event.
-		// Empty string means meta was never set; only '0' means explicitly disabled.
-		if (
-			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
-			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
-		) {
+		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -16,6 +16,7 @@ use GatherPress\Core\Block;
 use GatherPress\Core\Blocks\Form_Field;
 use GatherPress\Core\Blocks\General_Block;
 use GatherPress\Core\Event;
+use GatherPress\Core\Rsvp as Core_Rsvp;
 use GatherPress\Core\Rsvp_Setup;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
@@ -110,7 +111,7 @@ class Rsvp {
 			return '';
 		}
 
-		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
+		if ( ! ( new Core_Rsvp( $post_id ) )->is_rsvp_enabled() ) {
 			return '';
 		}
 

--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -669,12 +669,7 @@ class Event_Rest_Api {
 					'featured_image'           => get_the_post_thumbnail( $post_id, 'medium' ),
 					'featured_image_large'     => get_the_post_thumbnail( $post_id, 'large' ),
 					'featured_image_thumbnail' => get_the_post_thumbnail( $post_id, 'thumbnail' ),
-					'enable_rsvp'              => 'disabled' !== Settings::get_instance()->get( 'rsvp_mode' ) &&
-						(
-							// phpcs:ignore Generic.Files.LineLength.TooLong
-							! in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) ||
-							'0' !== get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
-						),
+					'enable_rsvp'              => Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
 					'enable_anonymous_rsvp'    => (bool) get_post_meta(
 						$post_id,
 						'gatherpress_enable_anonymous_rsvp',

--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -669,6 +669,12 @@ class Event_Rest_Api {
 					'featured_image'           => get_the_post_thumbnail( $post_id, 'medium' ),
 					'featured_image_large'     => get_the_post_thumbnail( $post_id, 'large' ),
 					'featured_image_thumbnail' => get_the_post_thumbnail( $post_id, 'thumbnail' ),
+					'enable_rsvp'              => 'disabled' !== Settings::get_instance()->get( 'rsvp_mode' ) &&
+						(
+							// phpcs:ignore Generic.Files.LineLength.TooLong
+							! in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) ||
+							'0' !== get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
+						),
 					'enable_anonymous_rsvp'    => (bool) get_post_meta(
 						$post_id,
 						'gatherpress_enable_anonymous_rsvp',

--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -669,7 +669,7 @@ class Event_Rest_Api {
 					'featured_image'           => get_the_post_thumbnail( $post_id, 'medium' ),
 					'featured_image_large'     => get_the_post_thumbnail( $post_id, 'large' ),
 					'featured_image_thumbnail' => get_the_post_thumbnail( $post_id, 'thumbnail' ),
-					'enable_rsvp'              => ( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+					'enable_rsvp'              => ( new Rsvp( $post_id ) )->is_enabled(),
 					'enable_anonymous_rsvp'    => (bool) get_post_meta(
 						$post_id,
 						'gatherpress_enable_anonymous_rsvp',

--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -669,7 +669,7 @@ class Event_Rest_Api {
 					'featured_image'           => get_the_post_thumbnail( $post_id, 'medium' ),
 					'featured_image_large'     => get_the_post_thumbnail( $post_id, 'large' ),
 					'featured_image_thumbnail' => get_the_post_thumbnail( $post_id, 'thumbnail' ),
-					'enable_rsvp'              => Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
+					'enable_rsvp'              => ( new Rsvp( $post_id ) )->is_rsvp_enabled(),
 					'enable_anonymous_rsvp'    => (bool) get_post_meta(
 						$post_id,
 						'gatherpress_enable_anonymous_rsvp',

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -313,7 +313,7 @@ class Event_Setup {
 		// Always register gatherpress_enable_rsvp so it can be written in all modes.
 		// Missing meta is treated as "on"; only an explicit 0 disables RSVP per event.
 		$event_only_meta = array(
-			'gatherpress_enable_rsvp' => array(
+			'gatherpress_enable_rsvp'           => array(
 				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
@@ -321,39 +321,38 @@ class Event_Setup {
 				'type'              => 'integer',
 				'default'           => 1,
 			),
-		);
-
-		$event_only_meta['gatherpress_max_guest_limit']       = array(
-			'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
-			'sanitize_callback' => 'absint',
-			'show_in_rest'      => true,
-			'single'            => true,
-			'type'              => 'integer',
-			'default'           => (int) Settings::get_instance()->get( 'max_guest_limit' ),
-		);
-		$event_only_meta['gatherpress_enable_anonymous_rsvp'] = array(
-			'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
-			'sanitize_callback' => 'rest_sanitize_boolean',
-			'show_in_rest'      => true,
-			'single'            => true,
-			'type'              => 'boolean',
-			'default'           => (bool) Settings::get_instance()->get( 'enable_anonymous_rsvp' ),
-		);
-		$event_only_meta['gatherpress_online_event_link']     = array(
-			'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
-			'sanitize_callback' => 'sanitize_url',
-			'show_in_rest'      => true,
-			'single'            => true,
-			'type'              => 'string',
-			'default'           => '',
-		);
-		$event_only_meta['gatherpress_max_attendance_limit']  = array(
-			'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
-			'sanitize_callback' => 'absint',
-			'show_in_rest'      => true,
-			'single'            => true,
-			'type'              => 'integer',
-			'default'           => (int) Settings::get_instance()->get( 'max_attendance_limit' ),
+			'gatherpress_max_guest_limit'       => array(
+				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'sanitize_callback' => 'absint',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'integer',
+				'default'           => (int) Settings::get_instance()->get( 'max_guest_limit' ),
+			),
+			'gatherpress_enable_anonymous_rsvp' => array(
+				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'boolean',
+				'default'           => (bool) Settings::get_instance()->get( 'enable_anonymous_rsvp' ),
+			),
+			'gatherpress_online_event_link'     => array(
+				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'sanitize_callback' => 'sanitize_url',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
+				'default'           => '',
+			),
+			'gatherpress_max_attendance_limit'  => array(
+				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'sanitize_callback' => 'absint',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'integer',
+				'default'           => (int) Settings::get_instance()->get( 'max_attendance_limit' ),
+			),
 		);
 
 		foreach ( $event_only_meta as $meta_key => $args ) {

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -310,39 +310,50 @@ class Event_Setup {
 		}
 
 		// Non-datetime meta remains on the event post type only.
+		// Always register gatherpress_enable_rsvp so it can be written in all modes.
+		// Missing meta is treated as "on"; only an explicit 0 disables RSVP per event.
 		$event_only_meta = array(
-			'gatherpress_max_guest_limit'       => array(
+			'gatherpress_enable_rsvp' => array(
 				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,
 				'type'              => 'integer',
-				'default'           => (int) Settings::get_instance()->get( 'max_guest_limit' ),
+				'default'           => 1,
 			),
-			'gatherpress_enable_anonymous_rsvp' => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
-				'sanitize_callback' => 'rest_sanitize_boolean',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'boolean',
-				'default'           => (bool) Settings::get_instance()->get( 'enable_anonymous_rsvp' ),
-			),
-			'gatherpress_online_event_link'     => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
-				'sanitize_callback' => 'sanitize_url',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'string',
-				'default'           => '',
-			),
-			'gatherpress_max_attendance_limit'  => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
-				'sanitize_callback' => 'absint',
-				'show_in_rest'      => true,
-				'single'            => true,
-				'type'              => 'integer',
-				'default'           => (int) Settings::get_instance()->get( 'max_attendance_limit' ),
-			),
+		);
+
+		$event_only_meta['gatherpress_max_guest_limit']       = array(
+			'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+			'sanitize_callback' => 'absint',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'integer',
+			'default'           => (int) Settings::get_instance()->get( 'max_guest_limit' ),
+		);
+		$event_only_meta['gatherpress_enable_anonymous_rsvp'] = array(
+			'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'boolean',
+			'default'           => (bool) Settings::get_instance()->get( 'enable_anonymous_rsvp' ),
+		);
+		$event_only_meta['gatherpress_online_event_link']     = array(
+			'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+			'sanitize_callback' => 'sanitize_url',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'string',
+			'default'           => '',
+		);
+		$event_only_meta['gatherpress_max_attendance_limit']  = array(
+			'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+			'sanitize_callback' => 'absint',
+			'show_in_rest'      => true,
+			'single'            => true,
+			'type'              => 'integer',
+			'default'           => (int) Settings::get_instance()->get( 'max_attendance_limit' ),
 		);
 
 		foreach ( $event_only_meta as $meta_key => $args ) {

--- a/includes/core/classes/class-rsvp-form.php
+++ b/includes/core/classes/class-rsvp-form.php
@@ -161,12 +161,7 @@ class Rsvp_Form {
 			);
 		}
 
-		// Check if RSVP is enabled for this event.
-		// Empty string means meta was never set; only '0' means explicitly disabled.
-		if (
-			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
-			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
-		) {
+		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
 			wp_die(
 				esc_html__( 'RSVP is disabled for this event.', 'gatherpress' ),
 				esc_html__( 'RSVP Disabled', 'gatherpress' ),

--- a/includes/core/classes/class-rsvp-form.php
+++ b/includes/core/classes/class-rsvp-form.php
@@ -161,7 +161,7 @@ class Rsvp_Form {
 			);
 		}
 
-		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
 			wp_die(
 				esc_html__( 'RSVP is disabled for this event.', 'gatherpress' ),
 				esc_html__( 'RSVP Disabled', 'gatherpress' ),

--- a/includes/core/classes/class-rsvp-form.php
+++ b/includes/core/classes/class-rsvp-form.php
@@ -161,6 +161,19 @@ class Rsvp_Form {
 			);
 		}
 
+		// Check if RSVP is enabled for this event.
+		// Empty string means meta was never set; only '0' means explicitly disabled.
+		if (
+			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
+			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
+		) {
+			wp_die(
+				esc_html__( 'RSVP is disabled for this event.', 'gatherpress' ),
+				esc_html__( 'RSVP Disabled', 'gatherpress' ),
+				403
+			);
+		}
+
 		// Check if event has passed - prevent RSVPs to past events.
 		$event = new Event( $post_id );
 		if ( $event->has_event_past() ) {

--- a/includes/core/classes/class-rsvp-form.php
+++ b/includes/core/classes/class-rsvp-form.php
@@ -152,20 +152,22 @@ class Rsvp_Form {
 		$email   = Utility::get_http_input( INPUT_POST, 'email', 'sanitize_email' );
 		$post_id = intval( $comment_data['comment_post_ID'] );
 
+		// Check sitewide/per-event RSVP setting before any post-type check so that
+		// globally-disabled mode returns the correct 403 rather than a misleading 400.
+		if ( ! ( new Rsvp( $post_id ) )->is_enabled() ) {
+			wp_die(
+				esc_html__( 'RSVP is disabled for this event.', 'gatherpress' ),
+				esc_html__( 'RSVP Disabled', 'gatherpress' ),
+				403
+			);
+		}
+
 		// Validate that the post supports RSVP.
 		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
 			wp_die(
 				esc_html__( 'Invalid event ID.', 'gatherpress' ),
 				esc_html__( 'Invalid Request', 'gatherpress' ),
 				400
-			);
-		}
-
-		if ( ! ( new Rsvp( $post_id ) )->is_enabled() ) {
-			wp_die(
-				esc_html__( 'RSVP is disabled for this event.', 'gatherpress' ),
-				esc_html__( 'RSVP Disabled', 'gatherpress' ),
-				403
 			);
 		}
 

--- a/includes/core/classes/class-rsvp-form.php
+++ b/includes/core/classes/class-rsvp-form.php
@@ -161,7 +161,7 @@ class Rsvp_Form {
 			);
 		}
 
-		if ( ! ( new Rsvp( $post_id ) )->is_rsvp_enabled() ) {
+		if ( ! ( new Rsvp( $post_id ) )->is_enabled() ) {
 			wp_die(
 				esc_html__( 'RSVP is disabled for this event.', 'gatherpress' ),
 				esc_html__( 'RSVP Disabled', 'gatherpress' ),

--- a/includes/core/classes/class-rsvp-setup.php
+++ b/includes/core/classes/class-rsvp-setup.php
@@ -248,12 +248,7 @@ class Rsvp_Setup {
 	}
 
 	/**
-	 * Writes an explicit gatherpress_enable_rsvp = 1 value when RSVP mode is all_on.
-	 *
-	 * This ensures that if an admin later switches to a per-event mode, all events
-	 * created under all_on mode already have meta = 1 and appear correctly as enabled.
-	 * Events without the meta are also treated as on (missing = on convention), but
-	 * writing it explicitly makes the state unambiguous.
+	 * Delegates to Rsvp::initialize_enabled() for the wp_after_insert_post hook.
 	 *
 	 * @since 1.0.0
 	 *
@@ -262,18 +257,7 @@ class Rsvp_Setup {
 	 * @return void
 	 */
 	public function maybe_set_rsvp_meta_default( int $post_id ): void {
-		if ( 'all_on' !== Settings::get_instance()->get( 'rsvp_mode' ) ) {
-			return;
-		}
-
-		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
-			return;
-		}
-
-		// Only write if meta has never been explicitly set.
-		if ( '' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ) ) {
-			update_post_meta( $post_id, 'gatherpress_enable_rsvp', 1 );
-		}
+		( new Rsvp( $post_id ) )->initialize_enabled();
 	}
 
 	/**

--- a/includes/core/classes/class-rsvp-setup.php
+++ b/includes/core/classes/class-rsvp-setup.php
@@ -79,6 +79,7 @@ class Rsvp_Setup {
 	protected function setup_hooks(): void {
 		add_action( 'init', array( $this, 'register_taxonomy' ) );
 		add_action( 'init', array( $this, 'handle_rsvp_token' ) );
+		// Priority 11 ensures post types are already registered (priority 10) before removing RSVP support.
 		add_action( 'init', array( $this, 'maybe_disable_rsvp' ), 11 );
 		add_action( 'wp_after_insert_post', array( $this, 'maybe_process_waiting_list' ) );
 		add_action( 'wp_after_insert_post', array( $this, 'maybe_set_rsvp_meta_default' ) );
@@ -173,7 +174,7 @@ class Rsvp_Setup {
 				array_filter(
 					$allowed_block_types,
 					static function ( $name ): bool {
-						return ! is_string( $name ) || 0 !== strpos( $name, 'gatherpress/rsvp' );
+						return ! str_contains( $name, 'gatherpress/rsvp' );
 					}
 				)
 			);

--- a/includes/core/classes/class-rsvp-setup.php
+++ b/includes/core/classes/class-rsvp-setup.php
@@ -257,6 +257,11 @@ class Rsvp_Setup {
 	 * @return void
 	 */
 	public function maybe_set_rsvp_meta_default( int $post_id ): void {
+		// Skip non-event post types early to avoid an unnecessary Rsvp instantiation.
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
+			return;
+		}
+
 		( new Rsvp( $post_id ) )->initialize_enabled();
 	}
 

--- a/includes/core/classes/class-rsvp-setup.php
+++ b/includes/core/classes/class-rsvp-setup.php
@@ -18,6 +18,7 @@ use GatherPress\Core\Blocks\Rsvp_Form;
 use GatherPress\Core\Rsvp_Token;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
+use WP_Block_Type_Registry;
 use WP_Comment;
 use WP_User;
 
@@ -78,8 +79,11 @@ class Rsvp_Setup {
 	protected function setup_hooks(): void {
 		add_action( 'init', array( $this, 'register_taxonomy' ) );
 		add_action( 'init', array( $this, 'handle_rsvp_token' ) );
+		add_action( 'init', array( $this, 'maybe_disable_rsvp' ), 11 );
 		add_action( 'wp_after_insert_post', array( $this, 'maybe_process_waiting_list' ) );
+		add_action( 'wp_after_insert_post', array( $this, 'maybe_set_rsvp_meta_default' ) );
 		add_action( 'admin_menu', array( $this, 'add_rsvp_submenu_page' ) );
+		add_filter( 'allowed_block_types_all', array( $this, 'filter_rsvp_block_types' ) );
 		add_filter( 'comment_notification_recipients', array( $this, 'remove_rsvp_notification_emails' ), 10, 2 );
 
 		add_filter(
@@ -120,7 +124,63 @@ class Rsvp_Setup {
 		);
 	}
 
+	/**
+	 * Disables RSVP sitewide when the master RSVP switch is turned off.
+	 *
+	 * Removes the `gatherpress-rsvp` post type support from all post types
+	 * that currently support it. This causes all existing `post_type_supports()`
+	 * guards throughout the plugin to return false, effectively disabling RSVP
+	 * functionality without requiring individual checks everywhere.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function maybe_disable_rsvp(): void {
+		if ( 'disabled' !== Settings::get_instance()->get( 'rsvp_mode' ) ) {
+			return;
+		}
 
+		foreach ( get_post_types_by_support( 'gatherpress-rsvp' ) as $post_type ) {
+			remove_post_type_support( $post_type, 'gatherpress-rsvp' );
+		}
+	}
+
+	/**
+	 * Filters RSVP blocks out of the allowed block types when RSVP is globally disabled.
+	 *
+	 * Removes all `gatherpress/rsvp*` blocks from the block inserter while leaving
+	 * existing RSVP blocks already placed in posts fully intact for editing.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param bool|string[] $allowed_block_types Array of block type slugs or true for all blocks.
+	 *
+	 * @return bool|string[] Filtered allowed block types.
+	 */
+	public function filter_rsvp_block_types( $allowed_block_types ) {
+		if ( 'disabled' !== Settings::get_instance()->get( 'rsvp_mode' ) ) {
+			return $allowed_block_types;
+		}
+
+		// Build list from all registered blocks when all are currently allowed.
+		if ( true === $allowed_block_types ) {
+			$allowed_block_types = array_keys( WP_Block_Type_Registry::get_instance()->get_all_registered() );
+		}
+
+		if ( is_array( $allowed_block_types ) ) {
+			return array_values(
+				array_filter(
+					$allowed_block_types,
+					static function ( $name ): bool {
+						return ! is_string( $name ) || 0 !== strpos( $name, 'gatherpress/rsvp' );
+					}
+				)
+			);
+		}
+
+		return $allowed_block_types;
+	}
 
 	/**
 	 * Get user identifier for RSVP operations.
@@ -188,6 +248,35 @@ class Rsvp_Setup {
 	}
 
 	/**
+	 * Writes an explicit gatherpress_enable_rsvp = 1 value when RSVP mode is all_on.
+	 *
+	 * This ensures that if an admin later switches to a per-event mode, all events
+	 * created under all_on mode already have meta = 1 and appear correctly as enabled.
+	 * Events without the meta are also treated as on (missing = on convention), but
+	 * writing it explicitly makes the state unambiguous.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id The ID of the post being saved.
+	 *
+	 * @return void
+	 */
+	public function maybe_set_rsvp_meta_default( int $post_id ): void {
+		if ( 'all_on' !== Settings::get_instance()->get( 'rsvp_mode' ) ) {
+			return;
+		}
+
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
+			return;
+		}
+
+		// Only write if meta has never been explicitly set.
+		if ( '' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ) ) {
+			update_post_meta( $post_id, 'gatherpress_enable_rsvp', 1 );
+		}
+	}
+
+	/**
 	 * Adds a submenu page for managing GatherPress RSVPs.
 	 *
 	 * This method adds a submenu page under the Events menu in the WordPress admin.
@@ -200,6 +289,11 @@ class Rsvp_Setup {
 	 * @return void
 	 */
 	public function add_rsvp_submenu_page(): void {
+		// Do not show the RSVPs submenu when RSVP is globally disabled.
+		if ( 'disabled' === Settings::get_instance()->get( 'rsvp_mode' ) ) {
+			return;
+		}
+
 		$hook = add_submenu_page(
 			sprintf( 'edit.php?post_type=%s', Event::POST_TYPE ),
 			__( 'RSVPs', 'gatherpress' ),

--- a/includes/core/classes/class-rsvp-setup.php
+++ b/includes/core/classes/class-rsvp-setup.php
@@ -125,26 +125,6 @@ class Rsvp_Setup {
 	}
 
 	/**
-	 * Determines whether RSVP is enabled for a specific event.
-	 *
-	 * In per-event modes (`per_event_on` or `per_event_off`), RSVP is enabled
-	 * for an individual event when its `gatherpress_enable_rsvp` meta is not
-	 * explicitly set to `'0'`. An empty string (meta never set) is treated as enabled.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int $post_id The post ID to check.
-	 *
-	 * @return bool True if RSVP is enabled for this event, false otherwise.
-	 */
-	public static function is_rsvp_enabled_for_event( int $post_id ): bool {
-		$rsvp_mode = Settings::get_instance()->get( 'rsvp_mode' );
-
-		return ! in_array( $rsvp_mode, array( 'per_event_on', 'per_event_off' ), true ) ||
-			'0' !== get_post_meta( $post_id, 'gatherpress_enable_rsvp', true );
-	}
-
-	/**
 	 * Disables RSVP sitewide when the master RSVP switch is turned off.
 	 *
 	 * Removes the `gatherpress-rsvp` post type support from all post types

--- a/includes/core/classes/class-rsvp-setup.php
+++ b/includes/core/classes/class-rsvp-setup.php
@@ -125,6 +125,26 @@ class Rsvp_Setup {
 	}
 
 	/**
+	 * Determines whether RSVP is enabled for a specific event.
+	 *
+	 * In per-event modes (`per_event_on` or `per_event_off`), RSVP is enabled
+	 * for an individual event when its `gatherpress_enable_rsvp` meta is not
+	 * explicitly set to `'0'`. An empty string (meta never set) is treated as enabled.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id The post ID to check.
+	 *
+	 * @return bool True if RSVP is enabled for this event, false otherwise.
+	 */
+	public static function is_rsvp_enabled_for_event( int $post_id ): bool {
+		$rsvp_mode = Settings::get_instance()->get( 'rsvp_mode' );
+
+		return ! in_array( $rsvp_mode, array( 'per_event_on', 'per_event_off' ), true ) ||
+			'0' !== get_post_meta( $post_id, 'gatherpress_enable_rsvp', true );
+	}
+
+	/**
 	 * Disables RSVP sitewide when the master RSVP switch is turned off.
 	 *
 	 * Removes the `gatherpress-rsvp` post type support from all post types

--- a/includes/core/classes/class-rsvp.php
+++ b/includes/core/classes/class-rsvp.php
@@ -241,12 +241,7 @@ class Rsvp {
 			return $data;
 		}
 
-		// Check if RSVP is enabled for this event.
-		// Empty string means meta was never set; only '0' means explicitly disabled.
-		if (
-			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
-			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
-		) {
+		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
 			return $data;
 		}
 

--- a/includes/core/classes/class-rsvp.php
+++ b/includes/core/classes/class-rsvp.php
@@ -188,12 +188,39 @@ class Rsvp {
 	 *
 	 * @return bool True if RSVP is enabled for this event, false otherwise.
 	 */
-	public function is_rsvp_enabled(): bool {
+	public function is_enabled(): bool {
 		$post_id   = $this->event->ID ?? 0;
 		$rsvp_mode = Settings::get_instance()->get( 'rsvp_mode' );
 
 		return ! in_array( $rsvp_mode, array( 'per_event_on', 'per_event_off' ), true ) ||
 			'0' !== get_post_meta( $post_id, 'gatherpress_enable_rsvp', true );
+	}
+
+	/**
+	 * Writes an explicit enabled value when RSVP mode is all_on and meta is unset.
+	 *
+	 * Ensures that if an admin later switches to a per-event mode, events created
+	 * under all_on already have meta = 1 and appear correctly as enabled.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function initialize_enabled(): void {
+		$post_id = $this->event->ID ?? 0;
+
+		if ( 'all_on' !== Settings::get_instance()->get( 'rsvp_mode' ) ) {
+			return;
+		}
+
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
+			return;
+		}
+
+		// Only write if meta has never been explicitly set.
+		if ( '' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ) ) {
+			update_post_meta( $post_id, 'gatherpress_enable_rsvp', 1 );
+		}
 	}
 
 	/**
@@ -261,7 +288,7 @@ class Rsvp {
 			return $data;
 		}
 
-		if ( ! $this->is_rsvp_enabled() ) {
+		if ( ! $this->is_enabled() ) {
 			return $data;
 		}
 

--- a/includes/core/classes/class-rsvp.php
+++ b/includes/core/classes/class-rsvp.php
@@ -180,9 +180,12 @@ class Rsvp {
 	/**
 	 * Determines whether RSVP is enabled for this event.
 	 *
-	 * In per-event modes (`per_event_on` or `per_event_off`), RSVP is enabled
-	 * when the `gatherpress_enable_rsvp` meta is not explicitly set to `'0'`.
-	 * An empty string (meta never set) is treated as enabled.
+	 * Returns false immediately when the sitewide mode is `disabled`.
+	 * Returns true when the mode is `all_on` (every event has RSVP).
+	 * In per-event modes (`per_event_on` or `per_event_off`), the
+	 * `gatherpress_enable_rsvp` post meta is consulted. An unset meta
+	 * (empty string) falls back to the mode default: `per_event_on`
+	 * defaults to enabled, `per_event_off` defaults to disabled.
 	 *
 	 * @since 1.0.0
 	 *
@@ -192,24 +195,43 @@ class Rsvp {
 		$post_id   = $this->event->ID ?? 0;
 		$rsvp_mode = Settings::get_instance()->get( 'rsvp_mode' );
 
-		return ! in_array( $rsvp_mode, array( 'per_event_on', 'per_event_off' ), true ) ||
-			'0' !== get_post_meta( $post_id, 'gatherpress_enable_rsvp', true );
+		if ( 'disabled' === $rsvp_mode ) {
+			return false;
+		}
+
+		if ( ! in_array( $rsvp_mode, array( 'per_event_on', 'per_event_off' ), true ) ) {
+			return true;
+		}
+
+		$meta = get_post_meta( $post_id, 'gatherpress_enable_rsvp', true );
+
+		// Empty meta falls back to the mode default.
+		if ( '' === $meta ) {
+			return 'per_event_on' === $rsvp_mode;
+		}
+
+		return '0' !== $meta;
 	}
 
 	/**
-	 * Writes an explicit enabled value when RSVP mode is all_on and meta is unset.
+	 * Writes an explicit enabled value on first save, based on the active RSVP mode.
 	 *
-	 * Ensures that if an admin later switches to a per-event mode, events created
-	 * under all_on already have meta = 1 and appear correctly as enabled.
+	 * Ensures that programmatically created events (e.g. via WP-CLI or imports)
+	 * carry predictable meta regardless of which mode was active at creation time:
+	 * - `all_on`: writes meta = 1 so switching to a per-event mode later is safe.
+	 * - `per_event_on`: writes meta = 1 (default-on intent).
+	 * - `per_event_off`: writes meta = 0 (default-off intent).
+	 * - `disabled`: no meta is written.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
 	public function initialize_enabled(): void {
-		$post_id = $this->event->ID ?? 0;
+		$post_id   = $this->event->ID ?? 0;
+		$rsvp_mode = Settings::get_instance()->get( 'rsvp_mode' );
 
-		if ( 'all_on' !== Settings::get_instance()->get( 'rsvp_mode' ) ) {
+		if ( 'disabled' === $rsvp_mode ) {
 			return;
 		}
 
@@ -218,9 +240,12 @@ class Rsvp {
 		}
 
 		// Only write if meta has never been explicitly set.
-		if ( '' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ) ) {
-			update_post_meta( $post_id, 'gatherpress_enable_rsvp', 1 );
+		if ( '' !== get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ) ) {
+			return;
 		}
+
+		$default_value = ( 'per_event_off' === $rsvp_mode ) ? 0 : 1;
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', $default_value );
 	}
 
 	/**

--- a/includes/core/classes/class-rsvp.php
+++ b/includes/core/classes/class-rsvp.php
@@ -241,6 +241,15 @@ class Rsvp {
 			return $data;
 		}
 
+		// Check if RSVP is enabled for this event.
+		// Empty string means meta was never set; only '0' means explicitly disabled.
+		if (
+			in_array( Settings::get_instance()->get( 'rsvp_mode' ), array( 'per_event_on', 'per_event_off' ), true ) &&
+			'0' === get_post_meta( $post_id, 'gatherpress_enable_rsvp', true )
+		) {
+			return $data;
+		}
+
 		$args = array(
 			'post_id' => $post_id,
 		);

--- a/includes/core/classes/class-rsvp.php
+++ b/includes/core/classes/class-rsvp.php
@@ -14,6 +14,7 @@ namespace GatherPress\Core;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Settings;
 use GatherPress\Core\Settings\Roles;
 use WP_Post;
 
@@ -177,6 +178,25 @@ class Rsvp {
 	}
 
 	/**
+	 * Determines whether RSVP is enabled for this event.
+	 *
+	 * In per-event modes (`per_event_on` or `per_event_off`), RSVP is enabled
+	 * when the `gatherpress_enable_rsvp` meta is not explicitly set to `'0'`.
+	 * An empty string (meta never set) is treated as enabled.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool True if RSVP is enabled for this event, false otherwise.
+	 */
+	public function is_rsvp_enabled(): bool {
+		$post_id   = $this->event->ID ?? 0;
+		$rsvp_mode = Settings::get_instance()->get( 'rsvp_mode' );
+
+		return ! in_array( $rsvp_mode, array( 'per_event_on', 'per_event_off' ), true ) ||
+			'0' !== get_post_meta( $post_id, 'gatherpress_enable_rsvp', true );
+	}
+
+	/**
 	 * Saves a user's RSVP status for an event.
 	 *
 	 * Allows assigning one of the specified RSVP statuses to a user for an event. The user can be marked
@@ -241,7 +261,7 @@ class Rsvp {
 			return $data;
 		}
 
-		if ( ! Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ) ) {
+		if ( ! $this->is_rsvp_enabled() ) {
 			return $data;
 		}
 

--- a/includes/core/classes/settings/class-rsvp-settings.php
+++ b/includes/core/classes/settings/class-rsvp-settings.php
@@ -78,6 +78,27 @@ class Rsvp_Settings extends Base {
 					'gatherpress'
 				),
 				'options'     => array(
+					'rsvp_mode'             => array(
+						'labels'      => array(
+							'name' => __( 'RSVP Mode', 'gatherpress' ),
+						),
+						'description' => __(
+							'Control how RSVP works across your site.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'type'    => 'select',
+							'options' => array(
+								'default' => 'all_on',
+								'items'   => array(
+									'all_on'        => __( 'All events', 'gatherpress' ),
+									'per_event_on'  => __( 'Per event (default on)', 'gatherpress' ),
+									'per_event_off' => __( 'Per event (default off)', 'gatherpress' ),
+									'disabled'      => __( 'Disabled', 'gatherpress' ),
+								),
+							),
+						),
+					),
 					'max_attendance_limit'  => array(
 						'labels'      => array(
 							'name' => __( 'Maximum Attendance Limit', 'gatherpress' ),

--- a/src/blocks/rsvp-count/edit.js
+++ b/src/blocks/rsvp-count/edit.js
@@ -11,7 +11,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies.
  */
-import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isPostTypeSupporting } from '../../helpers/event';
+import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isPostTypeSupporting, isRsvpEnabledForEvent } from '../../helpers/event';
 import { EVENT_REST_API } from '../../helpers/namespace';
 import { isInFSETemplate } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
@@ -84,9 +84,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 		style: {
 			opacity:
 				isInFSETemplate() ||
-				( isValidEvent &&
-					'disabled' !== rsvpMode &&
-					( ( 'per_event_on' !== rsvpMode && 'per_event_off' !== rsvpMode ) || enableRsvp ) )
+				( isValidEvent && isRsvpEnabledForEvent( rsvpMode, enableRsvp ) )
 					? 1
 					: DISABLED_FIELD_OPACITY,
 		},

--- a/src/blocks/rsvp-count/edit.js
+++ b/src/blocks/rsvp-count/edit.js
@@ -14,6 +14,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isPostTypeSupporting } from '../../helpers/event';
 import { EVENT_REST_API } from '../../helpers/namespace';
 import { isInFSETemplate } from '../../helpers/editor';
+import { getFromSettings } from '../../helpers/editor-settings';
 
 /**
  * Fetch RSVP responses from the API.
@@ -61,12 +62,12 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	// Subscribe to event data to trigger re-renders when data loads.
 	// This ensures hasValidEventId works correctly after async data fetch.
 	// Only subscribe if we have a valid postId from event context.
-	useSelect(
+	const { enableRsvp } = useSelect(
 		( select ) => {
 			if ( postId && ( isDescendentOfQueryLoop || isEventContext ) ) {
 				return getEventMeta( select, postId, attributes );
 			}
-			return null;
+			return { enableRsvp: true };
 		},
 		[ postId, attributes, isDescendentOfQueryLoop, isEventContext ]
 	);
@@ -77,9 +78,17 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 		( isDescendentOfQueryLoop || isEventContext ) &&
 		hasValidEventId( postId, context?.postType );
 
+	const rsvpMode = getFromSettings( 'rsvpMode' ) ?? 'all_on';
+
 	const blockProps = useBlockProps( {
 		style: {
-			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : DISABLED_FIELD_OPACITY,
+			opacity:
+				isInFSETemplate() ||
+				( isValidEvent &&
+					'disabled' !== rsvpMode &&
+					( ( 'per_event_on' !== rsvpMode && 'per_event_off' !== rsvpMode ) || enableRsvp ) )
+					? 1
+					: DISABLED_FIELD_OPACITY,
 		},
 	} );
 

--- a/src/blocks/rsvp-form/edit.js
+++ b/src/blocks/rsvp-form/edit.js
@@ -18,6 +18,7 @@ import { getBlockTypes } from '@wordpress/blocks';
 import TEMPLATE from './template';
 import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta } from '../../helpers/event';
 import { isInFSETemplate, getEditorDocument } from '../../helpers/editor';
+import { getFromSettings } from '../../helpers/editor-settings';
 import { shouldHideBlock } from './visibility';
 
 const Edit = ( { attributes, clientId, context } ) => {
@@ -31,7 +32,7 @@ const Edit = ( { attributes, clientId, context } ) => {
 		.filter( ( name ) => 'gatherpress/rsvp-form' !== name );
 
 	// Get event data - either from override postId or current post.
-	const { maxGuestLimit: maxAttendanceLimit, enableAnonymousRsvp } = useSelect(
+	const { maxGuestLimit: maxAttendanceLimit, enableRsvp, enableAnonymousRsvp } = useSelect(
 		( select ) => getEventMeta( select, postId, attributes ),
 		[ postId, attributes ]
 	);
@@ -176,9 +177,17 @@ const Edit = ( { attributes, clientId, context } ) => {
 		};
 	}, [ maxAttendanceLimit, enableAnonymousRsvp, clientId ] );
 
+	const rsvpMode = getFromSettings( 'rsvpMode' ) ?? 'all_on';
+
 	const blockProps = useBlockProps( {
 		style: {
-			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : DISABLED_FIELD_OPACITY,
+			opacity:
+				isInFSETemplate() ||
+				( isValidEvent &&
+					'disabled' !== rsvpMode &&
+					( ( 'per_event_on' !== rsvpMode && 'per_event_off' !== rsvpMode ) || enableRsvp ) )
+					? 1
+					: DISABLED_FIELD_OPACITY,
 		},
 	} );
 

--- a/src/blocks/rsvp-form/edit.js
+++ b/src/blocks/rsvp-form/edit.js
@@ -16,7 +16,7 @@ import { getBlockTypes } from '@wordpress/blocks';
  * Internal dependencies.
  */
 import TEMPLATE from './template';
-import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta } from '../../helpers/event';
+import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isRsvpEnabledForEvent } from '../../helpers/event';
 import { isInFSETemplate, getEditorDocument } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
 import { shouldHideBlock } from './visibility';
@@ -183,9 +183,7 @@ const Edit = ( { attributes, clientId, context } ) => {
 		style: {
 			opacity:
 				isInFSETemplate() ||
-				( isValidEvent &&
-					'disabled' !== rsvpMode &&
-					( ( 'per_event_on' !== rsvpMode && 'per_event_off' !== rsvpMode ) || enableRsvp ) )
+				( isValidEvent && isRsvpEnabledForEvent( rsvpMode, enableRsvp ) )
 					? 1
 					: DISABLED_FIELD_OPACITY,
 		},

--- a/src/blocks/rsvp-response/edit.js
+++ b/src/blocks/rsvp-response/edit.js
@@ -27,7 +27,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import RsvpManager from './rsvp-manager';
 import TEMPLATE from './template';
-import { hasValidEventId, isPostTypeSupporting, DISABLED_FIELD_OPACITY, getEventMeta } from '../../helpers/event';
+import { hasValidEventId, isPostTypeSupporting, DISABLED_FIELD_OPACITY, getEventMeta, isRsvpEnabledForEvent } from '../../helpers/event';
 import { getEditorDocument, isInFSETemplate } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
 import { EVENT_REST_API } from '../../helpers/namespace';
@@ -95,9 +95,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 		style: {
 			opacity:
 				isInFSETemplate() ||
-				( isValidEvent &&
-					'disabled' !== rsvpMode &&
-					( ( 'per_event_on' !== rsvpMode && 'per_event_off' !== rsvpMode ) || enableRsvp ) )
+				( isValidEvent && isRsvpEnabledForEvent( rsvpMode, enableRsvp ) )
 					? 1
 					: DISABLED_FIELD_OPACITY,
 		},

--- a/src/blocks/rsvp-response/edit.js
+++ b/src/blocks/rsvp-response/edit.js
@@ -19,6 +19,7 @@ import {
 	Spinner,
 } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -26,8 +27,9 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import RsvpManager from './rsvp-manager';
 import TEMPLATE from './template';
-import { hasValidEventId, isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
+import { hasValidEventId, isPostTypeSupporting, DISABLED_FIELD_OPACITY, getEventMeta } from '../../helpers/event';
 import { getEditorDocument, isInFSETemplate } from '../../helpers/editor';
+import { getFromSettings } from '../../helpers/editor-settings';
 import { EVENT_REST_API } from '../../helpers/namespace';
 
 /**
@@ -82,9 +84,22 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 		( isDescendentOfQueryLoop || isEventContext ) &&
 		hasValidEventId( postId, context?.postType );
 
+	const { enableRsvp } = useSelect(
+		( select ) => getEventMeta( select, postId, attributes ),
+		[ postId, attributes ]
+	);
+
+	const rsvpMode = getFromSettings( 'rsvpMode' ) ?? 'all_on';
+
 	const blockProps = useBlockProps( {
 		style: {
-			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : DISABLED_FIELD_OPACITY,
+			opacity:
+				isInFSETemplate() ||
+				( isValidEvent &&
+					'disabled' !== rsvpMode &&
+					( ( 'per_event_on' !== rsvpMode && 'per_event_off' !== rsvpMode ) || enableRsvp ) )
+					? 1
+					: DISABLED_FIELD_OPACITY,
 		},
 	} );
 

--- a/src/blocks/rsvp/edit.js
+++ b/src/blocks/rsvp/edit.js
@@ -19,6 +19,7 @@ import { createBlock, parse, serialize } from '@wordpress/blocks';
 import TEMPLATES from './templates';
 import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isPostTypeSupporting } from '../../helpers/event';
 import { isInFSETemplate, getEditorDocument } from '../../helpers/editor';
+import { getFromSettings } from '../../helpers/editor-settings';
 
 /**
  * Helper function to convert a template to blocks.
@@ -69,12 +70,6 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 		( isDescendentOfQueryLoop || isEventContext ) &&
 		hasValidEventId( postId, context?.postType );
 
-	const blockProps = useBlockProps( {
-		style: {
-			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : DISABLED_FIELD_OPACITY,
-		},
-	} );
-
 	// Get the current inner blocks
 	const innerBlocks = useSelect(
 		( select ) => select( blockEditorStore ).getBlocks( clientId ),
@@ -82,10 +77,24 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 	);
 
 	// Get event data - either from override postId or current post.
-	const { maxGuestLimit: maxNumberOfGuests, enableAnonymousRsvp } = useSelect(
+	const { maxGuestLimit: maxNumberOfGuests, enableRsvp, enableAnonymousRsvp } = useSelect(
 		( select ) => getEventMeta( select, postId, attributes ),
 		[ postId, attributes ]
 	);
+
+	const rsvpMode = getFromSettings( 'rsvpMode' ) ?? 'all_on';
+
+	const blockProps = useBlockProps( {
+		style: {
+			opacity:
+				isInFSETemplate() ||
+				( isValidEvent &&
+					'disabled' !== rsvpMode &&
+					( ( 'per_event_on' !== rsvpMode && 'per_event_off' !== rsvpMode ) || enableRsvp ) )
+					? 1
+					: DISABLED_FIELD_OPACITY,
+		},
+	} );
 	/**
 	 * Apply conditional visibility class to form fields based on event settings.
 	 *

--- a/src/blocks/rsvp/edit.js
+++ b/src/blocks/rsvp/edit.js
@@ -17,7 +17,7 @@ import { createBlock, parse, serialize } from '@wordpress/blocks';
  * Internal dependencies.
  */
 import TEMPLATES from './templates';
-import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isPostTypeSupporting } from '../../helpers/event';
+import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isPostTypeSupporting, isRsvpEnabledForEvent } from '../../helpers/event';
 import { isInFSETemplate, getEditorDocument } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
 
@@ -88,9 +88,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 		style: {
 			opacity:
 				isInFSETemplate() ||
-				( isValidEvent &&
-					'disabled' !== rsvpMode &&
-					( ( 'per_event_on' !== rsvpMode && 'per_event_off' !== rsvpMode ) || enableRsvp ) )
+				( isValidEvent && isRsvpEnabledForEvent( rsvpMode, enableRsvp ) )
 					? 1
 					: DISABLED_FIELD_OPACITY,
 		},

--- a/src/components/EnableRsvp.js
+++ b/src/components/EnableRsvp.js
@@ -46,7 +46,7 @@ const EnableRsvp = () => {
 
 	const [ enableRsvp, setEnableRsvp ] = useState( defaultEnableRsvp );
 
-	// Guard ensures the new-event meta initialisation fires exactly once.
+	// Guard ensures the new-event meta initialization fires exactly once.
 	const initialized = useRef( false );
 
 	const updateEnableRsvp = useCallback(

--- a/src/components/EnableRsvp.js
+++ b/src/components/EnableRsvp.js
@@ -1,0 +1,73 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { CheckboxControl } from '@wordpress/components';
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies.
+ */
+import { getFromSettings } from '../helpers/editor-settings';
+
+/**
+ * EnableRsvp component.
+ *
+ * This component renders a checkbox control that toggles RSVP for a specific event.
+ * When creating a new event, the default state is determined by the global setting.
+ * For existing events, the current per-event setting is used.
+ *
+ * @return {JSX.Element} A checkbox control for enabling or disabling RSVP.
+ */
+const EnableRsvp = () => {
+	const { editPost, unlockPostSaving } = useDispatch( 'core/editor' );
+	const isNewEvent = useSelect( ( select ) => {
+		return select( 'core/editor' ).isCleanNewPost();
+	}, [] );
+
+	let defaultEnableRsvp = useSelect( ( select ) => {
+		const meta = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+		const rawValue = meta?.gatherpress_enable_rsvp;
+
+		// Stored as integer (0/1); undefined/null means not yet set - default to enabled.
+		return rawValue === undefined || null === rawValue ? true : 0 !== rawValue;
+	}, [] );
+
+	if ( isNewEvent ) {
+		// Default based on rsvp_mode: per_event_off defaults to disabled, per_event_on defaults to enabled.
+		defaultEnableRsvp = 'per_event_off' !== ( getFromSettings( 'rsvpMode' ) ?? 'all_on' );
+	}
+
+	const [ enableRsvp, setEnableRsvp ] = useState( defaultEnableRsvp );
+
+	const updateEnableRsvp = useCallback(
+		( value ) => {
+			// Save as integer (1/0) - WordPress stores boolean false as '' which is ambiguous.
+			const meta = { gatherpress_enable_rsvp: value ? 1 : 0 };
+
+			setEnableRsvp( value );
+			editPost( { meta } );
+			unlockPostSaving();
+		},
+		[ editPost, unlockPostSaving ],
+	);
+
+	useEffect( () => {
+		if ( isNewEvent ) {
+			updateEnableRsvp( defaultEnableRsvp );
+		}
+	}, [ isNewEvent, defaultEnableRsvp, updateEnableRsvp ] );
+
+	return (
+		<CheckboxControl
+			label={ __( 'Enable RSVP', 'gatherpress' ) }
+			checked={ enableRsvp }
+			onChange={ ( value ) => {
+				updateEnableRsvp( value );
+			} }
+		/>
+	);
+};
+
+export default EnableRsvp;

--- a/src/components/EnableRsvp.js
+++ b/src/components/EnableRsvp.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useState, useEffect, useCallback, useMemo, useRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
@@ -26,7 +26,7 @@ const EnableRsvp = () => {
 		return select( 'core/editor' ).isCleanNewPost();
 	}, [] );
 
-	let defaultEnableRsvp = useSelect( ( select ) => {
+	const metaDefault = useSelect( ( select ) => {
 		const meta = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const rawValue = meta?.gatherpress_enable_rsvp;
 
@@ -34,12 +34,20 @@ const EnableRsvp = () => {
 		return rawValue === undefined || null === rawValue ? true : 0 !== rawValue;
 	}, [] );
 
-	if ( isNewEvent ) {
-		// Default based on rsvp_mode: per_event_off defaults to disabled, per_event_on defaults to enabled.
-		defaultEnableRsvp = 'per_event_off' !== ( getFromSettings( 'rsvpMode' ) ?? 'all_on' );
-	}
+	// Compute the default once: new events use the global rsvp_mode setting;
+	// existing events use the per-event meta value.
+	const defaultEnableRsvp = useMemo( () => {
+		if ( isNewEvent ) {
+			// Default based on rsvp_mode: per_event_off defaults to disabled, all others default to enabled.
+			return 'per_event_off' !== ( getFromSettings( 'rsvpMode' ) ?? 'all_on' );
+		}
+		return metaDefault;
+	}, [ isNewEvent, metaDefault ] );
 
 	const [ enableRsvp, setEnableRsvp ] = useState( defaultEnableRsvp );
+
+	// Guard ensures the new-event meta initialisation fires exactly once.
+	const initialized = useRef( false );
 
 	const updateEnableRsvp = useCallback(
 		( value ) => {
@@ -54,7 +62,8 @@ const EnableRsvp = () => {
 	);
 
 	useEffect( () => {
-		if ( isNewEvent ) {
+		if ( isNewEvent && ! initialized.current ) {
+			initialized.current = true;
 			updateEnableRsvp( defaultEnableRsvp );
 		}
 	}, [ isNewEvent, defaultEnableRsvp, updateEnableRsvp ] );

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -239,6 +239,35 @@ export function hasOnlineEventTerm( postId = null ) {
 }
 
 /**
+ * Determines whether the current RSVP mode is a per-event mode.
+ *
+ * @param {string} rsvpMode The current RSVP mode setting.
+ *
+ * @return {boolean} True if the mode is per_event_on or per_event_off.
+ */
+export function isPerEventRsvpMode( rsvpMode ) {
+	return 'per_event_on' === rsvpMode || 'per_event_off' === rsvpMode;
+}
+
+/**
+ * Determines whether RSVP is enabled for a specific event.
+ *
+ * In per-event modes, RSVP is enabled only if the event's enableRsvp flag is true.
+ * In all_on mode RSVP is always enabled. In disabled mode it is never enabled.
+ *
+ * @param {string}  rsvpMode   The current RSVP mode setting.
+ * @param {boolean} enableRsvp Whether RSVP is enabled for this specific event.
+ *
+ * @return {boolean} True if RSVP is enabled for this event, false otherwise.
+ */
+export function isRsvpEnabledForEvent( rsvpMode, enableRsvp ) {
+	return (
+		'disabled' !== rsvpMode &&
+		( ! isPerEventRsvpMode( rsvpMode ) || enableRsvp )
+	);
+}
+
+/**
  * Gets event meta data (max guest limit, RSVP enabled flag, and anonymous RSVP setting).
  *
  * This function retrieves event meta data either from the current post being edited

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -239,7 +239,7 @@ export function hasOnlineEventTerm( postId = null ) {
 }
 
 /**
- * Gets event meta data (max guest limit and anonymous RSVP setting).
+ * Gets event meta data (max guest limit, RSVP enabled flag, and anonymous RSVP setting).
  *
  * This function retrieves event meta data either from the current post being edited
  * (for live updates) or from a specific post (for overrides). It handles three scenarios:
@@ -252,10 +252,11 @@ export function hasOnlineEventTerm( postId = null ) {
  * @param {Object}      selectFunc WordPress data select function.
  * @param {number|null} postId     Post ID from context or null.
  * @param {Object}      attributes Block attributes (may contain explicit postId override).
- * @return {Object} Object containing maxGuestLimit and enableAnonymousRsvp.
+ * @return {Object} Object containing maxGuestLimit, enableRsvp, and enableAnonymousRsvp.
  */
 export function getEventMeta( selectFunc, postId, attributes ) {
 	let maxLimit;
+	let enableRsvp;
 	let enableAnonymous;
 
 	// Check if there's an explicit postId override in attributes.
@@ -267,6 +268,8 @@ export function getEventMeta( selectFunc, postId, attributes ) {
 		// Explicit override - fetch from post via core data store.
 		const post = selectFunc( 'core' ).getEntityRecord( 'postType', 'gatherpress_event', postId );
 		maxLimit = post?.meta?.gatherpress_max_guest_limit;
+		// Stored as integer (0/1); undefined means not yet set, default to enabled.
+		enableRsvp = 0 !== post?.meta?.gatherpress_enable_rsvp;
 		enableAnonymous = Boolean( post?.meta?.gatherpress_enable_anonymous_rsvp );
 	} else {
 		// No override - check if current post is an event and use editor for live edits.
@@ -276,12 +279,15 @@ export function getEventMeta( selectFunc, postId, attributes ) {
 		if ( isCurrentPostEvent ) {
 			const meta = selectFunc( 'core/editor' ).getEditedPostAttribute( 'meta' );
 			maxLimit = meta?.gatherpress_max_guest_limit;
+			// Stored as integer (0/1); undefined means not yet set, default to enabled.
+			enableRsvp = 0 !== meta?.gatherpress_enable_rsvp;
 			enableAnonymous = Boolean( meta?.gatherpress_enable_anonymous_rsvp );
 		}
 	}
 
 	return {
 		maxGuestLimit: maxLimit ?? 0,
+		enableRsvp: enableRsvp ?? true,
 		enableAnonymousRsvp: enableAnonymous ?? false,
 	};
 }

--- a/src/panels/rsvp-settings/enable-rsvp/index.js
+++ b/src/panels/rsvp-settings/enable-rsvp/index.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies.
+ */
+import EnableRsvp from '../../../components/EnableRsvp';
+
+/**
+ * A panel component for managing the RSVP enabled setting.
+ *
+ * This component renders a section containing the `EnableRsvp` component,
+ * allowing editors to enable or disable RSVP for a specific event.
+ *
+ * @since 1.0.0
+ *
+ * @return {JSX.Element} The JSX element for the EnableRsvpPanel.
+ */
+const EnableRsvpPanel = () => {
+	return (
+		<section>
+			<EnableRsvp />
+		</section>
+	);
+};
+
+export default EnableRsvpPanel;

--- a/src/panels/rsvp-settings/index.js
+++ b/src/panels/rsvp-settings/index.js
@@ -12,7 +12,7 @@ import { PluginDocumentSettingPanel } from '@wordpress/editor';
 /**
  * Internal dependencies.
  */
-import { isEventPostType } from '../../helpers/event';
+import { isEventPostType, isPerEventRsvpMode } from '../../helpers/event';
 import { getFromSettings } from '../../helpers/editor-settings';
 import AnonymousRsvpPanel from './anonymous-rsvp';
 import EnableRsvpPanel from './enable-rsvp';
@@ -47,7 +47,7 @@ const RsvpSettings = () => {
 				<RsvpPluginDocumentSettings.Slot />
 
 				<VStack spacing={ 4 }>
-					{ ( 'per_event_on' === rsvpMode || 'per_event_off' === rsvpMode ) && <EnableRsvpPanel /> }
+					{ isPerEventRsvpMode( rsvpMode ) && <EnableRsvpPanel /> }
 					<GuestLimitPanel />
 					<MaxAttendanceLimitPanel />
 					<AnonymousRsvpPanel />

--- a/src/panels/rsvp-settings/index.js
+++ b/src/panels/rsvp-settings/index.js
@@ -13,7 +13,9 @@ import { PluginDocumentSettingPanel } from '@wordpress/editor';
  * Internal dependencies.
  */
 import { isEventPostType } from '../../helpers/event';
+import { getFromSettings } from '../../helpers/editor-settings';
 import AnonymousRsvpPanel from './anonymous-rsvp';
+import EnableRsvpPanel from './enable-rsvp';
 import GuestLimitPanel from './guest-limit';
 import MaxAttendanceLimitPanel from './max-attendance-limit';
 import { RsvpPluginDocumentSettings } from './slot';
@@ -31,8 +33,11 @@ import { RsvpPluginDocumentSettings } from './slot';
  * the current post type is an event; otherwise, returns null.
  */
 const RsvpSettings = () => {
+	// Only show per-event RSVP toggle when the admin has set rsvp_mode to per_event.
+	const rsvpMode = getFromSettings( 'rsvpMode' ) ?? 'all_on';
+
 	return (
-		isEventPostType() && (
+		isEventPostType() && 'disabled' !== rsvpMode && (
 			<PluginDocumentSettingPanel
 				name="gatherpress-rsvp-settings"
 				title={ __( 'RSVP settings', 'gatherpress' ) }
@@ -42,6 +47,7 @@ const RsvpSettings = () => {
 				<RsvpPluginDocumentSettings.Slot />
 
 				<VStack spacing={ 4 }>
+					{ ( 'per_event_on' === rsvpMode || 'per_event_off' === rsvpMode ) && <EnableRsvpPanel /> }
 					<GuestLimitPanel />
 					<MaxAttendanceLimitPanel />
 					<AnonymousRsvpPanel />

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -639,6 +639,7 @@ describe( 'getEventMeta', () => {
 
 		expect( result ).toEqual( {
 			maxGuestLimit: 0,
+			enableRsvp: true,
 			enableAnonymousRsvp: false,
 		} );
 	} );
@@ -669,6 +670,7 @@ describe( 'getEventMeta', () => {
 
 		expect( result ).toEqual( {
 			maxGuestLimit: 5,
+			enableRsvp: true,
 			enableAnonymousRsvp: true,
 		} );
 	} );
@@ -700,6 +702,7 @@ describe( 'getEventMeta', () => {
 
 		expect( result ).toEqual( {
 			maxGuestLimit: 10,
+			enableRsvp: true,
 			enableAnonymousRsvp: false,
 		} );
 	} );
@@ -736,6 +739,7 @@ describe( 'getEventMeta', () => {
 
 		expect( result ).toEqual( {
 			maxGuestLimit: 20,
+			enableRsvp: true,
 			enableAnonymousRsvp: true,
 		} );
 	} );
@@ -757,6 +761,7 @@ describe( 'getEventMeta', () => {
 
 		expect( result ).toEqual( {
 			maxGuestLimit: 0,
+			enableRsvp: true,
 			enableAnonymousRsvp: false,
 		} );
 	} );
@@ -776,6 +781,7 @@ describe( 'getEventMeta', () => {
 
 		expect( result ).toEqual( {
 			maxGuestLimit: 0,
+			enableRsvp: true,
 			enableAnonymousRsvp: false,
 		} );
 	} );

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -33,6 +33,8 @@ import {
 	hasValidEventId,
 	getEventMeta,
 	hasOnlineEventTerm,
+	isPerEventRsvpMode,
+	isRsvpEnabledForEvent,
 } from '@src/helpers/event';
 import { dateTimeDatabaseFormat } from '@src/helpers/datetime';
 
@@ -1101,5 +1103,57 @@ describe( 'hasOnlineEventTerm', () => {
 		} );
 
 		expect( hasOnlineEventTerm( 123 ) ).toBe( true );
+	} );
+} );
+
+/**
+ * Coverage for isPerEventRsvpMode.
+ */
+describe( 'isPerEventRsvpMode', () => {
+	it( 'returns true for per_event_on', () => {
+		expect( isPerEventRsvpMode( 'per_event_on' ) ).toBe( true );
+	} );
+
+	it( 'returns true for per_event_off', () => {
+		expect( isPerEventRsvpMode( 'per_event_off' ) ).toBe( true );
+	} );
+
+	it( 'returns false for all_on', () => {
+		expect( isPerEventRsvpMode( 'all_on' ) ).toBe( false );
+	} );
+
+	it( 'returns false for disabled', () => {
+		expect( isPerEventRsvpMode( 'disabled' ) ).toBe( false );
+	} );
+} );
+
+/**
+ * Coverage for isRsvpEnabledForEvent.
+ */
+describe( 'isRsvpEnabledForEvent', () => {
+	it( 'returns true for all_on mode regardless of enableRsvp', () => {
+		expect( isRsvpEnabledForEvent( 'all_on', true ) ).toBe( true );
+		expect( isRsvpEnabledForEvent( 'all_on', false ) ).toBe( true );
+	} );
+
+	it( 'returns true for per_event_on when enableRsvp is true', () => {
+		expect( isRsvpEnabledForEvent( 'per_event_on', true ) ).toBe( true );
+	} );
+
+	it( 'returns false for per_event_on when enableRsvp is false', () => {
+		expect( isRsvpEnabledForEvent( 'per_event_on', false ) ).toBe( false );
+	} );
+
+	it( 'returns true for per_event_off when enableRsvp is true', () => {
+		expect( isRsvpEnabledForEvent( 'per_event_off', true ) ).toBe( true );
+	} );
+
+	it( 'returns false for per_event_off when enableRsvp is false', () => {
+		expect( isRsvpEnabledForEvent( 'per_event_off', false ) ).toBe( false );
+	} );
+
+	it( 'returns false for disabled mode regardless of enableRsvp', () => {
+		expect( isRsvpEnabledForEvent( 'disabled', true ) ).toBe( false );
+		expect( isRsvpEnabledForEvent( 'disabled', false ) ).toBe( false );
 	} );
 } );

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-general-block.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-general-block.php
@@ -9,6 +9,8 @@
 namespace GatherPress\Tests\Core\Blocks;
 
 use GatherPress\Core\Blocks\General_Block;
+use GatherPress\Core\Rsvp;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Utility;
 use GatherPress\Tests\Base;
 
@@ -1201,5 +1203,65 @@ class Test_General_Block extends Base {
 
 		// Verify normal field is not affected.
 		$this->assertStringNotContainsString( 'normal-field gatherpress--is-hidden', $final_result );
+	}
+
+	/**
+	 * Tests process_guests_field returns empty string when per-event RSVP is disabled.
+	 *
+	 * @covers ::process_guests_field
+	 *
+	 * @return void
+	 */
+	public function test_process_guests_field_rsvp_disabled_per_event(): void {
+		$general_block = General_Block::get_instance();
+		$post_id       = $this->factory->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+			)
+		);
+
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', 0 );
+
+		$block_content = '<div class="gatherpress-rsvp-field-guests">Guests</div>';
+		$block         = array( 'attrs' => array( 'postId' => $post_id ) );
+
+		$result = $general_block->process_guests_field( $block_content, $block );
+
+		$this->assertSame( '', $result, 'Should return empty string when per-event RSVP is disabled.' );
+
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
+
+	/**
+	 * Tests process_anonymous_field returns empty string when per-event RSVP is disabled.
+	 *
+	 * @covers ::process_anonymous_field
+	 *
+	 * @return void
+	 */
+	public function test_process_anonymous_field_rsvp_disabled_per_event(): void {
+		$general_block = General_Block::get_instance();
+		$post_id       = $this->factory->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+			)
+		);
+
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', 0 );
+
+		$block_content = '<div class="gatherpress-rsvp-field-anonymous">Anonymous</div>';
+		$block         = array( 'attrs' => array( 'postId' => $post_id ) );
+
+		$result = $general_block->process_anonymous_field( $block_content, $block );
+
+		$this->assertSame( '', $result, 'Should return empty string when per-event RSVP is disabled.' );
+
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-form.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-form.php
@@ -11,6 +11,7 @@ namespace GatherPress\Tests\Core\Blocks;
 use GatherPress\Core\Blocks\Rsvp_Form;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
+use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 
@@ -2786,5 +2787,38 @@ class Test_Rsvp_Form extends Base {
 			$result,
 			'Should return null when visibility rules object is empty.'
 		);
+	}
+
+	/**
+	 * Tests that transform_block_content returns empty string when per-event RSVP is disabled.
+	 *
+	 * @covers ::transform_block_content
+	 *
+	 * @return void
+	 */
+	public function test_transform_block_content_rsvp_disabled_per_event(): void {
+		$instance = Rsvp_Form::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', 0 );
+
+		$block_content = '<div class="wp-block-gatherpress-rsvp-form">RSVP Form Content</div>';
+		$block         = array(
+			'blockName' => 'gatherpress/rsvp-form',
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+
+		$result = $instance->transform_block_content( $block_content, $block );
+
+		$this->assertSame( '', $result, 'Should return empty string when per-event RSVP is disabled.' );
+
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-response.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-response.php
@@ -10,6 +10,7 @@ namespace GatherPress\Tests\Core\Blocks;
 
 use GatherPress\Core\Blocks\Rsvp_Response;
 use GatherPress\Core\Rsvp;
+use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 
 /**
@@ -771,5 +772,38 @@ class Test_Rsvp_Response extends Base {
 			$result['extra_attr'],
 			'extra_attr should be cleared to an empty string when no style attribute is present.'
 		);
+	}
+
+	/**
+	 * Tests that transform_block_content returns empty string when per-event RSVP is disabled.
+	 *
+	 * @covers ::transform_block_content
+	 *
+	 * @return void
+	 */
+	public function test_transform_block_content_rsvp_disabled_per_event(): void {
+		$instance = Rsvp_Response::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type'   => 'gatherpress_event',
+				'post_status' => 'publish',
+			)
+		);
+
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', 0 );
+
+		$block_content = '<div class="wp-block-gatherpress-rsvp-response">Content</div>';
+		$block         = array(
+			'blockName' => 'gatherpress/rsvp-response',
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+
+		$result = $instance->transform_block_content( $block_content, $block );
+
+		$this->assertSame( '', $result, 'Should return empty string when per-event RSVP is disabled.' );
+
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-template.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-template.php
@@ -11,6 +11,7 @@ namespace GatherPress\Tests\Core\Blocks;
 use GatherPress\Core\Blocks\Rsvp_Template;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
+use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 use WP_Block;
 use WP_Block_Type_Registry;
@@ -757,5 +758,29 @@ class Test_Rsvp_Template extends Base {
 			$result,
 			'Failed to assert output was generated with responses.'
 		);
+	}
+
+	/**
+	 * Tests that generate_rsvp_template_block returns empty string when per-event RSVP is disabled.
+	 *
+	 * @covers ::generate_rsvp_template_block
+	 *
+	 * @return void
+	 */
+	public function test_generate_rsvp_template_block_rsvp_disabled_per_event(): void {
+		$instance = Rsvp_Template::get_instance();
+		$post     = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+		$post_id  = $post->ID;
+
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', 0 );
+
+		$wp_block = new WP_Block( array(), array( 'postId' => $post_id ) );
+		$result   = $instance->generate_rsvp_template_block( '<div>Original content</div>', array(), $wp_block );
+
+		$this->assertSame( '', $result, 'Should return empty string when per-event RSVP is disabled.' );
+
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
@@ -889,6 +889,53 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
+	 * Test transform_block_content returns empty string when RSVP is disabled for the event.
+	 *
+	 * @covers ::transform_block_content
+	 *
+	 * @return void
+	 */
+	public function test_transform_block_content_rsvp_disabled(): void {
+		$instance = Rsvp::get_instance();
+		$post     = $this->mock->post(
+			array(
+				'post_type'   => \GatherPress\Core\Event::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		)->get();
+
+		// Set rsvp_mode to per_event_on so that per-event disabling is respected.
+		$option = get_option( 'gatherpress_settings', array() );
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'per_event_on';
+		update_option( 'gatherpress_settings', $option );
+
+		// Explicitly disable RSVP for this event.
+		update_post_meta( $post->ID, 'gatherpress_enable_rsvp', 0 );
+
+		$block_content = '<div class="wp-block-gatherpress-rsvp"></div>';
+		$block         = array(
+			'blockName' => 'gatherpress/rsvp-v2',
+			'attrs'     => array(
+				'postId' => $post->ID,
+			),
+		);
+
+		$result = $instance->transform_block_content( $block_content, $block );
+
+		$this->assertSame(
+			'',
+			$result,
+			'Should return empty string when RSVP is disabled for the event.'
+		);
+
+		delete_post_meta( $post->ID, 'gatherpress_enable_rsvp' );
+
+		// Restore the setting for other tests.
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
+		update_option( 'gatherpress_settings', $option );
+	}
+
+	/**
 	 * Test apply_guests_input_interactivity method.
 	 *
 	 * Verifies that the method adds the form field filter hook

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
@@ -11,6 +11,7 @@ namespace GatherPress\Tests\Core\Blocks;
 use GatherPress\Core\Blocks\Rsvp;
 use GatherPress\Core\Event;
 use GatherPress\Core\Event_Setup;
+use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 
 /**
@@ -905,9 +906,7 @@ class Test_Rsvp extends Base {
 		)->get();
 
 		// Set rsvp_mode to per_event_on so that per-event disabling is respected.
-		$option = get_option( 'gatherpress_settings', array() );
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'per_event_on';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
 
 		// Explicitly disable RSVP for this event.
 		update_post_meta( $post->ID, 'gatherpress_enable_rsvp', 0 );
@@ -931,8 +930,7 @@ class Test_Rsvp extends Base {
 		delete_post_meta( $post->ID, 'gatherpress_enable_rsvp' );
 
 		// Restore the setting for other tests.
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-form.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-form.php
@@ -11,6 +11,7 @@ namespace GatherPress\Tests\Core;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp_Form;
+use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 
@@ -979,9 +980,7 @@ class Test_Rsvp_Form extends Base {
 		);
 
 		// Set rsvp_mode to per_event_on so that per-event disabling is respected.
-		$option = get_option( 'gatherpress_settings', array() );
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'per_event_on';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
 
 		// Explicitly disable RSVP for this event.
 		update_post_meta( $post_id, 'gatherpress_enable_rsvp', 0 );
@@ -1013,8 +1012,7 @@ class Test_Rsvp_Form extends Base {
 		remove_all_filters( 'gatherpress_pre_get_http_input' );
 
 		// Restore the setting for other tests.
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-form.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-form.php
@@ -967,6 +967,57 @@ class Test_Rsvp_Form extends Base {
 	}
 
 	/**
+	 * Tests preprocess_rsvp_comment when RSVP is disabled for the event.
+	 *
+	 * @covers ::preprocess_rsvp_comment
+	 */
+	public function test_preprocess_rsvp_comment_rsvp_disabled(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+
+		// Set rsvp_mode to per_event_on so that per-event disabling is respected.
+		$option = get_option( 'gatherpress_settings', array() );
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'per_event_on';
+		update_option( 'gatherpress_settings', $option );
+
+		// Explicitly disable RSVP for this event.
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', 0 );
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			function ( $pre_value, $type, $var_name ) {
+				if ( INPUT_POST === $type && 'author' === $var_name ) {
+					return 'Test Author';
+				}
+				if ( INPUT_POST === $type && 'email' === $var_name ) {
+					return 'test@example.com';
+				}
+				return '';
+			},
+			10,
+			3
+		);
+
+		$instance = Rsvp_Form::get_instance();
+
+		$comment_data = array(
+			'comment_post_ID' => $post_id,
+		);
+
+		$this->expectException( 'WPDieException' );
+		$instance->preprocess_rsvp_comment( $comment_data );
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+
+		// Restore the setting for other tests.
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
+		update_option( 'gatherpress_settings', $option );
+	}
+
+	/**
 	 * Tests preprocess_rsvp_comment with duplicate RSVP.
 	 *
 	 * @covers ::preprocess_rsvp_comment

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
@@ -13,6 +13,7 @@ use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp_List_Table;
 use GatherPress\Core\Rsvp_Setup;
 use GatherPress\Core\Rsvp_Token;
+use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 
@@ -847,8 +848,8 @@ class Test_Rsvp_Setup extends Base {
 		$instance = Rsvp_Setup::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 
-		// Confirm meta is not set initially.
-		$this->assertSame( '', get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ) );
+		// Clear any meta set by the wp_after_insert_post hook during post creation.
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
 
 		// Default mode is all_on; calling the method should write 1.
 		$instance->maybe_set_rsvp_meta_default( $post_id );
@@ -893,12 +894,11 @@ class Test_Rsvp_Setup extends Base {
 	 */
 	public function test_maybe_set_rsvp_meta_default_skips_non_all_on_modes(): void {
 		$instance = Rsvp_Setup::get_instance();
-		$post_id  = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 
-		// Switch to per_event_on mode.
-		$option = get_option( 'gatherpress_settings', array() );
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'per_event_on';
-		update_option( 'gatherpress_settings', $option );
+		// Switch to per_event_on mode BEFORE creating the post so the hook doesn't write meta.
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 
 		$instance->maybe_set_rsvp_meta_default( $post_id );
 
@@ -910,8 +910,7 @@ class Test_Rsvp_Setup extends Base {
 		);
 
 		// Restore setting.
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 
 	/**
@@ -951,9 +950,7 @@ class Test_Rsvp_Setup extends Base {
 		$instance = Rsvp_Setup::get_instance();
 
 		// Temporarily set rsvp_mode to disabled via the settings option.
-		$option = get_option( 'gatherpress_settings', array() );
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'disabled';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
 
 		// Ensure the event post type currently supports RSVP.
 		add_post_type_support( Event::POST_TYPE, 'gatherpress-rsvp' );
@@ -967,8 +964,7 @@ class Test_Rsvp_Setup extends Base {
 		);
 
 		// Restore the setting and support for other tests.
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 		add_post_type_support( Event::POST_TYPE, 'gatherpress-rsvp' );
 	}
 
@@ -1003,9 +999,7 @@ class Test_Rsvp_Setup extends Base {
 		$instance = Rsvp_Setup::get_instance();
 
 		// Temporarily set rsvp_mode to disabled via the settings option.
-		$option = get_option( 'gatherpress_settings', array() );
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'disabled';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
 
 		// Pass a known array containing RSVP and non-RSVP block names.
 		$block_list = array(
@@ -1048,7 +1042,6 @@ class Test_Rsvp_Setup extends Base {
 		);
 
 		// Restore the setting for other tests.
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
@@ -861,6 +861,26 @@ class Test_Rsvp_Setup extends Base {
 	}
 
 	/**
+	 * Test maybe_set_rsvp_meta_default skips non-event post types.
+	 *
+	 * @covers ::maybe_set_rsvp_meta_default
+	 *
+	 * @return void
+	 */
+	public function test_maybe_set_rsvp_meta_default_skips_non_event_post_type(): void {
+		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+
+		// Standard post type does not support gatherpress-rsvp; meta should not be written.
+		Rsvp_Setup::get_instance()->maybe_set_rsvp_meta_default( $post_id );
+
+		$this->assertSame(
+			'',
+			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
+			'Meta should not be written for non-event post types.'
+		);
+	}
+
+	/**
 	 * Test maybe_disable_rsvp when rsvp_mode is not disabled.
 	 *
 	 * @covers ::maybe_disable_rsvp

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
@@ -838,6 +838,65 @@ class Test_Rsvp_Setup extends Base {
 	}
 
 	/**
+	 * Coverage for is_rsvp_enabled_for_event method.
+	 *
+	 * @covers ::is_rsvp_enabled_for_event
+	 *
+	 * @return void
+	 */
+	public function test_is_rsvp_enabled_for_event(): void {
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		// Returns false when mode is per_event_on and meta is '0'.
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '0' );
+		$this->assertFalse(
+			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
+			'Should return false when mode is per_event_on and meta is 0.'
+		);
+
+		// Returns false when mode is per_event_off and meta is '0'.
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_off' );
+		$this->assertFalse(
+			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
+			'Should return false when mode is per_event_off and meta is 0.'
+		);
+
+		// Returns true when mode is per_event_on and meta is '1'.
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '1' );
+		$this->assertTrue(
+			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
+			'Should return true when mode is per_event_on and meta is 1.'
+		);
+
+		// Returns true when mode is per_event_on and meta is '' (never set).
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+		$this->assertTrue(
+			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
+			'Should return true when mode is per_event_on and meta is empty (never set).'
+		);
+
+		// Returns true when mode is all_on and meta is '0'.
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '0' );
+		$this->assertTrue(
+			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
+			'Should return true when mode is all_on regardless of meta.'
+		);
+
+		// Returns true when mode is disabled and meta is '0'.
+		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
+		$this->assertTrue(
+			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
+			'Should return true when mode is disabled regardless of meta.'
+		);
+
+		// Restore default setting.
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
+
+	/**
 	 * Test maybe_set_rsvp_meta_default writes meta in all_on mode when meta is unset.
 	 *
 	 * @covers ::maybe_set_rsvp_meta_default

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
@@ -838,65 +838,6 @@ class Test_Rsvp_Setup extends Base {
 	}
 
 	/**
-	 * Coverage for is_rsvp_enabled_for_event method.
-	 *
-	 * @covers ::is_rsvp_enabled_for_event
-	 *
-	 * @return void
-	 */
-	public function test_is_rsvp_enabled_for_event(): void {
-		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
-
-		// Returns false when mode is per_event_on and meta is '0'.
-		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
-		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '0' );
-		$this->assertFalse(
-			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
-			'Should return false when mode is per_event_on and meta is 0.'
-		);
-
-		// Returns false when mode is per_event_off and meta is '0'.
-		Settings::get_instance()->set( 'rsvp_mode', 'per_event_off' );
-		$this->assertFalse(
-			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
-			'Should return false when mode is per_event_off and meta is 0.'
-		);
-
-		// Returns true when mode is per_event_on and meta is '1'.
-		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
-		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '1' );
-		$this->assertTrue(
-			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
-			'Should return true when mode is per_event_on and meta is 1.'
-		);
-
-		// Returns true when mode is per_event_on and meta is '' (never set).
-		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
-		$this->assertTrue(
-			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
-			'Should return true when mode is per_event_on and meta is empty (never set).'
-		);
-
-		// Returns true when mode is all_on and meta is '0'.
-		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
-		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '0' );
-		$this->assertTrue(
-			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
-			'Should return true when mode is all_on regardless of meta.'
-		);
-
-		// Returns true when mode is disabled and meta is '0'.
-		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
-		$this->assertTrue(
-			Rsvp_Setup::is_rsvp_enabled_for_event( $post_id ),
-			'Should return true when mode is disabled regardless of meta.'
-		);
-
-		// Restore default setting.
-		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
-	}
-
-	/**
 	 * Test maybe_set_rsvp_meta_default writes meta in all_on mode when meta is unset.
 	 *
 	 * @covers ::maybe_set_rsvp_meta_default

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
@@ -991,4 +991,79 @@ class Test_Rsvp_Setup extends Base {
 		// Restore the setting for other tests.
 		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
+
+	/**
+	 * Tests filter_rsvp_block_types expands true to array and removes RSVP blocks when disabled.
+	 *
+	 * @covers ::filter_rsvp_block_types
+	 *
+	 * @return void
+	 */
+	public function test_filter_rsvp_block_types_expands_true_when_disabled(): void {
+		$instance = Rsvp_Setup::get_instance();
+
+		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
+
+		// Pass true (all blocks allowed) — should expand and filter out RSVP blocks.
+		$result = $instance->filter_rsvp_block_types( true );
+
+		$this->assertIsArray( $result, 'Result should be an array when all blocks were allowed.' );
+		$this->assertNotContains(
+			'gatherpress/rsvp',
+			$result,
+			'gatherpress/rsvp block should be removed when RSVP is disabled.'
+		);
+
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
+
+	/**
+	 * Tests filter_rsvp_block_types returns non-array value unchanged when disabled.
+	 *
+	 * @covers ::filter_rsvp_block_types
+	 *
+	 * @return void
+	 */
+	public function test_filter_rsvp_block_types_returns_non_array_unchanged_when_disabled(): void {
+		$instance = Rsvp_Setup::get_instance();
+
+		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
+
+		// Pass false (not true, not array) — should be returned as-is.
+		$result = $instance->filter_rsvp_block_types( false );
+
+		$this->assertFalse( $result, 'Non-array, non-true value should be returned unchanged.' );
+
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
+
+	/**
+	 * Tests add_rsvp_submenu_page returns early when RSVP is globally disabled.
+	 *
+	 * @covers ::add_rsvp_submenu_page
+	 *
+	 * @return void
+	 */
+	public function test_add_rsvp_submenu_page_skips_when_disabled(): void {
+		global $submenu;
+
+		if ( ! is_array( $submenu ) ) {
+			$submenu = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		}
+
+		$submenu_before = $submenu;
+
+		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
+
+		Rsvp_Setup::get_instance()->add_rsvp_submenu_page();
+
+		// Submenu should be unchanged since the method returns early.
+		$this->assertSame(
+			$submenu_before,
+			$submenu,
+			'No submenu page should be added when RSVP is globally disabled.'
+		);
+
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
@@ -838,79 +838,26 @@ class Test_Rsvp_Setup extends Base {
 	}
 
 	/**
-	 * Test maybe_set_rsvp_meta_default writes meta in all_on mode when meta is unset.
+	 * Test maybe_set_rsvp_meta_default delegates to Rsvp::initialize_enabled.
 	 *
 	 * @covers ::maybe_set_rsvp_meta_default
 	 *
 	 * @return void
 	 */
-	public function test_maybe_set_rsvp_meta_default_writes_meta_in_all_on_mode(): void {
-		$instance = Rsvp_Setup::get_instance();
-		$post_id  = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+	public function test_maybe_set_rsvp_meta_default_delegates_to_rsvp(): void {
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 
 		// Clear any meta set by the wp_after_insert_post hook during post creation.
 		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
 
-		// Default mode is all_on; calling the method should write 1.
-		$instance->maybe_set_rsvp_meta_default( $post_id );
+		// Default mode is all_on; the delegation should write 1.
+		Rsvp_Setup::get_instance()->maybe_set_rsvp_meta_default( $post_id );
 
 		$this->assertSame(
 			'1',
 			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
-			'Meta should be written as 1 in all_on mode when not previously set.'
+			'Delegation to Rsvp::initialize_enabled should write meta as 1 in all_on mode.'
 		);
-	}
-
-	/**
-	 * Test maybe_set_rsvp_meta_default does not overwrite an existing meta value.
-	 *
-	 * @covers ::maybe_set_rsvp_meta_default
-	 *
-	 * @return void
-	 */
-	public function test_maybe_set_rsvp_meta_default_does_not_overwrite_existing_meta(): void {
-		$instance = Rsvp_Setup::get_instance();
-		$post_id  = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
-
-		// Pre-set meta to 0 (RSVP disabled for this event).
-		update_post_meta( $post_id, 'gatherpress_enable_rsvp', 0 );
-
-		// Default mode is all_on; method should not overwrite the existing value.
-		$instance->maybe_set_rsvp_meta_default( $post_id );
-
-		$this->assertSame(
-			'0',
-			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
-			'Existing meta value should not be overwritten.'
-		);
-	}
-
-	/**
-	 * Test maybe_set_rsvp_meta_default is a no-op outside all_on mode.
-	 *
-	 * @covers ::maybe_set_rsvp_meta_default
-	 *
-	 * @return void
-	 */
-	public function test_maybe_set_rsvp_meta_default_skips_non_all_on_modes(): void {
-		$instance = Rsvp_Setup::get_instance();
-
-		// Switch to per_event_on mode BEFORE creating the post so the hook doesn't write meta.
-		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
-
-		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
-
-		$instance->maybe_set_rsvp_meta_default( $post_id );
-
-		// Meta should remain unset; per-event mode manages it via the editor UI.
-		$this->assertSame(
-			'',
-			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
-			'Meta should not be written when mode is per_event_on.'
-		);
-
-		// Restore setting.
-		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
@@ -63,15 +63,33 @@ class Test_Rsvp_Setup extends Base {
 			),
 			array(
 				'type'     => 'action',
+				'name'     => 'init',
+				'priority' => 11,
+				'callback' => array( $instance, 'maybe_disable_rsvp' ),
+			),
+			array(
+				'type'     => 'action',
 				'name'     => 'wp_after_insert_post',
 				'priority' => 10,
 				'callback' => array( $instance, 'maybe_process_waiting_list' ),
 			),
 			array(
 				'type'     => 'action',
+				'name'     => 'wp_after_insert_post',
+				'priority' => 10,
+				'callback' => array( $instance, 'maybe_set_rsvp_meta_default' ),
+			),
+			array(
+				'type'     => 'action',
 				'name'     => 'admin_menu',
 				'priority' => 10,
 				'callback' => array( $instance, 'add_rsvp_submenu_page' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'allowed_block_types_all',
+				'priority' => 10,
+				'callback' => array( $instance, 'filter_rsvp_block_types' ),
 			),
 			array(
 				'type'     => 'filter',
@@ -816,5 +834,221 @@ class Test_Rsvp_Setup extends Base {
 		$instance->render_rsvp_admin_page();
 
 		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test maybe_set_rsvp_meta_default writes meta in all_on mode when meta is unset.
+	 *
+	 * @covers ::maybe_set_rsvp_meta_default
+	 *
+	 * @return void
+	 */
+	public function test_maybe_set_rsvp_meta_default_writes_meta_in_all_on_mode(): void {
+		$instance = Rsvp_Setup::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		// Confirm meta is not set initially.
+		$this->assertSame( '', get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ) );
+
+		// Default mode is all_on; calling the method should write 1.
+		$instance->maybe_set_rsvp_meta_default( $post_id );
+
+		$this->assertSame(
+			'1',
+			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
+			'Meta should be written as 1 in all_on mode when not previously set.'
+		);
+	}
+
+	/**
+	 * Test maybe_set_rsvp_meta_default does not overwrite an existing meta value.
+	 *
+	 * @covers ::maybe_set_rsvp_meta_default
+	 *
+	 * @return void
+	 */
+	public function test_maybe_set_rsvp_meta_default_does_not_overwrite_existing_meta(): void {
+		$instance = Rsvp_Setup::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		// Pre-set meta to 0 (RSVP disabled for this event).
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', 0 );
+
+		// Default mode is all_on; method should not overwrite the existing value.
+		$instance->maybe_set_rsvp_meta_default( $post_id );
+
+		$this->assertSame(
+			'0',
+			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
+			'Existing meta value should not be overwritten.'
+		);
+	}
+
+	/**
+	 * Test maybe_set_rsvp_meta_default is a no-op outside all_on mode.
+	 *
+	 * @covers ::maybe_set_rsvp_meta_default
+	 *
+	 * @return void
+	 */
+	public function test_maybe_set_rsvp_meta_default_skips_non_all_on_modes(): void {
+		$instance = Rsvp_Setup::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		// Switch to per_event_on mode.
+		$option = get_option( 'gatherpress_settings', array() );
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'per_event_on';
+		update_option( 'gatherpress_settings', $option );
+
+		$instance->maybe_set_rsvp_meta_default( $post_id );
+
+		// Meta should remain unset; per-event mode manages it via the editor UI.
+		$this->assertSame(
+			'',
+			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
+			'Meta should not be written when mode is per_event_on.'
+		);
+
+		// Restore setting.
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
+		update_option( 'gatherpress_settings', $option );
+	}
+
+	/**
+	 * Test maybe_disable_rsvp when rsvp_mode is not disabled.
+	 *
+	 * @covers ::maybe_disable_rsvp
+	 *
+	 * @return void
+	 */
+	public function test_maybe_disable_rsvp_when_enabled(): void {
+		$instance = Rsvp_Setup::get_instance();
+
+		// Verify that the event post type supports RSVP before the call.
+		$this->assertTrue(
+			post_type_supports( Event::POST_TYPE, 'gatherpress-rsvp' ),
+			'Event post type should support gatherpress-rsvp before disabling.'
+		);
+
+		// With rsvp_mode defaulting to all_on, this should be a no-op.
+		$instance->maybe_disable_rsvp();
+
+		// Verify support is still present.
+		$this->assertTrue(
+			post_type_supports( Event::POST_TYPE, 'gatherpress-rsvp' ),
+			'Event post type should still support gatherpress-rsvp when RSVP is enabled.'
+		);
+	}
+
+	/**
+	 * Test maybe_disable_rsvp removes post type support when setting is disabled.
+	 *
+	 * @covers ::maybe_disable_rsvp
+	 *
+	 * @return void
+	 */
+	public function test_maybe_disable_rsvp_when_disabled(): void {
+		$instance = Rsvp_Setup::get_instance();
+
+		// Temporarily set rsvp_mode to disabled via the settings option.
+		$option = get_option( 'gatherpress_settings', array() );
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'disabled';
+		update_option( 'gatherpress_settings', $option );
+
+		// Ensure the event post type currently supports RSVP.
+		add_post_type_support( Event::POST_TYPE, 'gatherpress-rsvp' );
+
+		$instance->maybe_disable_rsvp();
+
+		// Verify support has been removed.
+		$this->assertFalse(
+			post_type_supports( Event::POST_TYPE, 'gatherpress-rsvp' ),
+			'Event post type should no longer support gatherpress-rsvp when RSVP is disabled.'
+		);
+
+		// Restore the setting and support for other tests.
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
+		update_option( 'gatherpress_settings', $option );
+		add_post_type_support( Event::POST_TYPE, 'gatherpress-rsvp' );
+	}
+
+	/**
+	 * Test filter_rsvp_block_types returns all blocks unchanged when RSVP is enabled.
+	 *
+	 * @covers ::filter_rsvp_block_types
+	 *
+	 * @return void
+	 */
+	public function test_filter_rsvp_block_types_when_enabled(): void {
+		$instance      = Rsvp_Setup::get_instance();
+		$initial_value = true;
+
+		$result = $instance->filter_rsvp_block_types( $initial_value );
+
+		$this->assertSame(
+			$initial_value,
+			$result,
+			'When RSVP is enabled, block types should be returned unchanged.'
+		);
+	}
+
+	/**
+	 * Test filter_rsvp_block_types removes RSVP blocks when RSVP is disabled.
+	 *
+	 * @covers ::filter_rsvp_block_types
+	 *
+	 * @return void
+	 */
+	public function test_filter_rsvp_block_types_when_disabled(): void {
+		$instance = Rsvp_Setup::get_instance();
+
+		// Temporarily set rsvp_mode to disabled via the settings option.
+		$option = get_option( 'gatherpress_settings', array() );
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'disabled';
+		update_option( 'gatherpress_settings', $option );
+
+		// Pass a known array containing RSVP and non-RSVP block names.
+		$block_list = array(
+			'core/paragraph',
+			'gatherpress/rsvp',
+			'gatherpress/rsvp-form',
+			'gatherpress/event-date',
+			'gatherpress/rsvp-response',
+		);
+
+		$result = $instance->filter_rsvp_block_types( $block_list );
+
+		// RSVP blocks should have been removed.
+		$this->assertNotContains(
+			'gatherpress/rsvp',
+			$result,
+			'gatherpress/rsvp block should be removed when RSVP is disabled.'
+		);
+		$this->assertNotContains(
+			'gatherpress/rsvp-form',
+			$result,
+			'gatherpress/rsvp-form block should be removed when RSVP is disabled.'
+		);
+		$this->assertNotContains(
+			'gatherpress/rsvp-response',
+			$result,
+			'gatherpress/rsvp-response block should be removed when RSVP is disabled.'
+		);
+
+		// Non-RSVP blocks should remain.
+		$this->assertContains(
+			'core/paragraph',
+			$result,
+			'core/paragraph block should remain when RSVP is disabled.'
+		);
+		$this->assertContains(
+			'gatherpress/event-date',
+			$result,
+			'gatherpress/event-date block should remain when RSVP is disabled.'
+		);
+
+		// Restore the setting for other tests.
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
+		update_option( 'gatherpress_settings', $option );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
@@ -522,27 +522,27 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
-	 * Coverage for is_rsvp_enabled method.
+	 * Coverage for is_enabled method.
 	 *
-	 * @covers ::is_rsvp_enabled
+	 * @covers ::is_enabled
 	 *
 	 * @return void
 	 */
-	public function test_is_rsvp_enabled(): void {
+	public function test_is_enabled(): void {
 		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 
 		// Returns false when mode is per_event_on and meta is '0'.
 		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
 		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '0' );
 		$this->assertFalse(
-			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			( new Rsvp( $post_id ) )->is_enabled(),
 			'Should return false when mode is per_event_on and meta is 0.'
 		);
 
 		// Returns false when mode is per_event_off and meta is '0'.
 		Settings::get_instance()->set( 'rsvp_mode', 'per_event_off' );
 		$this->assertFalse(
-			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			( new Rsvp( $post_id ) )->is_enabled(),
 			'Should return false when mode is per_event_off and meta is 0.'
 		);
 
@@ -550,14 +550,14 @@ class Test_Rsvp extends Base {
 		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
 		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '1' );
 		$this->assertTrue(
-			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			( new Rsvp( $post_id ) )->is_enabled(),
 			'Should return true when mode is per_event_on and meta is 1.'
 		);
 
 		// Returns true when mode is per_event_on and meta is '' (never set).
 		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
 		$this->assertTrue(
-			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			( new Rsvp( $post_id ) )->is_enabled(),
 			'Should return true when mode is per_event_on and meta is empty (never set).'
 		);
 
@@ -565,14 +565,14 @@ class Test_Rsvp extends Base {
 		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '0' );
 		$this->assertTrue(
-			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			( new Rsvp( $post_id ) )->is_enabled(),
 			'Should return true when mode is all_on regardless of meta.'
 		);
 
 		// Returns true when mode is disabled and meta is '0'.
 		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
 		$this->assertTrue(
-			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			( new Rsvp( $post_id ) )->is_enabled(),
 			'Should return true when mode is disabled regardless of meta.'
 		);
 
@@ -695,5 +695,77 @@ class Test_Rsvp extends Base {
 		// Verify only 3 attending (user2, user3, user4).
 		$responses = $rsvp->responses();
 		$this->assertEquals( 3, $responses['attending']['count'] );
+	}
+
+	/**
+	 * Coverage for initialize_enabled method.
+	 *
+	 * @covers ::initialize_enabled
+	 *
+	 * @return void
+	 */
+	public function test_initialize_enabled_writes_meta_in_all_on_mode(): void {
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		// Clear any meta set by the wp_after_insert_post hook during post creation.
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+
+		// Default mode is all_on; calling the method should write 1.
+		( new Rsvp( $post_id ) )->initialize_enabled();
+
+		$this->assertSame(
+			'1',
+			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
+			'Meta should be written as 1 in all_on mode when not previously set.'
+		);
+	}
+
+	/**
+	 * Coverage for initialize_enabled method.
+	 *
+	 * @covers ::initialize_enabled
+	 *
+	 * @return void
+	 */
+	public function test_initialize_enabled_does_not_overwrite_existing_meta(): void {
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		// Pre-set meta to 0 (RSVP disabled for this event).
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', 0 );
+
+		// Default mode is all_on; method should not overwrite the existing value.
+		( new Rsvp( $post_id ) )->initialize_enabled();
+
+		$this->assertSame(
+			'0',
+			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
+			'Existing meta value should not be overwritten.'
+		);
+	}
+
+	/**
+	 * Coverage for initialize_enabled method.
+	 *
+	 * @covers ::initialize_enabled
+	 *
+	 * @return void
+	 */
+	public function test_initialize_enabled_skips_non_all_on_modes(): void {
+		// Switch to per_event_on mode BEFORE creating the post so the hook does not write meta.
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		( new Rsvp( $post_id ) )->initialize_enabled();
+
+		// Meta should remain unset; per-event mode manages it via the editor UI.
+		$this->assertSame(
+			'',
+			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
+			'Meta should not be written when mode is per_event_on.'
+		);
+
+		// Restore setting.
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
@@ -492,6 +492,38 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
+	 * Test save method returns default data when RSVP is disabled for the event.
+	 *
+	 * @covers ::save
+	 */
+	public function test_save_rsvp_disabled(): void {
+		$post = $this->mock->post(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		)->get();
+
+		// Set rsvp_mode to per_event_on so that per-event disabling is respected.
+		$option = get_option( 'gatherpress_settings', array() );
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'per_event_on';
+		update_option( 'gatherpress_settings', $option );
+
+		// Explicitly disable RSVP for this event.
+		update_post_meta( $post->ID, 'gatherpress_enable_rsvp', 0 );
+
+		$rsvp    = new Rsvp( $post->ID );
+		$user_id = $this->factory->user->create();
+		$result  = $rsvp->save( $user_id, 'attending' );
+
+		$this->assertSame( 0, $result['post_id'], 'Should return default data when RSVP is disabled.' );
+		$this->assertSame( 'no_status', $result['status'], 'Should return no_status when RSVP is disabled.' );
+
+		// Restore the setting for other tests.
+		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
+		update_option( 'gatherpress_settings', $option );
+	}
+
+	/**
 	 * Test save method with email identifier.
 	 *
 	 * @covers ::save

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
@@ -10,6 +10,7 @@ namespace GatherPress\Tests\Core;
 
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
+use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 use WP_Error;
@@ -504,9 +505,7 @@ class Test_Rsvp extends Base {
 		)->get();
 
 		// Set rsvp_mode to per_event_on so that per-event disabling is respected.
-		$option = get_option( 'gatherpress_settings', array() );
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'per_event_on';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
 
 		// Explicitly disable RSVP for this event.
 		update_post_meta( $post->ID, 'gatherpress_enable_rsvp', 0 );
@@ -519,8 +518,7 @@ class Test_Rsvp extends Base {
 		$this->assertSame( 'no_status', $result['status'], 'Should return no_status when RSVP is disabled.' );
 
 		// Restore the setting for other tests.
-		$option['rsvp_settings']['rsvp_defaults']['rsvp_mode'] = 'all_on';
-		update_option( 'gatherpress_settings', $option );
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
@@ -561,6 +561,13 @@ class Test_Rsvp extends Base {
 			'Should return true when mode is per_event_on and meta is empty (never set).'
 		);
 
+		// Returns false when mode is per_event_off and meta is '' (never set).
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_off' );
+		$this->assertFalse(
+			( new Rsvp( $post_id ) )->is_enabled(),
+			'Should return false when mode is per_event_off and meta is empty (never set).'
+		);
+
 		// Returns true when mode is all_on and meta is '0'.
 		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '0' );
@@ -569,11 +576,11 @@ class Test_Rsvp extends Base {
 			'Should return true when mode is all_on regardless of meta.'
 		);
 
-		// Returns true when mode is disabled and meta is '0'.
+		// Returns false when mode is disabled regardless of meta.
 		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
-		$this->assertTrue(
+		$this->assertFalse(
 			( new Rsvp( $post_id ) )->is_enabled(),
-			'Should return true when mode is disabled regardless of meta.'
+			'Should return false when mode is disabled regardless of meta.'
 		);
 
 		// Restore default setting.
@@ -772,25 +779,86 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
-	 * Coverage for initialize_enabled method.
+	 * Coverage for initialize_enabled method in per_event_on mode.
 	 *
 	 * @covers ::initialize_enabled
 	 *
 	 * @return void
 	 */
-	public function test_initialize_enabled_skips_non_all_on_modes(): void {
+	public function test_initialize_enabled_writes_meta_in_per_event_on_mode(): void {
 		// Switch to per_event_on mode BEFORE creating the post so the hook does not write meta.
 		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
 
 		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 
+		// Clear meta set by the wp_after_insert_post hook during post creation.
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+
 		( new Rsvp( $post_id ) )->initialize_enabled();
 
-		// Meta should remain unset; per-event mode manages it via the editor UI.
+		// per_event_on default is enabled, so meta should be written as 1.
+		$this->assertSame(
+			'1',
+			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
+			'Meta should be written as 1 in per_event_on mode when not previously set.'
+		);
+
+		// Restore setting.
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
+
+	/**
+	 * Coverage for initialize_enabled method in per_event_off mode.
+	 *
+	 * @covers ::initialize_enabled
+	 *
+	 * @return void
+	 */
+	public function test_initialize_enabled_writes_meta_in_per_event_off_mode(): void {
+		// Switch to per_event_off mode BEFORE creating the post so the hook does not write meta.
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_off' );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		// Clear meta set by the wp_after_insert_post hook during post creation.
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+
+		( new Rsvp( $post_id ) )->initialize_enabled();
+
+		// per_event_off default is disabled, so meta should be written as 0.
+		$this->assertSame(
+			'0',
+			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
+			'Meta should be written as 0 in per_event_off mode when not previously set.'
+		);
+
+		// Restore setting.
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
+
+	/**
+	 * Coverage for initialize_enabled method in disabled mode.
+	 *
+	 * @covers ::initialize_enabled
+	 *
+	 * @return void
+	 */
+	public function test_initialize_enabled_skips_disabled_mode(): void {
+		// Switch to disabled mode BEFORE creating the post.
+		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		// Clear any meta that may have been set during post creation.
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+
+		( new Rsvp( $post_id ) )->initialize_enabled();
+
+		// Disabled mode writes no meta.
 		$this->assertSame(
 			'',
 			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
-			'Meta should not be written when mode is per_event_on.'
+			'Meta should not be written when mode is disabled.'
 		);
 
 		// Restore setting.

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
@@ -522,6 +522,65 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
+	 * Coverage for is_rsvp_enabled method.
+	 *
+	 * @covers ::is_rsvp_enabled
+	 *
+	 * @return void
+	 */
+	public function test_is_rsvp_enabled(): void {
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		// Returns false when mode is per_event_on and meta is '0'.
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '0' );
+		$this->assertFalse(
+			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			'Should return false when mode is per_event_on and meta is 0.'
+		);
+
+		// Returns false when mode is per_event_off and meta is '0'.
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_off' );
+		$this->assertFalse(
+			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			'Should return false when mode is per_event_off and meta is 0.'
+		);
+
+		// Returns true when mode is per_event_on and meta is '1'.
+		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '1' );
+		$this->assertTrue(
+			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			'Should return true when mode is per_event_on and meta is 1.'
+		);
+
+		// Returns true when mode is per_event_on and meta is '' (never set).
+		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
+		$this->assertTrue(
+			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			'Should return true when mode is per_event_on and meta is empty (never set).'
+		);
+
+		// Returns true when mode is all_on and meta is '0'.
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+		update_post_meta( $post_id, 'gatherpress_enable_rsvp', '0' );
+		$this->assertTrue(
+			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			'Should return true when mode is all_on regardless of meta.'
+		);
+
+		// Returns true when mode is disabled and meta is '0'.
+		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
+		$this->assertTrue(
+			( new Rsvp( $post_id ) )->is_rsvp_enabled(),
+			'Should return true when mode is disabled regardless of meta.'
+		);
+
+		// Restore default setting.
+		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
+
+	/**
 	 * Test save method with email identifier.
 	 *
 	 * @covers ::save

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
@@ -750,6 +750,34 @@ class Test_Rsvp extends Base {
 	 *
 	 * @return void
 	 */
+	/**
+	 * Coverage for initialize_enabled method.
+	 *
+	 * @covers ::initialize_enabled
+	 *
+	 * @return void
+	 */
+	public function test_initialize_enabled_skips_non_rsvp_post_type(): void {
+		// Use a standard post type that does not support gatherpress-rsvp.
+		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+
+		( new Rsvp( $post_id ) )->initialize_enabled();
+
+		// Meta should remain unset since the post type is not an RSVP-capable event.
+		$this->assertSame(
+			'',
+			get_post_meta( $post_id, 'gatherpress_enable_rsvp', true ),
+			'Meta should not be written for post types that do not support gatherpress-rsvp.'
+		);
+	}
+
+	/**
+	 * Coverage for initialize_enabled method.
+	 *
+	 * @covers ::initialize_enabled
+	 *
+	 * @return void
+	 */
 	public function test_initialize_enabled_skips_non_all_on_modes(): void {
 		// Switch to per_event_on mode BEFORE creating the post so the hook does not write meta.
 		Settings::get_instance()->set( 'rsvp_mode', 'per_event_on' );


### PR DESCRIPTION
### Description of the Change

Introduces a configurable **RSVP Mode** setting that replaces the previous always-on RSVP behavior with four distinct modes, giving site admins fine-grained control over how RSVP works across their site.

**New `rsvp_mode` setting (Settings → RSVP):**

- **All events** (`all_on`) — RSVP is enabled sitewide for all events. This is the default and preserves existing behavior. Events created in this mode have their `gatherpress_enable_rsvp` meta explicitly written as `1` so switching modes later produces predictable results.
- **Per event (default on)** (`per_event_on`) — A per-event toggle appears in the block editor. New events default to RSVP enabled; editors can disable per event.
- **Per event (default off)** (`per_event_off`) — Same as above but new events default to RSVP disabled.
- **Disabled** (`disabled`) — RSVP is turned off sitewide. RSVP blocks are hidden from the block inserter, the RSVPs admin submenu is removed, and the RSVP Settings editor panel is hidden. Existing block placements remain in posts but are dimmed in the editor and render nothing on the frontend.

**Key design decisions:**

- "Missing meta = on" convention: only an explicit `0` value for `gatherpress_enable_rsvp` disables RSVP per event. An unset meta is treated as enabled, making the default state safe across mode switches.
- RSVP blocks are removed from the block inserter (via `allowed_block_types_all`) when disabled, but existing placements are not destroyed — they simply do not render.
- `( new Rsvp( $post_id ) )->is_enabled()` centralizes the per-event gate check, replacing 9 inline copies of the same conditional across 8 files.
- `( new Rsvp( $post_id ) )->initialize_enabled()` is called on `wp_after_insert_post` in `all_on` mode to write the explicit meta, delegated from `Rsvp_Setup`.
- Two JS helpers — `isRsvpEnabledForEvent()` and `isPerEventRsvpMode()` — replace repeated inline expressions across four block edit files and the RSVP settings panel.

**Benefits:**

- Sites that don't use RSVP can cleanly disable it without leaving orphaned UI.
- Per-event control gives event managers flexibility without requiring sitewide changes.
- Mode switches produce predictable results on previously created events.

Closes #

### How to test the Change

1. Go to **Settings → GatherPress → RSVP** and confirm the new **RSVP Mode** select field is present with four options.

**All events mode (default):**

2. Leave mode set to "All events", create a new event — confirm RSVP blocks render normally and no per-event toggle appears in the block editor sidebar.

**Per event (default on):**

3. Switch mode to "Per event (default on)", create a new event — confirm an "Enable RSVP" toggle appears in the RSVP Settings sidebar panel and is checked by default. Uncheck it and save — confirm RSVP blocks render empty on the frontend.

**Per event (default off):**

4. Switch mode to "Per event (default off)", create a new event — confirm the toggle appears unchecked by default. Check it and save — confirm RSVP blocks render normally.

**Disabled:**

5. Switch mode to "Disabled" — confirm:
   - The RSVPs submenu disappears from the Events admin menu.
   - The RSVP Settings panel is gone from the block editor.
   - RSVP blocks (`gatherpress/rsvp`, `gatherpress/rsvp-form`, etc.) are absent from the block inserter.
   - Existing events with RSVP blocks already placed show them dimmed in the editor and render nothing on the frontend.
6. Switch back to "All events" — confirm everything returns to normal.

**Mode switching with existing events:**

7. Create several events in "All events" mode, then switch to "Per event (default on)" — confirm all existing events show the toggle as enabled (meta was written as `1`).
8. Create an event in "Per event (default off)" with RSVP disabled (meta = `0`), then switch to "All events" — confirm RSVP renders for that event (the per-event gate is inactive in `all_on` mode).

### Changelog Entry

> Added - RSVP Mode setting with four options: All events, Per event (default on), Per event (default off), and Disabled — giving admins sitewide control over RSVP availability.

### Credits

Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.