### PR TITLE
Add Open RSVP sitewide setting and per-event toggle

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ Customize how GatherPress behaves across your site:
 - **RSVP Mode** — choose between All events, Per event (default on), Per event (default off), or Disabled (see [RSVP system](user/rsvp-system.md#rsvp-mode))
 - Default RSVP limit
 - Enable or disable anonymous RSVPs
+- **Open RSVP** — allow visitors to RSVP without a site account using email verification (see [Open RSVP](user/rsvp-system.md#open-rsvp-without-an-account))
 - Date and time formats
 - Display timezone for events
 - Set pages for Upcoming and Past Events listings

--- a/docs/developer/settings/README.md
+++ b/docs/developer/settings/README.md
@@ -51,6 +51,7 @@ The settings page is organized into tabs, each managed by its own class:
 | `max_attendance_limit` | number | `50` | Maximum attendees per event (0 = unlimited) |
 | `max_guest_limit` | number | `0` | Maximum guests per attendee (0-5) |
 | `enable_anonymous_rsvp` | checkbox | `false` | Allow anonymous RSVPs |
+| `enable_open_rsvp` | checkbox | `true` | Allow visitors to RSVP without a site account (email verification). Enabled by default. |
 | `rsvp_cleanup_switch` | select | `'off'` | Enable/disable RSVP cleanup |
 | `rsvp_cleanup_frequency` | select | `'daily'` | Cleanup frequency (hourly, daily, weekly, monthly, yearly) |
 | `rsvp_cleanup_interval` | number | `1` | Interval multiplier for cleanup frequency |

--- a/docs/user/rsvp-system.md
+++ b/docs/user/rsvp-system.md
@@ -21,9 +21,17 @@ What is known and visible in the UI:
 - Default RSVP behavior comes from GatherPress settings.  
 - Event-level settings override global defaults when a per-event mode is active.
 
-## RSVP without an account
+## Open RSVP (without an account)
 
-This feature is under development and requires, for now, manual addition of a RSVP Form in the RSVP modal content. This allows visitors to RSVP without an account, and triggers an email handshake with a confirmation link sent to the visitor. The RSVP is only confirmed after the link is clicked or if an administrator approves the RSVP.
+Open RSVP is enabled by default. Site administrators can disable it from **Events - Settings - RSVP** by unchecking **Enable Open RSVP for events**.
+
+When enabled, visitors can RSVP using only their name and email address. An email with a confirmation link is sent to the visitor, and the RSVP is only confirmed after the link is clicked or an administrator approves it manually.
+
+When disabled:
+
+- The RSVP Form block is removed from the block inserter.
+- Any RSVP Form blocks already placed on an event render nothing on the frontend.
+- Direct form POST or REST API submissions return a 403 response.
 
 ## Managing RSVPs
 

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -127,6 +127,10 @@ class Rsvp_Form {
 			return '';
 		}
 
+		if ( ! ( new Rsvp( $post_id ) )->is_open_rsvp_enabled() ) {
+			return '';
+		}
+
 		$unique_form_id = $this->generate_form_id();
 		$schema_form_id = $this->get_form_schema_id( $post_id, $block );
 

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -127,7 +127,7 @@ class Rsvp_Form {
 			return '';
 		}
 
-		if ( ! ( new Rsvp( $post_id ) )->is_open_rsvp_enabled() ) {
+		if ( ! ( new Rsvp( $post_id ) )->allows_open_rsvp() ) {
 			return '';
 		}
 

--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -909,7 +909,7 @@ class Event_Rest_Api {
 			}
 		}
 
-		if ( ! ( new Rsvp( $data['post_id'] ) )->is_open_rsvp_enabled() ) {
+		if ( ! ( new Rsvp( $data['post_id'] ) )->allows_open_rsvp() ) {
 			$response = array(
 				'success' => false,
 				'message' => __( 'Open RSVP is disabled for this event.', 'gatherpress' ),

--- a/includes/core/classes/class-event-rest-api.php
+++ b/includes/core/classes/class-event-rest-api.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use Exception;
 use GatherPress\Core\Blocks\Rsvp_Template;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp_Form as Rsvp_Form_Core;
 use GatherPress\Core\Traits\Singleton;
 use WP_REST_Request;
@@ -906,6 +907,15 @@ class Event_Rest_Api {
 					}
 				}
 			}
+		}
+
+		if ( ! ( new Rsvp( $data['post_id'] ) )->is_open_rsvp_enabled() ) {
+			$response = array(
+				'success' => false,
+				'message' => __( 'Open RSVP is disabled for this event.', 'gatherpress' ),
+			);
+
+			return new WP_REST_Response( $response, 403 );
 		}
 
 		// Check if event has passed - prevent RSVPs to past events.

--- a/includes/core/classes/class-event-setup.php
+++ b/includes/core/classes/class-event-setup.php
@@ -337,6 +337,16 @@ class Event_Setup {
 				'type'              => 'boolean',
 				'default'           => (bool) Settings::get_instance()->get( 'enable_anonymous_rsvp' ),
 			),
+			// Always register so it can be written regardless of open RSVP mode.
+			// Stored as integer (1 = enabled, 0 = disabled); an unset meta (empty string) is treated as enabled.
+			'gatherpress_enable_open_rsvp'      => array(
+				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'sanitize_callback' => 'absint',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'integer',
+				'default'           => 1,
+			),
 			'gatherpress_online_event_link'     => array(
 				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
 				'sanitize_callback' => 'sanitize_url',

--- a/includes/core/classes/class-rsvp-form.php
+++ b/includes/core/classes/class-rsvp-form.php
@@ -162,7 +162,7 @@ class Rsvp_Form {
 			);
 		}
 
-		if ( ! ( new Rsvp( $post_id ) )->is_open_rsvp_enabled() ) {
+		if ( ! ( new Rsvp( $post_id ) )->allows_open_rsvp() ) {
 			wp_die(
 				esc_html__( 'Open RSVP is disabled for this site.', 'gatherpress' ),
 				esc_html__( 'Open RSVP Disabled', 'gatherpress' ),

--- a/includes/core/classes/class-rsvp-form.php
+++ b/includes/core/classes/class-rsvp-form.php
@@ -162,6 +162,14 @@ class Rsvp_Form {
 			);
 		}
 
+		if ( ! ( new Rsvp( $post_id ) )->is_open_rsvp_enabled() ) {
+			wp_die(
+				esc_html__( 'Open RSVP is disabled for this site.', 'gatherpress' ),
+				esc_html__( 'Open RSVP Disabled', 'gatherpress' ),
+				403
+			);
+		}
+
 		// Validate that the post supports RSVP.
 		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
 			wp_die(

--- a/includes/core/classes/class-rsvp-setup.php
+++ b/includes/core/classes/class-rsvp-setup.php
@@ -160,7 +160,11 @@ class Rsvp_Setup {
 	 * @return bool|string[] Filtered allowed block types.
 	 */
 	public function filter_rsvp_block_types( $allowed_block_types ) {
-		if ( 'disabled' !== Settings::get_instance()->get( 'rsvp_mode' ) ) {
+		$settings         = Settings::get_instance();
+		$remove_all_rsvp  = 'disabled' === $settings->get( 'rsvp_mode' );
+		$remove_open_form = ! $settings->get( 'enable_open_rsvp' );
+
+		if ( ! $remove_all_rsvp && ! $remove_open_form ) {
 			return $allowed_block_types;
 		}
 
@@ -173,8 +177,14 @@ class Rsvp_Setup {
 			return array_values(
 				array_filter(
 					$allowed_block_types,
-					static function ( $name ): bool {
-						return ! str_contains( $name, 'gatherpress/rsvp' );
+					static function ( $name ) use ( $remove_all_rsvp, $remove_open_form ): bool {
+						if ( $remove_all_rsvp && str_contains( $name, 'gatherpress/rsvp' ) ) {
+							return false;
+						}
+						if ( $remove_open_form && 'gatherpress/rsvp-form' === $name ) {
+							return false;
+						}
+						return true;
 					}
 				)
 			);

--- a/includes/core/classes/class-rsvp.php
+++ b/includes/core/classes/class-rsvp.php
@@ -224,7 +224,7 @@ class Rsvp {
 	 *
 	 * @return bool True if Open RSVP is enabled for this event, false otherwise.
 	 */
-	public function is_open_rsvp_enabled(): bool {
+	public function allows_open_rsvp(): bool {
 		$post_id = $this->event->ID ?? 0;
 
 		// Sitewide gate: if open RSVP is globally disabled, always return false.

--- a/includes/core/classes/class-rsvp.php
+++ b/includes/core/classes/class-rsvp.php
@@ -214,6 +214,36 @@ class Rsvp {
 	}
 
 	/**
+	 * Determines whether Open RSVP (email/token, non-logged-in) is enabled for this event.
+	 *
+	 * Returns false immediately if the sitewide `enable_open_rsvp` setting is off.
+	 * When sitewide is on, consults the per-event `gatherpress_enable_open_rsvp` post meta.
+	 * An unset meta (empty string) is treated as enabled (the default).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool True if Open RSVP is enabled for this event, false otherwise.
+	 */
+	public function is_open_rsvp_enabled(): bool {
+		$post_id = $this->event->ID ?? 0;
+
+		// Sitewide gate: if open RSVP is globally disabled, always return false.
+		if ( ! Settings::get_instance()->get( 'enable_open_rsvp' ) ) {
+			return false;
+		}
+
+		// Per-event override; stored as integer (1 = enabled, 0 = disabled).
+		$meta = get_post_meta( $post_id, 'gatherpress_enable_open_rsvp', true );
+
+		// Not explicitly set defaults to enabled.
+		if ( '' === $meta ) {
+			return true;
+		}
+
+		return '0' !== (string) $meta;
+	}
+
+	/**
 	 * Writes an explicit enabled value on first save, based on the active RSVP mode.
 	 *
 	 * Ensures that programmatically created events (e.g. via WP-CLI or imports)

--- a/includes/core/classes/settings/class-rsvp-settings.php
+++ b/includes/core/classes/settings/class-rsvp-settings.php
@@ -99,6 +99,25 @@ class Rsvp_Settings extends Base {
 							),
 						),
 					),
+					'enable_open_rsvp'      => array(
+						'labels'      => array(
+							'name' => __( 'Open RSVP', 'gatherpress' ),
+						),
+						'description' => __(
+							'Allow visitors to RSVP without a site account using email verification.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __(
+								'Enable Open RSVP for events.',
+								'gatherpress'
+							),
+							'type'    => 'checkbox',
+							'options' => array(
+								'default' => true,
+							),
+						),
+					),
 					'max_attendance_limit'  => array(
 						'labels'      => array(
 							'name' => __( 'Maximum Attendance Limit', 'gatherpress' ),

--- a/src/blocks/rsvp-form/edit.js
+++ b/src/blocks/rsvp-form/edit.js
@@ -16,7 +16,7 @@ import { getBlockTypes } from '@wordpress/blocks';
  * Internal dependencies.
  */
 import TEMPLATE from './template';
-import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isRsvpEnabledForEvent } from '../../helpers/event';
+import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isRsvpEnabledForEvent, isOpenRsvpEnabled } from '../../helpers/event';
 import { isInFSETemplate, getEditorDocument } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
 import { shouldHideBlock } from './visibility';
@@ -36,6 +36,13 @@ const Edit = ( { attributes, clientId, context } ) => {
 		( select ) => getEventMeta( select, postId, attributes ),
 		[ postId, attributes ]
 	);
+
+	// Read per-event open RSVP setting (integer 0/1; undefined/null defaults to enabled).
+	const enableOpenRsvpPerEvent = useSelect( ( select ) => {
+		const meta = select( 'core/editor' )?.getEditedPostAttribute( 'meta' );
+		const rawValue = meta?.gatherpress_enable_open_rsvp;
+		return rawValue === undefined || null === rawValue ? true : 0 !== rawValue;
+	}, [] );
 
 	// Check if block has a valid event connection.
 	const isValidEvent = hasValidEventId( postId );
@@ -178,12 +185,16 @@ const Edit = ( { attributes, clientId, context } ) => {
 	}, [ maxAttendanceLimit, enableAnonymousRsvp, clientId ] );
 
 	const rsvpMode = getFromSettings( 'rsvpMode' ) ?? 'all_on';
+	const enableOpenRsvp = getFromSettings( 'enableOpenRsvp' ) ?? true;
 
 	const blockProps = useBlockProps( {
 		style: {
 			opacity:
 				isInFSETemplate() ||
-				( isValidEvent && isRsvpEnabledForEvent( rsvpMode, enableRsvp ) )
+				( isValidEvent &&
+					isRsvpEnabledForEvent( rsvpMode, enableRsvp ) &&
+					isOpenRsvpEnabled( enableOpenRsvp ) &&
+					enableOpenRsvpPerEvent )
 					? 1
 					: DISABLED_FIELD_OPACITY,
 		},

--- a/src/components/AnonymousRsvp.js
+++ b/src/components/AnonymousRsvp.js
@@ -62,6 +62,10 @@ const AnonymousRsvp = () => {
 	return (
 		<CheckboxControl
 			label={ __( 'Enable Anonymous RSVP', 'gatherpress' ) }
+			help={ __(
+				'Allow attendees to hide their name and avatar from the public attendee list. Administrators can still see their details.',
+				'gatherpress',
+			) }
 			checked={ anonymousRsvp }
 			onChange={ ( value ) => {
 				updateAnonymousRsvp( value );

--- a/src/components/EnableOpenRsvp.js
+++ b/src/components/EnableOpenRsvp.js
@@ -1,0 +1,73 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { CheckboxControl } from '@wordpress/components';
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * EnableOpenRsvp component.
+ *
+ * Renders a checkbox that toggles Open RSVP for a specific event.
+ * Open RSVP allows visitors without a site account to submit an RSVP
+ * using their name and email address. This per-event toggle is only
+ * visible when the sitewide Open RSVP setting is enabled.
+ *
+ * @return {JSX.Element} A checkbox control for enabling or disabling Open RSVP per event.
+ */
+const EnableOpenRsvp = () => {
+	const { editPost, unlockPostSaving } = useDispatch( 'core/editor' );
+	const isNewEvent = useSelect( ( select ) => {
+		return select( 'core/editor' ).isCleanNewPost();
+	}, [] );
+
+	const metaDefault = useSelect( ( select ) => {
+		const meta = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+		const rawValue = meta?.gatherpress_enable_open_rsvp;
+
+		// Stored as integer (0/1); undefined/null means not yet set — default to enabled.
+		return rawValue === undefined || null === rawValue ? true : 0 !== rawValue;
+	}, [] );
+
+	// New events default to enabled; existing events use the per-event meta value.
+	const defaultEnableOpenRsvp = isNewEvent ? true : metaDefault;
+
+	const [ enableOpenRsvp, setEnableOpenRsvp ] = useState(
+		defaultEnableOpenRsvp,
+	);
+
+	const updateEnableOpenRsvp = useCallback(
+		( value ) => {
+			// Save as integer (1/0) — WordPress stores boolean false as '' which is ambiguous.
+			const meta = { gatherpress_enable_open_rsvp: value ? 1 : 0 };
+
+			setEnableOpenRsvp( value );
+			editPost( { meta } );
+			unlockPostSaving();
+		},
+		[ editPost, unlockPostSaving ],
+	);
+
+	useEffect( () => {
+		if ( isNewEvent ) {
+			updateEnableOpenRsvp( defaultEnableOpenRsvp );
+		}
+	}, [ isNewEvent, defaultEnableOpenRsvp, updateEnableOpenRsvp ] );
+
+	return (
+		<CheckboxControl
+			label={ __( 'Enable Open RSVP', 'gatherpress' ) }
+			help={ __(
+				'Requires the RSVP Form block. Visitors without an account can RSVP using their name and email address.',
+				'gatherpress',
+			) }
+			checked={ enableOpenRsvp }
+			onChange={ ( value ) => {
+				updateEnableOpenRsvp( value );
+			} }
+		/>
+	);
+};
+
+export default EnableOpenRsvp;

--- a/src/components/EnableRsvp.js
+++ b/src/components/EnableRsvp.js
@@ -71,6 +71,10 @@ const EnableRsvp = () => {
 	return (
 		<CheckboxControl
 			label={ __( 'Enable RSVP', 'gatherpress' ) }
+			help={ __(
+				'When disabled, RSVP blocks are hidden and registration is unavailable for this event.',
+				'gatherpress',
+			) }
 			checked={ enableRsvp }
 			onChange={ ( value ) => {
 				updateEnableRsvp( value );

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -268,6 +268,17 @@ export function isRsvpEnabledForEvent( rsvpMode, enableRsvp ) {
 }
 
 /**
+ * Determines whether Open RSVP (email/token, non-logged-in) is enabled sitewide.
+ *
+ * @param {boolean} enableOpenRsvp The sitewide Open RSVP setting value.
+ *
+ * @return {boolean} True if Open RSVP is enabled sitewide, false otherwise.
+ */
+export function isOpenRsvpEnabled( enableOpenRsvp ) {
+	return true === enableOpenRsvp;
+}
+
+/**
  * Gets event meta data (max guest limit, RSVP enabled flag, and anonymous RSVP setting).
  *
  * This function retrieves event meta data either from the current post being edited

--- a/src/panels/rsvp-settings/enable-open-rsvp/index.js
+++ b/src/panels/rsvp-settings/enable-open-rsvp/index.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies.
+ */
+import EnableOpenRsvp from '../../../components/EnableOpenRsvp';
+
+/**
+ * A panel component for managing the Open RSVP enabled setting per event.
+ *
+ * Renders a section containing the `EnableOpenRsvp` component, allowing
+ * editors to control whether visitors without an account can RSVP to
+ * this specific event. Only visible when Open RSVP is enabled sitewide.
+ *
+ * @since 1.0.0
+ *
+ * @return {JSX.Element} The JSX element for the EnableOpenRsvpPanel.
+ */
+const EnableOpenRsvpPanel = () => {
+	return (
+		<section>
+			<EnableOpenRsvp />
+		</section>
+	);
+};
+
+export default EnableOpenRsvpPanel;

--- a/src/panels/rsvp-settings/index.js
+++ b/src/panels/rsvp-settings/index.js
@@ -12,9 +12,10 @@ import { PluginDocumentSettingPanel } from '@wordpress/editor';
 /**
  * Internal dependencies.
  */
-import { isEventPostType, isPerEventRsvpMode } from '../../helpers/event';
+import { isEventPostType, isOpenRsvpEnabled, isPerEventRsvpMode } from '../../helpers/event';
 import { getFromSettings } from '../../helpers/editor-settings';
 import AnonymousRsvpPanel from './anonymous-rsvp';
+import EnableOpenRsvpPanel from './enable-open-rsvp';
 import EnableRsvpPanel from './enable-rsvp';
 import GuestLimitPanel from './guest-limit';
 import MaxAttendanceLimitPanel from './max-attendance-limit';
@@ -35,6 +36,7 @@ import { RsvpPluginDocumentSettings } from './slot';
 const RsvpSettings = () => {
 	// Only show per-event RSVP toggle when the admin has set rsvp_mode to per_event.
 	const rsvpMode = getFromSettings( 'rsvpMode' ) ?? 'all_on';
+	const enableOpenRsvp = getFromSettings( 'enableOpenRsvp' ) ?? true;
 
 	return (
 		isEventPostType() && 'disabled' !== rsvpMode && (
@@ -48,6 +50,9 @@ const RsvpSettings = () => {
 
 				<VStack spacing={ 4 }>
 					{ isPerEventRsvpMode( rsvpMode ) && <EnableRsvpPanel /> }
+					{ isOpenRsvpEnabled( enableOpenRsvp ) && (
+						<EnableOpenRsvpPanel />
+					) }
 					<GuestLimitPanel />
 					<MaxAttendanceLimitPanel />
 					<AnonymousRsvpPanel />

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -35,6 +35,7 @@ import {
 	hasOnlineEventTerm,
 	isPerEventRsvpMode,
 	isRsvpEnabledForEvent,
+	isOpenRsvpEnabled,
 } from '@src/helpers/event';
 import { dateTimeDatabaseFormat } from '@src/helpers/datetime';
 
@@ -1124,6 +1125,28 @@ describe( 'isPerEventRsvpMode', () => {
 
 	it( 'returns false for disabled', () => {
 		expect( isPerEventRsvpMode( 'disabled' ) ).toBe( false );
+	} );
+} );
+
+/**
+ * Coverage for isOpenRsvpEnabled.
+ */
+describe( 'isOpenRsvpEnabled', () => {
+	it( 'returns true when enableOpenRsvp is true', () => {
+		expect( isOpenRsvpEnabled( true ) ).toBe( true );
+	} );
+
+	it( 'returns false when enableOpenRsvp is false', () => {
+		expect( isOpenRsvpEnabled( false ) ).toBe( false );
+	} );
+
+	it( 'returns false when enableOpenRsvp is undefined', () => {
+		expect( isOpenRsvpEnabled( undefined ) ).toBe( false );
+	} );
+
+	it( 'returns false for truthy non-boolean values', () => {
+		expect( isOpenRsvpEnabled( 1 ) ).toBe( false );
+		expect( isOpenRsvpEnabled( 'true' ) ).toBe( false );
 	} );
 } );
 

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-form.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-form.php
@@ -22,6 +22,26 @@ use PMC\Unit_Test\Utility;
  */
 class Test_Rsvp_Form extends Base {
 	/**
+	 * Enable open RSVP for all tests in this class since most exercise the form rendering path.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+	}
+
+	/**
+	 * Restore open RSVP to its default disabled state after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+		parent::tearDown();
+	}
+
+	/**
 	 * Tests the setup_hooks method.
 	 *
 	 * Verifies that the appropriate filters are registered during setup,
@@ -2820,5 +2840,65 @@ class Test_Rsvp_Form extends Base {
 
 		delete_post_meta( $post_id, 'gatherpress_enable_rsvp' );
 		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
+
+	/**
+	 * Tests that transform_block_content returns empty string when open RSVP is disabled sitewide.
+	 *
+	 * @covers ::transform_block_content
+	 *
+	 * @return void
+	 */
+	public function test_transform_block_content_open_rsvp_disabled(): void {
+		$instance = Rsvp_Form::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		// Disable open RSVP sitewide (override the setUp default).
+		Settings::get_instance()->set( 'enable_open_rsvp', false );
+
+		$block_content = '<div class="wp-block-gatherpress-rsvp-form">RSVP Form Content</div>';
+		$block         = array(
+			'blockName' => 'gatherpress/rsvp-form',
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+
+		$result = $instance->transform_block_content( $block_content, $block );
+
+		$this->assertSame( '', $result, 'Should return empty string when open RSVP is disabled sitewide.' );
+	}
+
+	/**
+	 * Tests that transform_block_content returns empty string when open RSVP is disabled per event.
+	 *
+	 * @covers ::transform_block_content
+	 *
+	 * @return void
+	 */
+	public function test_transform_block_content_open_rsvp_disabled_per_event(): void {
+		$instance = Rsvp_Form::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		// Sitewide open RSVP is enabled (setUp default), but disabled for this event.
+		update_post_meta( $post_id, 'gatherpress_enable_open_rsvp', 0 );
+
+		$block_content = '<div class="wp-block-gatherpress-rsvp-form">RSVP Form Content</div>';
+		$block         = array(
+			'blockName' => 'gatherpress/rsvp-form',
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+
+		$result = $instance->transform_block_content( $block_content, $block );
+
+		$this->assertSame( '', $result, 'Should return empty string when open RSVP is disabled for this event.' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-event-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-event-rest-api.php
@@ -12,6 +12,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Event_Rest_Api;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp_Token;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Setup;
 use GatherPress\Core\Topic;
 use GatherPress\Core\Venue;
@@ -27,6 +28,26 @@ use WP_REST_Server;
  * @coversDefaultClass \GatherPress\Core\Event_Rest_Api
  */
 class Test_Event_Rest_Api extends Base {
+	/**
+	 * Enable open RSVP for all tests in this class so RSVP form submission paths are exercisable.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+	}
+
+	/**
+	 * Restore open RSVP to its default disabled state after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+		parent::tearDown();
+	}
+
 	/**
 	 * Coverage for setup_hooks method.
 	 *
@@ -890,6 +911,70 @@ class Test_Event_Rest_Api extends Base {
 		$data = $response->get_data();
 		$this->assertFalse( $data['success'] );
 		$this->assertStringContainsString( 'closed', $data['message'] );
+	}
+
+	/**
+	 * Tests handle_rsvp_form_submission returns 403 when open RSVP is disabled sitewide.
+	 *
+	 * @covers ::handle_rsvp_form_submission
+	 *
+	 * @return void
+	 */
+	public function test_handle_rsvp_form_submission_open_rsvp_disabled(): void {
+		$instance = Event_Rest_Api::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+
+		// Disable open RSVP sitewide (overrides setUp default).
+		Settings::get_instance()->set( 'enable_open_rsvp', false );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'comment_post_ID', $post_id );
+		$request->set_param( 'author', 'Test Author' );
+		$request->set_param( 'email', 'test@example.com' );
+
+		$response = $instance->handle_rsvp_form_submission( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['success'] );
+		$this->assertStringContainsString( 'Open RSVP', $data['message'] );
+	}
+
+	/**
+	 * Tests handle_rsvp_form_submission returns 403 when open RSVP is disabled per event.
+	 *
+	 * @covers ::handle_rsvp_form_submission
+	 *
+	 * @return void
+	 */
+	public function test_handle_rsvp_form_submission_open_rsvp_disabled_per_event(): void {
+		$instance = Event_Rest_Api::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+
+		// Sitewide open RSVP is enabled (setUp default), but disabled for this event.
+		update_post_meta( $post_id, 'gatherpress_enable_open_rsvp', 0 );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'comment_post_ID', $post_id );
+		$request->set_param( 'author', 'Test Author' );
+		$request->set_param( 'email', 'test@example.com' );
+
+		$response = $instance->handle_rsvp_form_submission( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['success'] );
+		$this->assertStringContainsString( 'Open RSVP', $data['message'] );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-form.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-form.php
@@ -21,6 +21,25 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Rsvp_Form
  */
 class Test_Rsvp_Form extends Base {
+	/**
+	 * Enable open RSVP for all tests in this class so form processing paths are exercisable.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+	}
+
+	/**
+	 * Restore open RSVP to its default disabled state after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+		parent::tearDown();
+	}
 
 	/**
 	 * Coverage for setup_hooks.
@@ -1013,6 +1032,92 @@ class Test_Rsvp_Form extends Base {
 
 		// Restore the setting for other tests.
 		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
+
+	/**
+	 * Tests preprocess_rsvp_comment when open RSVP is disabled sitewide.
+	 *
+	 * @covers ::preprocess_rsvp_comment
+	 *
+	 * @return void
+	 */
+	public function test_preprocess_rsvp_comment_open_rsvp_disabled(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+
+		// Disable open RSVP sitewide (overrides setUp default).
+		Settings::get_instance()->set( 'enable_open_rsvp', false );
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			function ( $pre_value, $type, $var_name ) {
+				if ( INPUT_POST === $type && 'author' === $var_name ) {
+					return 'Test Author';
+				}
+				if ( INPUT_POST === $type && 'email' === $var_name ) {
+					return 'test@example.com';
+				}
+				return '';
+			},
+			10,
+			3
+		);
+
+		$instance     = Rsvp_Form::get_instance();
+		$comment_data = array(
+			'comment_post_ID' => $post_id,
+		);
+
+		$this->expectException( 'WPDieException' );
+		$instance->preprocess_rsvp_comment( $comment_data );
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+	}
+
+	/**
+	 * Tests preprocess_rsvp_comment when open RSVP is disabled per event.
+	 *
+	 * @covers ::preprocess_rsvp_comment
+	 *
+	 * @return void
+	 */
+	public function test_preprocess_rsvp_comment_open_rsvp_disabled_per_event(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+
+		// Sitewide open RSVP is enabled (setUp default), but disabled for this event.
+		update_post_meta( $post_id, 'gatherpress_enable_open_rsvp', 0 );
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			function ( $pre_value, $type, $var_name ) {
+				if ( INPUT_POST === $type && 'author' === $var_name ) {
+					return 'Test Author';
+				}
+				if ( INPUT_POST === $type && 'email' === $var_name ) {
+					return 'test@example.com';
+				}
+				return '';
+			},
+			10,
+			3
+		);
+
+		$instance     = Rsvp_Form::get_instance();
+		$comment_data = array(
+			'comment_post_ID' => $post_id,
+		);
+
+		$this->expectException( 'WPDieException' );
+		$instance->preprocess_rsvp_comment( $comment_data );
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-setup.php
@@ -943,16 +943,22 @@ class Test_Rsvp_Setup extends Base {
 	 * @return void
 	 */
 	public function test_filter_rsvp_block_types_when_enabled(): void {
-		$instance      = Rsvp_Setup::get_instance();
-		$initial_value = true;
+		$instance = Rsvp_Setup::get_instance();
 
-		$result = $instance->filter_rsvp_block_types( $initial_value );
+		// Both rsvp_mode and enable_open_rsvp must be active for no filtering to occur.
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+
+		$initial_value = true;
+		$result        = $instance->filter_rsvp_block_types( $initial_value );
 
 		$this->assertSame(
 			$initial_value,
 			$result,
-			'When RSVP is enabled, block types should be returned unchanged.'
+			'When both RSVP mode and open RSVP are enabled, block types should be returned unchanged.'
 		);
+
+		// Restore setting.
+		Settings::get_instance()->set( 'enable_open_rsvp', false );
 	}
 
 	/**
@@ -1055,6 +1061,106 @@ class Test_Rsvp_Setup extends Base {
 		$this->assertFalse( $result, 'Non-array, non-true value should be returned unchanged.' );
 
 		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
+	}
+
+	/**
+	 * Tests filter_rsvp_block_types removes only rsvp-form when open RSVP is disabled.
+	 *
+	 * @covers ::filter_rsvp_block_types
+	 *
+	 * @return void
+	 */
+	public function test_filter_rsvp_block_types_removes_rsvp_form_when_open_rsvp_disabled(): void {
+		$instance = Rsvp_Setup::get_instance();
+
+		Settings::get_instance()->set( 'enable_open_rsvp', false );
+
+		$block_list = array(
+			'core/paragraph',
+			'gatherpress/rsvp',
+			'gatherpress/rsvp-form',
+			'gatherpress/rsvp-response',
+			'gatherpress/event-date',
+		);
+
+		$result = $instance->filter_rsvp_block_types( $block_list );
+
+		// Only gatherpress/rsvp-form should be removed.
+		$this->assertNotContains(
+			'gatherpress/rsvp-form',
+			$result,
+			'gatherpress/rsvp-form should be removed when open RSVP is disabled.'
+		);
+
+		// Other RSVP blocks should remain.
+		$this->assertContains(
+			'gatherpress/rsvp',
+			$result,
+			'gatherpress/rsvp block should remain when only open RSVP is disabled.'
+		);
+		$this->assertContains(
+			'gatherpress/rsvp-response',
+			$result,
+			'gatherpress/rsvp-response block should remain when only open RSVP is disabled.'
+		);
+		$this->assertContains(
+			'core/paragraph',
+			$result,
+			'core/paragraph block should remain when only open RSVP is disabled.'
+		);
+
+		// Restore setting.
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+	}
+
+	/**
+	 * Tests filter_rsvp_block_types expands true to array and removes only rsvp-form when open RSVP is disabled.
+	 *
+	 * @covers ::filter_rsvp_block_types
+	 *
+	 * @return void
+	 */
+	public function test_filter_rsvp_block_types_expands_true_when_open_rsvp_disabled(): void {
+		$instance = Rsvp_Setup::get_instance();
+
+		Settings::get_instance()->set( 'enable_open_rsvp', false );
+
+		$result = $instance->filter_rsvp_block_types( true );
+
+		$this->assertIsArray( $result, 'Result should be an array when all blocks were allowed.' );
+		$this->assertNotContains(
+			'gatherpress/rsvp-form',
+			$result,
+			'gatherpress/rsvp-form should be removed when open RSVP is disabled.'
+		);
+		$this->assertContains(
+			'gatherpress/rsvp',
+			$result,
+			'gatherpress/rsvp block should remain when only open RSVP is disabled.'
+		);
+
+		// Restore setting.
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+	}
+
+	/**
+	 * Tests filter_rsvp_block_types returns non-array value unchanged when only open RSVP is disabled.
+	 *
+	 * @covers ::filter_rsvp_block_types
+	 *
+	 * @return void
+	 */
+	public function test_filter_rsvp_block_types_returns_non_array_unchanged_when_open_rsvp_disabled(): void {
+		$instance = Rsvp_Setup::get_instance();
+
+		Settings::get_instance()->set( 'enable_open_rsvp', false );
+
+		$result = $instance->filter_rsvp_block_types( false );
+
+		$this->assertFalse( $result, 'Non-array, non-true value should be returned unchanged.' );
+
+		// Restore setting.
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
@@ -864,4 +864,48 @@ class Test_Rsvp extends Base {
 		// Restore setting.
 		Settings::get_instance()->set( 'rsvp_mode', 'all_on' );
 	}
+
+	/**
+	 * Coverage for is_open_rsvp_enabled method.
+	 *
+	 * @covers ::is_open_rsvp_enabled
+	 *
+	 * @return void
+	 */
+	public function test_is_open_rsvp_enabled(): void {
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+
+		// Sitewide disabled returns false regardless of per-event meta.
+		Settings::get_instance()->set( 'enable_open_rsvp', false );
+		update_post_meta( $post_id, 'gatherpress_enable_open_rsvp', 1 );
+		$this->assertFalse(
+			( new Rsvp( $post_id ) )->is_open_rsvp_enabled(),
+			'Should return false when sitewide enable_open_rsvp is false, even with per-event meta enabled.'
+		);
+
+		// Sitewide enabled and meta not set defaults to true.
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+		delete_post_meta( $post_id, 'gatherpress_enable_open_rsvp' );
+		$this->assertTrue(
+			( new Rsvp( $post_id ) )->is_open_rsvp_enabled(),
+			'Should return true when sitewide is enabled and per-event meta is not set.'
+		);
+
+		// Sitewide enabled and per-event meta explicitly enabled returns true.
+		update_post_meta( $post_id, 'gatherpress_enable_open_rsvp', 1 );
+		$this->assertTrue(
+			( new Rsvp( $post_id ) )->is_open_rsvp_enabled(),
+			'Should return true when sitewide is enabled and per-event meta is explicitly enabled.'
+		);
+
+		// Sitewide enabled and per-event meta explicitly disabled returns false.
+		update_post_meta( $post_id, 'gatherpress_enable_open_rsvp', 0 );
+		$this->assertFalse(
+			( new Rsvp( $post_id ) )->is_open_rsvp_enabled(),
+			'Should return false when sitewide is enabled but per-event meta is explicitly disabled.'
+		);
+
+		// Restore the sitewide setting for other tests.
+		Settings::get_instance()->set( 'enable_open_rsvp', true );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
@@ -866,20 +866,20 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
-	 * Coverage for is_open_rsvp_enabled method.
+	 * Coverage for allows_open_rsvp method.
 	 *
-	 * @covers ::is_open_rsvp_enabled
+	 * @covers ::allows_open_rsvp
 	 *
 	 * @return void
 	 */
-	public function test_is_open_rsvp_enabled(): void {
+	public function test_allows_open_rsvp(): void {
 		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 
 		// Sitewide disabled returns false regardless of per-event meta.
 		Settings::get_instance()->set( 'enable_open_rsvp', false );
 		update_post_meta( $post_id, 'gatherpress_enable_open_rsvp', 1 );
 		$this->assertFalse(
-			( new Rsvp( $post_id ) )->is_open_rsvp_enabled(),
+			( new Rsvp( $post_id ) )->allows_open_rsvp(),
 			'Should return false when sitewide enable_open_rsvp is false, even with per-event meta enabled.'
 		);
 
@@ -887,21 +887,21 @@ class Test_Rsvp extends Base {
 		Settings::get_instance()->set( 'enable_open_rsvp', true );
 		delete_post_meta( $post_id, 'gatherpress_enable_open_rsvp' );
 		$this->assertTrue(
-			( new Rsvp( $post_id ) )->is_open_rsvp_enabled(),
+			( new Rsvp( $post_id ) )->allows_open_rsvp(),
 			'Should return true when sitewide is enabled and per-event meta is not set.'
 		);
 
 		// Sitewide enabled and per-event meta explicitly enabled returns true.
 		update_post_meta( $post_id, 'gatherpress_enable_open_rsvp', 1 );
 		$this->assertTrue(
-			( new Rsvp( $post_id ) )->is_open_rsvp_enabled(),
+			( new Rsvp( $post_id ) )->allows_open_rsvp(),
 			'Should return true when sitewide is enabled and per-event meta is explicitly enabled.'
 		);
 
 		// Sitewide enabled and per-event meta explicitly disabled returns false.
 		update_post_meta( $post_id, 'gatherpress_enable_open_rsvp', 0 );
 		$this->assertFalse(
-			( new Rsvp( $post_id ) )->is_open_rsvp_enabled(),
+			( new Rsvp( $post_id ) )->allows_open_rsvp(),
 			'Should return false when sitewide is enabled but per-event meta is explicitly disabled.'
 		);
 


### PR DESCRIPTION
### Description of the Change

Introduces a two-level control for Open RSVP — the feature that allows visitors without a site account to RSVP using only their name and email address (via the RSVP Form block).

**Sitewide setting** (`enable_open_rsvp`, default `true`):
- Added to **Events → Settings → RSVP**, directly below RSVP Mode.
- When disabled: the RSVP Form block is removed from the block inserter, any placed RSVP Form blocks render nothing on the frontend, and direct form POST and REST API submissions return a 403 response.

**Per-event toggle** (`gatherpress_enable_open_rsvp` post meta, integer 0/1):
- An "Enable Open RSVP" checkbox appears in the RSVP settings panel in the block editor, but only when the sitewide setting is enabled.
- Disabling it for a specific event hides the RSVP Form block on the frontend and returns a 403 for any submission attempt against that event.
- The RSVP Form block dims in the editor when the per-event toggle is unchecked, matching existing dim behavior for other disabled states.

**Help text** added to three RSVP settings panel checkboxes:
- *Enable RSVP* — clarifies that disabling hides RSVP blocks entirely.
- *Enable Open RSVP* — notes the RSVP Form block requirement.
- *Enable Anonymous RSVP* — explains that admins can still see attendee details.

**Implementation notes:**
- `Rsvp::is_open_rsvp_enabled()` encapsulates the combined sitewide + per-event check used in all three submission paths (`preprocess_rsvp_comment`, `handle_rsvp_form_submission`, `transform_block_content`).
- Integer storage (`1`/`0`) is used for the per-event meta — the same pattern as `gatherpress_enable_rsvp` — to avoid the PHP `false` → `''` ambiguity that makes "explicitly disabled" indistinguishable from "never set".
- Default is `true` to preserve existing behavior on upgrade for sites already using the RSVP Form block.

Closes #1261 

### How to test the Change

**Sitewide disable:**
1. Go to **Events → Settings → RSVP** and uncheck **Enable Open RSVP for events**.
2. Open any event in the block editor — the RSVP Form block should no longer appear in the block inserter.
3. On the frontend, any existing RSVP Form blocks should render nothing.
4. Submitting directly via the REST API (`/wp-json/gatherpress/v1/rsvp-form`) should return a 403.

**Per-event disable:**
1. Ensure **Enable Open RSVP** is checked sitewide.
2. Open an event in the block editor — an **Enable Open RSVP** checkbox should be visible in the RSVP settings panel.
3. Uncheck it — the RSVP Form block in the editor canvas should dim.
4. Save and view the event on the frontend — the RSVP Form block should not render.
5. Re-check the toggle and save — the RSVP Form block should reappear.

**Default behavior:**
1. With a fresh install, Open RSVP should be enabled by default at both levels — no change in behavior from before this PR.

### Changelog Entry

> Added - Sitewide and per-event controls for Open RSVP, allowing administrators to disable email-based RSVP globally or on individual events.

### Credits

Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.