### PR TITLE
Expose WordPress Geodata standard meta on venue post types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ GatherPress uses custom `post_type_supports` to decouple features from specific 
 
 **Venue post type supports** (declared on post types that act as venues):
 
-- `gatherpress-venue-information` — **Core venue identifier.** Address, phone, website, lat/lng meta (JSON), venue detail blocks, and automatic `_gatherpress_venue` taxonomy term management. Declaring this support is what makes a post type a venue source.
+- `gatherpress-venue-information` — **Core venue identifier.** Address, phone, website, lat/lng meta (JSON), venue detail blocks, and automatic `_gatherpress_venue` taxonomy term management. Also registers [WordPress Geodata standard](https://codex.wordpress.org/Geodata) keys (`geo_latitude`, `geo_longitude`, `geo_address`, `geo_public`) as read-only meta derived from the JSON on `wp_after_insert_post` — do not write these directly. Meta revisions (`revisions_enabled`) are opted-in per post type and only applied when the post type declares `revisions` in its `supports` array. Declaring this support is what makes a post type a venue source.
 - `gatherpress-venue-map` — Map display meta (show/zoom/height) and the venue map block
 
 **How it works:**

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -124,6 +124,7 @@ These supports are declared on post types that act as **venues**. `gatherpress-v
 The core identifier for venue post types. Enables venue address and contact data. This includes:
 
 - Registration of the `gatherpress_venue_information` meta field (JSON: address, phone, website, lat/lng)
+- Registration of [WordPress Geodata standard](https://codex.wordpress.org/Geodata) meta keys (`geo_latitude`, `geo_longitude`, `geo_address`, `geo_public`) as read-only post meta. These are derived from `gatherpress_venue_information` on `wp_after_insert_post` and exposed so any plugin that follows the standard (e.g. [Simple Location](https://wordpress.org/plugins/simple-location/)) can interoperate with GatherPress venues without parsing our JSON. `geo_public` is bound to `post_status` (`1` when published, `0` otherwise). Meta revisions are enabled automatically when your venue post type declares `revisions` in its `supports` array.
 - Venue detail blocks (address, phone number, website)
 - Automatic creation and management of the corresponding `_gatherpress_venue` taxonomy term
 - `post_type_supports( $type, 'gatherpress-venue-information' )` is the canonical check for "is this a venue?"
@@ -136,6 +137,8 @@ register_post_type( 'my_custom_venue', array(
     // ... other args
 ) );
 ```
+
+> **Note:** The `geo_*` meta keys are derived — do not write to them directly. Update `gatherpress_venue_information` and the geo meta will be rewritten on the next save. REST API writes to `geo_latitude`, `geo_longitude`, `geo_address`, or `geo_public` are silently stripped.
 
 ### `gatherpress-venue-map`
 

--- a/includes/core/classes/class-venue.php
+++ b/includes/core/classes/class-venue.php
@@ -457,6 +457,8 @@ class Venue {
 			}
 
 			// Strip derived geo meta from REST requests so the editor can't write it directly.
+			// Venue post types registered after init:11 inherit the same timing constraint as the
+			// meta registration above — they won't pick up this filter and should declare their own.
 			add_filter(
 				sprintf( 'rest_pre_insert_%s', $post_type ),
 				array( $this, 'filter_readonly_meta' ),
@@ -515,7 +517,15 @@ class Venue {
 	 * that adhere to the standard interoperate with GatherPress venues without reading
 	 * our JSON format.
 	 *
-	 * geo_public is bound to post_status: 1 when published, 0 otherwise.
+	 * Non-numeric latitude or longitude values in the JSON are stored as empty strings
+	 * rather than passed through, so downstream consumers that expect floats (e.g.
+	 * Simple Location) don't choke on legacy or imported garbage data.
+	 *
+	 * Note on geo_public: the WP Geodata codex defines geo_public as an opt-in privacy
+	 * flag (1 public, 0 private). GatherPress intentionally binds it to publication
+	 * status — 1 when post_status is 'publish', 0 otherwise — because a venue that
+	 * isn't published is not publicly accessible anywhere in the site. Plugins that
+	 * need a separate user-facing privacy toggle can filter the value.
 	 *
 	 * @since 1.0.0
 	 *
@@ -523,6 +533,12 @@ class Venue {
 	 * @return void
 	 */
 	public function set_geodata( int $post_id ): void {
+		// wp_after_insert_post fires for revisions and autosaves; skip both to avoid
+		// writing derived meta onto revision posts where it's not useful.
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+
 		$post_type = (string) get_post_type( $post_id );
 
 		if ( ! post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
@@ -538,8 +554,8 @@ class Venue {
 			$data = array();
 		}
 
-		$latitude  = isset( $data['latitude'] ) ? (string) $data['latitude'] : '';
-		$longitude = isset( $data['longitude'] ) ? (string) $data['longitude'] : '';
+		$latitude  = isset( $data['latitude'] ) && is_numeric( $data['latitude'] ) ? (string) $data['latitude'] : '';
+		$longitude = isset( $data['longitude'] ) && is_numeric( $data['longitude'] ) ? (string) $data['longitude'] : '';
 		$address   = isset( $data['fullAddress'] ) ? (string) $data['fullAddress'] : '';
 		$public    = ( 'publish' === get_post_status( $post_id ) ) ? 1 : 0;
 

--- a/includes/core/classes/class-venue.php
+++ b/includes/core/classes/class-venue.php
@@ -15,8 +15,10 @@ namespace GatherPress\Core;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
+use stdClass;
 use WP_Block_Patterns_Registry;
 use WP_Post;
+use WP_REST_Request;
 
 /**
  * Class Venue.
@@ -85,6 +87,7 @@ class Venue {
 		add_action( 'init', array( $this, 'register_taxonomy' ), 11 );
 		add_action( 'post_updated', array( $this, 'maybe_update_term_slug' ), 10, 3 );
 		add_action( 'delete_post', array( $this, 'delete_venue_term' ) );
+		add_action( 'wp_after_insert_post', array( $this, 'set_geodata' ) );
 		add_filter( 'block_editor_settings_all', array( $this, 'add_editor_settings' ) );
 	}
 
@@ -371,6 +374,43 @@ class Venue {
 				'single'            => true,
 				'type'              => 'string',
 				'default'           => '',
+				'revisions_enabled' => true,
+			),
+			// WordPress Geodata standard: https://codex.wordpress.org/Geodata.
+			// Derived from gatherpress_venue_information JSON on save. Read-only via REST.
+			'geo_latitude'                  => array(
+				'auth_callback'     => '__return_false',
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
+				'revisions_enabled' => true,
+			),
+			'geo_longitude'                 => array(
+				'auth_callback'     => '__return_false',
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
+				'revisions_enabled' => true,
+			),
+			'geo_address'                   => array(
+				'auth_callback'     => '__return_false',
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
+				'revisions_enabled' => true,
+			),
+			// Bound to post_status: 1 when published, 0 otherwise.
+			'geo_public'                    => array(
+				'auth_callback'     => '__return_false',
+				'sanitize_callback' => 'absint',
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'integer',
+				'default'           => 1,
+				'revisions_enabled' => true,
 			),
 		);
 
@@ -403,9 +443,26 @@ class Venue {
 		);
 
 		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $post_type ) {
+			$supports_revisions = post_type_supports( $post_type, 'revisions' );
+
 			foreach ( $venue_information_meta as $meta_key => $args ) {
+				// revisions_enabled is only valid when the post type supports revisions.
+				// Silently drop it for venue post types that opt out (e.g. companion plugins
+				// registering a minimal venue post type without revisions support).
+				if ( ! $supports_revisions ) {
+					unset( $args['revisions_enabled'] );
+				}
+
 				register_post_meta( $post_type, $meta_key, $args );
 			}
+
+			// Strip derived geo meta from REST requests so the editor can't write it directly.
+			add_filter(
+				sprintf( 'rest_pre_insert_%s', $post_type ),
+				array( $this, 'filter_readonly_meta' ),
+				10,
+				2
+			);
 		}
 
 		foreach ( get_post_types_by_support( 'gatherpress-venue-map' ) as $post_type ) {
@@ -413,6 +470,83 @@ class Venue {
 				register_post_meta( $post_type, $meta_key, $args );
 			}
 		}
+	}
+
+	/**
+	 * Filter out read-only geo meta from REST API requests.
+	 *
+	 * The geo_* meta keys are derived from gatherpress_venue_information on save via
+	 * set_geodata(), so any values submitted through REST should be silently discarded
+	 * rather than triggering a permission error from the __return_false auth callback.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param stdClass        $prepared_post An object representing a single post prepared for inserting or updating.
+	 * @param WP_REST_Request $request       Request object.
+	 * @return stdClass The prepared post object.
+	 */
+	public function filter_readonly_meta( stdClass $prepared_post, WP_REST_Request $request ): stdClass {
+		$readonly_keys = array(
+			'geo_latitude',
+			'geo_longitude',
+			'geo_address',
+			'geo_public',
+		);
+
+		$meta = $request->get_param( 'meta' );
+
+		if ( is_array( $meta ) ) {
+			foreach ( $readonly_keys as $key ) {
+				unset( $meta[ $key ] );
+			}
+
+			$request->set_param( 'meta', $meta );
+		}
+
+		return $prepared_post;
+	}
+
+	/**
+	 * Derive WordPress Geodata standard meta from gatherpress_venue_information JSON.
+	 *
+	 * Parses the JSON venue information meta and writes the individual geo_latitude,
+	 * geo_longitude, geo_address, and geo_public meta keys following the WordPress
+	 * Geodata standard (https://codex.wordpress.org/Geodata). This lets other plugins
+	 * that adhere to the standard interoperate with GatherPress venues without reading
+	 * our JSON format.
+	 *
+	 * geo_public is bound to post_status: 1 when published, 0 otherwise.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id The ID of the post being saved.
+	 * @return void
+	 */
+	public function set_geodata( int $post_id ): void {
+		$post_type = (string) get_post_type( $post_id );
+
+		if ( ! post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
+			return;
+		}
+
+		$data = json_decode(
+			(string) get_post_meta( $post_id, 'gatherpress_venue_information', true ),
+			true
+		);
+
+		if ( ! is_array( $data ) ) {
+			$data = array();
+		}
+
+		$latitude  = isset( $data['latitude'] ) ? (string) $data['latitude'] : '';
+		$longitude = isset( $data['longitude'] ) ? (string) $data['longitude'] : '';
+		$address   = isset( $data['fullAddress'] ) ? (string) $data['fullAddress'] : '';
+		$public    = ( 'publish' === get_post_status( $post_id ) ) ? 1 : 0;
+
+		update_post_meta( $post_id, 'geo_latitude', $latitude );
+		update_post_meta( $post_id, 'geo_longitude', $longitude );
+		update_post_meta( $post_id, 'geo_address', $address );
+		update_post_meta( $post_id, 'geo_public', $public );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue.php
@@ -325,6 +325,46 @@ class Test_Venue extends Base {
 	}
 
 	/**
+	 * Coverage for register_post_meta when the venue post type does not support revisions.
+	 *
+	 * Registers a throwaway venue post type that declares gatherpress-venue-information
+	 * support but omits WordPress revisions support. Verifies that register_post_meta
+	 * silently drops revisions_enabled for that post type and still registers the meta
+	 * without triggering a WordPress _doing_it_wrong notice.
+	 *
+	 * @covers ::register_post_meta
+	 *
+	 * @return void
+	 */
+	public function test_register_post_meta_without_revisions_support(): void {
+		$instance = Venue::get_instance();
+		$test_pt  = 'gp_test_venue_no_rev';
+
+		register_post_type(
+			$test_pt,
+			array(
+				'label'    => 'Test Venues (no revisions)',
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-venue-information' ),
+			)
+		);
+
+		$instance->register_post_meta();
+
+		$meta = get_registered_meta_keys( 'post', $test_pt );
+
+		foreach ( array( 'gatherpress_venue_information', 'geo_latitude', 'geo_longitude', 'geo_address', 'geo_public' ) as $key ) {
+			$this->assertArrayHasKey(
+				$key,
+				$meta,
+				sprintf( 'Failed to assert %s is registered for a venue post type without revisions support.', $key )
+			);
+		}
+
+		unregister_post_type( $test_pt );
+	}
+
+	/**
 	 * Coverage for set_geodata method.
 	 *
 	 * Verifies that the WordPress Geodata standard meta keys are derived from

--- a/test/unit/php/includes/tests/core/classes/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue.php
@@ -76,6 +76,12 @@ class Test_Venue extends Base {
 				'callback' => array( $instance, 'delete_venue_term' ),
 			),
 			array(
+				'type'     => 'action',
+				'name'     => 'wp_after_insert_post',
+				'priority' => 10,
+				'callback' => array( $instance, 'set_geodata' ),
+			),
+			array(
 				'type'     => 'filter',
 				'name'     => 'block_editor_settings_all',
 				'priority' => 10,
@@ -268,6 +274,10 @@ class Test_Venue extends Base {
 
 		unregister_post_meta( Venue::POST_TYPE, 'gatherpress_venue_information' );
 		unregister_post_meta( Venue::POST_TYPE, 'gatherpress_venue_map_show' );
+		unregister_post_meta( Venue::POST_TYPE, 'geo_latitude' );
+		unregister_post_meta( Venue::POST_TYPE, 'geo_longitude' );
+		unregister_post_meta( Venue::POST_TYPE, 'geo_address' );
+		unregister_post_meta( Venue::POST_TYPE, 'geo_public' );
 
 		$meta = get_registered_meta_keys( 'post', Venue::POST_TYPE );
 
@@ -281,6 +291,12 @@ class Test_Venue extends Base {
 			'gatherpress_venue_map_show',
 			$meta,
 			'Failed to assert that gatherpress_venue_map_show does not exist.'
+		);
+
+		$this->assertArrayNotHasKey(
+			'geo_latitude',
+			$meta,
+			'Failed to assert that geo_latitude does not exist.'
 		);
 
 		$instance->register_post_meta();
@@ -297,6 +313,191 @@ class Test_Venue extends Base {
 			'gatherpress_venue_map_show',
 			$meta,
 			'Failed to assert that gatherpress_venue_map_show exists for gatherpress-venue-map support.'
+		);
+
+		foreach ( array( 'geo_latitude', 'geo_longitude', 'geo_address', 'geo_public' ) as $key ) {
+			$this->assertArrayHasKey(
+				$key,
+				$meta,
+				sprintf( 'Failed to assert that %s is registered for gatherpress-venue-information support.', $key )
+			);
+		}
+	}
+
+	/**
+	 * Coverage for set_geodata method.
+	 *
+	 * Verifies that the WordPress Geodata standard meta keys are derived from
+	 * gatherpress_venue_information JSON and written as individual post_meta entries.
+	 *
+	 * @covers ::set_geodata
+	 *
+	 * @return void
+	 */
+	public function test_set_geodata(): void {
+		$instance = Venue::get_instance();
+
+		$venue_id = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		$venue_information = wp_json_encode(
+			array(
+				'fullAddress' => '123 Main St, Paris',
+				'latitude'    => '48.856613',
+				'longitude'   => '2.352222',
+			)
+		);
+
+		update_post_meta( $venue_id, 'gatherpress_venue_information', $venue_information );
+
+		$instance->set_geodata( $venue_id );
+
+		$this->assertSame(
+			'48.856613',
+			get_post_meta( $venue_id, 'geo_latitude', true ),
+			'Failed to assert that geo_latitude was set from the JSON meta.'
+		);
+		$this->assertSame(
+			'2.352222',
+			get_post_meta( $venue_id, 'geo_longitude', true ),
+			'Failed to assert that geo_longitude was set from the JSON meta.'
+		);
+		$this->assertSame(
+			'123 Main St, Paris',
+			get_post_meta( $venue_id, 'geo_address', true ),
+			'Failed to assert that geo_address was set from the JSON meta.'
+		);
+		$this->assertSame(
+			'1',
+			get_post_meta( $venue_id, 'geo_public', true ),
+			'Failed to assert that geo_public is 1 for a published venue.'
+		);
+	}
+
+	/**
+	 * Tests that set_geodata returns early for post types without venue information support.
+	 *
+	 * @covers ::set_geodata
+	 *
+	 * @return void
+	 */
+	public function test_set_geodata_unsupported_post_type(): void {
+		$instance = Venue::get_instance();
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+
+		$instance->set_geodata( $post_id );
+
+		$this->assertSame(
+			'',
+			get_post_meta( $post_id, 'geo_latitude', true ),
+			'Failed to assert that geo_latitude is not written for unsupported post types.'
+		);
+	}
+
+	/**
+	 * Tests that geo_public is 0 for non-published venues.
+	 *
+	 * @covers ::set_geodata
+	 *
+	 * @return void
+	 */
+	public function test_set_geodata_private_post(): void {
+		$instance = Venue::get_instance();
+
+		$venue_id = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'draft',
+			)
+		);
+
+		$instance->set_geodata( $venue_id );
+
+		$this->assertSame(
+			'0',
+			get_post_meta( $venue_id, 'geo_public', true ),
+			'Failed to assert that geo_public is 0 for a non-published venue.'
+		);
+	}
+
+	/**
+	 * Tests that invalid JSON in gatherpress_venue_information is handled gracefully.
+	 *
+	 * @covers ::set_geodata
+	 *
+	 * @return void
+	 */
+	public function test_set_geodata_invalid_json(): void {
+		$instance = Venue::get_instance();
+
+		$venue_id = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		update_post_meta( $venue_id, 'gatherpress_venue_information', 'not-valid-json' );
+
+		$instance->set_geodata( $venue_id );
+
+		$this->assertSame(
+			'',
+			get_post_meta( $venue_id, 'geo_latitude', true ),
+			'Failed to assert geo_latitude is empty when JSON is invalid.'
+		);
+		$this->assertSame(
+			'',
+			get_post_meta( $venue_id, 'geo_address', true ),
+			'Failed to assert geo_address is empty when JSON is invalid.'
+		);
+	}
+
+	/**
+	 * Coverage for filter_readonly_meta.
+	 *
+	 * Verifies that geo_* meta keys are stripped from REST API meta payloads
+	 * so the editor cannot write derived values directly.
+	 *
+	 * @covers ::filter_readonly_meta
+	 *
+	 * @return void
+	 */
+	public function test_filter_readonly_meta(): void {
+		$instance = Venue::get_instance();
+		$request  = new \WP_REST_Request();
+
+		$request->set_param(
+			'meta',
+			array(
+				'geo_latitude'                  => '99.99',
+				'geo_longitude'                 => '99.99',
+				'geo_address'                   => 'Hack St',
+				'geo_public'                    => 0,
+				'gatherpress_venue_information' => '{"fullAddress":"Real St"}',
+			)
+		);
+
+		$prepared = new \stdClass();
+		$result   = $instance->filter_readonly_meta( $prepared, $request );
+
+		$this->assertSame( $prepared, $result, 'Filter must return the prepared post object.' );
+
+		$meta = $request->get_param( 'meta' );
+
+		$this->assertArrayNotHasKey( 'geo_latitude', $meta, 'geo_latitude should be stripped.' );
+		$this->assertArrayNotHasKey( 'geo_longitude', $meta, 'geo_longitude should be stripped.' );
+		$this->assertArrayNotHasKey( 'geo_address', $meta, 'geo_address should be stripped.' );
+		$this->assertArrayNotHasKey( 'geo_public', $meta, 'geo_public should be stripped.' );
+		$this->assertArrayHasKey(
+			'gatherpress_venue_information',
+			$meta,
+			'Non-geo meta keys should pass through untouched.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue.php
@@ -507,6 +507,208 @@ class Test_Venue extends Base {
 	}
 
 	/**
+	 * Tests that partial JSON (missing keys or non-numeric lat/lng) is handled gracefully.
+	 *
+	 * The isset() + is_numeric() fallbacks are the main path for messy real-world data
+	 * (legacy venues, partial imports). This exercises each combination: a present but
+	 * non-numeric latitude is stored empty, a missing longitude is stored empty, and a
+	 * present fullAddress still flows through.
+	 *
+	 * @covers ::set_geodata
+	 *
+	 * @return void
+	 */
+	public function test_set_geodata_partial_json(): void {
+		$instance = Venue::get_instance();
+
+		$venue_id = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		update_post_meta(
+			$venue_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'latitude'    => 'not-a-number',
+					'fullAddress' => '123 Main St',
+				)
+			)
+		);
+
+		$instance->set_geodata( $venue_id );
+
+		$this->assertSame(
+			'',
+			get_post_meta( $venue_id, 'geo_latitude', true ),
+			'Failed to assert non-numeric latitude is stored empty.'
+		);
+		$this->assertSame(
+			'',
+			get_post_meta( $venue_id, 'geo_longitude', true ),
+			'Failed to assert missing longitude is stored empty.'
+		);
+		$this->assertSame(
+			'123 Main St',
+			get_post_meta( $venue_id, 'geo_address', true ),
+			'Failed to assert fullAddress flows through when lat/lng are invalid.'
+		);
+	}
+
+	/**
+	 * Tests that set_geodata skips revision posts.
+	 *
+	 * The wp_after_insert_post hook fires for revisions; set_geodata must not write
+	 * derived meta onto the revision itself since the parent post is the authoritative
+	 * source.
+	 *
+	 * @covers ::set_geodata
+	 *
+	 * @return void
+	 */
+	public function test_set_geodata_skips_revisions(): void {
+		$instance = Venue::get_instance();
+
+		$venue_id = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		update_post_meta(
+			$venue_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'latitude'  => '48.856613',
+					'longitude' => '2.352222',
+				)
+			)
+		);
+
+		$revision_id = wp_save_post_revision( $venue_id );
+
+		$this->assertIsInt( $revision_id, 'wp_save_post_revision should return a revision ID.' );
+
+		$instance->set_geodata( (int) $revision_id );
+
+		$this->assertSame(
+			'',
+			get_post_meta( (int) $revision_id, 'geo_latitude', true ),
+			'Failed to assert revision posts are skipped (no geo_latitude written).'
+		);
+	}
+
+	/**
+	 * Tests that set_geodata skips autosave posts.
+	 *
+	 * The wp_after_insert_post hook fires for autosaves as well as revisions;
+	 * set_geodata must skip both so derived meta isn't written onto draft copies.
+	 *
+	 * @covers ::set_geodata
+	 *
+	 * @return void
+	 */
+	public function test_set_geodata_skips_autosaves(): void {
+		$instance = Venue::get_instance();
+
+		$author_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $author_id );
+
+		$venue_id = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+				'post_author' => $author_id,
+			)
+		);
+
+		update_post_meta(
+			$venue_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'latitude'  => '48.856613',
+					'longitude' => '2.352222',
+				)
+			)
+		);
+
+		$autosave_id = wp_create_post_autosave(
+			array(
+				'post_ID'      => $venue_id,
+				'post_content' => 'Autosave draft.',
+				'post_title'   => 'Autosave Title',
+			)
+		);
+
+		$this->assertIsInt( $autosave_id, 'wp_create_post_autosave should return an autosave ID.' );
+
+		$instance->set_geodata( (int) $autosave_id );
+
+		$this->assertSame(
+			'',
+			get_post_meta( (int) $autosave_id, 'geo_latitude', true ),
+			'Failed to assert autosave posts are skipped (no geo_latitude written).'
+		);
+	}
+
+	/**
+	 * End-to-end coverage: verifies set_geodata is wired to wp_after_insert_post.
+	 *
+	 * Inserts a venue via wp_insert_post with venue information meta, then confirms
+	 * the derived geo_* keys are populated without an explicit call to set_geodata().
+	 *
+	 * @covers ::set_geodata
+	 *
+	 * @return void
+	 */
+	public function test_set_geodata_runs_on_wp_after_insert_post(): void {
+		// Ensure the Venue singleton is instantiated so its hooks are registered.
+		Venue::get_instance();
+
+		$venue_id = wp_insert_post(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => 'End to End Venue',
+				'meta_input'  => array(
+					'gatherpress_venue_information' => wp_json_encode(
+						array(
+							'fullAddress' => '1600 Pennsylvania Ave NW',
+							'latitude'    => '38.8977',
+							'longitude'   => '-77.0365',
+						)
+					),
+				),
+			)
+		);
+
+		$this->assertIsInt( $venue_id, 'wp_insert_post should return a venue post ID.' );
+		$this->assertGreaterThan( 0, $venue_id, 'wp_insert_post should return a positive post ID.' );
+
+		$this->assertSame(
+			'38.8977',
+			get_post_meta( $venue_id, 'geo_latitude', true ),
+			'Failed to assert geo_latitude was set via wp_after_insert_post.'
+		);
+		$this->assertSame(
+			'-77.0365',
+			get_post_meta( $venue_id, 'geo_longitude', true ),
+			'Failed to assert geo_longitude was set via wp_after_insert_post.'
+		);
+		$this->assertSame(
+			'1600 Pennsylvania Ave NW',
+			get_post_meta( $venue_id, 'geo_address', true ),
+			'Failed to assert geo_address was set via wp_after_insert_post.'
+		);
+	}
+
+	/**
 	 * Coverage for filter_readonly_meta.
 	 *
 	 * Verifies that geo_* meta keys are stripped from REST API meta payloads
@@ -547,6 +749,28 @@ class Test_Venue extends Base {
 			$meta,
 			'Non-geo meta keys should pass through untouched.'
 		);
+	}
+
+	/**
+	 * Tests that filter_readonly_meta handles a REST request with no meta param.
+	 *
+	 * Exercises the is_array() guard: when the request has no meta (or a non-array
+	 * value), the filter must return the prepared post object unchanged without
+	 * mutating the request.
+	 *
+	 * @covers ::filter_readonly_meta
+	 *
+	 * @return void
+	 */
+	public function test_filter_readonly_meta_no_meta_param(): void {
+		$instance = Venue::get_instance();
+		$request  = new \WP_REST_Request();
+		$prepared = new \stdClass();
+
+		$result = $instance->filter_readonly_meta( $prepared, $request );
+
+		$this->assertSame( $prepared, $result, 'Filter must return the prepared post object unchanged.' );
+		$this->assertNull( $request->get_param( 'meta' ), 'Missing meta param should remain null.' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue.php
@@ -353,7 +353,15 @@ class Test_Venue extends Base {
 
 		$meta = get_registered_meta_keys( 'post', $test_pt );
 
-		foreach ( array( 'gatherpress_venue_information', 'geo_latitude', 'geo_longitude', 'geo_address', 'geo_public' ) as $key ) {
+		$expected_keys = array(
+			'gatherpress_venue_information',
+			'geo_latitude',
+			'geo_longitude',
+			'geo_address',
+			'geo_public',
+		);
+
+		foreach ( $expected_keys as $key ) {
 			$this->assertArrayHasKey(
 				$key,
 				$meta,


### PR DESCRIPTION
### Description of the Change

Adopts the [WordPress Geodata standard](https://codex.wordpress.org/Geodata) on the `gatherpress_venue` post type (and any custom post type declaring `gatherpress-venue-information` support).

The existing `gatherpress_venue_information` JSON meta remains the single user-writable source. On every save (`wp_after_insert_post`), a new `Venue::set_geodata()` method decodes the JSON and writes four read-only, individual meta keys that any Geodata-aware plugin (e.g. [Simple Location](https://wordpress.org/plugins/simple-location/)) can consume directly:

- `geo_latitude` — from JSON `latitude`
- `geo_longitude` — from JSON `longitude`
- `geo_address` — from JSON `fullAddress`
- `geo_public` — `1` when the post is published, `0` otherwise

Each key is registered with `auth_callback => '__return_false'` so the block editor can't write derived values, and a `rest_pre_insert_{venue_post_type}` filter silently strips any `geo_*` values from incoming REST payloads (mirroring the pattern already used for read-only datetime meta in [Event_Setup](includes/core/classes/class-event-setup.php)).

Meta revisions (`revisions_enabled`) are enabled per post type — only applied when the venue post type declares `revisions` in its `supports` array, so companion plugins that register minimal venue post types don't trigger a `_doing_it_wrong` notice.

Follow-up PRs: [#1264](https://github.com/GatherPress/gatherpress/issues/1264) (richer schema.org PostalAddress fields + OSM autofill) and [#1263](https://github.com/GatherPress/gatherpress/issues/1263) (events API filters incl. geolocation) build on this foundation.

Closes #560

### How to test the Change

1. Check out the branch and run `npm run build` (no frontend changes, but keeps assets consistent).
2. Create or edit a venue. Fill in the address fields — GatherPress will geocode them into `gatherpress_venue_information` as before.
3. Publish the venue, then inspect its post meta (via the REST API, `wp post meta list`, or a query):
   - `geo_latitude`, `geo_longitude`, `geo_address`, and `geo_public` should all be populated from the JSON.
   - `geo_public` should be `1`.
4. Move the venue to Draft / Trash and resave — `geo_public` should flip to `0`.
5. Try to PATCH `geo_latitude` via REST (e.g. `wp rest /wp/v2/gatherpress_venues/{id}` with `meta.geo_latitude = "0"`). The value should be silently ignored — the REST filter strips read-only geo meta before it reaches meta storage.
6. Install a Geodata-aware plugin such as Simple Location and confirm it picks up the venue coordinates without any extra configuration.
7. Verify `http://yoursite.local/` loads with zero PHP notices/warnings on a site that declares a companion venue post type without `revisions` support (e.g. `gp_shindig_venue`).
8. Run the test suite:
   - `npm run lint:php`
   - `npm run lint:phpstan`
   - `npm run test:unit:php:multisite -- --filter=Test_Venue`

Existing venues will be backfilled automatically on their next save. A [companion migration](https://github.com/GatherPress/gatherpress-alpha/) has been added to `gatherpress-alpha` (run via `wp gatherpress alpha fix` or the admin UI) to backfill all existing `gatherpress_venue` posts in bulk without requiring a manual resave.

### Changelog Entry

> Added - Expose WordPress Geodata standard meta (`geo_latitude`, `geo_longitude`, `geo_address`, `geo_public`) on venue post types, derived read-only from `gatherpress_venue_information` JSON on save.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.