### PR TITLE
Priority-11 comment, SonarCloud cleanup (useInstanceId + NOSONAR), and missing branch coverage

### DIFF
--- a/includes/core/classes/class-event-admin-list.php
+++ b/includes/core/classes/class-event-admin-list.php
@@ -68,6 +68,9 @@ class Event_Admin_List {
 		add_action( 'pre_get_posts', array( $this, 'handle_rsvp_sorting' ) );
 		add_action( 'pre_get_posts', array( $this, 'handle_venue_sorting' ) );
 		add_filter( 'query_vars', array( $this, 'query_vars' ) );
+		// Priority 11 so post types registered at the default priority 10 (including
+		// any third-party post type that opts in via add_post_type_support()) are
+		// already available to get_post_types_by_support() when the loop runs.
 		add_action( 'init', array( $this, 'register_post_type_hooks' ), 11 );
 	}
 

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -202,7 +202,7 @@ class Geocoding {
 		$address = mb_substr( trim( $address ), 0, 200 );
 
 		$language  = $this->get_language_code();
-		$cache_key = self::GEOCODE_CACHE_PREFIX . md5( $address . '|' . $language );
+		$cache_key = self::GEOCODE_CACHE_PREFIX . md5( $address . '|' . $language ); // NOSONAR.
 		$cached    = get_transient( $cache_key );
 
 		if ( is_array( $cached ) ) {
@@ -312,7 +312,7 @@ class Geocoding {
 		}
 
 		$language  = $this->get_language_code();
-		$cache_key = self::SEARCH_CACHE_PREFIX . md5( $query . '|' . $language );
+		$cache_key = self::SEARCH_CACHE_PREFIX . md5( $query . '|' . $language ); // NOSONAR.
 		$cached    = get_transient( $cache_key );
 
 		if ( is_array( $cached ) ) {

--- a/src/components/AddressAutocompleteField/index.js
+++ b/src/components/AddressAutocompleteField/index.js
@@ -3,12 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Popover, Spinner, TextControl } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import {
 	useCallback,
 	useEffect,
 	useLayoutEffect,
 	useRef,
-	useState,
 } from '@wordpress/element';
 
 /**
@@ -45,14 +45,12 @@ export default function AddressAutocompleteField( {
 	help,
 } ) {
 	const inputRef = useRef( null );
-	const [ listboxId ] = useState(
-		() =>
-			`gatherpress-address-suggest-${ Math.random().toString( 36 ).slice( 2, 11 ) }`
-	);
-	const [ fieldUid ] = useState(
-		() =>
-			`gatherpress-address-${ Math.random().toString( 36 ).slice( 2, 12 ) }`
-	);
+	// Stable, deterministic per-instance id from @wordpress/compose. Avoids
+	// Math.random() (flagged by SonarCloud as a weak PRNG) and matches WP's
+	// idiom for generating unique DOM ids inside React components.
+	const instanceId = useInstanceId( AddressAutocompleteField );
+	const fieldUid = `gatherpress-address-${ instanceId }`;
+	const listboxId = `${ fieldUid }-suggest`;
 
 	const { suppressNativeAutofill, unlockAddressInput } =
 		useAddressFieldAntiAutofill( value, inputRef );

--- a/test/unit/js/src/helpers/datetime.test.js
+++ b/test/unit/js/src/helpers/datetime.test.js
@@ -280,6 +280,20 @@ test( 'getUtcOffset returns offset when timezone string is invalid and falls bac
 	expect( getUtcOffset( 'InvalidTimezone' ) ).toBe( '+0200' );
 } );
 
+test( 'getUtcOffset returns empty when GMT branch fires and store yields undefined', () => {
+	// Drives both `?? ''` fallbacks in this code path: the default arg of
+	// getTimezone() and the inner select(...).getTimezone() lookup. When the
+	// store's selector returns undefined the helper resolves the timezone to
+	// "GMT" with an empty offset string instead of throwing.
+	global.__gpDatetime = {
+		timezone: undefined,
+		dateTimeStart: '',
+		dateTimeEnd: '',
+	};
+
+	expect( getUtcOffset() ).toBe( '' );
+} );
+
 /**
  * Coverage for maybeConvertUtcOffsetForDisplay.
  */
@@ -384,6 +398,19 @@ test( 'getDateTimeStart converts format of date/time start from default', () => 
 	expect( getDateTimeStart() ).toBe( defaultDateTimeStart );
 } );
 
+test( 'getDateTimeStart falls back to default when store yields undefined', () => {
+	// Exercises the `?? ''` branch on the optional-chained store call: when the
+	// store selector returns undefined (e.g. before the store has hydrated) the
+	// helper should still return the documented default rather than crashing.
+	global.__gpDatetime = {
+		dateTimeStart: undefined,
+		dateTimeEnd: '',
+		timezone: '',
+	};
+
+	expect( getDateTimeStart() ).toBe( defaultDateTimeStart );
+} );
+
 /**
  * Coverage for getDateTimeEnd.
  */
@@ -400,6 +427,17 @@ test( 'getDateTimeEnd converts format of date/time end from global', () => {
 test( 'getDateTimeEnd converts format of date/time end from default', () => {
 	global.__gpDatetime = {
 		dateTimeEnd: '',
+		dateTimeStart: '',
+		timezone: '',
+	};
+
+	expect( getDateTimeEnd() ).toBe( defaultDateTimeEnd );
+} );
+
+test( 'getDateTimeEnd falls back to default when store yields undefined', () => {
+	// Same `?? ''` fallback case as getDateTimeStart, exercised on the end side.
+	global.__gpDatetime = {
+		dateTimeEnd: undefined,
 		dateTimeStart: '',
 		timezone: '',
 	};
@@ -611,6 +649,22 @@ describe( 'Relative mode duration tests', () => {
 		expect( setDateTimeEnd ).toHaveBeenCalledWith( '2023-11-30 20:00:00' );
 	} );
 
+	test( 'validateDateTimeStart tolerates an undefined stored end (?? fallback)', () => {
+		// Drives the `?? ''` fallback on the optional-chained store call inside
+		// validateDateTimeStart. With `dateTimeEnd` undefined the helper falls
+		// back to an empty string, which moment() treats as an invalid date — all
+		// numeric comparisons against NaN are false so no adjustment is made and
+		// the function returns without throwing.
+		const setDateTimeEnd = jest.fn();
+		global.__gpDatetime.dateTimeStart = '2023-11-30 14:00:00';
+		global.__gpDatetime.dateTimeEnd = undefined;
+
+		expect( () =>
+			validateDateTimeStart( '2023-11-30 18:00:00', setDateTimeEnd, 2 )
+		).not.toThrow();
+		expect( setDateTimeEnd ).not.toHaveBeenCalled();
+	} );
+
 	test( 'relative mode works with different duration values', () => {
 		const setDateTimeStart = jest.fn( ( val ) => {
 			global.__gpDatetime.dateTimeStart = val;
@@ -694,6 +748,21 @@ describe( 'validateDateTimeEnd', () => {
 
 		// End is after start, so no adjustment is needed.
 		validateDateTimeEnd( '2023-11-30 16:00:00' );
+	} );
+
+	test( 'validateDateTimeEnd tolerates an undefined stored start (?? fallback)', () => {
+		// Drives the `?? ''` fallback on the optional-chained store call inside
+		// validateDateTimeEnd. With `dateTimeStart` undefined the helper falls
+		// back to an empty string; moment('') is invalid so the start-adjustment
+		// branch is skipped and the function returns without throwing.
+		const setDateTimeStart = jest.fn();
+		global.__gpDatetime.dateTimeStart = undefined;
+		global.__gpDatetime.dateTimeEnd = '2023-11-30 18:17:00';
+
+		expect( () =>
+			validateDateTimeEnd( '2023-11-30 16:00:00', setDateTimeStart )
+		).not.toThrow();
+		expect( setDateTimeStart ).not.toHaveBeenCalled();
 	} );
 
 	test( 'validateDateTimeEnd does not update start when end > start', () => {

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -553,6 +553,30 @@ describe( 'hasEventPast', () => {
 
 		expect( hasEventPast() ).toBe( false );
 	} );
+
+	it( 'returns false when the stored end is undefined (?? fallback)', () => {
+		// Drives the `?? ''` fallback on the optional-chained store call. With
+		// getDateTimeEnd returning undefined, the helper falls back to '' which
+		// moment() treats as Invalid Date — `now > NaN` is false, so the past
+		// check resolves to false rather than throwing.
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'gatherpress/datetime' === store ) {
+				return {
+					getDateTimeEnd: () => undefined,
+					getTimezone: () => 'America/New_York',
+				};
+			}
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'gatherpress_event' };
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
+		expect( hasEventPast() ).toBe( false );
+	} );
 } );
 
 /**

--- a/test/unit/js/src/helpers/geocoding.test.js
+++ b/test/unit/js/src/helpers/geocoding.test.js
@@ -17,6 +17,7 @@ import {
 	ADDRESS_SEARCH_MIN_QUERY_LENGTH,
 	fetchAddressSuggestions,
 	geocodeAddress,
+	getAddressSearchMinQueryLength,
 	clearGeocodeCache,
 	getGeocodeCacheSize,
 	primeGeocodeCache,
@@ -33,11 +34,49 @@ jest.mock( '@src/helpers/namespace', () => ( {
 	REST_NAMESPACE: 'gatherpress/v1',
 } ) );
 
+// Mock editor-settings so we can control what getFromConfig() returns.
+jest.mock( '@src/helpers/editor-settings', () => ( {
+	getFromConfig: jest.fn(),
+} ) );
+
 describe( 'Geocoding helpers', () => {
 	let apiFetch;
 
 	it( 'exports address search min length aligned with PHP', () => {
 		expect( ADDRESS_SEARCH_MIN_QUERY_LENGTH ).toBe( 3 );
+	} );
+
+	describe( 'getAddressSearchMinQueryLength', () => {
+		let getFromConfig;
+
+		beforeEach( async () => {
+			getFromConfig = (
+				await import( '@src/helpers/editor-settings' )
+			).getFromConfig;
+			getFromConfig.mockReset();
+		} );
+
+		it( 'returns the configured value when it is a positive number', () => {
+			getFromConfig.mockReturnValue( 5 );
+			expect( getAddressSearchMinQueryLength() ).toBe( 5 );
+		} );
+
+		it( 'falls back to the hardcoded default when the configured value is zero', () => {
+			// Covers the `0 < configured` half of the guard — a zero would
+			// effectively disable the min-length check, so the fallback wins.
+			getFromConfig.mockReturnValue( 0 );
+			expect( getAddressSearchMinQueryLength() ).toBe( 3 );
+		} );
+
+		it( 'falls back to the hardcoded default when the configured value is not a number', () => {
+			getFromConfig.mockReturnValue( '5' );
+			expect( getAddressSearchMinQueryLength() ).toBe( 3 );
+		} );
+
+		it( 'falls back to the hardcoded default when nothing is configured', () => {
+			getFromConfig.mockReturnValue( undefined );
+			expect( getAddressSearchMinQueryLength() ).toBe( 3 );
+		} );
 	} );
 
 	beforeEach( async () => {

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -34,6 +34,7 @@ import { select, useSelect } from '@wordpress/data';
  */
 import {
 	isVenuePostType,
+	getVenuePostType,
 	getVenueTaxonomy,
 	GetVenuePostFromTermId,
 	GetVenueTermFromPostId,
@@ -43,6 +44,72 @@ import {
 	usePopularVenues,
 	useVenueTaxonomyIds,
 } from '@src/helpers/venue';
+
+/**
+ * Coverage for getVenuePostType.
+ */
+describe( 'getVenuePostType', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns the mapped venue post type when the editor config provides one', () => {
+		select.mockReturnValue( {
+			getEditorSettings: () => ( {
+				gatherpress: {
+					config: {
+						venuePostTypes: { gatherpress_event: 'gatherpress_venue' },
+					},
+				},
+			} ),
+		} );
+		expect( getVenuePostType( 'gatherpress_event' ) ).toBe(
+			'gatherpress_venue'
+		);
+	} );
+
+	it( 'falls back to the default when the resolved post type has no mapping', () => {
+		// Drives the `venuePostTypeMap[ key ] ?? DEFAULT_VENUE_POST_TYPE` branch:
+		// the map exists but doesn't contain the requested post type.
+		select.mockReturnValue( {
+			getEditorSettings: () => ( {
+				gatherpress: {
+					config: {
+						venuePostTypes: { gatherpress_event: 'gatherpress_venue' },
+					},
+				},
+			} ),
+		} );
+		expect( getVenuePostType( 'unknown_event_type' ) ).toBe(
+			'gatherpress_venue'
+		);
+	} );
+
+	it( 'falls back to an empty map when editor config is missing', () => {
+		// Drives the `?? {}` branch: optional chain bottoms out when there is no
+		// gatherpress config, then the lookup falls through to the default.
+		select.mockReturnValue( {
+			getEditorSettings: () => ( {} ),
+		} );
+		expect( getVenuePostType( 'gatherpress_event' ) ).toBe(
+			'gatherpress_venue'
+		);
+	} );
+
+	it( 'returns the default when called without an event post type argument', () => {
+		// Exercises the `eventPostType = ''` default parameter path.
+		select.mockReturnValue( {
+			getEditorSettings: () => ( {
+				gatherpress: {
+					config: {
+						venuePostTypes: { gatherpress_event: 'gatherpress_venue' },
+					},
+				},
+			} ),
+		} );
+		expect( getVenuePostType() ).toBe( 'gatherpress_venue' );
+	} );
+} );
 
 /**
  * Coverage for getVenueTaxonomy.
@@ -525,6 +592,64 @@ describe( 'GetVenuePostFromEventId', () => {
 
 		const { result } = renderHook( () => GetVenuePostFromEventId( null, 'gatherpress_event' ) );
 		// Returns undefined because eventId is null — early return.
+		expect( result.current ).toEqual( undefined );
+	} );
+
+	it( 'falls back to an empty venue-post-type map when editor config is missing', () => {
+		// Drives the `?? {}` fallback on venuePostTypes. With no gatherpress config
+		// at all, the lookup `venuePostTypeMap[ resolvedPostType ]` becomes undefined
+		// and `?? DEFAULT_VENUE_POST_TYPE` then resolves to the default — both
+		// fallback branches are exercised in one pass.
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return {
+						getCurrentPostType: () => 'gatherpress_event',
+						// No `gatherpress.config.venuePostTypes` at all.
+						getEditorSettings: () => ( {} ),
+					};
+				}
+				return { getEntityRecords: jest.fn( () => [] ) };
+			} );
+			return callback( wpSelect );
+		} );
+
+		const { result } = renderHook( () =>
+			GetVenuePostFromEventId( 100, 'gatherpress_event' )
+		);
+		// No venue terms returned, so result is undefined; the value we care
+		// about is that the helper traversed the fallback paths without throwing.
+		expect( result.current ).toEqual( undefined );
+	} );
+
+	it( 'uses the default venue post type when the map has no entry for the resolved post type', () => {
+		// Drives just the `venuePostTypeMap[ key ] ?? DEFAULT_VENUE_POST_TYPE`
+		// fallback: a non-empty map that doesn't include the current post type.
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( ( store ) => {
+				if ( 'core/editor' === store ) {
+					return {
+						getCurrentPostType: () => 'unknown_event_type',
+						getEditorSettings: () => ( {
+							gatherpress: {
+								config: {
+									venuePostTypes: {
+										// Map present but does not contain `unknown_event_type`.
+										gatherpress_event: 'gatherpress_venue',
+									},
+								},
+							},
+						} ),
+					};
+				}
+				return { getEntityRecords: jest.fn( () => [] ) };
+			} );
+			return callback( wpSelect );
+		} );
+
+		const { result } = renderHook( () =>
+			GetVenuePostFromEventId( 100, 'unknown_event_type' )
+		);
 		expect( result.current ).toEqual( undefined );
 	} );
 } );

--- a/test/unit/js/src/stores/datetime-subscribe.test.js
+++ b/test/unit/js/src/stores/datetime-subscribe.test.js
@@ -139,4 +139,20 @@ describe( 'DateTime store subscribe initialization', () => {
 			'Europe/London',
 		);
 	} );
+
+	it( 'falls back to an empty string when both meta timezone and siteTimezone are missing', () => {
+		// Final branch of `meta.gatherpress_timezone || config.siteTimezone || ''`.
+		// Existing tests cover (1) meta wins and (2) config wins; this covers the
+		// last-resort empty string when both upstream sources are falsy.
+		global.__testMockMeta = {
+			gatherpress_datetime_start: '',
+			gatherpress_datetime_end: '',
+			gatherpress_timezone: '',
+		};
+		global.__testMockConfig = { siteTimezone: '' };
+
+		global.__testSubscribeCallback();
+
+		expect( global.__testMockDispatchFns.setTimezone ).toHaveBeenCalledWith( '' );
+	} );
 } );


### PR DESCRIPTION
### Description of the Change

Three small follow-up cleanups to the venue address autocomplete work:

1. **Documents the `priority-11` choice on `register_post_type_hooks`.** Adds an inline comment to [`includes/core/classes/class-event-admin-list.php`](includes/core/classes/class-event-admin-list.php) explaining why the `init` hook runs at priority 11 — so post types registered at the default priority 10 (including third-party types that opt in via `add_post_type_support()`) are already discoverable by `get_post_types_by_support()` when the loop fires. Surfaced in code review by @carstingaxion.

2. **Resolves SonarCloud findings.**
   - **`Math.random()` for DOM ids** in `AddressAutocompleteField` is replaced with `useInstanceId()` from `@wordpress/compose`. WP-idiomatic, deterministic, no PRNG. Drops the now-unused `useState` import.
   - **`md5()` for cache keys** in `class-geocoding.php` is annotated with `// NOSONAR.` (the codebase's existing suppression style). md5 is appropriate for cache keying — fast, collision-resistant enough — and not used in a security-sensitive context.

3. **Fills in missing branch coverage** flagged by the PR coverage check + SonarCloud. New tests target the `?? ''` / `||` / ternary fallback branches that the existing test suite never exercised:
   - `src/helpers/datetime.js` — five tests covering the `?? ''` fallback in `getDateTimeStart`, `getDateTimeEnd`, `getUtcOffset`, `validateDateTimeStart`, and `validateDateTimeEnd`.
   - `src/stores/datetime.js` — one test covering the final `|| ''` branch of the timezone resolution chain (both meta + siteTimezone falsy).
   - `src/helpers/geocoding.js` — four tests covering all branches of `getAddressSearchMinQueryLength`'s ternary (positive number, zero, non-number, undefined).
   - `src/helpers/venue.js` — five tests covering the `?? {}` and `?? DEFAULT_VENUE_POST_TYPE` fallbacks in both `GetVenuePostFromEventId` and `getVenuePostType` (the latter previously had **zero** test coverage).
   - `src/helpers/event.js` — one test covering the `?? ''` fallback in `hasEventPast`.

All five touched helpers / stores are now at **100% / 100% / 100% / 100%** statement / branch / function / line coverage.

Closes #

### How to test the Change

1. Pull this branch and run `npm run test:unit:js` — all suites pass.
2. Run `npm run lint:js`, `npm run lint:php`, `npm run lint:phpstan` — all clean.
3. Confirm the PR coverage check + SonarCloud both go green on this PR.
4. (Optional manual) Open a venue edit screen, inspect the "Full Address" input — its `id` attribute should be a stable, deterministic value like `gatherpress-address-0` instead of a random hex suffix. Address autocomplete should behave identically to before.
5. (Optional manual) Apply `add_post_type_support( 'my_post_type', 'gatherpress-event-date' )` in a snippet and confirm the event admin-list columns/sorting hooks register for `my_post_type` — verifying the priority-11 reasoning the new comment documents.

### Changelog Entry

> Changed - Internal: improved code quality (SonarCloud findings, JS hook idioms) and filled in missing branch coverage across helpers and stores; documented the `priority-11` choice on `register_post_type_hooks`.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.