### PR TITLE
Honor WordPress comment privacy filters on RSVP inserts

### DIFF
--- a/docs/user/privacy.md
+++ b/docs/user/privacy.md
@@ -16,3 +16,18 @@ With the help of contributors this prepared text may even be already translated 
 
 Go to `Settings > Privacy > Policy Guide` to find a new '*GatherPress*' dropdown in the 'Policies' list
 
+## Redacting RSVP IP addresses and user agents
+
+RSVPs are stored as WordPress comments, so the visitor's IP address and browser user agent are recorded by default. To help comply with GDPR/DSGVO or other privacy regulations, you can redact this information with the same WordPress-native filters that apply to regular comments:
+
+```php
+add_filter( 'pre_comment_user_ip', static function () {
+    return '127.0.0.1';
+} );
+
+add_filter( 'pre_comment_user_agent', static function () {
+    return '';
+} );
+```
+
+Drop the snippet into a must-use plugin, a site-specific plugin, or your theme's `functions.php`. It applies to all RSVP paths — form submissions, REST/AJAX submissions, and waiting-list promotions.

--- a/docs/user/privacy.md
+++ b/docs/user/privacy.md
@@ -31,3 +31,10 @@ add_filter( 'pre_comment_user_agent', static function () {
 ```
 
 Drop the snippet into a must-use plugin, a site-specific plugin, or your theme's `functions.php`. It applies to all RSVP paths — form submissions, REST/AJAX submissions, and waiting-list promotions.
+
+The same mechanism exposes the rest of WordPress's comment-data filters to RSVPs, should you want to sanitize or override them:
+
+- `pre_comment_author_name`
+- `pre_comment_author_email`
+- `pre_comment_author_url`
+- `pre_comment_content`

--- a/includes/core/classes/class-rsvp-form.php
+++ b/includes/core/classes/class-rsvp-form.php
@@ -348,6 +348,10 @@ class Rsvp_Form {
 		// Prepare comment data.
 		$comment_data = $this->prepare_comment_data( $post_id, $author, $email );
 
+		// Run WordPress-native comment filters so sites can honor
+		// pre_comment_user_ip, pre_comment_user_agent, etc. for privacy.
+		$comment_data = wp_filter_comment( $comment_data );
+
 		// Insert the comment.
 		$comment_id_result = wp_insert_comment( $comment_data );
 

--- a/includes/core/classes/class-rsvp.php
+++ b/includes/core/classes/class-rsvp.php
@@ -407,6 +407,7 @@ class Rsvp {
 					'comment_author'       => '',
 					'comment_author_email' => '',
 					'comment_author_url'   => '',
+					'comment_author_IP'    => '127.0.0.1',
 					'comment_content'      => '',
 				),
 				$args

--- a/includes/core/classes/class-rsvp.php
+++ b/includes/core/classes/class-rsvp.php
@@ -401,6 +401,20 @@ class Rsvp {
 		}
 
 		if ( empty( $rsvp ) ) {
+			// Ensure keys that wp_filter_comment accesses without isset() are present.
+			$args = array_merge(
+				array(
+					'comment_author'       => '',
+					'comment_author_email' => '',
+					'comment_author_url'   => '',
+					'comment_content'      => '',
+				),
+				$args
+			);
+
+			// Run WordPress-native comment filters so sites can honor
+			// pre_comment_user_ip, pre_comment_user_agent, etc. for privacy.
+			$args       = wp_filter_comment( $args );
 			$comment_id = wp_insert_comment( $args );
 		} else {
 			$comment_id               = $rsvp->comment_ID;

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-form.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-form.php
@@ -1409,42 +1409,52 @@ class Test_Rsvp_Form extends Base {
 
 	/**
 	 * Tests that process_rsvp runs wp_filter_comment so WordPress-native
-	 * privacy filters like pre_comment_user_ip are honored on the stored RSVP.
+	 * privacy filters like pre_comment_user_ip and pre_comment_user_agent
+	 * are honored on the stored RSVP.
 	 *
 	 * @covers ::process_rsvp
 	 *
 	 * @return void
 	 */
-	public function test_process_rsvp_applies_pre_comment_user_ip_filter(): void {
+	public function test_process_rsvp_applies_comment_privacy_filters(): void {
 		$post_id = $this->factory->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
 			)
 		);
 
-		$_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+		$_SERVER['REMOTE_ADDR']     = '203.0.113.42';
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (test browser)';
 
-		$redact = static function () {
+		$redact_ip    = static function () {
 			return '127.0.0.1';
 		};
-		add_filter( 'pre_comment_user_ip', $redact );
+		$redact_agent = static function () {
+			return '';
+		};
+		add_filter( 'pre_comment_user_ip', $redact_ip );
+		add_filter( 'pre_comment_user_agent', $redact_agent );
 
-		$data = array(
-			'post_id' => $post_id,
-			'author'  => 'Privacy User',
-			'email'   => 'privacy@example.com',
-		);
+		try {
+			$data = array(
+				'post_id' => $post_id,
+				'author'  => 'Privacy User',
+				'email'   => 'privacy@example.com',
+			);
 
-		$instance = Rsvp_Form::get_instance();
-		$result   = $instance->process_rsvp( $data );
+			$instance = Rsvp_Form::get_instance();
+			$result   = $instance->process_rsvp( $data );
 
-		$this->assertTrue( $result['success'] );
+			$this->assertTrue( $result['success'] );
 
-		$comment = get_comment( $result['comment_id'] );
-		$this->assertSame( '127.0.0.1', $comment->comment_author_IP );
-
-		remove_filter( 'pre_comment_user_ip', $redact );
-		unset( $_SERVER['REMOTE_ADDR'] );
+			$comment = get_comment( $result['comment_id'] );
+			$this->assertSame( '127.0.0.1', $comment->comment_author_IP );
+			$this->assertSame( '', $comment->comment_agent );
+		} finally {
+			remove_filter( 'pre_comment_user_ip', $redact_ip );
+			remove_filter( 'pre_comment_user_agent', $redact_agent );
+			unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_USER_AGENT'] );
+		}
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-form.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-form.php
@@ -1408,6 +1408,46 @@ class Test_Rsvp_Form extends Base {
 	}
 
 	/**
+	 * Tests that process_rsvp runs wp_filter_comment so WordPress-native
+	 * privacy filters like pre_comment_user_ip are honored on the stored RSVP.
+	 *
+	 * @covers ::process_rsvp
+	 *
+	 * @return void
+	 */
+	public function test_process_rsvp_applies_pre_comment_user_ip_filter(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+
+		$redact = static function () {
+			return '127.0.0.1';
+		};
+		add_filter( 'pre_comment_user_ip', $redact );
+
+		$data = array(
+			'post_id' => $post_id,
+			'author'  => 'Privacy User',
+			'email'   => 'privacy@example.com',
+		);
+
+		$instance = Rsvp_Form::get_instance();
+		$result   = $instance->process_rsvp( $data );
+
+		$this->assertTrue( $result['success'] );
+
+		$comment = get_comment( $result['comment_id'] );
+		$this->assertSame( '127.0.0.1', $comment->comment_author_IP );
+
+		remove_filter( 'pre_comment_user_ip', $redact );
+		unset( $_SERVER['REMOTE_ADDR'] );
+	}
+
+	/**
 	 * Tests process_custom_fields with traditional form submission.
 	 *
 	 * @covers ::process_fields

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
@@ -658,13 +658,14 @@ class Test_Rsvp extends Base {
 
 	/**
 	 * Test that save() runs wp_filter_comment so WordPress-native
-	 * privacy filters like pre_comment_user_ip are honored on inserted RSVPs.
+	 * privacy filters like pre_comment_user_ip and pre_comment_user_agent
+	 * are honored on inserted RSVPs.
 	 *
 	 * @covers ::save
 	 *
 	 * @return void
 	 */
-	public function test_save_applies_pre_comment_user_ip_filter(): void {
+	public function test_save_applies_comment_privacy_filters(): void {
 		$post    = $this->mock->post(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -673,22 +674,31 @@ class Test_Rsvp extends Base {
 		$rsvp    = new Rsvp( $post->ID );
 		$user_id = $this->factory->user->create();
 
-		$_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+		$_SERVER['REMOTE_ADDR']     = '203.0.113.42';
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (test browser)';
 
-		$redact = static function () {
+		$redact_ip    = static function () {
 			return '127.0.0.1';
 		};
-		add_filter( 'pre_comment_user_ip', $redact );
+		$redact_agent = static function () {
+			return '';
+		};
+		add_filter( 'pre_comment_user_ip', $redact_ip );
+		add_filter( 'pre_comment_user_agent', $redact_agent );
 
-		$data = $rsvp->save( $user_id, 'attending' );
+		try {
+			$data = $rsvp->save( $user_id, 'attending' );
 
-		$this->assertSame( 'attending', $data['status'] );
+			$this->assertSame( 'attending', $data['status'] );
 
-		$comment = get_comment( $data['comment_id'] );
-		$this->assertSame( '127.0.0.1', $comment->comment_author_IP );
-
-		remove_filter( 'pre_comment_user_ip', $redact );
-		unset( $_SERVER['REMOTE_ADDR'] );
+			$comment = get_comment( $data['comment_id'] );
+			$this->assertSame( '127.0.0.1', $comment->comment_author_IP );
+			$this->assertSame( '', $comment->comment_agent );
+		} finally {
+			remove_filter( 'pre_comment_user_ip', $redact_ip );
+			remove_filter( 'pre_comment_user_agent', $redact_agent );
+			unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_USER_AGENT'] );
+		}
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp.php
@@ -657,6 +657,41 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
+	 * Test that save() runs wp_filter_comment so WordPress-native
+	 * privacy filters like pre_comment_user_ip are honored on inserted RSVPs.
+	 *
+	 * @covers ::save
+	 *
+	 * @return void
+	 */
+	public function test_save_applies_pre_comment_user_ip_filter(): void {
+		$post    = $this->mock->post(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		)->get();
+		$rsvp    = new Rsvp( $post->ID );
+		$user_id = $this->factory->user->create();
+
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+
+		$redact = static function () {
+			return '127.0.0.1';
+		};
+		add_filter( 'pre_comment_user_ip', $redact );
+
+		$data = $rsvp->save( $user_id, 'attending' );
+
+		$this->assertSame( 'attending', $data['status'] );
+
+		$comment = get_comment( $data['comment_id'] );
+		$this->assertSame( '127.0.0.1', $comment->comment_author_IP );
+
+		remove_filter( 'pre_comment_user_ip', $redact );
+		unset( $_SERVER['REMOTE_ADDR'] );
+	}
+
+	/**
 	 * Test check_waiting_list when not enough people on waiting list.
 	 *
 	 * @covers ::check_waiting_list


### PR DESCRIPTION
### Description of the Change

RSVP inserts were bypassing WordPress's native comment filters. Both `Rsvp_Form::process_rsvp()` (REST/AJAX path) and `Rsvp::save()` (programmatic path, e.g. waiting-list promotions) built their own comment data arrays and called `wp_insert_comment()` directly, which does **not** run `wp_filter_comment()`. As a result, privacy-oriented filters like `pre_comment_user_ip`, `pre_comment_user_agent`, and `pre_comment_author_*` had no effect on stored RSVPs, so GDPR/DSGVO-conscious sites could not redact IPs or user agents using the standard WordPress snippet.

This PR runs `wp_filter_comment()` on the prepared data in both call sites before `wp_insert_comment()`. The traditional form-submission path (via the `preprocess_comment` filter) already flows through `wp_new_comment()` → `wp_filter_comment()` in WordPress core and is unchanged. `Rsvp::save()` required small default-key prefills (`comment_author`, `comment_content`, `comment_author_url`, `comment_author_email`) because its `$args` shape is sparser than the form path and `wp_filter_comment()` accesses those keys without `isset()` checks.

Closes #1346

### How to test the Change

1. Drop this snippet into a must-use plugin or `functions.php`:
   ```php
   add_filter( 'pre_comment_user_ip', static fn() => '127.0.0.1' );
   add_filter( 'pre_comment_user_agent', static fn() => '' );
   ```
2. Submit an RSVP on an event (as a logged-out or logged-in user) via the RSVP form.
3. In the admin, open the event's RSVP list (or inspect the `wp_comments` row directly) and confirm `comment_author_IP` is `127.0.0.1` and `comment_agent` is empty.
4. Verify an event where the waiting list auto-promotes an attendee also stores the redacted IP (triggers the `Rsvp::save()` path).
5. Run `npm run test:unit:php -- --filter='Rsvp'` — 451 tests should pass, including the two new regression tests.

### Changelog Entry

> Added - Run `wp_filter_comment` on RSVP inserts so sites can use WordPress-native filters (`pre_comment_user_ip`, `pre_comment_user_agent`, etc.) to redact RSVP metadata for privacy/GDPR compliance.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.