### PR TITLE
Add server-rendered static maps to the venue-map block

### DIFF
--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -71,8 +71,56 @@ jobs:
           mkdir tmp-build
           unzip gatherpress.zip -d tmp-build
 
-      - name: Run plugin check
-        uses: wordpress/plugin-check-action@v1.1.5
+      # The wordpress/plugin-check-action composite action installs
+      # @wordpress/env globally and runs it, but the wp-env Dockerfile
+      # currently fails because Composer's audit blocks every PHPUnit
+      # version covered by the new PKSA-5jz8-6tcw-pbk4 / PKSA-z3gr-8qht-p93v
+      # advisories. Inline the action's steps here so we can patch the
+      # generated Dockerfile to skip the audit before `wp-env start` runs.
+      # Revert to `uses: wordpress/plugin-check-action@…` once upstream ships
+      # a fix.
+      - name: Set up Node for plugin-check
+        uses: actions/setup-node@v4
         with:
-          build-dir: './tmp-build/gatherpress'
-          wp-version: 'latest'
+          node-version: '24'
+
+      - name: Export plugin paths
+        run: |
+          PLUGIN_DIR=$(realpath "./tmp-build/gatherpress")
+          echo "PLUGIN_DIR=$PLUGIN_DIR" >> "$GITHUB_ENV"
+          echo "PLUGIN_SLUG=$(basename $PLUGIN_DIR)" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Install and patch wp-env
+        run: |
+          # Same config the official action emits.
+          echo "{ \"core\": null, \"port\": 8880, \"testsPort\": 8881, \"plugins\": [ \"https://downloads.wordpress.org/plugin/plugin-check.zip\" ], \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
+
+          npm -g --no-fund i @wordpress/env
+
+          # Bypass Composer's new audit block on PHPUnit security advisories.
+          WP_ENV_DOCKER_CONFIG="$(npm root -g)/@wordpress/env/lib/runtime/docker/docker-config.js"
+          if grep -q 'composer global require --dev phpunit/phpunit' "$WP_ENV_DOCKER_CONFIG" \
+             && ! grep -q 'audit.block-insecure' "$WP_ENV_DOCKER_CONFIG"; then
+            sed -i \
+              's|RUN composer global require --dev phpunit/phpunit:|RUN composer global config --no-plugins audit.abandoned ignore\nRUN composer global config --no-plugins audit.block-insecure false\nRUN composer global require --dev phpunit/phpunit:|' \
+              "$WP_ENV_DOCKER_CONFIG"
+          fi
+        shell: bash
+
+      - name: Start wp-env
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: bash
+          command: wp-env start --update
+
+      - name: Run Plugin Check
+        run: |
+          wp-env run cli wp plugin activate "$PLUGIN_SLUG"
+          wp-env run cli wp plugin check "$PLUGIN_SLUG" \
+            --format=json \
+            --exclude-files=.wp-env.json \
+            --require=./wp-content/plugins/plugin-check/cli.php
+        shell: bash

--- a/docs/user/venues.md
+++ b/docs/user/venues.md
@@ -40,3 +40,27 @@ What this allows:
 Venue information is displayed on its own page, or in an event to which that specific venue has been assigned.
 
 You can have an hybrid event with a physical venue and an online link. For this, you need to add both the Online event block and the Venue block in the event.
+
+## Venue map
+
+Every venue with a real address ships with a map, rendered in one of two modes set on the Venue Map block:
+
+- **Interactive** — a live, pan-and-zoom map powered by Leaflet (OpenStreetMap) or Google Maps, depending on the mapping platform you pick under `Settings > GatherPress > Venues > Maps`. Requires JavaScript on the visitor's side.
+- **Static image** — a pre-rendered PNG of the map, composited server-side from OpenStreetMap tiles on the first save and cached under `wp-content/uploads/gatherpress/static-maps/`. No JavaScript required, which makes it the right choice for email previews, reader modes, cached HTML, and visitors who block scripts. Attribution for OpenStreetMap and CartoDB is rendered alongside the image automatically.
+
+The block's inspector sidebar lets you pick the render mode, zoom level (1–20), and height (100–800 px). You can mix modes across events — one event can show the static image, another the interactive map, both pointing at the same venue.
+
+### Sitewide defaults
+
+`Settings > GatherPress > Venues > Maps` exposes four defaults that apply to newly inserted Venue Map blocks:
+
+- **Default Render Mode** — interactive or static image.
+- **Default Zoom Level** — 1 (world) to 20 (street).
+- **Default Height** — in pixels.
+- **Default Map Type** — roadmap, satellite, hybrid, or terrain (Google Maps only; OpenStreetMap and static images ignore this).
+
+Changing a default only affects blocks added afterwards — existing blocks keep the values the editor chose at insertion time, so a sitewide change never rewrites published content.
+
+### Regeneration
+
+Static images regenerate automatically when any input the image depends on changes — venue address, coordinates, zoom level, or block height. Each `(zoom, height)` combination is cached separately, so two events showing the same venue at different sizes each get a crisp PNG. Old images are cleaned up when the venue is updated or deleted.

--- a/includes/core/classes/class-block.php
+++ b/includes/core/classes/class-block.php
@@ -186,41 +186,46 @@ class Block {
 			)
 		);
 
+		// Descriptive note shown to developers who enumerate registered
+		// patterns (REST API, pattern registry). These patterns exist as
+		// anchors for the Block Hooks API so other plugins can hook blocks
+		// before/after the canonical event/venue block — they are not
+		// user-facing design patterns, hence `'inserter' => false`.
+		$hook_anchor_description = __(
+			// phpcs:ignore Generic.Files.LineLength.TooLong -- Translator-facing sentence; keep it on one line for the .pot extractor.
+			'Default content seeded into a new post. Anchors the Block Hooks API so other plugins can inject blocks around the core GatherPress block.',
+			'gatherpress'
+		);
+
 		$block_patterns = array(
 			array(
 				'gatherpress/event-template',
 				array(
-					'title'    => __( 'Invisible Event Template Block Pattern', 'gatherpress' ),
-					// Even this paragraph seems useless, it's not.
-					// It is the entry point for all our hooked blocks
-					// and as such absolutely important!
-					'content'  => '<!-- wp:gatherpress/event-date /-->', // Other blocks are hooked-in here.
-					'inserter' => false,
-					'source'   => 'plugin',
+					'title'       => __( 'Event Post Default Content', 'gatherpress' ),
+					'description' => $hook_anchor_description,
+					'content'     => '<!-- wp:gatherpress/event-date /-->',
+					'inserter'    => false,
+					'source'      => 'plugin',
 				),
 			),
 			array(
 				'gatherpress/venue-template',
 				array(
-					'title'    => __( 'Invisible Venue Template Block Pattern', 'gatherpress' ),
-					// Even this block seems useless, it's not.
-					// It is the entry point for all our hooked blocks
-					// and as such absolutely important!
-					'content'  => '<!-- wp:gatherpress/venue /-->', // Other blocks are hooked-in here.
-					'inserter' => false,
-					'source'   => 'plugin',
+					'title'       => __( 'Venue Post Default Content', 'gatherpress' ),
+					'description' => $hook_anchor_description,
+					'content'     => '<!-- wp:gatherpress/venue /-->',
+					'inserter'    => false,
+					'source'      => 'plugin',
 				),
 			),
 			array(
 				'gatherpress/venue-details',
 				array(
-					'title'    => __( 'Invisible Venue Details Block Pattern', 'gatherpress' ),
-					// Even this post-title seems useless, it's not.
-					// It is the entry point for all our hooked blocks
-					// and as such absolutely important!
-					'content'  => '<!-- wp:post-title /-->', // Other blocks are hooked-in here.
-					'inserter' => false,
-					'source'   => 'plugin',
+					'title'       => __( 'Venue Details Default Content', 'gatherpress' ),
+					'description' => $hook_anchor_description,
+					'content'     => '<!-- wp:post-title /-->',
+					'inserter'    => false,
+					'source'      => 'plugin',
 				),
 			),
 		);

--- a/includes/core/classes/class-rsvp-token.php
+++ b/includes/core/classes/class-rsvp-token.php
@@ -146,12 +146,25 @@ class Rsvp_Token {
 	 * Changes the comment status from pending to approved, typically used
 	 * when a user clicks a verification link in their email.
 	 *
+	 * No-ops when the comment is already approved. The token URL is sticky
+	 * — the user's browser keeps `?gatherpress_rsvp_token=…` on reload and
+	 * on every subsequent click inside the event page — so `init` would
+	 * otherwise re-run `wp_set_comment_status()` on each request. WordPress
+	 * only fires `wp_transition_comment_status` on actual status changes,
+	 * but third-party listeners on that hook (e.g. ActivityPub) can crash
+	 * on marginal inputs, and there's no reason to give them a repeat
+	 * opportunity once the comment is already approved.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
 	public function approve_comment(): void {
 		if ( ! $this->comment ) {
+			return;
+		}
+
+		if ( '1' === (string) $this->comment->comment_approved ) {
 			return;
 		}
 

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -80,8 +80,8 @@ class Setup {
 		Settings\Venues::get_instance();
 		Topic::get_instance();
 		User::get_instance();
+		Venue_Map::get_instance();
 		Venue_Setup::get_instance();
-		Venue_Static_Map::get_instance();
 	}
 
 	/**

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -81,6 +81,7 @@ class Setup {
 		Topic::get_instance();
 		User::get_instance();
 		Venue_Setup::get_instance();
+		Venue_Static_Map::get_instance();
 	}
 
 	/**

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -7,9 +7,10 @@
  * coordinates, compositing them into a single PNG with a marker stamped at
  * the venue's exact position, and storing the result under
  * `wp-content/uploads/gatherpress/static-maps/`. The file URL and an
- * input-hash are persisted (per zoom) in venue post meta so the front-end
- * can serve the image directly and so subsequent saves regenerate only when
- * inputs (address, coordinates, tile URL, size) actually change.
+ * input-hash are persisted (per zoom+height combo) in venue post meta so
+ * the front-end can serve the image directly and so subsequent saves
+ * regenerate only when inputs (address, coordinates, tile URL, size)
+ * actually change.
  *
  * The class is named for its broader role — venue-map — so future
  * map-related additions (REST endpoint for the editor preview, interactive
@@ -26,14 +27,15 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
 use GdImage;
+use WP_Post;
 
 /**
  * Class Venue_Map.
  *
  * Singleton hosting the venue map server-side pipeline. Currently owns the
- * static PNG cache keyed by zoom; structured so that additional map-related
- * methods (REST, async jobs, etc.) can land here without proliferating
- * classes.
+ * static PNG cache keyed by (zoom, height) combo; structured so that
+ * additional map-related methods (REST, async jobs, etc.) can land here
+ * without proliferating classes.
  *
  * @since 1.0.0
  */
@@ -46,45 +48,32 @@ class Venue_Map {
 	/**
 	 * Default `renderMode` attribute for the venue-map block.
 	 *
-	 * Must mirror the default declared in the block's `block.json`. `render.php`
-	 * and any other caller that resolves the block attribute should read the
-	 * constant rather than hardcoding the string.
-	 *
 	 * @since 1.0.0
 	 * @var string
 	 */
 	const DEFAULT_RENDER_MODE = 'interactive';
 
 	/**
-	 * Default `zoom` attribute for the venue-map block.
-	 *
-	 * Note this is distinct from {@see self::DEFAULT_ZOOM} — the latter is the
-	 * fallback used by the generator when a caller requests a map without
-	 * specifying a zoom; the block-level default is what a fresh block saves
-	 * with, matching the `block.json` declaration.
+	 * Default zoom level. Used by the generator and the block.
 	 *
 	 * @since 1.0.0
 	 * @var int
 	 */
-	const DEFAULT_BLOCK_ZOOM = 18;
+	const DEFAULT_ZOOM = 18;
 
 	/**
-	 * Default `height` attribute (in pixels) for the venue-map block wrapper.
-	 *
-	 * The generated PNG is always 600×400; this is the DOM height applied to
-	 * the wrapper so the static image (with `object-fit: cover`) fills it.
+	 * Default height (in pixels). Used by the generator and the block.
 	 *
 	 * @since 1.0.0
 	 * @var int
 	 */
-	const DEFAULT_BLOCK_HEIGHT = 300;
+	const DEFAULT_HEIGHT = 300;
 
 	/**
 	 * Default `type` attribute for the venue-map block.
 	 *
 	 * Google Maps–specific (roadmap / satellite / hybrid / terrain). Ignored by
-	 * the static renderer and by Leaflet/OSM, but preserved as a block-level
-	 * default so Google Maps users get a sensible first value.
+	 * the static renderer and by Leaflet/OSM.
 	 *
 	 * @since 1.0.0
 	 * @var string
@@ -100,31 +89,18 @@ class Venue_Map {
 	const TILE_SIZE = 256;
 
 	/**
-	 * Default zoom level for generated static maps.
+	 * PNG aspect ratio (width ÷ height).
 	 *
-	 * Street-level context without zooming so far in that neighborhood
-	 * landmarks fall outside the crop.
-	 *
-	 * @since 1.0.0
-	 * @var int
-	 */
-	const DEFAULT_ZOOM = 15;
-
-	/**
-	 * Default output image width in pixels.
+	 * The block exposes height but not width (blocks render 100% of their
+	 * container). We still need *some* pixel width for the PNG, so the
+	 * generator derives it from the block's chosen height at this ratio —
+	 * 2:1 by default, which gives a comfortably landscape map without the
+	 * venue marker feeling tight against the edges.
 	 *
 	 * @since 1.0.0
-	 * @var int
+	 * @var float
 	 */
-	const DEFAULT_WIDTH = 600;
-
-	/**
-	 * Default output image height in pixels.
-	 *
-	 * @since 1.0.0
-	 * @var int
-	 */
-	const DEFAULT_HEIGHT = 400;
+	const IMAGE_ASPECT_RATIO = 2.0;
 
 	/**
 	 * CartoDB Positron tile URL template. `{z}`, `{x}`, `{y}` are substituted.
@@ -274,19 +250,24 @@ class Venue_Map {
 			return;
 		}
 
-		// Regenerate every zoom the venue is already known at, so a content
-		// change (new address/coords) cascades to all cached variants. For a
-		// fresh venue with nothing stored, seed the zoom that newly-inserted
-		// venue-map blocks will actually request — otherwise the editor falls
-		// back to the interactive preview on the very first save because
-		// cache[18] is missing but block.zoom = 18.
-		$zooms = array_keys( $this->get_all_descriptors( $post_id ) );
-		if ( empty( $zooms ) ) {
-			$zooms = array( $this->get_block_default_zoom() );
+		// Regenerate every (zoom, height) combo the venue is already cached
+		// at so a content change (new address/coords) cascades to all cached
+		// variants. For a fresh venue with nothing stored, seed the default
+		// combo that newly-inserted venue-map blocks will actually request —
+		// otherwise the editor falls back to the interactive preview on the
+		// very first save because the default cache entry is missing.
+		$combos = $this->get_cached_combos( $post_id );
+		if ( empty( $combos ) ) {
+			$combos = array(
+				array(
+					'zoom'   => $this->get_zoom(),
+					'height' => $this->get_height(),
+				),
+			);
 		}
 
-		foreach ( $zooms as $zoom ) {
-			$this->ensure_descriptor_for_zoom( $post_id, $info, (int) $zoom );
+		foreach ( $combos as $combo ) {
+			$this->ensure_descriptor_for_combo( $post_id, $info, $combo['zoom'], $combo['height'] );
 		}
 	}
 
@@ -312,9 +293,9 @@ class Venue_Map {
 	 * Accepts either a venue post ID (supports `gatherpress-venue-information`)
 	 * or an event post ID (supports `gatherpress-venue`) and returns the URL
 	 * of the stored static map for the corresponding venue at the requested
-	 * zoom. When the cache doesn't yet have an image for that zoom, the method
-	 * generates one synchronously — first render pays the cost, subsequent
-	 * renders hit the cache.
+	 * zoom and height. When the cache doesn't yet have an image for that
+	 * combo, the method generates one synchronously — first render pays the
+	 * cost, subsequent renders hit the cache.
 	 *
 	 * Returns '' when the post isn't venue-related, the venue has no
 	 * coordinates, or the on-demand generation failed.
@@ -324,9 +305,15 @@ class Venue_Map {
 	 * @param int      $post_id   Event or venue post ID.
 	 * @param string   $post_type The post type of `$post_id`.
 	 * @param int|null $zoom      Desired zoom level. Null falls back to the default.
+	 * @param int|null $height    Desired pixel height. Null falls back to the default.
 	 * @return string Static map URL, or '' when unavailable.
 	 */
-	public function get_url_for_post( int $post_id, string $post_type, ?int $zoom = null ): string {
+	public function get_url_for_post(
+		int $post_id,
+		string $post_type,
+		?int $zoom = null,
+		?int $height = null
+	): string {
 		$venue_post_id = 0;
 
 		if ( post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
@@ -334,7 +321,7 @@ class Venue_Map {
 		} elseif ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
 			$venue_post = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
 
-			if ( $venue_post instanceof \WP_Post ) {
+			if ( $venue_post instanceof WP_Post ) {
 				$venue_post_id = $venue_post->ID;
 			}
 		}
@@ -350,34 +337,37 @@ class Venue_Map {
 			return '';
 		}
 
-		$descriptor = $this->ensure_descriptor_for_zoom(
+		$descriptor = $this->ensure_descriptor_for_combo(
 			$venue_post_id,
 			$info,
-			$zoom ?? $this->get_block_default_zoom()
+			$zoom ?? $this->get_zoom(),
+			$height ?? $this->get_height()
 		);
 
 		return null === $descriptor ? '' : $descriptor['url'];
 	}
 
 	/**
-	 * Return the descriptor for the default zoom, or null if nothing is stored.
+	 * Return the descriptor for the default (zoom, height) combo, or null if
+	 * nothing is stored.
 	 *
 	 * Kept for callers that only care about "has this venue been rendered at
-	 * all?" — the richer per-zoom map lives behind {@see self::get_all_descriptors()}.
+	 * all?" — the richer per-combo map lives behind
+	 * {@see self::get_all_descriptors()}.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param int $post_id The venue post ID.
-	 * @return array{url: string, hash: string}|null
+	 * @return array{url: string, hash: string, zoom: int, height: int}|null
 	 */
 	public function get_stored_descriptor( int $post_id ): ?array {
 		$all = $this->get_all_descriptors( $post_id );
 
-		return $all[ $this->get_block_default_zoom() ] ?? null;
+		return $all[ $this->combo_key( $this->get_zoom(), $this->get_height() ) ] ?? null;
 	}
 
 	/**
-	 * Return every stored descriptor for the venue, keyed by zoom level.
+	 * Return every stored descriptor for the venue, keyed by `{zoom}x{height}`.
 	 *
 	 * Silently filters out malformed entries so callers can iterate without
 	 * defensive shape checks.
@@ -385,7 +375,7 @@ class Venue_Map {
 	 * @since 1.0.0
 	 *
 	 * @param int $post_id The venue post ID.
-	 * @return array<int, array{url: string, hash: string}>
+	 * @return array<string, array{url: string, hash: string, zoom: int, height: int}>
 	 */
 	public function get_all_descriptors( int $post_id ): array {
 		$raw = get_post_meta( $post_id, self::META_KEY, true );
@@ -396,14 +386,25 @@ class Venue_Map {
 
 		$descriptors = array();
 
-		foreach ( $raw as $zoom => $entry ) {
+		foreach ( $raw as $key => $entry ) {
 			if ( ! is_array( $entry ) || empty( $entry['url'] ) || empty( $entry['hash'] ) ) {
 				continue;
 			}
 
-			$descriptors[ (int) $zoom ] = array(
-				'url'  => (string) $entry['url'],
-				'hash' => (string) $entry['hash'],
+			$zoom   = isset( $entry['zoom'] ) ? (int) $entry['zoom'] : 0;
+			$height = isset( $entry['height'] ) ? (int) $entry['height'] : 0;
+
+			// Without a zoom/height on the entry there's no way to know which
+			// block configuration the file belongs to — skip rather than guess.
+			if ( $zoom <= 0 || $height <= 0 ) {
+				continue;
+			}
+
+			$descriptors[ (string) $key ] = array(
+				'url'    => (string) $entry['url'],
+				'hash'   => (string) $entry['hash'],
+				'zoom'   => $zoom,
+				'height' => $height,
 			);
 		}
 
@@ -411,33 +412,72 @@ class Venue_Map {
 	}
 
 	/**
-	 * Ensure a descriptor exists for `$zoom` and return it.
+	 * Parse stored meta into the list of (zoom, height) combos already cached.
+	 *
+	 * Used by {@see self::maybe_generate()} to cascade content changes (new
+	 * address, new coordinates) across every variant a venue has ever been
+	 * rendered at, so blocks pointing at a non-default combo aren't stranded
+	 * with a stale image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id Venue post ID.
+	 * @return array<int, array{zoom: int, height: int}>
+	 */
+	public function get_cached_combos( int $post_id ): array {
+		$combos = array();
+
+		foreach ( $this->get_all_descriptors( $post_id ) as $descriptor ) {
+			$combos[] = array(
+				'zoom'   => $descriptor['zoom'],
+				'height' => $descriptor['height'],
+			);
+		}
+
+		return $combos;
+	}
+
+	/**
+	 * Build the meta-storage key for a (zoom, height) combo.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $zoom   Zoom level.
+	 * @param int $height Pixel height.
+	 * @return string
+	 */
+	protected function combo_key( int $zoom, int $height ): string {
+		return sprintf( '%dx%d', $zoom, $height );
+	}
+
+	/**
+	 * Ensure a descriptor exists for the `($zoom, $height)` combo and return it.
 	 *
 	 * Hits the filesystem cache when the stored hash already matches the
 	 * current inputs and the PNG is still on disk; otherwise composites a
 	 * fresh image, saves it, updates the meta, and removes the old PNG for
-	 * that zoom (if any).
+	 * that combo (if any).
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param int   $post_id Venue post ID.
 	 * @param array $info    Parsed venue information.
 	 * @param int   $zoom    Zoom level to render at.
-	 * @return array{url: string, hash: string}|null
+	 * @param int   $height  Pixel height of the PNG. Width is derived via IMAGE_ASPECT_RATIO.
+	 * @return array{url: string, hash: string, zoom: int, height: int}|null
 	 */
-	protected function ensure_descriptor_for_zoom( int $post_id, array $info, int $zoom ): ?array {
+	protected function ensure_descriptor_for_combo( int $post_id, array $info, int $zoom, int $height ): ?array {
 		// Callers (maybe_generate, get_url_for_post) must have validated the
 		// coordinates via parse_coord() already — cast directly.
 		$latitude  = (float) $info['latitude'];
 		$longitude = (float) $info['longitude'];
 
-		$width  = $this->get_width();
-		$height = $this->get_height();
-		$tiles  = $this->get_tile_url_template();
-		$hash   = $this->hash_for( $info, $zoom, $width, $height, $tiles );
+		$tiles = $this->get_tile_url_template();
+		$hash  = $this->hash_for( $info, $zoom, $height, $tiles );
+		$key   = $this->combo_key( $zoom, $height );
 
 		$all      = $this->get_all_descriptors( $post_id );
-		$existing = $all[ $zoom ] ?? null;
+		$existing = $all[ $key ] ?? null;
 
 		if ( null !== $existing && $existing['hash'] === $hash ) {
 			$path = $this->url_to_path( $existing['url'] );
@@ -446,7 +486,7 @@ class Venue_Map {
 			}
 		}
 
-		$image = $this->composite_image( $latitude, $longitude, $zoom, $width, $height, $tiles );
+		$image = $this->composite_image( $latitude, $longitude, $zoom, $height, $tiles );
 
 		// Downstream of the GD-missing branch in composite_image(); only
 		// reached on PHP builds without the GD extension.
@@ -454,6 +494,7 @@ class Venue_Map {
 			return null; // @codeCoverageIgnore
 		}
 
+		$width = (int) round( $height * self::IMAGE_ASPECT_RATIO );
 		$this->stamp_marker( $image, (int) round( $width / 2 ), (int) round( $height / 2 ) );
 
 		$url = $this->save_image( $image, $post_id, $hash );
@@ -467,18 +508,16 @@ class Venue_Map {
 			$this->delete_file_by_url( $existing['url'] );
 		}
 
-		$all[ $zoom ]   = array(
-			'url'  => $url,
-			'hash' => $hash,
+		$all[ $key ] = array(
+			'url'    => $url,
+			'hash'   => $hash,
+			'zoom'   => $zoom,
+			'height' => $height,
 		);
-		$sanitized_meta = array();
-		foreach ( $all as $z => $descriptor ) {
-			$sanitized_meta[ (string) $z ] = $descriptor;
-		}
 
-		update_post_meta( $post_id, self::META_KEY, $sanitized_meta );
+		update_post_meta( $post_id, self::META_KEY, $all );
 
-		return $all[ $zoom ];
+		return $all[ $key ];
 	}
 
 	/**
@@ -501,21 +540,23 @@ class Venue_Map {
 	/**
 	 * Compute a stable hash from the inputs that determine the rendered PNG.
 	 *
-	 * Any change to address, coords, zoom, size, or tile provider invalidates
-	 * the previous image. Unrelated venue edits (title, excerpt, other meta)
-	 * keep the same hash and skip regeneration.
+	 * Any change to address, coords, zoom, height, or tile provider invalidates
+	 * the previous image. Width is fully derived from height via
+	 * {@see self::IMAGE_ASPECT_RATIO} so it doesn't need to go into the hash.
+	 * Unrelated venue edits (title, excerpt, other meta) keep the same hash
+	 * and skip regeneration.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param array  $info   Parsed venue information.
 	 * @param int    $zoom   Map zoom level.
-	 * @param int    $width  Output width.
 	 * @param int    $height Output height.
 	 * @param string $tiles  Tile URL template.
-	 * @return string SHA-1 hex digest.
+	 * @return string MD5 hex digest.
 	 */
-	public function hash_for( array $info, int $zoom, int $width, int $height, string $tiles ): string {
-		return sha1(
+	public function hash_for( array $info, int $zoom, int $height, string $tiles ): string {
+		// md5() here is a non-cryptographic cache-key discriminator, matching class-geocoding.php.
+		return md5( // NOSONAR.
 			implode(
 				'|',
 				array(
@@ -523,7 +564,6 @@ class Venue_Map {
 					(string) ( $info['latitude'] ?? '' ),
 					(string) ( $info['longitude'] ?? '' ),
 					(string) $zoom,
-					(string) $width,
 					(string) $height,
 					$tiles,
 				)
@@ -582,9 +622,8 @@ class Venue_Map {
 	 *
 	 * @param float  $lat    Latitude in degrees.
 	 * @param float  $lng    Longitude in degrees.
-	 * @param int    $zoom   Zoom level.
-	 * @param int    $width  Output width in pixels.
-	 * @param int    $height Output height in pixels.
+	 * @param int    $zoom   Zoom level (same zoom Leaflet would use for the same CSS viewport).
+	 * @param int    $height Output pixel height. Width is derived via IMAGE_ASPECT_RATIO.
 	 * @param string $tiles  Tile URL template.
 	 * @return GdImage|null Composited image, or null when GD is unavailable.
 	 */
@@ -592,7 +631,6 @@ class Venue_Map {
 		float $lat,
 		float $lng,
 		int $zoom,
-		int $width,
 		int $height,
 		string $tiles
 	): ?GdImage {
@@ -600,6 +638,8 @@ class Venue_Map {
 		if ( ! function_exists( 'imagecreatetruecolor' ) ) { // @codeCoverageIgnore
 			return null; // @codeCoverageIgnore
 		}
+
+		$width = (int) round( $height * self::IMAGE_ASPECT_RATIO );
 
 		$venue_world_x = $this->lng_to_world_pixel( $lng, $zoom );
 		$venue_world_y = $this->lat_to_world_pixel( $lat, $zoom );
@@ -743,13 +783,21 @@ class Venue_Map {
 	}
 
 	/**
-	 * Zoom level to render at. Filterable.
+	 * Zoom level used by the generator and by the block.
+	 *
+	 * Prefers the site-wide setting; falls back to {@see self::DEFAULT_ZOOM}
+	 * when the setting is unset or zero. Result is piped through the
+	 * `gatherpress_venue_map_zoom` filter so code-level overrides
+	 * (themes, site-specific plugins) can still take precedence.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return int
 	 */
 	protected function get_zoom(): int {
+		$setting = (int) Settings::get_instance()->get( 'venue_map_default_zoom' );
+		$default = $setting > 0 ? $setting : self::DEFAULT_ZOOM;
+
 		/**
 		 * Filter the zoom level used when rendering the static venue map.
 		 *
@@ -757,61 +805,35 @@ class Venue_Map {
 		 *
 		 * @param int $zoom Default zoom level.
 		 */
-		return (int) apply_filters( 'gatherpress_venue_static_map_zoom', self::DEFAULT_ZOOM );
+		return (int) apply_filters( 'gatherpress_venue_map_zoom', $default );
 	}
 
 	/**
-	 * Zoom level that newly-inserted venue-map blocks request.
+	 * Height (in pixels) used by the generator and by the block.
 	 *
-	 * Used by {@see self::maybe_generate()} when seeding a fresh venue so the
-	 * initial cache entry matches the zoom those blocks will actually ask for.
-	 * Prefers the site-wide setting; falls back to the block-level constant
-	 * when the setting has never been written.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return int
-	 */
-	protected function get_block_default_zoom(): int {
-		$setting = (int) Settings::get_instance()->get( 'venue_map_default_zoom' );
-
-		return $setting > 0 ? $setting : self::DEFAULT_BLOCK_ZOOM;
-	}
-
-	/**
-	 * Output image width in pixels. Filterable.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return int
-	 */
-	protected function get_width(): int {
-		/**
-		 * Filter the width of the rendered static venue map.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param int $width Default width in pixels.
-		 */
-		return (int) apply_filters( 'gatherpress_venue_static_map_width', self::DEFAULT_WIDTH );
-	}
-
-	/**
-	 * Output image height in pixels. Filterable.
+	 * Mirrors {@see self::get_zoom()} — Settings value wins, falls back to
+	 * {@see self::DEFAULT_HEIGHT}, then runs through
+	 * `gatherpress_venue_map_height` for code-level overrides. Because the
+	 * PNG is rendered at exactly this height (no oversampling), the generator
+	 * and the block see the same value and Leaflet's zoom matches the
+	 * static map's zoom visually.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return int
 	 */
 	protected function get_height(): int {
+		$setting = (int) Settings::get_instance()->get( 'venue_map_default_height' );
+		$default = $setting > 0 ? $setting : self::DEFAULT_HEIGHT;
+
 		/**
-		 * Filter the height of the rendered static venue map.
+		 * Filter the height used when rendering the static venue map.
 		 *
 		 * @since 1.0.0
 		 *
 		 * @param int $height Default height in pixels.
 		 */
-		return (int) apply_filters( 'gatherpress_venue_static_map_height', self::DEFAULT_HEIGHT );
+		return (int) apply_filters( 'gatherpress_venue_map_height', $default );
 	}
 
 	/**
@@ -829,7 +851,7 @@ class Venue_Map {
 		 *
 		 * @param string $template Tile URL with `{z}`, `{x}`, `{y}` placeholders.
 		 */
-		return (string) apply_filters( 'gatherpress_venue_static_map_tile_url', self::DEFAULT_TILE_URL );
+		return (string) apply_filters( 'gatherpress_venue_map_tile_url', self::DEFAULT_TILE_URL );
 	}
 
 	/**

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -198,9 +198,13 @@ class Venue_Map {
 	 * @return void
 	 */
 	protected function setup_hooks(): void {
-		// Priority 20 so Venue_Setup::set_geodata (priority 10) has already
-		// derived geo_latitude/longitude from the venue information JSON.
-		add_action( 'wp_after_insert_post', array( $this, 'maybe_generate' ), 20 );
+		// Priority 11 — just after the default-10 batch, so any other
+		// wp_after_insert_post callback touching venue meta during the
+		// same save has already run. We read `gatherpress_venue_information`
+		// directly, so there's no hard dependency on any specific hook, but
+		// trailing the default batch is the cheapest guard against future
+		// ordering surprises.
+		add_action( 'wp_after_insert_post', array( $this, 'maybe_generate' ), 11 );
 		add_action( 'registered_post_type', array( $this, 'maybe_register_delete_hook' ) );
 		add_filter( 'block_type_metadata', array( $this, 'apply_block_attribute_defaults' ) );
 	}
@@ -299,8 +303,8 @@ class Venue_Map {
 			null === $this->parse_coord( $info['longitude'] ) ) {
 			// No usable coordinates — the address was edited to something
 			// un-geocodable, or cleared entirely. Purge any previously
-			// generated PNGs so stale images don't keep serving on the
-			// front end; the placeholder will surface the "no address"
+			// generated PNG files so stale images don't keep serving on
+			// the front end; the placeholder will surface the "no address"
 			// state until geocoding succeeds again.
 			$this->delete_stored_image( $post_id );
 			return;
@@ -722,7 +726,21 @@ class Venue_Map {
 		$bg = imagecolorallocate( $canvas, 238, 238, 238 );
 		imagefilledrectangle( $canvas, 0, 0, $width - 1, $height - 1, $bg );
 
-		$deadline = microtime( true ) + self::COMPOSITE_TIME_BUDGET;
+		/**
+		 * Filter the wall-clock budget (in seconds) for a single
+		 * composite_image() call. When the deadline is exceeded mid-loop,
+		 * remaining tiles are skipped and the gray background shows
+		 * through. Accepts int or float.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param float $budget Default budget from COMPOSITE_TIME_BUDGET.
+		 */
+		$budget   = (float) apply_filters(
+			'gatherpress_venue_map_composite_time_budget',
+			self::COMPOSITE_TIME_BUDGET
+		);
+		$deadline = microtime( true ) + $budget;
 
 		for ( $tx = $left_tile; $tx <= $right_tile; $tx++ ) {
 			for ( $ty = $top_tile; $ty <= $bottom_tile; $ty++ ) {

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -121,7 +121,7 @@ class Venue_Map {
 	const META_KEY = 'gatherpress_venue_static_map';
 
 	/**
-	 * Subdirectory of `wp-content/uploads` where generated PNGs are written.
+	 * Subdirectory of `wp-content/uploads` where generated PNG files are written.
 	 *
 	 * @since 1.0.0
 	 * @var string

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -1,13 +1,19 @@
 <?php
 /**
- * Generates and stores a pre-rendered static map image for a venue.
+ * Home for venue map server-side concerns.
  *
- * Fetches a small set of CartoDB basemap tiles around the venue's coordinates,
- * composites them into a single PNG with a marker stamped at the venue's exact
- * position, and stores the result under `wp-content/uploads/gatherpress/static-maps/`.
- * The file path/URL and an input-hash are persisted in venue post meta so the
- * front-end can serve the image directly and so subsequent saves regenerate
- * only when inputs (address, coordinates, tile URL, size) actually change.
+ * Today this singleton owns the pre-rendered static-map PNG pipeline:
+ * fetching a small set of CartoDB basemap tiles around the venue's
+ * coordinates, compositing them into a single PNG with a marker stamped at
+ * the venue's exact position, and storing the result under
+ * `wp-content/uploads/gatherpress/static-maps/`. The file URL and an
+ * input-hash are persisted (per zoom) in venue post meta so the front-end
+ * can serve the image directly and so subsequent saves regenerate only when
+ * inputs (address, coordinates, tile URL, size) actually change.
+ *
+ * The class is named for its broader role — venue-map — so future
+ * map-related additions (REST endpoint for the editor preview, interactive
+ * map server-side bits, async regeneration, etc.) have a natural home.
  *
  * @package GatherPress\Core
  * @since 1.0.0
@@ -22,18 +28,68 @@ use GatherPress\Core\Traits\Singleton;
 use GdImage;
 
 /**
- * Class Venue_Static_Map.
+ * Class Venue_Map.
  *
- * Singleton responsible for (re)generating the per-venue static-map PNG, keyed
- * by a hash of the generator inputs so unchanged saves are cheap no-ops.
+ * Singleton hosting the venue map server-side pipeline. Currently owns the
+ * static PNG cache keyed by zoom; structured so that additional map-related
+ * methods (REST, async jobs, etc.) can land here without proliferating
+ * classes.
  *
  * @since 1.0.0
  */
-class Venue_Static_Map {
+class Venue_Map {
 	/**
 	 * Enforces a single instance of this class.
 	 */
 	use Singleton;
+
+	/**
+	 * Default `renderMode` attribute for the venue-map block.
+	 *
+	 * Must mirror the default declared in the block's `block.json`. `render.php`
+	 * and any other caller that resolves the block attribute should read the
+	 * constant rather than hardcoding the string.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const DEFAULT_RENDER_MODE = 'interactive';
+
+	/**
+	 * Default `zoom` attribute for the venue-map block.
+	 *
+	 * Note this is distinct from {@see self::DEFAULT_ZOOM} — the latter is the
+	 * fallback used by the generator when a caller requests a map without
+	 * specifying a zoom; the block-level default is what a fresh block saves
+	 * with, matching the `block.json` declaration.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const DEFAULT_BLOCK_ZOOM = 18;
+
+	/**
+	 * Default `height` attribute (in pixels) for the venue-map block wrapper.
+	 *
+	 * The generated PNG is always 600×400; this is the DOM height applied to
+	 * the wrapper so the static image (with `object-fit: cover`) fills it.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const DEFAULT_BLOCK_HEIGHT = 300;
+
+	/**
+	 * Default `type` attribute for the venue-map block.
+	 *
+	 * Google Maps–specific (roadmap / satellite / hybrid / terrain). Ignored by
+	 * the static renderer and by Leaflet/OSM, but preserved as a block-level
+	 * default so Google Maps users get a sensible first value.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const DEFAULT_MAP_TYPE = 'roadmap';
 
 	/**
 	 * Slippy-tile dimension in pixels. CartoDB basemaps use 256×256.
@@ -117,6 +173,50 @@ class Venue_Static_Map {
 		// derived geo_latitude/longitude from the venue information JSON.
 		add_action( 'wp_after_insert_post', array( $this, 'maybe_generate' ), 20 );
 		add_action( 'registered_post_type', array( $this, 'maybe_register_delete_hook' ) );
+		add_filter( 'block_type_metadata', array( $this, 'apply_block_attribute_defaults' ) );
+	}
+
+	/**
+	 * Override the venue-map block's attribute defaults with user-chosen values
+	 * from Settings → Venues → Maps.
+	 *
+	 * Runs once per block registration. Because Gutenberg only consults the
+	 * defaults when an attribute isn't present on a saved block, this affects
+	 * newly inserted blocks and preserves explicit customizations on existing
+	 * ones — changing the setting won't retroactively rewrite old content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $metadata Parsed `block.json` metadata for the block being registered.
+	 * @return array The metadata array, potentially with updated attribute defaults.
+	 */
+	public function apply_block_attribute_defaults( array $metadata ): array {
+		if ( 'gatherpress/venue-map' !== ( $metadata['name'] ?? '' ) ) {
+			return $metadata;
+		}
+
+		$settings = Settings::get_instance();
+		$defaults = array(
+			'renderMode' => (string) $settings->get( 'venue_map_default_render_mode' ),
+			'zoom'       => (int) $settings->get( 'venue_map_default_zoom' ),
+			'height'     => (int) $settings->get( 'venue_map_default_height' ),
+			'type'       => (string) $settings->get( 'venue_map_default_type' ),
+		);
+
+		foreach ( $defaults as $attr => $value ) {
+			// Guard against a Settings row that's never been written — keep
+			// the block.json default rather than stamping on an empty string
+			// or zero that the UI would silently accept.
+			if ( '' === $value || 0 === $value ) {
+				continue;
+			}
+
+			if ( isset( $metadata['attributes'][ $attr ] ) ) {
+				$metadata['attributes'][ $attr ]['default'] = $value;
+			}
+		}
+
+		return $metadata;
 	}
 
 	/**
@@ -176,10 +276,13 @@ class Venue_Static_Map {
 
 		// Regenerate every zoom the venue is already known at, so a content
 		// change (new address/coords) cascades to all cached variants. For a
-		// fresh venue with nothing stored, seed the default zoom.
+		// fresh venue with nothing stored, seed the zoom that newly-inserted
+		// venue-map blocks will actually request — otherwise the editor falls
+		// back to the interactive preview on the very first save because
+		// cache[18] is missing but block.zoom = 18.
 		$zooms = array_keys( $this->get_all_descriptors( $post_id ) );
 		if ( empty( $zooms ) ) {
-			$zooms = array( $this->get_zoom() );
+			$zooms = array( $this->get_block_default_zoom() );
 		}
 
 		foreach ( $zooms as $zoom ) {
@@ -247,7 +350,11 @@ class Venue_Static_Map {
 			return '';
 		}
 
-		$descriptor = $this->ensure_descriptor_for_zoom( $venue_post_id, $info, $zoom ?? $this->get_zoom() );
+		$descriptor = $this->ensure_descriptor_for_zoom(
+			$venue_post_id,
+			$info,
+			$zoom ?? $this->get_block_default_zoom()
+		);
 
 		return null === $descriptor ? '' : $descriptor['url'];
 	}
@@ -266,7 +373,7 @@ class Venue_Static_Map {
 	public function get_stored_descriptor( int $post_id ): ?array {
 		$all = $this->get_all_descriptors( $post_id );
 
-		return $all[ $this->get_zoom() ] ?? null;
+		return $all[ $this->get_block_default_zoom() ] ?? null;
 	}
 
 	/**
@@ -651,6 +758,24 @@ class Venue_Static_Map {
 		 * @param int $zoom Default zoom level.
 		 */
 		return (int) apply_filters( 'gatherpress_venue_static_map_zoom', self::DEFAULT_ZOOM );
+	}
+
+	/**
+	 * Zoom level that newly-inserted venue-map blocks request.
+	 *
+	 * Used by {@see self::maybe_generate()} when seeding a fresh venue so the
+	 * initial cache entry matches the zoom those blocks will actually ask for.
+	 * Prefers the site-wide setting; falls back to the block-level constant
+	 * when the setting has never been written.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int
+	 */
+	protected function get_block_default_zoom(): int {
+		$setting = (int) Settings::get_instance()->get( 'venue_map_default_zoom' );
+
+		return $setting > 0 ? $setting : self::DEFAULT_BLOCK_ZOOM;
 	}
 
 	/**

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -69,6 +69,60 @@ class Venue_Map {
 	const DEFAULT_HEIGHT = 300;
 
 	/**
+	 * Bounds for the zoom level.
+	 *
+	 * Matches what the block's editor RangeControl exposes. Enforced
+	 * server-side as well so a filter override, hand-edited block attribute,
+	 * or bad Settings row can't drive the generator to render a useless
+	 * world-view (zoom 0) or crash out on a value the tile provider won't
+	 * serve (zoom 30).
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const ZOOM_MIN = 1;
+
+	/**
+	 * See self::ZOOM_MIN.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const ZOOM_MAX = 20;
+
+	/**
+	 * Bounds for the pixel height. Mirrors the block's RangeControl so
+	 * out-of-range Settings / filter values can't produce an absurd canvas
+	 * (a 10,000-px-tall image would allocate gigabytes of GD memory and
+	 * fetch hundreds of tiles).
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const HEIGHT_MIN = 100;
+
+	/**
+	 * See self::HEIGHT_MIN.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const HEIGHT_MAX = 800;
+
+	/**
+	 * Total wall-clock budget (in seconds) for a single composite_image()
+	 * call. CartoDB typically serves tiles in well under 500ms, but a slow
+	 * tile host, a DNS hiccup, or a bad proxy can chain wp_safe_remote_get()
+	 * timeouts together and pin a save for tens of seconds. When the
+	 * budget is exceeded mid-composite, remaining tiles are skipped and the
+	 * gray background shows through instead — degraded, not hung.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const COMPOSITE_TIME_BUDGET = 10;
+
+	/**
 	 * Default `type` attribute for the venue-map block.
 	 *
 	 * Google Maps–specific (roadmap / satellite / hybrid / terrain). Ignored by
@@ -243,9 +297,12 @@ class Venue_Map {
 
 		if ( null === $this->parse_coord( $info['latitude'] ) ||
 			null === $this->parse_coord( $info['longitude'] ) ) {
-			// No usable coordinates — leave any previously-generated images
-			// alone and bail. The front-end placeholder will surface the
-			// "no address" state for the user.
+			// No usable coordinates — the address was edited to something
+			// un-geocodable, or cleared entirely. Purge any previously
+			// generated PNGs so stale images don't keep serving on the
+			// front end; the placeholder will surface the "no address"
+			// state until geocoding succeeds again.
+			$this->delete_stored_image( $post_id );
 			return;
 		}
 
@@ -471,6 +528,13 @@ class Venue_Map {
 		$latitude  = (float) $info['latitude'];
 		$longitude = (float) $info['longitude'];
 
+		// Clamp caller-provided values before they influence the cache key
+		// or the canvas. Block attributes come from the editor already
+		// within range, but a hand-edited block, a filter that mutates the
+		// attribute, or bad meta could sneak an out-of-range value in.
+		$zoom   = $this->clamp_zoom( $zoom );
+		$height = $this->clamp_height( $height );
+
 		$tiles = $this->get_tile_url_template();
 		$hash  = $this->hash_for( $info, $zoom, $height, $tiles );
 		$key   = $this->combo_key( $zoom, $height );
@@ -658,8 +722,19 @@ class Venue_Map {
 		$bg = imagecolorallocate( $canvas, 238, 238, 238 );
 		imagefilledrectangle( $canvas, 0, 0, $width - 1, $height - 1, $bg );
 
+		$deadline = microtime( true ) + self::COMPOSITE_TIME_BUDGET;
+
 		for ( $tx = $left_tile; $tx <= $right_tile; $tx++ ) {
 			for ( $ty = $top_tile; $ty <= $bottom_tile; $ty++ ) {
+				// Budget guard: once the total wall-clock time for this
+				// composite exceeds COMPOSITE_TIME_BUDGET, stop fetching
+				// and let the gray background show through for any tiles
+				// we haven't filled in yet. Bounds the worst-case stall
+				// from a slow tile host.
+				if ( microtime( true ) >= $deadline ) {
+					break 2;
+				}
+
 				$tile_png = $this->fetch_tile( $zoom, $tx, $ty, $tiles );
 
 				if ( null === $tile_png ) {
@@ -762,6 +837,18 @@ class Venue_Map {
 		}
 
 		$relative = substr( $url, strlen( $base_url ) );
+
+		// Restrict the relative portion to filenames this class actually
+		// generates: `{post_id}-{md5-hex}.png`. The prefix check above only
+		// guards the URL origin — without this allow-list a value like
+		// `…/static-maps/../../wp-config.php`, if it ever slipped into the
+		// meta (direct update_post_meta, import, a future filter), would
+		// concatenate through to a path outside the uploads subdir and
+		// hand `wp_delete_file()` a target it shouldn't touch.
+		if ( ! preg_match( '#\A\d+-[a-f0-9]{32}\.png\z#', $relative ) ) {
+			return null;
+		}
+
 		$base_dir = trailingslashit( $dirs['basedir'] ) . self::UPLOADS_SUBDIR . '/';
 
 		return $base_dir . $relative;
@@ -805,7 +892,9 @@ class Venue_Map {
 		 *
 		 * @param int $zoom Default zoom level.
 		 */
-		return (int) apply_filters( 'gatherpress_venue_map_zoom', $default );
+		$zoom = (int) apply_filters( 'gatherpress_venue_map_zoom', $default );
+
+		return $this->clamp_zoom( $zoom );
 	}
 
 	/**
@@ -833,7 +922,33 @@ class Venue_Map {
 		 *
 		 * @param int $height Default height in pixels.
 		 */
-		return (int) apply_filters( 'gatherpress_venue_map_height', $default );
+		$height = (int) apply_filters( 'gatherpress_venue_map_height', $default );
+
+		return $this->clamp_height( $height );
+	}
+
+	/**
+	 * Clamp a zoom level to the supported range.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $zoom Raw zoom value.
+	 * @return int
+	 */
+	protected function clamp_zoom( int $zoom ): int {
+		return max( self::ZOOM_MIN, min( self::ZOOM_MAX, $zoom ) );
+	}
+
+	/**
+	 * Clamp a pixel height to the supported range.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $height Raw height value.
+	 * @return int
+	 */
+	protected function clamp_height( int $height ): int {
+		return max( self::HEIGHT_MIN, min( self::HEIGHT_MAX, $height ) );
 	}
 
 	/**

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -26,7 +26,6 @@ namespace GatherPress\Core;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GdImage;
 use WP_Post;
 
 /**
@@ -490,7 +489,7 @@ class Venue_Map {
 
 		// Downstream of the GD-missing branch in composite_image(); only
 		// reached on PHP builds without the GD extension.
-		if ( ! $image instanceof GdImage ) { // @codeCoverageIgnore
+		if ( null === $image ) { // @codeCoverageIgnore
 			return null; // @codeCoverageIgnore
 		}
 
@@ -625,7 +624,8 @@ class Venue_Map {
 	 * @param int    $zoom   Zoom level (same zoom Leaflet would use for the same CSS viewport).
 	 * @param int    $height Output pixel height. Width is derived via IMAGE_ASPECT_RATIO.
 	 * @param string $tiles  Tile URL template.
-	 * @return GdImage|null Composited image, or null when GD is unavailable.
+	 * @return \GdImage|resource|null Composited image, or null when GD is unavailable.
+	 *                                GdImage on PHP 8+, resource on PHP 7.4.
 	 */
 	public function composite_image(
 		float $lat,
@@ -633,7 +633,7 @@ class Venue_Map {
 		int $zoom,
 		int $height,
 		string $tiles
-	): ?GdImage {
+	) {
 		// PHP built without the GD extension. Can't simulate in a unit test without making the runtime itself broken.
 		if ( ! function_exists( 'imagecreatetruecolor' ) ) { // @codeCoverageIgnore
 			return null; // @codeCoverageIgnore
@@ -668,7 +668,7 @@ class Venue_Map {
 
 				$tile = imagecreatefromstring( $tile_png );
 
-				if ( ! $tile instanceof GdImage ) {
+				if ( false === $tile ) {
 					continue;
 				}
 
@@ -688,12 +688,12 @@ class Venue_Map {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param GdImage $canvas Destination canvas.
-	 * @param int     $x      Pixel X position (marker center).
-	 * @param int     $y      Pixel Y position (marker center).
+	 * @param \GdImage|resource $canvas Destination canvas (GdImage on PHP 8+, resource on PHP 7.4).
+	 * @param int               $x      Pixel X position (marker center).
+	 * @param int               $y      Pixel Y position (marker center).
 	 * @return void
 	 */
-	public function stamp_marker( GdImage $canvas, int $x, int $y ): void {
+	public function stamp_marker( $canvas, int $x, int $y ): void {
 		$white = imagecolorallocate( $canvas, 255, 255, 255 );
 		$red   = imagecolorallocate( $canvas, 220, 53, 69 );
 		$dark  = imagecolorallocate( $canvas, 30, 30, 30 );
@@ -709,12 +709,12 @@ class Venue_Map {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param GdImage $image   The finished composite.
-	 * @param int     $post_id The venue post ID (used in the filename).
-	 * @param string  $hash    Input hash (used in the filename).
+	 * @param \GdImage|resource $image   The finished composite (GdImage on PHP 8+, resource on PHP 7.4).
+	 * @param int               $post_id The venue post ID (used in the filename).
+	 * @param string            $hash    Input hash (used in the filename).
 	 * @return string|null Public URL of the saved file, or null on failure.
 	 */
-	public function save_image( GdImage $image, int $post_id, string $hash ): ?string {
+	public function save_image( $image, int $post_id, string $hash ): ?string {
 		$dirs = wp_get_upload_dir();
 
 		if ( ! empty( $dirs['error'] ) ) {

--- a/includes/core/classes/class-venue-setup.php
+++ b/includes/core/classes/class-venue-setup.php
@@ -292,6 +292,28 @@ class Venue_Setup {
 				'default'           => 1,
 				'revisions_enabled' => true,
 			),
+			// Venue_Map keeps a per-zoom descriptor map here: { "15": { url,
+			// hash }, ... }. Exposed read-only via REST so the block editor
+			// can preview the cached static image when the user picks
+			// renderMode="static". Writes are denied ­— the server-side
+			// pipeline is the only thing allowed to populate this meta.
+			Venue_Map::META_KEY             => array(
+				'auth_callback' => '__return_false',
+				'show_in_rest'  => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'additionalProperties' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'url'  => array( 'type' => 'string' ),
+								'hash' => array( 'type' => 'string' ),
+							),
+						),
+					),
+				),
+				'single'        => true,
+				'type'          => 'object',
+			),
 		);
 
 		$venue_map_meta = array(
@@ -371,6 +393,7 @@ class Venue_Setup {
 			'geo_longitude',
 			'geo_address',
 			'geo_public',
+			Venue_Map::META_KEY,
 		);
 
 		$meta = $request->get_param( 'meta' );

--- a/includes/core/classes/class-venue-static-map.php
+++ b/includes/core/classes/class-venue-static-map.php
@@ -1,0 +1,737 @@
+<?php
+/**
+ * Generates and stores a pre-rendered static map image for a venue.
+ *
+ * Fetches a small set of CartoDB basemap tiles around the venue's coordinates,
+ * composites them into a single PNG with a marker stamped at the venue's exact
+ * position, and stores the result under `wp-content/uploads/gatherpress/static-maps/`.
+ * The file path/URL and an input-hash are persisted in venue post meta so the
+ * front-end can serve the image directly and so subsequent saves regenerate
+ * only when inputs (address, coordinates, tile URL, size) actually change.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Core;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Traits\Singleton;
+use GdImage;
+
+/**
+ * Class Venue_Static_Map.
+ *
+ * Singleton responsible for (re)generating the per-venue static-map PNG, keyed
+ * by a hash of the generator inputs so unchanged saves are cheap no-ops.
+ *
+ * @since 1.0.0
+ */
+class Venue_Static_Map {
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Slippy-tile dimension in pixels. CartoDB basemaps use 256×256.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const TILE_SIZE = 256;
+
+	/**
+	 * Default zoom level for generated static maps.
+	 *
+	 * Street-level context without zooming so far in that neighborhood
+	 * landmarks fall outside the crop.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const DEFAULT_ZOOM = 15;
+
+	/**
+	 * Default output image width in pixels.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const DEFAULT_WIDTH = 600;
+
+	/**
+	 * Default output image height in pixels.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const DEFAULT_HEIGHT = 400;
+
+	/**
+	 * CartoDB Positron tile URL template. `{z}`, `{x}`, `{y}` are substituted.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const DEFAULT_TILE_URL = 'https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png';
+
+	/**
+	 * Post meta key under which the static-map descriptor is stored.
+	 *
+	 * Value shape: `array{ url: string, hash: string }`.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const META_KEY = 'gatherpress_venue_static_map';
+
+	/**
+	 * Subdirectory of `wp-content/uploads` where generated PNGs are written.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const UPLOADS_SUBDIR = 'gatherpress/static-maps';
+
+	/**
+	 * Class constructor — wires hooks.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Register the save- and delete-side hooks that own the static map lifecycle.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks(): void {
+		// Priority 20 so Venue_Setup::set_geodata (priority 10) has already
+		// derived geo_latitude/longitude from the venue information JSON.
+		add_action( 'wp_after_insert_post', array( $this, 'maybe_generate' ), 20 );
+		add_action( 'registered_post_type', array( $this, 'maybe_register_delete_hook' ) );
+	}
+
+	/**
+	 * Wire `delete_post_{$type}` → `delete_stored_image` for venue post types.
+	 *
+	 * Mirrors the registered_post_type pattern used elsewhere so companion
+	 * plugins declaring custom venue post types automatically get cleanup.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $post_type The post type that was just registered.
+	 * @return void
+	 */
+	public function maybe_register_delete_hook( string $post_type ): void {
+		if ( ! post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
+			return;
+		}
+
+		add_action(
+			sprintf( 'delete_post_%s', $post_type ),
+			array( $this, 'delete_stored_image' )
+		);
+	}
+
+	/**
+	 * Regenerate the static map when a venue save actually changes the inputs.
+	 *
+	 * Called on `wp_after_insert_post` for every post; bails early for
+	 * revisions, autosaves, and non-venue post types. When the hash of the
+	 * relevant inputs is unchanged from the last stored descriptor, the
+	 * method no-ops — this is the "set it and forget it" guarantee.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id The post ID being saved.
+	 * @return void
+	 */
+	public function maybe_generate( int $post_id ): void {
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-venue-information' ) ) {
+			return;
+		}
+
+		$venue = new Venue( $post_id );
+		$info  = $venue->get_information();
+
+		if ( null === $this->parse_coord( $info['latitude'] ) ||
+			null === $this->parse_coord( $info['longitude'] ) ) {
+			// No usable coordinates — leave any previously-generated images
+			// alone and bail. The front-end placeholder will surface the
+			// "no address" state for the user.
+			return;
+		}
+
+		// Regenerate every zoom the venue is already known at, so a content
+		// change (new address/coords) cascades to all cached variants. For a
+		// fresh venue with nothing stored, seed the default zoom.
+		$zooms = array_keys( $this->get_all_descriptors( $post_id ) );
+		if ( empty( $zooms ) ) {
+			$zooms = array( $this->get_zoom() );
+		}
+
+		foreach ( $zooms as $zoom ) {
+			$this->ensure_descriptor_for_zoom( $post_id, $info, (int) $zoom );
+		}
+	}
+
+	/**
+	 * Delete every stored static-map PNG (at any zoom) and clear the meta.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id The venue post ID.
+	 * @return void
+	 */
+	public function delete_stored_image( int $post_id ): void {
+		foreach ( $this->get_all_descriptors( $post_id ) as $descriptor ) {
+			$this->delete_file_by_url( $descriptor['url'] );
+		}
+
+		delete_post_meta( $post_id, self::META_KEY );
+	}
+
+	/**
+	 * Resolve the static map URL for any GatherPress post context.
+	 *
+	 * Accepts either a venue post ID (supports `gatherpress-venue-information`)
+	 * or an event post ID (supports `gatherpress-venue`) and returns the URL
+	 * of the stored static map for the corresponding venue at the requested
+	 * zoom. When the cache doesn't yet have an image for that zoom, the method
+	 * generates one synchronously — first render pays the cost, subsequent
+	 * renders hit the cache.
+	 *
+	 * Returns '' when the post isn't venue-related, the venue has no
+	 * coordinates, or the on-demand generation failed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int      $post_id   Event or venue post ID.
+	 * @param string   $post_type The post type of `$post_id`.
+	 * @param int|null $zoom      Desired zoom level. Null falls back to the default.
+	 * @return string Static map URL, or '' when unavailable.
+	 */
+	public function get_url_for_post( int $post_id, string $post_type, ?int $zoom = null ): string {
+		$venue_post_id = 0;
+
+		if ( post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
+			$venue_post_id = $post_id;
+		} elseif ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
+			$venue_post = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
+
+			if ( $venue_post instanceof \WP_Post ) {
+				$venue_post_id = $venue_post->ID;
+			}
+		}
+
+		if ( 0 === $venue_post_id ) {
+			return '';
+		}
+
+		$info = ( new Venue( $venue_post_id ) )->get_information();
+
+		if ( null === $this->parse_coord( $info['latitude'] ) ||
+			null === $this->parse_coord( $info['longitude'] ) ) {
+			return '';
+		}
+
+		$descriptor = $this->ensure_descriptor_for_zoom( $venue_post_id, $info, $zoom ?? $this->get_zoom() );
+
+		return null === $descriptor ? '' : $descriptor['url'];
+	}
+
+	/**
+	 * Return the descriptor for the default zoom, or null if nothing is stored.
+	 *
+	 * Kept for callers that only care about "has this venue been rendered at
+	 * all?" — the richer per-zoom map lives behind {@see self::get_all_descriptors()}.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id The venue post ID.
+	 * @return array{url: string, hash: string}|null
+	 */
+	public function get_stored_descriptor( int $post_id ): ?array {
+		$all = $this->get_all_descriptors( $post_id );
+
+		return $all[ $this->get_zoom() ] ?? null;
+	}
+
+	/**
+	 * Return every stored descriptor for the venue, keyed by zoom level.
+	 *
+	 * Silently filters out malformed entries so callers can iterate without
+	 * defensive shape checks.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id The venue post ID.
+	 * @return array<int, array{url: string, hash: string}>
+	 */
+	public function get_all_descriptors( int $post_id ): array {
+		$raw = get_post_meta( $post_id, self::META_KEY, true );
+
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$descriptors = array();
+
+		foreach ( $raw as $zoom => $entry ) {
+			if ( ! is_array( $entry ) || empty( $entry['url'] ) || empty( $entry['hash'] ) ) {
+				continue;
+			}
+
+			$descriptors[ (int) $zoom ] = array(
+				'url'  => (string) $entry['url'],
+				'hash' => (string) $entry['hash'],
+			);
+		}
+
+		return $descriptors;
+	}
+
+	/**
+	 * Ensure a descriptor exists for `$zoom` and return it.
+	 *
+	 * Hits the filesystem cache when the stored hash already matches the
+	 * current inputs and the PNG is still on disk; otherwise composites a
+	 * fresh image, saves it, updates the meta, and removes the old PNG for
+	 * that zoom (if any).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int   $post_id Venue post ID.
+	 * @param array $info    Parsed venue information.
+	 * @param int   $zoom    Zoom level to render at.
+	 * @return array{url: string, hash: string}|null
+	 */
+	protected function ensure_descriptor_for_zoom( int $post_id, array $info, int $zoom ): ?array {
+		// Callers (maybe_generate, get_url_for_post) must have validated the
+		// coordinates via parse_coord() already — cast directly.
+		$latitude  = (float) $info['latitude'];
+		$longitude = (float) $info['longitude'];
+
+		$width  = $this->get_width();
+		$height = $this->get_height();
+		$tiles  = $this->get_tile_url_template();
+		$hash   = $this->hash_for( $info, $zoom, $width, $height, $tiles );
+
+		$all      = $this->get_all_descriptors( $post_id );
+		$existing = $all[ $zoom ] ?? null;
+
+		if ( null !== $existing && $existing['hash'] === $hash ) {
+			$path = $this->url_to_path( $existing['url'] );
+			if ( null !== $path && file_exists( $path ) ) {
+				return $existing;
+			}
+		}
+
+		$image = $this->composite_image( $latitude, $longitude, $zoom, $width, $height, $tiles );
+
+		// Downstream of the GD-missing branch in composite_image(); only
+		// reached on PHP builds without the GD extension.
+		if ( ! $image instanceof GdImage ) { // @codeCoverageIgnore
+			return null; // @codeCoverageIgnore
+		}
+
+		$this->stamp_marker( $image, (int) round( $width / 2 ), (int) round( $height / 2 ) );
+
+		$url = $this->save_image( $image, $post_id, $hash );
+		imagedestroy( $image );
+
+		if ( null === $url ) {
+			return null;
+		}
+
+		if ( null !== $existing && $existing['url'] !== $url ) {
+			$this->delete_file_by_url( $existing['url'] );
+		}
+
+		$all[ $zoom ]   = array(
+			'url'  => $url,
+			'hash' => $hash,
+		);
+		$sanitized_meta = array();
+		foreach ( $all as $z => $descriptor ) {
+			$sanitized_meta[ (string) $z ] = $descriptor;
+		}
+
+		update_post_meta( $post_id, self::META_KEY, $sanitized_meta );
+
+		return $all[ $zoom ];
+	}
+
+	/**
+	 * Delete a stored PNG by URL, no-op if the URL is out of scope or the
+	 * file is already gone.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $url Stored URL.
+	 * @return void
+	 */
+	protected function delete_file_by_url( string $url ): void {
+		$path = $this->url_to_path( $url );
+
+		if ( null !== $path && file_exists( $path ) ) {
+			wp_delete_file( $path );
+		}
+	}
+
+	/**
+	 * Compute a stable hash from the inputs that determine the rendered PNG.
+	 *
+	 * Any change to address, coords, zoom, size, or tile provider invalidates
+	 * the previous image. Unrelated venue edits (title, excerpt, other meta)
+	 * keep the same hash and skip regeneration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $info   Parsed venue information.
+	 * @param int    $zoom   Map zoom level.
+	 * @param int    $width  Output width.
+	 * @param int    $height Output height.
+	 * @param string $tiles  Tile URL template.
+	 * @return string SHA-1 hex digest.
+	 */
+	public function hash_for( array $info, int $zoom, int $width, int $height, string $tiles ): string {
+		return sha1(
+			implode(
+				'|',
+				array(
+					(string) ( $info['fullAddress'] ?? '' ),
+					(string) ( $info['latitude'] ?? '' ),
+					(string) ( $info['longitude'] ?? '' ),
+					(string) $zoom,
+					(string) $width,
+					(string) $height,
+					$tiles,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Fetch, decode, and return the raw PNG bytes for a tile at (z, x, y).
+	 *
+	 * Returns null on any HTTP failure so callers can skip that tile without
+	 * aborting the whole composite; the resulting image will simply have a
+	 * blank patch where the fetch failed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $zoom    Tile zoom.
+	 * @param int    $x       Tile x coordinate.
+	 * @param int    $y       Tile y coordinate.
+	 * @param string $tiles   Tile URL template containing `{z}`, `{x}`, `{y}`.
+	 * @return string|null PNG bytes, or null on failure.
+	 */
+	public function fetch_tile( int $zoom, int $x, int $y, string $tiles ): ?string {
+		$url = strtr(
+			$tiles,
+			array(
+				'{z}' => (string) $zoom,
+				'{x}' => (string) $x,
+				'{y}' => (string) $y,
+			)
+		);
+
+		$response = wp_safe_remote_get( $url, array( 'timeout' => 5 ) );
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$body = (string) wp_remote_retrieve_body( $response );
+
+		return '' !== $body ? $body : null;
+	}
+
+	/**
+	 * Composite the tiles needed to cover the output image centered on (lat, lng).
+	 *
+	 * Builds a blank canvas of the requested size, fetches every tile whose
+	 * bounds intersect the canvas window, and copies each into its correct
+	 * pixel offset. Caller is responsible for `imagedestroy()` on the result.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param float  $lat    Latitude in degrees.
+	 * @param float  $lng    Longitude in degrees.
+	 * @param int    $zoom   Zoom level.
+	 * @param int    $width  Output width in pixels.
+	 * @param int    $height Output height in pixels.
+	 * @param string $tiles  Tile URL template.
+	 * @return GdImage|null Composited image, or null when GD is unavailable.
+	 */
+	public function composite_image(
+		float $lat,
+		float $lng,
+		int $zoom,
+		int $width,
+		int $height,
+		string $tiles
+	): ?GdImage {
+		// PHP built without the GD extension. Can't simulate in a unit test without making the runtime itself broken.
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) { // @codeCoverageIgnore
+			return null; // @codeCoverageIgnore
+		}
+
+		$venue_world_x = $this->lng_to_world_pixel( $lng, $zoom );
+		$venue_world_y = $this->lat_to_world_pixel( $lat, $zoom );
+
+		$left_pixel = (int) round( $venue_world_x - $width / 2 );
+		$top_pixel  = (int) round( $venue_world_y - $height / 2 );
+
+		$left_tile   = (int) floor( $left_pixel / self::TILE_SIZE );
+		$top_tile    = (int) floor( $top_pixel / self::TILE_SIZE );
+		$right_tile  = (int) floor( ( $left_pixel + $width - 1 ) / self::TILE_SIZE );
+		$bottom_tile = (int) floor( ( $top_pixel + $height - 1 ) / self::TILE_SIZE );
+
+		$canvas = imagecreatetruecolor( $width, $height );
+
+		// Background: neutral gray so missing tiles blend rather than glaring black.
+		$bg = imagecolorallocate( $canvas, 238, 238, 238 );
+		imagefilledrectangle( $canvas, 0, 0, $width - 1, $height - 1, $bg );
+
+		for ( $tx = $left_tile; $tx <= $right_tile; $tx++ ) {
+			for ( $ty = $top_tile; $ty <= $bottom_tile; $ty++ ) {
+				$tile_png = $this->fetch_tile( $zoom, $tx, $ty, $tiles );
+
+				if ( null === $tile_png ) {
+					continue;
+				}
+
+				$tile = imagecreatefromstring( $tile_png );
+
+				if ( ! $tile instanceof GdImage ) {
+					continue;
+				}
+
+				$dst_x = $tx * self::TILE_SIZE - $left_pixel;
+				$dst_y = $ty * self::TILE_SIZE - $top_pixel;
+
+				imagecopy( $canvas, $tile, $dst_x, $dst_y, 0, 0, self::TILE_SIZE, self::TILE_SIZE );
+				imagedestroy( $tile );
+			}
+		}
+
+		return $canvas;
+	}
+
+	/**
+	 * Draw a simple pin marker at the given pixel coordinates.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param GdImage $canvas Destination canvas.
+	 * @param int     $x      Pixel X position (marker center).
+	 * @param int     $y      Pixel Y position (marker center).
+	 * @return void
+	 */
+	public function stamp_marker( GdImage $canvas, int $x, int $y ): void {
+		$white = imagecolorallocate( $canvas, 255, 255, 255 );
+		$red   = imagecolorallocate( $canvas, 220, 53, 69 );
+		$dark  = imagecolorallocate( $canvas, 30, 30, 30 );
+
+		imagefilledellipse( $canvas, $x, $y, 20, 20, $white );
+		imagefilledellipse( $canvas, $x, $y, 16, 16, $red );
+		imageellipse( $canvas, $x, $y, 16, 16, $dark );
+		imagefilledellipse( $canvas, $x, $y, 6, 6, $white );
+	}
+
+	/**
+	 * Save the composited image to the uploads directory and return its URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param GdImage $image   The finished composite.
+	 * @param int     $post_id The venue post ID (used in the filename).
+	 * @param string  $hash    Input hash (used in the filename).
+	 * @return string|null Public URL of the saved file, or null on failure.
+	 */
+	public function save_image( GdImage $image, int $post_id, string $hash ): ?string {
+		$dirs = wp_get_upload_dir();
+
+		if ( ! empty( $dirs['error'] ) ) {
+			return null;
+		}
+
+		$base_dir = trailingslashit( $dirs['basedir'] ) . self::UPLOADS_SUBDIR;
+		$base_url = trailingslashit( $dirs['baseurl'] ) . self::UPLOADS_SUBDIR;
+
+		// uploads/ not writable or disk full — can't reproduce in a unit test without breaking the test filesystem.
+		if ( ! wp_mkdir_p( $base_dir ) ) { // @codeCoverageIgnore
+			return null; // @codeCoverageIgnore
+		}
+
+		$filename = sprintf( '%d-%s.png', $post_id, $hash );
+		$path     = trailingslashit( $base_dir ) . $filename;
+		$url      = trailingslashit( $base_url ) . $filename;
+
+		// Disk fills up mid-write, or target dir lost write permission between the mkdir check and the imagepng call.
+		if ( ! imagepng( $image, $path ) ) { // @codeCoverageIgnore
+			return null; // @codeCoverageIgnore
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Convert a stored URL back to its filesystem path for deletion.
+	 *
+	 * Returns null when the URL doesn't sit inside this plugin's uploads
+	 * subdir — a safety check so we never interpret a filter-injected URL
+	 * as a path to unlink.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $url URL to convert.
+	 * @return string|null Absolute filesystem path, or null when out of scope.
+	 */
+	public function url_to_path( string $url ): ?string {
+		$dirs     = wp_get_upload_dir();
+		$base_url = trailingslashit( $dirs['baseurl'] ) . self::UPLOADS_SUBDIR . '/';
+
+		if ( 0 !== strpos( $url, $base_url ) ) {
+			return null;
+		}
+
+		$relative = substr( $url, strlen( $base_url ) );
+		$base_dir = trailingslashit( $dirs['basedir'] ) . self::UPLOADS_SUBDIR . '/';
+
+		return $base_dir . $relative;
+	}
+
+	/**
+	 * Coerce a stored coordinate string to a float, or null for non-numeric input.
+	 *
+	 * Stored coordinates are strings ("40.7128"); empty string / "null" / text
+	 * should not generate a bogus (0, 0) map off the west coast of Africa.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $raw Raw coordinate from venue information.
+	 * @return float|null
+	 */
+	protected function parse_coord( $raw ): ?float {
+		return is_numeric( $raw ) ? (float) $raw : null;
+	}
+
+	/**
+	 * Zoom level to render at. Filterable.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int
+	 */
+	protected function get_zoom(): int {
+		/**
+		 * Filter the zoom level used when rendering the static venue map.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $zoom Default zoom level.
+		 */
+		return (int) apply_filters( 'gatherpress_venue_static_map_zoom', self::DEFAULT_ZOOM );
+	}
+
+	/**
+	 * Output image width in pixels. Filterable.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int
+	 */
+	protected function get_width(): int {
+		/**
+		 * Filter the width of the rendered static venue map.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $width Default width in pixels.
+		 */
+		return (int) apply_filters( 'gatherpress_venue_static_map_width', self::DEFAULT_WIDTH );
+	}
+
+	/**
+	 * Output image height in pixels. Filterable.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int
+	 */
+	protected function get_height(): int {
+		/**
+		 * Filter the height of the rendered static venue map.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $height Default height in pixels.
+		 */
+		return (int) apply_filters( 'gatherpress_venue_static_map_height', self::DEFAULT_HEIGHT );
+	}
+
+	/**
+	 * Tile URL template used by the static renderer. Filterable.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	protected function get_tile_url_template(): string {
+		/**
+		 * Filter the tile URL template used by the static venue map.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Tile URL with `{z}`, `{x}`, `{y}` placeholders.
+		 */
+		return (string) apply_filters( 'gatherpress_venue_static_map_tile_url', self::DEFAULT_TILE_URL );
+	}
+
+	/**
+	 * Convert longitude to absolute pixel X in world pixel space at `$zoom`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param float $lng  Longitude in degrees.
+	 * @param int   $zoom Zoom level.
+	 * @return float
+	 */
+	protected function lng_to_world_pixel( float $lng, int $zoom ): float {
+		return ( ( $lng + 180.0 ) / 360.0 ) * self::TILE_SIZE * ( 2 ** $zoom );
+	}
+
+	/**
+	 * Convert latitude to absolute pixel Y in world pixel space at `$zoom`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param float $lat  Latitude in degrees.
+	 * @param int   $zoom Zoom level.
+	 * @return float
+	 */
+	protected function lat_to_world_pixel( float $lat, int $zoom ): float {
+		$rad = deg2rad( $lat );
+
+		return ( 1 - log( tan( $rad ) + 1 / cos( $rad ) ) / M_PI ) / 2 * self::TILE_SIZE * ( 2 ** $zoom );
+	}
+}

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -16,6 +16,7 @@ namespace GatherPress\Core\Settings;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Venue_Map;
 
 /**
  * Class Venues.
@@ -115,7 +116,7 @@ class Venues extends Base {
 							'label'   => __( 'Render mode for new blocks:', 'gatherpress' ),
 							'type'    => 'select',
 							'options' => array(
-								'default' => 'interactive',
+								'default' => Venue_Map::DEFAULT_RENDER_MODE,
 								'items'   => array(
 									'interactive' => __( 'Interactive', 'gatherpress' ),
 									'static'      => __( 'Static image', 'gatherpress' ),
@@ -136,7 +137,7 @@ class Venues extends Base {
 							'type'    => 'number',
 							'size'    => 'small',
 							'options' => array(
-								'default' => 18,
+								'default' => Venue_Map::DEFAULT_ZOOM,
 								'min'     => '1',
 								'max'     => '20',
 							),
@@ -155,7 +156,7 @@ class Venues extends Base {
 							'type'    => 'number',
 							'size'    => 'small',
 							'options' => array(
-								'default' => 300,
+								'default' => Venue_Map::DEFAULT_HEIGHT,
 								'min'     => '100',
 								'max'     => '800',
 							),
@@ -174,7 +175,7 @@ class Venues extends Base {
 							'label'   => __( 'Map type for new blocks:', 'gatherpress' ),
 							'type'    => 'select',
 							'options' => array(
-								'default' => 'roadmap',
+								'default' => Venue_Map::DEFAULT_MAP_TYPE,
 								'items'   => array(
 									'roadmap'   => __( 'Roadmap', 'gatherpress' ),
 									'satellite' => __( 'Satellite', 'gatherpress' ),

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -79,11 +79,11 @@ class Venues extends Base {
 			'maps' => array(
 				'name'        => __( 'Maps', 'gatherpress' ),
 				'description' => __(
-					'Configure the mapping platform used for venue display.',
+					'Configure the mapping platform and defaults applied to new venue map blocks.',
 					'gatherpress'
 				),
 				'options'     => array(
-					'map_platform' => array(
+					'map_platform'                  => array(
 						'labels'      => array(
 							'name' => __( 'Mapping Platform', 'gatherpress' ),
 						),
@@ -99,6 +99,87 @@ class Venues extends Base {
 								'items'   => array(
 									'osm'    => __( 'OpenStreetMap', 'gatherpress' ),
 									'google' => __( 'Google Maps', 'gatherpress' ),
+								),
+							),
+						),
+					),
+					'venue_map_default_render_mode' => array(
+						'labels'      => array(
+							'name' => __( 'Default Render Mode', 'gatherpress' ),
+						),
+						'description' => __(
+							'Default rendering mode applied to new venue map blocks.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Render mode for new blocks:', 'gatherpress' ),
+							'type'    => 'select',
+							'options' => array(
+								'default' => 'interactive',
+								'items'   => array(
+									'interactive' => __( 'Interactive', 'gatherpress' ),
+									'static'      => __( 'Static image', 'gatherpress' ),
+								),
+							),
+						),
+					),
+					'venue_map_default_zoom'        => array(
+						'labels'      => array(
+							'name' => __( 'Default Zoom Level', 'gatherpress' ),
+						),
+						'description' => __(
+							'Default zoom applied to new venue map blocks.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Zoom level for new blocks:', 'gatherpress' ),
+							'type'    => 'number',
+							'size'    => 'small',
+							'options' => array(
+								'default' => 18,
+								'min'     => '1',
+								'max'     => '20',
+							),
+						),
+					),
+					'venue_map_default_height'      => array(
+						'labels'      => array(
+							'name' => __( 'Default Height', 'gatherpress' ),
+						),
+						'description' => __(
+							'Default pixel height applied to new venue map blocks.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Height for new blocks (px):', 'gatherpress' ),
+							'type'    => 'number',
+							'size'    => 'small',
+							'options' => array(
+								'default' => 300,
+								'min'     => '100',
+								'max'     => '800',
+							),
+						),
+					),
+					'venue_map_default_type'        => array(
+						'labels'      => array(
+							'name' => __( 'Default Map Type', 'gatherpress' ),
+						),
+						'description' => __(
+							// phpcs:ignore Generic.Files.LineLength.TooLong -- Single translator-facing sentence; keep on one line for .pot extractor.
+							'Default map type for new venue map blocks. Only rendered by Google Maps; OpenStreetMap and static images ignore this value.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Map type for new blocks:', 'gatherpress' ),
+							'type'    => 'select',
+							'options' => array(
+								'default' => 'roadmap',
+								'items'   => array(
+									'roadmap'   => __( 'Roadmap', 'gatherpress' ),
+									'satellite' => __( 'Satellite', 'gatherpress' ),
+									'hybrid'    => __( 'Hybrid', 'gatherpress' ),
+									'terrain'   => __( 'Terrain', 'gatherpress' ),
 								),
 							),
 						),

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
 				"lodash": "^4.18.1",
 				"moment": "^2.30.1",
 				"moment-timezone": "^0.6.0",
+				"patch-package": "^8.0.1",
 				"playwright": "^1.58.2",
 				"prettier": "^3.8.1",
 				"rimraf": "^6.1.3",
@@ -13360,6 +13361,13 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/@zip.js/zip.js": {
 			"version": "2.7.57",
 			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
@@ -18615,6 +18623,16 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/find-yarn-workspace-root": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"micromatch": "^4.0.2"
 			}
 		},
 		"node_modules/flat": {
@@ -23979,6 +23997,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-stable-stringify": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+			"integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"isarray": "^2.0.5",
+				"jsonify": "^0.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -24024,6 +24062,16 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+			"integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+			"dev": true,
+			"license": "Public Domain",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/jsonwebtoken": {
@@ -24122,6 +24170,16 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"node_modules/kleur": {
@@ -26574,6 +26632,107 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/patch-package": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+			"integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@yarnpkg/lockfile": "^1.1.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^3.7.0",
+				"cross-spawn": "^7.0.3",
+				"find-yarn-workspace-root": "^2.0.0",
+				"fs-extra": "^10.0.0",
+				"json-stable-stringify": "^1.0.2",
+				"klaw-sync": "^6.0.0",
+				"minimist": "^1.2.6",
+				"open": "^7.4.2",
+				"semver": "^7.5.3",
+				"slash": "^2.0.0",
+				"tmp": "^0.2.4",
+				"yaml": "^2.2.2"
+			},
+			"bin": {
+				"patch-package": "index.js"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">5"
+			}
+		},
+		"node_modules/patch-package/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/patch-package/node_modules/open": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+			"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0",
+				"is-wsl": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/patch-package/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/patch-package/node_modules/slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/patch-package/node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/path-case": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"lodash": "^4.18.1",
 		"moment": "^2.30.1",
 		"moment-timezone": "^0.6.0",
+		"patch-package": "^8.0.1",
 		"playwright": "^1.58.2",
 		"prettier": "^3.8.1",
 		"rimraf": "^6.1.3",
@@ -79,6 +80,7 @@
 		"minimatch@9": "9.0.7"
 	},
 	"scripts": {
+		"postinstall": "patch-package",
 		"build": "rimraf build && wp-scripts build --experimental-modules",
 		"check-engines": "wp-scripts check-engines",
 		"check-licenses": "wp-scripts check-licenses",

--- a/patches/@wordpress+env+11.2.0.patch
+++ b/patches/@wordpress+env+11.2.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js b/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
+index 0820bcc..fd22583 100644
+--- a/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
++++ b/node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
+@@ -229,6 +229,8 @@ RUN rm /tmp/composer-setup.php`;
+ 	dockerFileContent += `
+ USER $HOST_UID:$HOST_GID
+ ENV PATH="\${PATH}:/home/$HOST_USERNAME/.composer/vendor/bin"
++RUN composer global config --no-plugins audit.abandoned ignore
++RUN composer global config --no-plugins audit.block-insecure false
+ RUN composer global require --dev phpunit/phpunit:"^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+ USER root`;
+ 

--- a/phpstan.stubs
+++ b/phpstan.stubs
@@ -23,4 +23,16 @@ namespace {
      * @return string
      */
     function wxr_cdata( string $str ): string {}
+
+    /**
+     * GD image resource. Introduced in PHP 8.0; on PHP 7.4 the GD extension
+     * returns a plain `resource`. Stubbed here so PHPStan recognizes the
+     * class name in docblocks such as `@return \GdImage|resource|null` —
+     * GatherPress never instantiates it directly. Guarded with class_exists
+     * because this file is loaded as a bootstrap on PHP 8+, where the real
+     * class already exists and redeclaring would fatal.
+     */
+    if ( ! class_exists( '\GdImage', false ) ) {
+        class GdImage {}
+    }
 }

--- a/src/blocks/venue-detail/hooks/use-geocoding.js
+++ b/src/blocks/venue-detail/hooks/use-geocoding.js
@@ -8,7 +8,7 @@ import { useDebounce } from '@wordpress/compose';
 /**
  * Internal dependencies.
  */
-import { geocodeAddress } from '../../../helpers/geocoding';
+import { geocodeAddress, GEOCODE_LOCK_NAME } from '../../../helpers/geocoding';
 
 /**
  * Custom hook for geocoding address fields.
@@ -29,6 +29,12 @@ export function useGeocoding( fieldType, fieldValue, updateVenueField, enabled =
 	// Get dispatch functions for venue store.
 	const { updateVenueLatitude, updateVenueLongitude } =
 		useDispatch( 'gatherpress/venue' );
+
+	// Dispatches used to block Save while geocoding is pending — prevents
+	// the "saved new address with stale lat/long" race that otherwise bakes
+	// a wrong-location static map until the next save.
+	const { lockPostSaving, unlockPostSaving } =
+		useDispatch( 'core/editor' );
 
 	// Get mapCustomLatLong setting from venue store.
 	const { mapCustomLatLong } = useSelect(
@@ -53,31 +59,35 @@ export function useGeocoding( fieldType, fieldValue, updateVenueField, enabled =
 			return;
 		}
 
-		// If address is empty, clear lat/long.
-		if ( ! address ) {
-			if ( ! mapCustomLatLong ) {
-				// Clear venue store for live preview.
-				updateVenueLatitude( '' );
-				updateVenueLongitude( '' );
+		try {
+			// If address is empty, clear lat/long.
+			if ( ! address ) {
+				if ( ! mapCustomLatLong ) {
+					// Clear venue store for live preview.
+					updateVenueLatitude( '' );
+					updateVenueLongitude( '' );
 
-				// Clear meta for the venue post.
-				updateVenueField( { latitude: '', longitude: '' } );
+					// Clear meta for the venue post.
+					updateVenueField( { latitude: '', longitude: '' } );
+				}
+				return;
 			}
-			return;
-		}
 
-		const { latitude, longitude } = await geocodeAddress( address );
+			const { latitude, longitude } = await geocodeAddress( address );
 
-		if ( ! mapCustomLatLong ) {
-			// Update venue store for live preview.
-			updateVenueLatitude( latitude || null );
-			updateVenueLongitude( longitude || null );
+			if ( ! mapCustomLatLong ) {
+				// Update venue store for live preview.
+				updateVenueLatitude( latitude || null );
+				updateVenueLongitude( longitude || null );
 
-			// Update meta for the venue post.
-			updateVenueField( {
-				latitude: latitude || '',
-				longitude: longitude || '',
-			} );
+				// Update meta for the venue post.
+				updateVenueField( {
+					latitude: latitude || '',
+					longitude: longitude || '',
+				} );
+			}
+		} finally {
+			unlockPostSaving( GEOCODE_LOCK_NAME );
 		}
 	}, [
 		fieldType,
@@ -85,6 +95,7 @@ export function useGeocoding( fieldType, fieldValue, updateVenueField, enabled =
 		updateVenueLatitude,
 		updateVenueLongitude,
 		updateVenueField,
+		unlockPostSaving,
 	] );
 
 	// Longer debounce than autocomplete: geocoding is not user-visible during
@@ -95,8 +106,15 @@ export function useGeocoding( fieldType, fieldValue, updateVenueField, enabled =
 	// Trigger geocoding when address field value changes.
 	useEffect( () => {
 		if ( enabled && 'address' === fieldType ) {
+			lockPostSaving( GEOCODE_LOCK_NAME );
 			debouncedGeocode();
+
+			return () => {
+				unlockPostSaving( GEOCODE_LOCK_NAME );
+			};
 		}
+
+		return undefined;
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ fieldValue, fieldType, enabled ] );
 

--- a/src/blocks/venue-map/block.json
+++ b/src/blocks/venue-map/block.json
@@ -21,6 +21,10 @@
 		"height": {
 			"type": "number",
 			"default": 300
+		},
+		"renderMode": {
+			"type": "string",
+			"default": "interactive"
 		}
 	},
 	"supports": {

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -33,8 +33,8 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const { zoom, type, height, renderMode } = attributes;
 	const blockProps = useBlockProps();
 
-	// Determine the venue post ID and get venue info.
-	const { isEditingThisVenue, venueInfoJson } = useSelect(
+	// Determine the venue post ID and get venue info + static-map descriptors.
+	const { isEditingThisVenue, venueInfoJson, staticMapDescriptors } = useSelect(
 		( select ) => {
 			const currentPostId = select( 'core/editor' )?.getCurrentPostId();
 			const contextPostId = context?.postId || 0;
@@ -49,6 +49,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				return {
 					isEditingThisVenue: false,
 					venueInfoJson: '{}',
+					staticMapDescriptors: {},
 				};
 			}
 
@@ -63,6 +64,8 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				return {
 					isEditingThisVenue: true,
 					venueInfoJson: meta?.gatherpress_venue_information || '{}',
+					staticMapDescriptors:
+						meta?.gatherpress_venue_static_map || {},
 				};
 			}
 
@@ -79,6 +82,8 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 			return {
 				isEditingThisVenue: false,
 				venueInfoJson: venuePost?.meta?.gatherpress_venue_information || '{}',
+				staticMapDescriptors:
+					venuePost?.meta?.gatherpress_venue_static_map || {},
 			};
 		},
 		[ context?.postId, context?.postType ]
@@ -122,6 +127,19 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const showMapTypeControl =
 		'interactive' === renderMode &&
 		'google' === getFromSettings( 'mapPlatform' );
+
+	// When the block is in static mode we show one of two previews in place of
+	// the interactive MapEmbed: (a) the actual cached PNG for this venue+zoom
+	// if it's been generated, or (b) a placeholder surface noting that the
+	// image will be generated on the next save. The interactive MapEmbed only
+	// renders when the user explicitly picked Interactive.
+	const staticMapDescriptor =
+		staticMapDescriptors?.[ String( zoom ) ] ||
+		staticMapDescriptors?.[ zoom ];
+	const staticMapUrl = staticMapDescriptor?.url || '';
+	const isStaticMode = 'static' === renderMode;
+	const showStaticImage = isStaticMode && '' !== staticMapUrl;
+	const showStaticPlaceholder = isStaticMode && '' === staticMapUrl;
 
 	return (
 		<>
@@ -193,14 +211,43 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 			</InspectorControls>
 			<div { ...blockProps }>
 				<div className="block-editor-inner-blocks">
-					<MapEmbed
-						location={ fullAddress }
-						latitude={ latitude }
-						longitude={ longitude }
-						zoom={ zoom }
-						type={ type }
-						height={ height }
-					/>
+					{ showStaticImage && (
+						<div
+							className="gatherpress-venue-map gatherpress-venue-map--static"
+							style={ { height: `${ height }px` } }
+						>
+							<img
+								className="gatherpress-venue-map__image"
+								src={ staticMapUrl }
+								alt={ fullAddress
+									? `${ __( 'Map of', 'gatherpress' ) } ${ fullAddress }`
+									: __( 'Venue map', 'gatherpress' ) }
+							/>
+						</div>
+					) }
+					{ showStaticPlaceholder && (
+						<div
+							className="gatherpress-venue-map gatherpress-venue-map--static"
+							style={ { height: `${ height }px` } }
+						>
+							<div className="gatherpress-venue-map__placeholder">
+								{ __(
+									'Static map preview appears after venue is saved.',
+									'gatherpress'
+								) }
+							</div>
+						</div>
+					) }
+					{ ! isStaticMode && (
+						<MapEmbed
+							location={ fullAddress }
+							latitude={ latitude }
+							longitude={ longitude }
+							zoom={ zoom }
+							type={ type }
+							height={ height }
+						/>
+					) }
 				</div>
 			</div>
 		</>

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -14,6 +14,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies.
  */
 import { isVenuePostType } from '../../helpers/venue';
+import { getFromSettings } from '../../helpers/editor-settings';
 import MapEmbed from '../../components/MapEmbed';
 
 /**
@@ -29,7 +30,7 @@ import MapEmbed from '../../components/MapEmbed';
  * @return {JSX.Element} The rendered React component.
  */
 const Edit = ( { attributes, setAttributes, context } ) => {
-	const { zoom, type, height } = attributes;
+	const { zoom, type, height, renderMode } = attributes;
 	const blockProps = useBlockProps();
 
 	// Determine the venue post ID and get venue info.
@@ -115,10 +116,34 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 		longitude = null !== storeLng && storeLng !== undefined ? String( storeLng ) : longitude;
 	}
 
+	// Map type is a Google Maps–only concept; only expose the selector when
+	// the map platform is Google and we're rendering interactively on the
+	// front-end. The OSM/Leaflet and static-image paths both ignore it.
+	const showMapTypeControl =
+		'interactive' === renderMode &&
+		'google' === getFromSettings( 'mapPlatform' );
+
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Map settings', 'gatherpress' ) }>
+					<SelectControl
+						label={ __( 'Render mode', 'gatherpress' ) }
+						value={ renderMode }
+						options={ [
+							{
+								label: __( 'Interactive', 'gatherpress' ),
+								value: 'interactive',
+							},
+							{
+								label: __( 'Static image', 'gatherpress' ),
+								value: 'static',
+							},
+						] }
+						onChange={ ( value ) =>
+							setAttributes( { renderMode: value } )
+						}
+					/>
 					<RangeControl
 						label={ __( 'Zoom level', 'gatherpress' ) }
 						value={ zoom }
@@ -128,29 +153,33 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 						min={ 1 }
 						max={ 20 }
 					/>
-					<SelectControl
-						label={ __( 'Map type', 'gatherpress' ) }
-						value={ type }
-						options={ [
-							{
-								label: __( 'Roadmap', 'gatherpress' ),
-								value: 'roadmap',
-							},
-							{
-								label: __( 'Satellite', 'gatherpress' ),
-								value: 'satellite',
-							},
-							{
-								label: __( 'Hybrid', 'gatherpress' ),
-								value: 'hybrid',
-							},
-							{
-								label: __( 'Terrain', 'gatherpress' ),
-								value: 'terrain',
-							},
-						] }
-						onChange={ ( value ) => setAttributes( { type: value } ) }
-					/>
+					{ showMapTypeControl && (
+						<SelectControl
+							label={ __( 'Map type', 'gatherpress' ) }
+							value={ type }
+							options={ [
+								{
+									label: __( 'Roadmap', 'gatherpress' ),
+									value: 'roadmap',
+								},
+								{
+									label: __( 'Satellite', 'gatherpress' ),
+									value: 'satellite',
+								},
+								{
+									label: __( 'Hybrid', 'gatherpress' ),
+									value: 'hybrid',
+								},
+								{
+									label: __( 'Terrain', 'gatherpress' ),
+									value: 'terrain',
+								},
+							] }
+							onChange={ ( value ) =>
+								setAttributes( { type: value } )
+							}
+						/>
+					) }
 					<RangeControl
 						label={ __( 'Height (px)', 'gatherpress' ) }
 						value={ height }

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -34,7 +34,15 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const blockProps = useBlockProps();
 
 	// Determine the venue post ID and get venue info + static-map descriptors.
-	const { isEditingThisVenue, venueInfoJson, staticMapDescriptors } = useSelect(
+	// `savedVenueInfoJson` reflects what's persisted server-side — compared
+	// against the edited JSON below to detect unsaved address/coord changes
+	// and force the placeholder until the next save regenerates the PNG.
+	const {
+		isEditingThisVenue,
+		venueInfoJson,
+		savedVenueInfoJson,
+		staticMapDescriptors,
+	} = useSelect(
 		( select ) => {
 			const currentPostId = select( 'core/editor' )?.getCurrentPostId();
 			const contextPostId = context?.postId || 0;
@@ -49,6 +57,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				return {
 					isEditingThisVenue: false,
 					venueInfoJson: '{}',
+					savedVenueInfoJson: '{}',
 					staticMapDescriptors: {},
 				};
 			}
@@ -61,9 +70,13 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				// Read from core/editor store for the current post being edited.
 				const meta =
 					select( 'core/editor' )?.getEditedPostAttribute( 'meta' ) || {};
+				const savedPost =
+					select( 'core/editor' )?.getCurrentPost() || {};
 				return {
 					isEditingThisVenue: true,
 					venueInfoJson: meta?.gatherpress_venue_information || '{}',
+					savedVenueInfoJson:
+						savedPost?.meta?.gatherpress_venue_information || '{}',
 					staticMapDescriptors:
 						meta?.gatherpress_venue_static_map || {},
 				};
@@ -79,9 +92,13 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				effectiveVenuePostId
 			);
 
+			const venueInfo =
+				venuePost?.meta?.gatherpress_venue_information || '{}';
+
 			return {
 				isEditingThisVenue: false,
-				venueInfoJson: venuePost?.meta?.gatherpress_venue_information || '{}',
+				venueInfoJson: venueInfo,
+				savedVenueInfoJson: venueInfo,
 				staticMapDescriptors:
 					venuePost?.meta?.gatherpress_venue_static_map || {},
 			};
@@ -129,17 +146,38 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 		'google' === getFromSettings( 'mapPlatform' );
 
 	// When the block is in static mode we show one of two previews in place of
-	// the interactive MapEmbed: (a) the actual cached PNG for this venue+zoom
-	// if it's been generated, or (b) a placeholder surface noting that the
-	// image will be generated on the next save. The interactive MapEmbed only
-	// renders when the user explicitly picked Interactive.
-	const staticMapDescriptor =
-		staticMapDescriptors?.[ String( zoom ) ] ||
-		staticMapDescriptors?.[ zoom ];
+	// the interactive MapEmbed: (a) the actual cached PNG for this venue's
+	// (zoom, height) combo if it's been generated, or (b) a placeholder
+	// noting that the image will be generated on the next save. The
+	// interactive MapEmbed only renders when the user explicitly picked
+	// Interactive.
+	//
+	// While the venue is being edited we compare the edited address/coords
+	// against the last-saved snapshot so the cached PNG doesn't linger as a
+	// stale preview after the user types a new address — the placeholder
+	// takes over until the next save regenerates the image.
+	let savedVenueInfo = {};
+	try {
+		savedVenueInfo = JSON.parse( savedVenueInfoJson );
+	} catch ( e ) {
+		savedVenueInfo = {};
+	}
+	const hasUnsavedMapInputs =
+		isEditingThisVenue &&
+		( ( venueInfo.fullAddress || '' ) !==
+			( savedVenueInfo.fullAddress || '' ) ||
+			( venueInfo.latitude || '' ) !==
+				( savedVenueInfo.latitude || '' ) ||
+			( venueInfo.longitude || '' ) !==
+				( savedVenueInfo.longitude || '' ) );
+
+	const comboKey = `${ zoom }x${ height }`;
+	const staticMapDescriptor = staticMapDescriptors?.[ comboKey ];
 	const staticMapUrl = staticMapDescriptor?.url || '';
 	const isStaticMode = 'static' === renderMode;
-	const showStaticImage = isStaticMode && '' !== staticMapUrl;
-	const showStaticPlaceholder = isStaticMode && '' === staticMapUrl;
+	const showStaticImage =
+		isStaticMode && '' !== staticMapUrl && ! hasUnsavedMapInputs;
+	const showStaticPlaceholder = isStaticMode && ! showStaticImage;
 
 	return (
 		<>

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Settings;
 use GatherPress\Core\Venue_Setup;
-use GatherPress\Core\Venue_Static_Map;
+use GatherPress\Core\Venue_Map;
 
 if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {
 	return;
@@ -35,10 +35,12 @@ if ( '' === $gatherpress_address ) {
 	return;
 }
 
-$gatherpress_render_mode    = 'static' === ( $attributes['renderMode'] ?? 'interactive' ) ? 'static' : 'interactive';
-$gatherpress_zoom           = (int) ( $attributes['zoom'] ?? 18 );
-$gatherpress_height         = (int) ( $attributes['height'] ?? 300 );
-$gatherpress_static_map_url = Venue_Static_Map::get_instance()->get_url_for_post(
+$gatherpress_render_mode    = 'static' === ( $attributes['renderMode'] ?? Venue_Map::DEFAULT_RENDER_MODE )
+	? 'static'
+	: 'interactive';
+$gatherpress_zoom           = (int) ( $attributes['zoom'] ?? Venue_Map::DEFAULT_BLOCK_ZOOM );
+$gatherpress_height         = (int) ( $attributes['height'] ?? Venue_Map::DEFAULT_BLOCK_HEIGHT );
+$gatherpress_static_map_url = Venue_Map::get_instance()->get_url_for_post(
 	$gatherpress_post_id,
 	$gatherpress_post_type,
 	$gatherpress_zoom
@@ -61,9 +63,9 @@ if ( 'interactive' === $gatherpress_render_mode ) {
 		'fullAddress'  => $gatherpress_address,
 		'latitude'     => (string) ( $gatherpress_venue_meta['latitude'] ?? '' ),
 		'longitude'    => (string) ( $gatherpress_venue_meta['longitude'] ?? '' ),
-		'mapZoomLevel' => $attributes['zoom'] ?? 18,
-		'mapType'      => $attributes['type'] ?? 'roadmap',
-		'mapHeight'    => $attributes['height'] ?? 300,
+		'mapZoomLevel' => $attributes['zoom'] ?? Venue_Map::DEFAULT_BLOCK_ZOOM,
+		'mapType'      => $attributes['type'] ?? Venue_Map::DEFAULT_MAP_TYPE,
+		'mapHeight'    => $attributes['height'] ?? Venue_Map::DEFAULT_BLOCK_HEIGHT,
 		'mapPlatform'  => Settings::get_instance()->get( 'map_platform' ),
 		'pluginUrl'    => GATHERPRESS_CORE_URL,
 	);

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -38,12 +38,13 @@ if ( '' === $gatherpress_address ) {
 $gatherpress_render_mode    = 'static' === ( $attributes['renderMode'] ?? Venue_Map::DEFAULT_RENDER_MODE )
 	? 'static'
 	: 'interactive';
-$gatherpress_zoom           = (int) ( $attributes['zoom'] ?? Venue_Map::DEFAULT_BLOCK_ZOOM );
-$gatherpress_height         = (int) ( $attributes['height'] ?? Venue_Map::DEFAULT_BLOCK_HEIGHT );
+$gatherpress_zoom           = (int) ( $attributes['zoom'] ?? Venue_Map::DEFAULT_ZOOM );
+$gatherpress_height         = (int) ( $attributes['height'] ?? Venue_Map::DEFAULT_HEIGHT );
 $gatherpress_static_map_url = Venue_Map::get_instance()->get_url_for_post(
 	$gatherpress_post_id,
 	$gatherpress_post_type,
-	$gatherpress_zoom
+	$gatherpress_zoom,
+	$gatherpress_height
 );
 
 // Hydration data sits on the outer wrapper so view.js can replace the
@@ -63,9 +64,9 @@ if ( 'interactive' === $gatherpress_render_mode ) {
 		'fullAddress'  => $gatherpress_address,
 		'latitude'     => (string) ( $gatherpress_venue_meta['latitude'] ?? '' ),
 		'longitude'    => (string) ( $gatherpress_venue_meta['longitude'] ?? '' ),
-		'mapZoomLevel' => $attributes['zoom'] ?? Venue_Map::DEFAULT_BLOCK_ZOOM,
+		'mapZoomLevel' => $attributes['zoom'] ?? Venue_Map::DEFAULT_ZOOM,
 		'mapType'      => $attributes['type'] ?? Venue_Map::DEFAULT_MAP_TYPE,
-		'mapHeight'    => $attributes['height'] ?? Venue_Map::DEFAULT_BLOCK_HEIGHT,
+		'mapHeight'    => $attributes['height'] ?? Venue_Map::DEFAULT_HEIGHT,
 		'mapPlatform'  => Settings::get_instance()->get( 'map_platform' ),
 		'pluginUrl'    => GATHERPRESS_CORE_URL,
 	);
@@ -112,7 +113,7 @@ if ( '' !== $gatherpress_static_map_url ) {
 } else {
 	printf(
 		'<div class="gatherpress-venue-map__placeholder">%s</div>',
-		esc_html__( 'Map is being prepared — check back in a moment.', 'gatherpress' )
+		esc_html__( 'Map is being prepared, check back in a moment.', 'gatherpress' )
 	);
 }
 

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -2,6 +2,13 @@
 /**
  * Render Venue Map block.
  *
+ * Emits the pre-rendered static map as the baseline (no JavaScript required).
+ * When `renderMode === 'interactive'` the wrapper also carries the data
+ * attributes the view.js script reads to swap the `<img>` for a live Leaflet
+ * map at hydration time. When the venue has no coordinates yet — e.g. a brand
+ * new venue that hasn't been geocoded — a short placeholder surfaces the
+ * "map coming soon" state in place of the image.
+ *
  * @package GatherPress\Core
  * @since 1.0.0
  */
@@ -11,36 +18,100 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Settings;
 use GatherPress\Core\Venue_Setup;
+use GatherPress\Core\Venue_Static_Map;
 
 if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {
 	return;
 }
 
-$gatherpress_venue      = Venue_Setup::get_instance();
-$gatherpress_venue_meta = $gatherpress_venue->get_venue_meta( get_the_ID(), get_post_type() );
+$gatherpress_post_id     = (int) get_the_ID();
+$gatherpress_post_type   = (string) get_post_type();
+$gatherpress_venue_setup = Venue_Setup::get_instance();
+$gatherpress_venue_meta  = $gatherpress_venue_setup->get_venue_meta( $gatherpress_post_id, $gatherpress_post_type );
 
-// Get venue data.
-$gatherpress_venue_address   = $gatherpress_venue_meta['fullAddress'] ?? '';
-$gatherpress_venue_latitude  = $gatherpress_venue_meta['latitude'] ?? '';
-$gatherpress_venue_longitude = $gatherpress_venue_meta['longitude'] ?? '';
+$gatherpress_address = (string) ( $gatherpress_venue_meta['fullAddress'] ?? '' );
 
-if ( empty( $gatherpress_venue_address ) ) {
+if ( '' === $gatherpress_address ) {
 	return;
 }
 
-// Prepare attributes for the map.
-$gatherpress_map_attrs = array(
-	'fullAddress'  => $gatherpress_venue_address,
-	'latitude'     => $gatherpress_venue_latitude,
-	'longitude'    => $gatherpress_venue_longitude,
-	'mapZoomLevel' => $attributes['zoom'] ?? 18,
-	'mapType'      => $attributes['type'] ?? 'roadmap',
-	'mapHeight'    => $attributes['height'] ?? 300,
-	'mapPlatform'  => Settings::get_instance()->get( 'map_platform' ),
-	'pluginUrl'    => GATHERPRESS_CORE_URL,
+$gatherpress_render_mode    = 'static' === ( $attributes['renderMode'] ?? 'interactive' ) ? 'static' : 'interactive';
+$gatherpress_zoom           = (int) ( $attributes['zoom'] ?? 18 );
+$gatherpress_height         = (int) ( $attributes['height'] ?? 300 );
+$gatherpress_static_map_url = Venue_Static_Map::get_instance()->get_url_for_post(
+	$gatherpress_post_id,
+	$gatherpress_post_type,
+	$gatherpress_zoom
 );
 
-?>
-<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
-	<div data-gatherpress_block_name="map-embed" data-gatherpress_block_attrs="<?php echo esc_attr( htmlspecialchars( wp_json_encode( $gatherpress_map_attrs ), ENT_QUOTES, 'UTF-8' ) ); ?>"></div>
-</div>
+// Hydration data sits on the outer wrapper so view.js can replace the
+// wrapper's children with a live Leaflet map (the `<img>` inside is a void
+// element that React can't mount into directly).
+$gatherpress_wrapper_attr_args = array(
+	'class'            => sprintf( 'gatherpress-venue-map gatherpress-venue-map--%s', $gatherpress_render_mode ),
+	'data-render-mode' => $gatherpress_render_mode,
+	// Apply the block-level height to the wrapper so the static <img> (with
+	// object-fit: cover) fills it, and so the interactive Leaflet container
+	// gets the exact same footprint after hydration.
+	'style'            => sprintf( 'height:%dpx;', $gatherpress_height ),
+);
+
+if ( 'interactive' === $gatherpress_render_mode ) {
+	$gatherpress_block_attrs = array(
+		'fullAddress'  => $gatherpress_address,
+		'latitude'     => (string) ( $gatherpress_venue_meta['latitude'] ?? '' ),
+		'longitude'    => (string) ( $gatherpress_venue_meta['longitude'] ?? '' ),
+		'mapZoomLevel' => $attributes['zoom'] ?? 18,
+		'mapType'      => $attributes['type'] ?? 'roadmap',
+		'mapHeight'    => $attributes['height'] ?? 300,
+		'mapPlatform'  => Settings::get_instance()->get( 'map_platform' ),
+		'pluginUrl'    => GATHERPRESS_CORE_URL,
+	);
+
+	$gatherpress_wrapper_attr_args['data-gatherpress_block_name']  = 'map-embed';
+	$gatherpress_wrapper_attr_args['data-gatherpress_block_attrs'] = htmlspecialchars(
+		(string) wp_json_encode( $gatherpress_block_attrs ),
+		ENT_QUOTES,
+		'UTF-8'
+	);
+}
+
+printf(
+	'<div %s>',
+	get_block_wrapper_attributes( $gatherpress_wrapper_attr_args ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped by core.
+);
+
+if ( '' !== $gatherpress_static_map_url ) {
+	/* translators: %s: full address of the venue. */
+	$gatherpress_alt = sprintf( __( 'Map of %s', 'gatherpress' ), $gatherpress_address );
+
+	printf(
+		'<img class="gatherpress-venue-map__image" src="%s" alt="%s" loading="lazy" />',
+		esc_url( $gatherpress_static_map_url ),
+		esc_attr( $gatherpress_alt )
+	);
+
+	// CartoDB + OpenStreetMap attribution is required whenever the static
+	// image is on display. Leaflet ships its own attribution control, so when
+	// the interactive map hydrates it replaces this caption entirely.
+	printf(
+		'<small class="gatherpress-venue-map__attribution">%s</small>',
+		wp_kses(
+			Settings::get_map_tile_attribution(),
+			array(
+				'a' => array(
+					'href'   => true,
+					'target' => true,
+					'rel'    => true,
+				),
+			)
+		)
+	);
+} else {
+	printf(
+		'<div class="gatherpress-venue-map__placeholder">%s</div>',
+		esc_html__( 'Map is being prepared — check back in a moment.', 'gatherpress' )
+	);
+}
+
+echo '</div>';

--- a/src/blocks/venue-map/style.scss
+++ b/src/blocks/venue-map/style.scss
@@ -21,3 +21,52 @@
 		}
 	}
 }
+
+.gatherpress-venue-map {
+	// The wrapper owns the block-level height (set inline by render.php); the
+	// static <img> fills that box via object-fit: cover so the image stays
+	// crisp and cropped rather than stretched when the block's aspect ratio
+	// differs from the 600×400 generator default.
+	position: relative;
+	overflow: hidden;
+
+	&__image {
+		display: block;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	&__placeholder {
+		display: flex;
+		width: 100%;
+		height: 100%;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem;
+		text-align: center;
+		background: #f0f0f0;
+		border: 1px dashed #ccc;
+		color: #666;
+		box-sizing: border-box;
+	}
+
+	// CartoDB/OSM attribution — mirrors the bottom-right placement Leaflet
+	// uses so static + interactive modes look consistent. Semi-transparent
+	// background keeps the text readable against any basemap underneath.
+	&__attribution {
+		position: absolute;
+		right: 0;
+		bottom: 0;
+		padding: 0.1rem 0.5rem;
+		background: rgb(255 255 255 / 75%);
+		color: #333;
+		font-size: 0.65rem;
+		line-height: 1.4;
+
+		a {
+			color: inherit;
+			text-decoration: underline;
+		}
+	}
+}

--- a/src/blocks/venue-map/view.js
+++ b/src/blocks/venue-map/view.js
@@ -10,11 +10,13 @@ import { createRoot } from '@wordpress/element';
 import MapEmbed from '../../components/MapEmbed';
 
 /**
- * Render GatherPress Map Embed blocks on the frontend.
+ * Upgrade venue-map blocks marked `data-render-mode="interactive"` into a live
+ * Leaflet map.
  *
- * This code initializes the rendering of Map Embed blocks by identifying
- * containers using the 'data-gatherpress_block_name' attribute, extracting
- * block attributes from the dataset, and rendering the MapEmbed component.
+ * Static-mode wrappers are left alone — their pre-rendered `<img>` is the
+ * final output. For interactive wrappers we read the JSON payload that
+ * render.php emitted on the outer `<div>`, replace the wrapper's static
+ * children with a React root, and mount `MapEmbed` (which drives Leaflet).
  *
  * @since 1.0.0
  *
@@ -22,11 +24,17 @@ import MapEmbed from '../../components/MapEmbed';
  */
 domReady( () => {
 	const containers = document.querySelectorAll(
-		`[data-gatherpress_block_name="map-embed"]`
+		'[data-render-mode="interactive"][data-gatherpress_block_name="map-embed"]'
 	);
 
 	for ( const container of containers ) {
-		const attrs = JSON.parse( container.dataset.gatherpress_block_attrs );
+		let attrs;
+		try {
+			attrs = JSON.parse( container.dataset.gatherpress_block_attrs );
+		} catch ( e ) {
+			// Malformed JSON — leave the static baseline in place.
+			continue;
+		}
 
 		createRoot( container ).render(
 			<MapEmbed

--- a/src/components/GoogleMap.js
+++ b/src/components/GoogleMap.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies.
+ */
+import { select } from '@wordpress/data';
+
+/**
  * GoogleMap component for GatherPress.
  *
  * This component is used to embed a Google Map with specified location,
@@ -17,6 +22,20 @@
  *
  * @return {JSX.Element} The rendered React component.
  */
+/**
+ * Google Maps embed expects single-letter codes for the `t=` (map type)
+ * query parameter. The block stores the friendly name ("roadmap", etc.)
+ * so we translate here; unknown values fall through to the Google default.
+ *
+ * @see https://developers.google.com/maps/documentation/embed/map-parameters
+ */
+const GOOGLE_MAP_TYPE_CODES = {
+	roadmap: 'm',
+	satellite: 'k',
+	hybrid: 'h',
+	terrain: 'p',
+};
+
 const GoogleMap = ( props ) => {
 	const { zoom, type, className, location, latitude, longitude, height } =
 		props;
@@ -27,11 +46,16 @@ const GoogleMap = ( props ) => {
 	const params = new URLSearchParams( {
 		q: latitude + ',' + longitude,
 		z: zoom || 10,
-		t: type || 'm',
+		t: GOOGLE_MAP_TYPE_CODES[ type ] || GOOGLE_MAP_TYPE_CODES.roadmap,
 		output: 'embed',
 	} );
 
 	const srcURL = baseUrl + '?' + params.toString();
+
+	// Matches the OpenStreetMap editor fix: the `inert` attribute stops the
+	// iframe from capturing clicks/focus so the user can select the block
+	// itself instead of interacting with the embedded map inside the canvas.
+	const isPostEditor = Boolean( select( 'core/edit-post' ) );
 
 	return (
 		<iframe
@@ -39,6 +63,7 @@ const GoogleMap = ( props ) => {
 			style={ style }
 			className={ className }
 			title={ location }
+			{ ...( isPostEditor && { inert: '' } ) }
 		></iframe>
 	);
 };

--- a/src/components/VenueInformation.js
+++ b/src/components/VenueInformation.js
@@ -10,7 +10,7 @@ import { useDebounce } from '@wordpress/compose';
 /**
  * Internal dependencies.
  */
-import { geocodeAddress } from '../helpers/geocoding';
+import { geocodeAddress, GEOCODE_LOCK_NAME } from '../helpers/geocoding';
 import AddressAutocompleteField from './AddressAutocompleteField';
 
 /**
@@ -74,7 +74,8 @@ const getUpdatedVenueInfo = ( fields ) => {
  * @return {JSX.Element} The rendered React component.
  */
 const VenueInformation = () => {
-	const { editPost } = useDispatch( 'core/editor' );
+	const { editPost, lockPostSaving, unlockPostSaving } =
+		useDispatch( 'core/editor' );
 
 	const { updateVenueLatitude, updateVenueLongitude } =
 		useDispatch( 'gatherpress/venue' );
@@ -135,31 +136,38 @@ const VenueInformation = () => {
 		// Read current address from ref to avoid recreating this callback.
 		const address = fullAddressRef.current;
 
-		// If address is empty, clear lat/long.
-		if ( ! address ) {
-			if ( ! mapCustomLatLong ) {
-				updateVenueLatitude( '' );
-				updateVenueLongitude( '' );
-				updateVenueField( { latitude: '', longitude: '' } );
+		try {
+			// If address is empty, clear lat/long.
+			if ( ! address ) {
+				if ( ! mapCustomLatLong ) {
+					updateVenueLatitude( '' );
+					updateVenueLongitude( '' );
+					updateVenueField( { latitude: '', longitude: '' } );
+				}
+				return;
 			}
-			return;
-		}
 
-		const { latitude, longitude } = await geocodeAddress( address );
+			const { latitude, longitude } = await geocodeAddress( address );
 
-		if ( ! mapCustomLatLong ) {
-			updateVenueLatitude( latitude || null );
-			updateVenueLongitude( longitude || null );
-			updateVenueField( {
-				latitude: latitude || '',
-				longitude: longitude || '',
-			} );
+			if ( ! mapCustomLatLong ) {
+				updateVenueLatitude( latitude || null );
+				updateVenueLongitude( longitude || null );
+				updateVenueField( {
+					latitude: latitude || '',
+					longitude: longitude || '',
+				} );
+			}
+		} finally {
+			// Release the save lock even when geocoding throws — otherwise
+			// the editor would be stuck in the locked state forever.
+			unlockPostSaving( GEOCODE_LOCK_NAME );
 		}
 	}, [
 		mapCustomLatLong,
 		updateVenueLatitude,
 		updateVenueLongitude,
 		updateVenueField,
+		unlockPostSaving,
 	] ); // fullAddress removed - read from ref instead.
 
 	// Longer debounce than autocomplete: geocoding is not user-visible during
@@ -168,7 +176,19 @@ const VenueInformation = () => {
 	const debouncedGetData = useDebounce( getData, 1000 );
 
 	useEffect( () => {
+		// Block the Save button while the address is being geocoded. Without
+		// this, a quick save persists the new address with the previous
+		// lat/long and Venue_Map bakes the static PNG at the wrong coords
+		// until a second save rebuilds it. lockPostSaving is idempotent on
+		// the same lock name, so repeat keystrokes don't stack locks.
+		lockPostSaving( GEOCODE_LOCK_NAME );
 		debouncedGetData();
+
+		return () => {
+			// If the component unmounts mid-geocode, release the lock so the
+			// editor doesn't stay wedged.
+			unlockPostSaving( GEOCODE_LOCK_NAME );
+		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ fullAddress ] ); // Only depend on fullAddress, not debouncedGetData.
 

--- a/src/helpers/geocoding.js
+++ b/src/helpers/geocoding.js
@@ -20,6 +20,20 @@ import { REST_NAMESPACE } from './namespace';
 const ADDRESS_SEARCH_MIN_QUERY_LENGTH_FALLBACK = 3;
 
 /**
+ * Post-saving lock name held while a venue geocode is pending.
+ *
+ * Address changes debounce for a second before hitting Photon. If the user
+ * saves inside that window, the post persists a new address with stale
+ * lat/long — and the venue-map generator then bakes a PNG at the wrong
+ * coords until a second save fires. Callers pass this lock name to
+ * `lockPostSaving` / `unlockPostSaving` on `core/editor` so the Save button
+ * stays disabled until geocoding resolves.
+ *
+ * @type {string}
+ */
+export const GEOCODE_LOCK_NAME = 'gatherpress/venue-geocoding';
+
+/**
  * Minimum trimmed query length before calling the address search REST route.
  * Resolved dynamically from the block editor config (PHP source of truth),
  * with a 3-char fallback when the config value is not yet available.

--- a/test/unit/js/src/components/MapEmbed.test.js
+++ b/test/unit/js/src/components/MapEmbed.test.js
@@ -146,7 +146,7 @@ test( 'MapEmbed returns address in source when location, zoom, map type, height,
 			latitude="40.8117036"
 			longitude="-74.2187738"
 			zoom={ 20 }
-			type="k"
+			type="satellite"
 			className="unit-test"
 			height={ 100 }
 		/>,

--- a/test/unit/php/includes/tests/core/classes/class-test-rsvp-token.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-rsvp-token.php
@@ -346,6 +346,49 @@ class Test_Rsvp_Token extends Base {
 	}
 
 	/**
+	 * Calling approve_comment() on an already-approved comment must not
+	 * fire wp_transition_comment_status again — the token URL sticks in
+	 * the browser and revisits would otherwise re-run the transition on
+	 * every request.
+	 *
+	 * @covers ::approve_comment
+	 *
+	 * @return void
+	 */
+	public function test_approve_comment_skips_already_approved_comment(): void {
+		$post = $this->mock->post(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		)->get();
+
+		$comment_id = $this->factory->comment->create(
+			array(
+				'comment_post_ID'  => $post->ID,
+				'comment_type'     => Rsvp::COMMENT_TYPE,
+				'comment_approved' => '1',
+			)
+		);
+
+		$transition_count = 0;
+		$spy              = static function () use ( &$transition_count ) {
+			++$transition_count;
+		};
+		add_action( 'wp_transition_comment_status', $spy );
+
+		$token = new Rsvp_Token( $comment_id );
+		$token->approve_comment();
+
+		remove_action( 'wp_transition_comment_status', $spy );
+
+		$this->assertSame(
+			0,
+			$transition_count,
+			'wp_transition_comment_status must not re-fire for already-approved comments.'
+		);
+	}
+
+	/**
 	 * Coverage for get_comment method.
 	 *
 	 * @covers ::get_comment

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -302,11 +302,11 @@ class Test_Venue_Map extends Base {
 			'longitude'   => '-122.0312',
 		);
 
-		$baseline = $instance->hash_for( $info, 15, 600, 400, Venue_Map::DEFAULT_TILE_URL );
+		$baseline = $instance->hash_for( $info, 15, 400, Venue_Map::DEFAULT_TILE_URL );
 
 		$this->assertSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 600, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should be stable when every input is identical.'
 		);
 
@@ -316,20 +316,20 @@ class Test_Venue_Map extends Base {
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $moved_info, 15, 600, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $moved_info, 15, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when coordinates change.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 14, 600, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 14, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when the zoom level changes.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
-			'Hash should change when the width changes.'
+			$instance->hash_for( $info, 15, 500, Venue_Map::DEFAULT_TILE_URL ),
+			'Hash should change when the height changes.'
 		);
 	}
 
@@ -367,7 +367,7 @@ class Test_Venue_Map extends Base {
 
 		$this->assertIsArray( $descriptor, 'Expected a descriptor array after generation.' );
 		$this->assertNotEmpty( $descriptor['url'], 'Descriptor URL should be populated.' );
-		$this->assertSame( 40, strlen( $descriptor['hash'] ), 'Descriptor hash should be a SHA-1 hex string.' );
+		$this->assertSame( 32, strlen( $descriptor['hash'] ), 'Descriptor hash should be an MD5 hex string.' );
 
 		$path = $instance->url_to_path( $descriptor['url'] );
 
@@ -621,32 +621,45 @@ class Test_Venue_Map extends Base {
 			$post_id,
 			Venue_Map::META_KEY,
 			array(
-				'15' => array(
-					'url'  => 'https://example.test/a.png',
-					'hash' => 'abc',
+				'15x300'        => array(
+					'url'    => 'https://example.test/a.png',
+					'hash'   => 'abc',
+					'zoom'   => 15,
+					'height' => 300,
 				),
-				'18' => 'not-an-array',
-				'20' => array( 'url' => 'https://example.test/b.png' ), // Missing hash.
+				'18x400'        => 'not-an-array',
+				'20x500'        => array(
+					'url'    => 'https://example.test/b.png',
+					'zoom'   => 20,
+					'height' => 500,
+				), // Missing hash.
+				'missing-shape' => array(
+					'url'  => 'https://example.test/c.png',
+					'hash' => 'def',
+				), // Missing zoom/height.
 			)
 		);
 
 		$descriptors = $instance->get_all_descriptors( $post_id );
 
-		$this->assertArrayHasKey( 15, $descriptors );
-		$this->assertArrayNotHasKey( 18, $descriptors );
-		$this->assertArrayNotHasKey( 20, $descriptors );
+		$this->assertArrayHasKey( '15x300', $descriptors );
+		$this->assertArrayNotHasKey( '18x400', $descriptors );
+		$this->assertArrayNotHasKey( '20x500', $descriptors );
+		$this->assertArrayNotHasKey( 'missing-shape', $descriptors );
+		$this->assertSame( 15, $descriptors['15x300']['zoom'] );
+		$this->assertSame( 300, $descriptors['15x300']['height'] );
 	}
 
 	/**
-	 * Requesting a previously-uncached zoom triggers synchronous generation
-	 * and caches the result for next time.
+	 * Requesting a previously-uncached (zoom, height) combo triggers
+	 * synchronous generation and caches the result for next time.
 	 *
 	 * @covers ::get_url_for_post
-	 * @covers ::ensure_descriptor_for_zoom
+	 * @covers ::ensure_descriptor_for_combo
 	 *
 	 * @return void
 	 */
-	public function test_get_url_for_post_lazily_generates_new_zoom(): void {
+	public function test_get_url_for_post_lazily_generates_new_combo(): void {
 		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
@@ -663,36 +676,87 @@ class Test_Venue_Map extends Base {
 		);
 		$instance->maybe_generate( $post_id );
 
+		$default_key = sprintf(
+			'%dx%d',
+			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT
+		);
+
 		$descriptors_before = $instance->get_all_descriptors( $post_id );
 
 		$this->assertCount(
 			1,
 			$descriptors_before,
-			'Initial save should seed only the block-default zoom.'
+			'Initial save should seed only the default (zoom, height) combo.'
 		);
-		$this->assertArrayHasKey( Venue_Map::DEFAULT_BLOCK_ZOOM, $descriptors_before );
+		$this->assertArrayHasKey( $default_key, $descriptors_before );
 
 		// Request a different zoom — simulates a block customized to zoom 14.
-		$url = $instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14 );
+		$new_key = sprintf( '14x%d', Venue_Map::DEFAULT_HEIGHT );
+		$url     = $instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14 );
 
 		$this->assertNotEmpty( $url, 'Lazy generation should return a non-empty URL.' );
 
 		$descriptors_after = $instance->get_all_descriptors( $post_id );
 
-		$this->assertCount( 2, $descriptors_after, 'New zoom should have been cached.' );
-		$this->assertArrayHasKey( 14, $descriptors_after );
-		$this->assertSame( $url, $descriptors_after[14]['url'] );
+		$this->assertCount( 2, $descriptors_after, 'New combo should have been cached.' );
+		$this->assertArrayHasKey( $new_key, $descriptors_after );
+		$this->assertSame( $url, $descriptors_after[ $new_key ]['url'] );
 	}
 
 	/**
-	 * A content change (e.g. new coordinates) regenerates every known zoom.
+	 * Requesting a combo with a different height from the default also caches
+	 * a new descriptor — the PNG is rendered at exactly that block height.
 	 *
-	 * @covers ::maybe_generate
-	 * @covers ::ensure_descriptor_for_zoom
+	 * @covers ::get_url_for_post
+	 * @covers ::ensure_descriptor_for_combo
 	 *
 	 * @return void
 	 */
-	public function test_maybe_generate_cascades_content_changes_to_all_cached_zooms(): void {
+	public function test_get_url_for_post_lazily_generates_new_height(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+
+		$tall_url = $instance->get_url_for_post(
+			$post_id,
+			Venue::POST_TYPE,
+			Venue_Map::DEFAULT_ZOOM,
+			500
+		);
+
+		$this->assertNotEmpty( $tall_url );
+
+		$key = sprintf( '%dx500', Venue_Map::DEFAULT_ZOOM );
+		$all = $instance->get_all_descriptors( $post_id );
+
+		$this->assertArrayHasKey( $key, $all, 'Tall-height combo should be cached under its own key.' );
+		$this->assertSame( 500, $all[ $key ]['height'] );
+	}
+
+	/**
+	 * A content change (e.g. new coordinates) regenerates every cached
+	 * (zoom, height) combo.
+	 *
+	 * @covers ::maybe_generate
+	 * @covers ::ensure_descriptor_for_combo
+	 * @covers ::get_cached_combos
+	 *
+	 * @return void
+	 */
+	public function test_maybe_generate_cascades_content_changes_to_all_cached_combos(): void {
 		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
@@ -708,14 +772,21 @@ class Test_Venue_Map extends Base {
 			)
 		);
 		$instance->maybe_generate( $post_id );
-		// Warm a second zoom (not the block-default seed) so we have two variants.
-		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14 );
+		// Warm a second combo (not the default seed) so we have two variants.
+		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14, 500 );
+
+		$default_key = sprintf(
+			'%dx%d',
+			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT
+		);
+		$second_key  = '14x500';
 
 		$before = $instance->get_all_descriptors( $post_id );
 
 		$this->assertCount( 2, $before );
 
-		// Change the address. maybe_generate should regenerate both zooms.
+		// Change the address. maybe_generate should regenerate both combos.
 		update_post_meta(
 			$post_id,
 			'gatherpress_venue_information',
@@ -731,26 +802,24 @@ class Test_Venue_Map extends Base {
 
 		$after = $instance->get_all_descriptors( $post_id );
 
-		$this->assertCount( 2, $after, 'Both zooms should still be present after regeneration.' );
+		$this->assertCount( 2, $after, 'Both combos should still be present after regeneration.' );
 		$this->assertNotSame(
-			$before[ Venue_Map::DEFAULT_BLOCK_ZOOM ]['hash'],
-			$after[ Venue_Map::DEFAULT_BLOCK_ZOOM ]['hash'],
-			'Block-default-zoom hash should change with new coordinates.'
+			$before[ $default_key ]['hash'],
+			$after[ $default_key ]['hash'],
+			'Default-combo hash should change with new coordinates.'
 		);
 		$this->assertNotSame(
-			$before[14]['hash'],
-			$after[14]['hash'],
-			'Zoom-14 hash should change with new coordinates.'
+			$before[ $second_key ]['hash'],
+			$after[ $second_key ]['hash'],
+			'Second-combo hash should change with new coordinates.'
 		);
 
 		// Old files should be gone.
 		$this->assertFileDoesNotExist(
-			(string) $instance->url_to_path(
-				$before[ Venue_Map::DEFAULT_BLOCK_ZOOM ]['url']
-			)
+			(string) $instance->url_to_path( $before[ $default_key ]['url'] )
 		);
 		$this->assertFileDoesNotExist(
-			(string) $instance->url_to_path( $before[14]['url'] )
+			(string) $instance->url_to_path( $before[ $second_key ]['url'] )
 		);
 	}
 
@@ -794,16 +863,16 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
-	 * Direct coverage for ensure_descriptor_for_zoom when save_image fails.
+	 * Direct coverage for ensure_descriptor_for_combo when save_image fails.
 	 *
 	 * Exercising it through the public API (maybe_generate) leaves this
 	 * branch uncredited by xdebug, so we invoke the protected method directly.
 	 *
-	 * @covers ::ensure_descriptor_for_zoom
+	 * @covers ::ensure_descriptor_for_combo
 	 *
 	 * @return void
 	 */
-	public function test_ensure_descriptor_for_zoom_returns_null_when_save_fails(): void {
+	public function test_ensure_descriptor_for_combo_returns_null_when_save_fails(): void {
 		$instance = Venue_Map::get_instance();
 
 		$force_error = static function ( $dirs ) {
@@ -814,7 +883,7 @@ class Test_Venue_Map extends Base {
 
 		$result = Utility::invoke_hidden_method(
 			$instance,
-			'ensure_descriptor_for_zoom',
+			'ensure_descriptor_for_combo',
 			array(
 				42,
 				array(
@@ -823,6 +892,7 @@ class Test_Venue_Map extends Base {
 					'longitude'   => '-122.0312',
 				),
 				15,
+				300,
 			)
 		);
 
@@ -832,10 +902,10 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
-	 * Second call to get_url_for_post for the same zoom hits the filesystem
+	 * Second call to get_url_for_post for the same combo hits the filesystem
 	 * cache (no PNG rewrite).
 	 *
-	 * @covers ::ensure_descriptor_for_zoom
+	 * @covers ::ensure_descriptor_for_combo
 	 *
 	 * @return void
 	 */
@@ -1103,12 +1173,12 @@ class Test_Venue_Map extends Base {
 			-122.0312,
 			15,
 			256,
-			256,
 			Venue_Map::DEFAULT_TILE_URL
 		);
 
 		$this->assertInstanceOf( \GdImage::class, $image );
-		$this->assertSame( 256, imagesx( $image ) );
+		// Width is derived from height via IMAGE_ASPECT_RATIO (2.0) → 512×256.
+		$this->assertSame( 512, imagesx( $image ) );
 		$this->assertSame( 256, imagesy( $image ) );
 
 		imagedestroy( $image );
@@ -1181,59 +1251,143 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
-	 * Coverage for get_block_default_zoom — Settings wins, falls back to constant.
+	 * Coverage for get_zoom — prefers Settings, falls back to constant,
+	 * then passes through the filter.
 	 *
-	 * @covers ::get_block_default_zoom
+	 * @covers ::get_zoom
 	 *
 	 * @return void
 	 */
-	public function test_get_block_default_zoom(): void {
+	public function test_get_zoom(): void {
 		$instance = Venue_Map::get_instance();
 		$settings = \GatherPress\Core\Settings::get_instance();
 
 		$settings->set( 'venue_map_default_zoom', 13 );
 		$this->assertSame(
 			13,
-			Utility::invoke_hidden_method( $instance, 'get_block_default_zoom' ),
+			Utility::invoke_hidden_method( $instance, 'get_zoom' ),
 			'Should prefer the stored Settings value.'
 		);
 
 		$settings->set( 'venue_map_default_zoom', 0 );
 		$this->assertSame(
-			Venue_Map::DEFAULT_BLOCK_ZOOM,
-			Utility::invoke_hidden_method( $instance, 'get_block_default_zoom' ),
-			'Should fall back to DEFAULT_BLOCK_ZOOM when the setting is unset/zero.'
+			Venue_Map::DEFAULT_ZOOM,
+			Utility::invoke_hidden_method( $instance, 'get_zoom' ),
+			'Should fall back to DEFAULT_ZOOM when the setting is unset/zero.'
 		);
 	}
 
 	/**
-	 * Coverage for the filterable getters.
+	 * Coverage for get_height — prefers Settings, falls back to constant,
+	 * then passes through the filter. Mirrors test_get_zoom.
 	 *
-	 * @covers ::get_zoom
-	 * @covers ::get_width
 	 * @covers ::get_height
+	 *
+	 * @return void
+	 */
+	public function test_get_height(): void {
+		$instance = Venue_Map::get_instance();
+		$settings = \GatherPress\Core\Settings::get_instance();
+
+		$settings->set( 'venue_map_default_height', 450 );
+		$this->assertSame(
+			450,
+			Utility::invoke_hidden_method( $instance, 'get_height' ),
+			'Should prefer the stored Settings value.'
+		);
+
+		$settings->set( 'venue_map_default_height', 0 );
+		$this->assertSame(
+			Venue_Map::DEFAULT_HEIGHT,
+			Utility::invoke_hidden_method( $instance, 'get_height' ),
+			'Should fall back to DEFAULT_HEIGHT when the setting is unset/zero.'
+		);
+	}
+
+	/**
+	 * Coverage for the generator's tile URL getter.
+	 *
 	 * @covers ::get_tile_url_template
 	 *
 	 * @return void
 	 */
-	public function test_filterable_getters(): void {
+	public function test_get_tile_url_template(): void {
 		$instance = Venue_Map::get_instance();
 
 		$this->assertSame(
-			Venue_Map::DEFAULT_ZOOM,
-			Utility::invoke_hidden_method( $instance, 'get_zoom' )
-		);
-		$this->assertSame(
-			Venue_Map::DEFAULT_WIDTH,
-			Utility::invoke_hidden_method( $instance, 'get_width' )
-		);
-		$this->assertSame(
-			Venue_Map::DEFAULT_HEIGHT,
-			Utility::invoke_hidden_method( $instance, 'get_height' )
-		);
-		$this->assertSame(
 			Venue_Map::DEFAULT_TILE_URL,
 			Utility::invoke_hidden_method( $instance, 'get_tile_url_template' )
+		);
+	}
+
+	/**
+	 * Coverage for combo_key — formats `{zoom}x{height}`.
+	 *
+	 * @covers ::combo_key
+	 *
+	 * @return void
+	 */
+	public function test_combo_key_formats_zoom_and_height(): void {
+		$instance = Venue_Map::get_instance();
+
+		$this->assertSame(
+			'14x500',
+			Utility::invoke_hidden_method( $instance, 'combo_key', array( 14, 500 ) )
+		);
+	}
+
+	/**
+	 * Coverage for get_cached_combos — returns unique (zoom, height) combos.
+	 *
+	 * @covers ::get_cached_combos
+	 *
+	 * @return void
+	 */
+	public function test_get_cached_combos(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		$this->assertSame(
+			array(),
+			$instance->get_cached_combos( $post_id ),
+			'Empty meta should yield zero combos.'
+		);
+
+		update_post_meta(
+			$post_id,
+			Venue_Map::META_KEY,
+			array(
+				'15x300' => array(
+					'url'    => 'https://example.test/a.png',
+					'hash'   => 'abc',
+					'zoom'   => 15,
+					'height' => 300,
+				),
+				'18x500' => array(
+					'url'    => 'https://example.test/b.png',
+					'hash'   => 'def',
+					'zoom'   => 18,
+					'height' => 500,
+				),
+			)
+		);
+
+		$combos = $instance->get_cached_combos( $post_id );
+
+		$this->assertCount( 2, $combos );
+		$this->assertContains(
+			array(
+				'zoom'   => 15,
+				'height' => 300,
+			),
+			$combos
+		);
+		$this->assertContains(
+			array(
+				'zoom'   => 18,
+				'height' => 500,
+			),
+			$combos
 		);
 	}
 
@@ -1257,7 +1411,6 @@ class Test_Venue_Map extends Base {
 			37.3318,
 			-122.0312,
 			15,
-			256,
 			256,
 			Venue_Map::DEFAULT_TILE_URL
 		);
@@ -1303,7 +1456,6 @@ class Test_Venue_Map extends Base {
 			37.3318,
 			-122.0312,
 			15,
-			256,
 			256,
 			Venue_Map::DEFAULT_TILE_URL
 		);

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Unit tests for GatherPress\Core\Venue_Static_Map.
+ * Unit tests for GatherPress\Core\Venue_Map.
  *
  * These tests cover the generator's hash logic, the save/regenerate/cleanup
  * lifecycle, and the hook wiring. The tile fetcher is stubbed via an HTTP
@@ -13,17 +13,17 @@
 namespace GatherPress\Tests\Core;
 
 use GatherPress\Core\Venue;
-use GatherPress\Core\Venue_Static_Map;
+use GatherPress\Core\Venue_Map;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 
 /**
- * Class Test_Venue_Static_Map.
+ * Class Test_Venue_Map.
  *
  * @group multisite
- * @coversDefaultClass \GatherPress\Core\Venue_Static_Map
+ * @coversDefaultClass \GatherPress\Core\Venue_Map
  */
-class Test_Venue_Static_Map extends Base {
+class Test_Venue_Map extends Base {
 	/**
 	 * Minimal valid 1×1 PNG used as a stand-in for every tile fetch.
 	 *
@@ -59,7 +59,7 @@ class Test_Venue_Static_Map extends Base {
 		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
 
 		$dirs     = wp_get_upload_dir();
-		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Static_Map::UPLOADS_SUBDIR;
+		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Map::UPLOADS_SUBDIR;
 
 		if ( is_dir( $base_dir ) ) {
 			foreach ( (array) glob( $base_dir . '/*.png' ) as $file ) {
@@ -104,7 +104,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_setup_hooks(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$hooks    = array(
 			array(
 				'type'     => 'action',
@@ -118,9 +118,131 @@ class Test_Venue_Static_Map extends Base {
 				'priority' => 10,
 				'callback' => array( $instance, 'maybe_register_delete_hook' ),
 			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'block_type_metadata',
+				'priority' => 10,
+				'callback' => array( $instance, 'apply_block_attribute_defaults' ),
+			),
 		);
 
 		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * Coverage for apply_block_attribute_defaults — overrides the venue-map
+	 * block.json defaults with user-chosen Settings values.
+	 *
+	 * @covers ::apply_block_attribute_defaults
+	 *
+	 * @return void
+	 */
+	public function test_apply_block_attribute_defaults_overrides_venue_map(): void {
+		$instance = Venue_Map::get_instance();
+		$settings = \GatherPress\Core\Settings::get_instance();
+
+		$settings->set( 'venue_map_default_render_mode', 'static' );
+		$settings->set( 'venue_map_default_zoom', 12 );
+		$settings->set( 'venue_map_default_height', 450 );
+		$settings->set( 'venue_map_default_type', 'satellite' );
+
+		$metadata = array(
+			'name'       => 'gatherpress/venue-map',
+			'attributes' => array(
+				'renderMode' => array(
+					'type'    => 'string',
+					'default' => 'interactive',
+				),
+				'zoom'       => array(
+					'type'    => 'number',
+					'default' => 18,
+				),
+				'height'     => array(
+					'type'    => 'number',
+					'default' => 300,
+				),
+				'type'       => array(
+					'type'    => 'string',
+					'default' => 'roadmap',
+				),
+			),
+		);
+
+		$result = $instance->apply_block_attribute_defaults( $metadata );
+
+		$this->assertSame( 'static', $result['attributes']['renderMode']['default'] );
+		$this->assertSame( 12, $result['attributes']['zoom']['default'] );
+		$this->assertSame( 450, $result['attributes']['height']['default'] );
+		$this->assertSame( 'satellite', $result['attributes']['type']['default'] );
+	}
+
+	/**
+	 * Unrelated block metadata passes through untouched.
+	 *
+	 * @covers ::apply_block_attribute_defaults
+	 *
+	 * @return void
+	 */
+	public function test_apply_block_attribute_defaults_ignores_other_blocks(): void {
+		$instance = Venue_Map::get_instance();
+		$metadata = array(
+			'name'       => 'core/paragraph',
+			'attributes' => array(
+				'content' => array(
+					'type'    => 'string',
+					'default' => '',
+				),
+			),
+		);
+
+		$this->assertSame( $metadata, $instance->apply_block_attribute_defaults( $metadata ) );
+	}
+
+	/**
+	 * Empty / zero settings values (e.g. a never-written row) must leave the
+	 * block.json default alone rather than stamping on garbage.
+	 *
+	 * @covers ::apply_block_attribute_defaults
+	 *
+	 * @return void
+	 */
+	public function test_apply_block_attribute_defaults_skips_empty_settings(): void {
+		$instance = Venue_Map::get_instance();
+		$settings = \GatherPress\Core\Settings::get_instance();
+
+		$settings->set( 'venue_map_default_render_mode', '' );
+		$settings->set( 'venue_map_default_zoom', 0 );
+		$settings->set( 'venue_map_default_height', 0 );
+		$settings->set( 'venue_map_default_type', '' );
+
+		$metadata = array(
+			'name'       => 'gatherpress/venue-map',
+			'attributes' => array(
+				'renderMode' => array(
+					'type'    => 'string',
+					'default' => 'interactive',
+				),
+				'zoom'       => array(
+					'type'    => 'number',
+					'default' => 18,
+				),
+				'height'     => array(
+					'type'    => 'number',
+					'default' => 300,
+				),
+				'type'       => array(
+					'type'    => 'string',
+					'default' => 'roadmap',
+				),
+			),
+		);
+
+		$result = $instance->apply_block_attribute_defaults( $metadata );
+
+		$this->assertSame( 'interactive', $result['attributes']['renderMode']['default'] );
+		$this->assertSame( 18, $result['attributes']['zoom']['default'] );
+		$this->assertSame( 300, $result['attributes']['height']['default'] );
+		$this->assertSame( 'roadmap', $result['attributes']['type']['default'] );
 	}
 
 	/**
@@ -131,7 +253,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_delete_hook(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $post_type ) {
 			$instance->maybe_register_delete_hook( $post_type );
@@ -155,7 +277,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_delete_hook_skips_unsupported_post_type(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		$instance->maybe_register_delete_hook( 'post' );
 
@@ -173,18 +295,18 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_hash_for_detects_relevant_input_changes(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$info     = array(
 			'fullAddress' => '1 Infinite Loop',
 			'latitude'    => '37.3318',
 			'longitude'   => '-122.0312',
 		);
 
-		$baseline = $instance->hash_for( $info, 15, 600, 400, Venue_Static_Map::DEFAULT_TILE_URL );
+		$baseline = $instance->hash_for( $info, 15, 600, 400, Venue_Map::DEFAULT_TILE_URL );
 
 		$this->assertSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 600, 400, Venue_Static_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 600, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should be stable when every input is identical.'
 		);
 
@@ -194,19 +316,19 @@ class Test_Venue_Static_Map extends Base {
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $moved_info, 15, 600, 400, Venue_Static_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $moved_info, 15, 600, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when coordinates change.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 14, 600, 400, Venue_Static_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 14, 600, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when the zoom level changes.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 800, 400, Venue_Static_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when the width changes.'
 		);
 	}
@@ -224,7 +346,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_writes_image_and_descriptor(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta(
@@ -261,7 +383,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_is_idempotent_when_inputs_unchanged(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta(
@@ -301,7 +423,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_regenerates_when_coordinates_change(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta(
@@ -359,7 +481,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_bails_without_coordinates(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta(
@@ -390,7 +512,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_skips_revisions_and_autosaves(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$venue_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta(
@@ -424,7 +546,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_delete_stored_image_removes_file_and_meta(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta(
@@ -462,7 +584,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_url_to_path_rejects_external_urls(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		$this->assertNull(
 			$instance->url_to_path( 'https://example.com/evil.png' ),
@@ -471,40 +593,40 @@ class Test_Venue_Static_Map extends Base {
 	}
 
 	/**
-	 * get_all_descriptors returns an empty array for a venue with nothing stored.
+	 * Returns an empty array from get_all_descriptors for an unsaved venue.
 	 *
 	 * @covers ::get_all_descriptors
 	 *
 	 * @return void
 	 */
 	public function test_get_all_descriptors_empty_when_nothing_stored(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		$this->assertSame( array(), $instance->get_all_descriptors( $post_id ) );
 	}
 
 	/**
-	 * get_all_descriptors silently drops malformed entries.
+	 * Silently drops malformed entries from get_all_descriptors output.
 	 *
 	 * @covers ::get_all_descriptors
 	 *
 	 * @return void
 	 */
 	public function test_get_all_descriptors_filters_malformed_entries(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta(
 			$post_id,
-			Venue_Static_Map::META_KEY,
+			Venue_Map::META_KEY,
 			array(
 				'15' => array(
 					'url'  => 'https://example.test/a.png',
 					'hash' => 'abc',
 				),
 				'18' => 'not-an-array',
-				'20' => array( 'url' => 'https://example.test/b.png' ), // missing hash
+				'20' => array( 'url' => 'https://example.test/b.png' ), // Missing hash.
 			)
 		);
 
@@ -525,7 +647,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_lazily_generates_new_zoom(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta(
@@ -543,20 +665,23 @@ class Test_Venue_Static_Map extends Base {
 
 		$descriptors_before = $instance->get_all_descriptors( $post_id );
 
-		$this->assertCount( 1, $descriptors_before, 'Initial save should seed only the default zoom.' );
-		$this->assertArrayHasKey( Venue_Static_Map::DEFAULT_ZOOM, $descriptors_before );
+		$this->assertCount(
+			1,
+			$descriptors_before,
+			'Initial save should seed only the block-default zoom.'
+		);
+		$this->assertArrayHasKey( Venue_Map::DEFAULT_BLOCK_ZOOM, $descriptors_before );
 
-		// Request a different zoom. This is the key user-facing flow: a block
-		// configured at zoom 18 gets its own cached image on first render.
-		$url = $instance->get_url_for_post( $post_id, Venue::POST_TYPE, 18 );
+		// Request a different zoom — simulates a block customized to zoom 14.
+		$url = $instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14 );
 
 		$this->assertNotEmpty( $url, 'Lazy generation should return a non-empty URL.' );
 
 		$descriptors_after = $instance->get_all_descriptors( $post_id );
 
 		$this->assertCount( 2, $descriptors_after, 'New zoom should have been cached.' );
-		$this->assertArrayHasKey( 18, $descriptors_after );
-		$this->assertSame( $url, $descriptors_after[18]['url'] );
+		$this->assertArrayHasKey( 14, $descriptors_after );
+		$this->assertSame( $url, $descriptors_after[14]['url'] );
 	}
 
 	/**
@@ -568,7 +693,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_cascades_content_changes_to_all_cached_zooms(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta(
@@ -583,8 +708,8 @@ class Test_Venue_Static_Map extends Base {
 			)
 		);
 		$instance->maybe_generate( $post_id );
-		// Warm a second zoom so we have two cached variants.
-		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 18 );
+		// Warm a second zoom (not the block-default seed) so we have two variants.
+		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14 );
 
 		$before = $instance->get_all_descriptors( $post_id );
 
@@ -608,22 +733,24 @@ class Test_Venue_Static_Map extends Base {
 
 		$this->assertCount( 2, $after, 'Both zooms should still be present after regeneration.' );
 		$this->assertNotSame(
-			$before[ Venue_Static_Map::DEFAULT_ZOOM ]['hash'],
-			$after[ Venue_Static_Map::DEFAULT_ZOOM ]['hash'],
-			'Default-zoom hash should change with new coordinates.'
+			$before[ Venue_Map::DEFAULT_BLOCK_ZOOM ]['hash'],
+			$after[ Venue_Map::DEFAULT_BLOCK_ZOOM ]['hash'],
+			'Block-default-zoom hash should change with new coordinates.'
 		);
 		$this->assertNotSame(
-			$before[18]['hash'],
-			$after[18]['hash'],
-			'Zoom-18 hash should change with new coordinates.'
+			$before[14]['hash'],
+			$after[14]['hash'],
+			'Zoom-14 hash should change with new coordinates.'
 		);
 
 		// Old files should be gone.
 		$this->assertFileDoesNotExist(
-			(string) $instance->url_to_path( $before[ Venue_Static_Map::DEFAULT_ZOOM ]['url'] )
+			(string) $instance->url_to_path(
+				$before[ Venue_Map::DEFAULT_BLOCK_ZOOM ]['url']
+			)
 		);
 		$this->assertFileDoesNotExist(
-			(string) $instance->url_to_path( $before[18]['url'] )
+			(string) $instance->url_to_path( $before[14]['url'] )
 		);
 	}
 
@@ -636,16 +763,18 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_delete_file_by_url_unlinks_in_scope(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		// Create a fixture file the method is allowed to delete.
 		$dirs     = wp_get_upload_dir();
-		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Static_Map::UPLOADS_SUBDIR;
+		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Map::UPLOADS_SUBDIR;
 		wp_mkdir_p( $base_dir );
 
 		$path = $base_dir . '/delete-me.png';
-		$url  = trailingslashit( $dirs['baseurl'] ) . Venue_Static_Map::UPLOADS_SUBDIR . '/delete-me.png';
-		file_put_contents( $path, 'stub' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations.file_put_contents
+		$url  = trailingslashit( $dirs['baseurl'] )
+			. Venue_Map::UPLOADS_SUBDIR . '/delete-me.png';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Fixture write inside the test-only uploads dir.
+		file_put_contents( $path, 'stub' );
 
 		$this->assertFileExists( $path );
 
@@ -660,7 +789,7 @@ class Test_Venue_Static_Map extends Base {
 			array( 'https://example.test/outside.png' )
 		);
 		// Terminal assertion to keep PHPUnit happy — the real guarantee is
-		// "no exception thrown, no unexpected side effects."
+		// that no exception is thrown and no unexpected side effects occur.
 		$this->assertTrue( true );
 	}
 
@@ -675,7 +804,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_ensure_descriptor_for_zoom_returns_null_when_save_fails(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		$force_error = static function ( $dirs ) {
 			$dirs['error'] = 'Simulated uploads failure.';
@@ -703,15 +832,15 @@ class Test_Venue_Static_Map extends Base {
 	}
 
 	/**
-	 * get_url_for_post on a second call for the same zoom is a cache hit
-	 * (no filesystem rewrite).
+	 * Second call to get_url_for_post for the same zoom hits the filesystem
+	 * cache (no PNG rewrite).
 	 *
 	 * @covers ::ensure_descriptor_for_zoom
 	 *
 	 * @return void
 	 */
 	public function test_get_url_for_post_is_cached_on_second_call(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta(
@@ -746,7 +875,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_resolves_venue_directly(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta(
@@ -778,7 +907,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_resolves_event_via_linked_venue(): void {
-		$instance    = Venue_Static_Map::get_instance();
+		$instance    = Venue_Map::get_instance();
 		$venue_setup = \GatherPress\Core\Venue_Setup::get_instance();
 
 		$venue = $this->mock->post(
@@ -828,7 +957,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_returns_empty_for_unrelated_post(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => 'post' ) );
 
 		$this->assertSame( '', $instance->get_url_for_post( $post_id, 'post' ) );
@@ -842,7 +971,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_returns_empty_when_no_map_generated(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		$this->assertSame( '', $instance->get_url_for_post( $post_id, Venue::POST_TYPE ) );
@@ -856,12 +985,12 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_url_to_path_resolves_plugin_subdir_url(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$dirs     = wp_get_upload_dir();
 		$url      = trailingslashit( $dirs['baseurl'] )
-			. Venue_Static_Map::UPLOADS_SUBDIR . '/42-abc.png';
+			. Venue_Map::UPLOADS_SUBDIR . '/42-abc.png';
 		$expected = trailingslashit( $dirs['basedir'] )
-			. Venue_Static_Map::UPLOADS_SUBDIR . '/42-abc.png';
+			. Venue_Map::UPLOADS_SUBDIR . '/42-abc.png';
 
 		$this->assertSame( $expected, $instance->url_to_path( $url ) );
 	}
@@ -874,7 +1003,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_skips_unsupported_post_type(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => 'post' ) );
 
 		$instance->maybe_generate( $post_id );
@@ -893,7 +1022,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_fetch_tile_returns_null_on_http_error(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		// Replace the success stub with a WP_Error short-circuit just for this test.
 		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
@@ -903,7 +1032,7 @@ class Test_Venue_Static_Map extends Base {
 		add_filter( 'pre_http_request', $fail, 10 );
 
 		$this->assertNull(
-			$instance->fetch_tile( 15, 1, 1, Venue_Static_Map::DEFAULT_TILE_URL )
+			$instance->fetch_tile( 15, 1, 1, Venue_Map::DEFAULT_TILE_URL )
 		);
 
 		remove_filter( 'pre_http_request', $fail, 10 );
@@ -918,7 +1047,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_fetch_tile_returns_null_on_non_200_response(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
 		$not_found = static function () {
@@ -936,7 +1065,7 @@ class Test_Venue_Static_Map extends Base {
 		add_filter( 'pre_http_request', $not_found, 10 );
 
 		$this->assertNull(
-			$instance->fetch_tile( 15, 1, 1, Venue_Static_Map::DEFAULT_TILE_URL )
+			$instance->fetch_tile( 15, 1, 1, Venue_Map::DEFAULT_TILE_URL )
 		);
 
 		remove_filter( 'pre_http_request', $not_found, 10 );
@@ -951,11 +1080,11 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_fetch_tile_returns_png_bytes(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		$this->assertSame(
 			$this->tile_png,
-			$instance->fetch_tile( 15, 1, 1, Venue_Static_Map::DEFAULT_TILE_URL )
+			$instance->fetch_tile( 15, 1, 1, Venue_Map::DEFAULT_TILE_URL )
 		);
 	}
 
@@ -967,7 +1096,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_returns_gd_image(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		$image = $instance->composite_image(
 			37.3318,
@@ -975,7 +1104,7 @@ class Test_Venue_Static_Map extends Base {
 			15,
 			256,
 			256,
-			Venue_Static_Map::DEFAULT_TILE_URL
+			Venue_Map::DEFAULT_TILE_URL
 		);
 
 		$this->assertInstanceOf( \GdImage::class, $image );
@@ -993,7 +1122,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_stamp_marker_draws_on_canvas(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$canvas   = imagecreatetruecolor( 40, 40 );
 		$instance->stamp_marker( $canvas, 20, 20 );
 
@@ -1016,14 +1145,14 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_save_image_writes_file_and_returns_url(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$canvas   = imagecreatetruecolor( 10, 10 );
 
 		$url = $instance->save_image( $canvas, 99, 'deadbeef' );
 		imagedestroy( $canvas );
 
 		$this->assertNotNull( $url, 'save_image should return a URL on success.' );
-		$this->assertStringContainsString( Venue_Static_Map::UPLOADS_SUBDIR, $url );
+		$this->assertStringContainsString( Venue_Map::UPLOADS_SUBDIR, $url );
 
 		$path = $instance->url_to_path( $url );
 		$this->assertFileExists( $path );
@@ -1037,7 +1166,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_parse_coord(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		$this->assertSame(
 			37.3318,
@@ -1052,6 +1181,32 @@ class Test_Venue_Static_Map extends Base {
 	}
 
 	/**
+	 * Coverage for get_block_default_zoom — Settings wins, falls back to constant.
+	 *
+	 * @covers ::get_block_default_zoom
+	 *
+	 * @return void
+	 */
+	public function test_get_block_default_zoom(): void {
+		$instance = Venue_Map::get_instance();
+		$settings = \GatherPress\Core\Settings::get_instance();
+
+		$settings->set( 'venue_map_default_zoom', 13 );
+		$this->assertSame(
+			13,
+			Utility::invoke_hidden_method( $instance, 'get_block_default_zoom' ),
+			'Should prefer the stored Settings value.'
+		);
+
+		$settings->set( 'venue_map_default_zoom', 0 );
+		$this->assertSame(
+			Venue_Map::DEFAULT_BLOCK_ZOOM,
+			Utility::invoke_hidden_method( $instance, 'get_block_default_zoom' ),
+			'Should fall back to DEFAULT_BLOCK_ZOOM when the setting is unset/zero.'
+		);
+	}
+
+	/**
 	 * Coverage for the filterable getters.
 	 *
 	 * @covers ::get_zoom
@@ -1062,22 +1217,22 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_filterable_getters(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		$this->assertSame(
-			Venue_Static_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_ZOOM,
 			Utility::invoke_hidden_method( $instance, 'get_zoom' )
 		);
 		$this->assertSame(
-			Venue_Static_Map::DEFAULT_WIDTH,
+			Venue_Map::DEFAULT_WIDTH,
 			Utility::invoke_hidden_method( $instance, 'get_width' )
 		);
 		$this->assertSame(
-			Venue_Static_Map::DEFAULT_HEIGHT,
+			Venue_Map::DEFAULT_HEIGHT,
 			Utility::invoke_hidden_method( $instance, 'get_height' )
 		);
 		$this->assertSame(
-			Venue_Static_Map::DEFAULT_TILE_URL,
+			Venue_Map::DEFAULT_TILE_URL,
 			Utility::invoke_hidden_method( $instance, 'get_tile_url_template' )
 		);
 	}
@@ -1090,7 +1245,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_continues_past_failed_fetch(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
 		$fail = static function () {
@@ -1104,7 +1259,7 @@ class Test_Venue_Static_Map extends Base {
 			15,
 			256,
 			256,
-			Venue_Static_Map::DEFAULT_TILE_URL
+			Venue_Map::DEFAULT_TILE_URL
 		);
 
 		remove_filter( 'pre_http_request', $fail, 10 );
@@ -1127,7 +1282,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_continues_past_invalid_png(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
 		$garbage = static function () {
@@ -1150,7 +1305,7 @@ class Test_Venue_Static_Map extends Base {
 			15,
 			256,
 			256,
-			Venue_Static_Map::DEFAULT_TILE_URL
+			Venue_Map::DEFAULT_TILE_URL
 		);
 
 		remove_filter( 'pre_http_request', $garbage, 10 );
@@ -1169,7 +1324,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_save_image_returns_null_when_uploads_report_error(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$canvas   = imagecreatetruecolor( 10, 10 );
 
 		$force_error = static function ( $dirs ) {
@@ -1197,7 +1352,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_bails_when_save_fails(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta(
@@ -1240,7 +1395,7 @@ class Test_Venue_Static_Map extends Base {
 	 * @return void
 	 */
 	public function test_world_pixel_conversions(): void {
-		$instance = Venue_Static_Map::get_instance();
+		$instance = Venue_Map::get_instance();
 
 		$this->assertSame(
 			128.0,

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -445,9 +445,9 @@ class Test_Venue_Map extends Base {
 			'gatherpress_venue_information',
 			wp_json_encode(
 				array(
-					'fullAddress' => '1600 Amphitheatre Parkway',
-					'latitude'    => '37.4220',
-					'longitude'   => '-122.0841',
+					'fullAddress' => '60 29th Street #343, San Francisco, CA 94110',
+					'latitude'    => '37.7573',
+					'longitude'   => '-122.4132',
 				)
 			)
 		);
@@ -792,9 +792,9 @@ class Test_Venue_Map extends Base {
 			'gatherpress_venue_information',
 			wp_json_encode(
 				array(
-					'fullAddress' => '1600 Amphitheatre Parkway',
-					'latitude'    => '37.4220',
-					'longitude'   => '-122.0841',
+					'fullAddress' => '60 29th Street #343, San Francisco, CA 94110',
+					'latitude'    => '37.7573',
+					'longitude'   => '-122.4132',
 				)
 			)
 		);

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -109,7 +109,7 @@ class Test_Venue_Map extends Base {
 			array(
 				'type'     => 'action',
 				'name'     => 'wp_after_insert_post',
-				'priority' => 20,
+				'priority' => 11,
 				'callback' => array( $instance, 'maybe_generate' ),
 			),
 			array(
@@ -475,7 +475,7 @@ class Test_Venue_Map extends Base {
 
 	/**
 	 * A previously-geocoded venue whose address is edited to something
-	 * un-geocodable must have its stored PNGs purged so stale images
+	 * un-geocodable must have its stored PNG files purged so stale images
 	 * don't keep serving under the new (wrong) address.
 	 *
 	 * @covers ::maybe_generate
@@ -1546,6 +1546,73 @@ class Test_Venue_Map extends Base {
 			),
 			$combos
 		);
+	}
+
+	/**
+	 * When the composite time budget is exhausted, the inner loop breaks
+	 * out and the canvas is returned with the pre-painted gray background
+	 * intact — no tiles fetched. Filter-driven so we don't have to wait
+	 * COMPOSITE_TIME_BUDGET seconds to exercise the branch.
+	 *
+	 * @covers ::composite_image
+	 *
+	 * @return void
+	 */
+	public function test_composite_image_aborts_when_time_budget_exhausted(): void {
+		$instance = Venue_Map::get_instance();
+
+		$fetches = 0;
+		$counter = static function () use ( &$fetches ) {
+			++$fetches;
+			return array(
+				'headers'  => array(),
+				'body'     => '',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		$budget  = static function () {
+			// A negative budget makes the deadline sit in the past from
+			// the first iteration, forcing break 2 before any fetch runs.
+			return -1;
+		};
+
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		add_filter( 'pre_http_request', $counter, 10 );
+		add_filter( 'gatherpress_venue_map_composite_time_budget', $budget );
+
+		$image = $instance->composite_image(
+			37.3318,
+			-122.0312,
+			15,
+			256,
+			Venue_Map::DEFAULT_TILE_URL
+		);
+
+		remove_filter( 'gatherpress_venue_map_composite_time_budget', $budget );
+		remove_filter( 'pre_http_request', $counter, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+
+		$this->assertInstanceOf(
+			\GdImage::class,
+			$image,
+			'Canvas should still be returned when the budget is exhausted.'
+		);
+		$this->assertSame( 0, $fetches, 'No tiles should be fetched when the deadline is already in the past.' );
+
+		// Center pixel should remain the neutral-gray background color since
+		// no tile was drawn.
+		$index = imagecolorat( $image, 128, 64 );
+		$rgb   = imagecolorsforindex( $image, $index );
+		$this->assertSame( 238, $rgb['red'] );
+		$this->assertSame( 238, $rgb['green'] );
+		$this->assertSame( 238, $rgb['blue'] );
+
+		imagedestroy( $image );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -474,6 +474,62 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
+	 * A previously-geocoded venue whose address is edited to something
+	 * un-geocodable must have its stored PNGs purged so stale images
+	 * don't keep serving under the new (wrong) address.
+	 *
+	 * @covers ::maybe_generate
+	 *
+	 * @return void
+	 */
+	public function test_maybe_generate_purges_when_coordinates_disappear(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		update_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+
+		$descriptor = $instance->get_stored_descriptor( $post_id );
+
+		$this->assertIsArray( $descriptor, 'Sanity: initial save should have produced a descriptor.' );
+		$path = $instance->url_to_path( $descriptor['url'] );
+		$this->assertFileExists( $path );
+
+		// Now clear the coordinates (e.g. address changed to something un-geocodable).
+		update_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => 'Nonexistent Place',
+					'latitude'    => '',
+					'longitude'   => '',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+
+		$this->assertNull(
+			$instance->get_stored_descriptor( $post_id ),
+			'Descriptor meta should be cleared when coordinates become un-geocodable.'
+		);
+		$this->assertFileDoesNotExist(
+			(string) $path,
+			'Orphaned PNG should be removed when coordinates disappear.'
+		);
+	}
+
+	/**
 	 * No image is written when the venue lacks usable coordinates.
 	 *
 	 * @covers ::maybe_generate
@@ -589,6 +645,35 @@ class Test_Venue_Map extends Base {
 		$this->assertNull(
 			$instance->url_to_path( 'https://example.com/evil.png' ),
 			'External URLs must not resolve to a filesystem path.'
+		);
+	}
+
+	/**
+	 * A URL whose origin matches the plugin uploads subdir but whose
+	 * filename contains path-traversal segments (`..`) must not resolve —
+	 * otherwise delete_file_by_url() could be steered at arbitrary files
+	 * if the meta were ever writable.
+	 *
+	 * @covers ::url_to_path
+	 *
+	 * @return void
+	 */
+	public function test_url_to_path_rejects_traversal_in_plugin_subdir_url(): void {
+		$instance = Venue_Map::get_instance();
+		$dirs     = wp_get_upload_dir();
+		$base_url = trailingslashit( $dirs['baseurl'] ) . Venue_Map::UPLOADS_SUBDIR . '/';
+
+		$this->assertNull(
+			$instance->url_to_path( $base_url . '../../../wp-config.php' ),
+			'Traversal segments in the relative portion must not resolve.'
+		);
+		$this->assertNull(
+			$instance->url_to_path( $base_url . '42-notahex.png' ),
+			'Filenames not matching the `{post_id}-{md5}.png` shape must not resolve.'
+		);
+		$this->assertNull(
+			$instance->url_to_path( $base_url . 'subdir/42-abcdef0123456789abcdef0123456789.png' ),
+			'Nested filenames (with slashes) must not resolve.'
 		);
 	}
 
@@ -839,9 +924,12 @@ class Test_Venue_Map extends Base {
 		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Map::UPLOADS_SUBDIR;
 		wp_mkdir_p( $base_dir );
 
-		$path = $base_dir . '/delete-me.png';
-		$url  = trailingslashit( $dirs['baseurl'] )
-			. Venue_Map::UPLOADS_SUBDIR . '/delete-me.png';
+		// Use a filename in the `{post_id}-{md5}.png` shape url_to_path()
+		// accepts. A fake hex string stands in for a real MD5 digest.
+		$filename = '99-abcdef0123456789abcdef0123456789.png';
+		$path     = $base_dir . '/' . $filename;
+		$url      = trailingslashit( $dirs['baseurl'] )
+			. Venue_Map::UPLOADS_SUBDIR . '/' . $filename;
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Fixture write inside the test-only uploads dir.
 		file_put_contents( $path, 'stub' );
 
@@ -1057,10 +1145,11 @@ class Test_Venue_Map extends Base {
 	public function test_url_to_path_resolves_plugin_subdir_url(): void {
 		$instance = Venue_Map::get_instance();
 		$dirs     = wp_get_upload_dir();
+		$filename = '42-abcdef0123456789abcdef0123456789.png';
 		$url      = trailingslashit( $dirs['baseurl'] )
-			. Venue_Map::UPLOADS_SUBDIR . '/42-abc.png';
+			. Venue_Map::UPLOADS_SUBDIR . '/' . $filename;
 		$expected = trailingslashit( $dirs['basedir'] )
-			. Venue_Map::UPLOADS_SUBDIR . '/42-abc.png';
+			. Venue_Map::UPLOADS_SUBDIR . '/' . $filename;
 
 		$this->assertSame( $expected, $instance->url_to_path( $url ) );
 	}
@@ -1218,7 +1307,10 @@ class Test_Venue_Map extends Base {
 		$instance = Venue_Map::get_instance();
 		$canvas   = imagecreatetruecolor( 10, 10 );
 
-		$url = $instance->save_image( $canvas, 99, 'deadbeef' );
+		// Use a 32-char hex hash matching what hash_for() produces; the
+		// url_to_path allow-list rejects anything else.
+		$hash = str_repeat( 'a', 32 );
+		$url  = $instance->save_image( $canvas, 99, $hash );
 		imagedestroy( $canvas );
 
 		$this->assertNotNull( $url, 'save_image should return a URL on success.' );
@@ -1275,6 +1367,71 @@ class Test_Venue_Map extends Base {
 			Utility::invoke_hidden_method( $instance, 'get_zoom' ),
 			'Should fall back to DEFAULT_ZOOM when the setting is unset/zero.'
 		);
+	}
+
+	/**
+	 * Clamps out-of-range zoom values from the Settings row or filter to
+	 * the supported range. Otherwise a stale/hand-edited setting or filter
+	 * override could drive the generator to render a useless world-view
+	 * (zoom 0) or crash out on a value the tile provider won't serve
+	 * (zoom 30+).
+	 *
+	 * @covers ::get_zoom
+	 * @covers ::clamp_zoom
+	 *
+	 * @return void
+	 */
+	public function test_get_zoom_clamps_out_of_range_values(): void {
+		$instance = Venue_Map::get_instance();
+		$settings = \GatherPress\Core\Settings::get_instance();
+
+		$settings->set( 'venue_map_default_zoom', 0 );
+		$too_high = static function () {
+			return 99;
+		};
+		add_filter( 'gatherpress_venue_map_zoom', $too_high );
+		$this->assertSame(
+			Venue_Map::ZOOM_MAX,
+			Utility::invoke_hidden_method( $instance, 'get_zoom' ),
+			'Zoom beyond ZOOM_MAX must clamp down.'
+		);
+		remove_filter( 'gatherpress_venue_map_zoom', $too_high );
+
+		$too_low = static function () {
+			return 0;
+		};
+		add_filter( 'gatherpress_venue_map_zoom', $too_low );
+		$this->assertSame(
+			Venue_Map::ZOOM_MIN,
+			Utility::invoke_hidden_method( $instance, 'get_zoom' ),
+			'Zoom below ZOOM_MIN must clamp up.'
+		);
+		remove_filter( 'gatherpress_venue_map_zoom', $too_low );
+	}
+
+	/**
+	 * Same coverage for get_height — clamps Settings + filter overrides.
+	 *
+	 * @covers ::get_height
+	 * @covers ::clamp_height
+	 *
+	 * @return void
+	 */
+	public function test_get_height_clamps_out_of_range_values(): void {
+		$instance = Venue_Map::get_instance();
+		$settings = \GatherPress\Core\Settings::get_instance();
+
+		$settings->set( 'venue_map_default_height', 0 );
+		$too_big = static function () {
+			return 9999;
+		};
+		add_filter( 'gatherpress_venue_map_height', $too_big );
+		$this->assertSame(
+			Venue_Map::HEIGHT_MAX,
+			Utility::invoke_hidden_method( $instance, 'get_height' ),
+			'Height beyond HEIGHT_MAX must clamp down.'
+		);
+		remove_filter( 'gatherpress_venue_map_height', $too_big );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-setup.php
@@ -1226,7 +1226,7 @@ class Test_Venue_Setup extends Base {
 		$registry->register(
 			'gatherpress/venue-template',
 			array(
-				'title'    => 'Invisible Venue Template Block Pattern',
+				'title'    => 'Venue Post Default Content',
 				'content'  => '<!-- wp:gatherpress/venue /-->',
 				'inserter' => false,
 				'source'   => 'plugin',

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-setup.php
@@ -173,6 +173,7 @@ class Test_Venue_Setup extends Base {
 
 		unregister_post_meta( Venue::POST_TYPE, 'gatherpress_venue_information' );
 		unregister_post_meta( Venue::POST_TYPE, 'gatherpress_venue_map_show' );
+		unregister_post_meta( Venue::POST_TYPE, 'gatherpress_venue_static_map' );
 		unregister_post_meta( Venue::POST_TYPE, 'geo_latitude' );
 		unregister_post_meta( Venue::POST_TYPE, 'geo_longitude' );
 		unregister_post_meta( Venue::POST_TYPE, 'geo_address' );
@@ -214,7 +215,14 @@ class Test_Venue_Setup extends Base {
 			'Failed to assert that gatherpress_venue_map_show exists for gatherpress-venue-map support.'
 		);
 
-		foreach ( array( 'geo_latitude', 'geo_longitude', 'geo_address', 'geo_public' ) as $key ) {
+		$expected_keys = array(
+			'geo_latitude',
+			'geo_longitude',
+			'geo_address',
+			'geo_public',
+			'gatherpress_venue_static_map',
+		);
+		foreach ( $expected_keys as $key ) {
 			$this->assertArrayHasKey(
 				$key,
 				$meta,
@@ -628,6 +636,12 @@ class Test_Venue_Setup extends Base {
 				'geo_longitude'                 => '99.99',
 				'geo_address'                   => 'Hack St',
 				'geo_public'                    => 0,
+				'gatherpress_venue_static_map'  => array(
+					'15' => array(
+						'url'  => 'evil.png',
+						'hash' => 'x',
+					),
+				),
 				'gatherpress_venue_information' => '{"fullAddress":"Real St"}',
 			)
 		);
@@ -643,10 +657,15 @@ class Test_Venue_Setup extends Base {
 		$this->assertArrayNotHasKey( 'geo_longitude', $meta, 'geo_longitude should be stripped.' );
 		$this->assertArrayNotHasKey( 'geo_address', $meta, 'geo_address should be stripped.' );
 		$this->assertArrayNotHasKey( 'geo_public', $meta, 'geo_public should be stripped.' );
+		$this->assertArrayNotHasKey(
+			'gatherpress_venue_static_map',
+			$meta,
+			'gatherpress_venue_static_map is server-generated and must not be writable via REST.'
+		);
 		$this->assertArrayHasKey(
 			'gatherpress_venue_information',
 			$meta,
-			'Non-geo meta keys should pass through untouched.'
+			'Non-readonly meta keys should pass through untouched.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-static-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-static-map.php
@@ -1,0 +1,1255 @@
+<?php
+/**
+ * Unit tests for GatherPress\Core\Venue_Static_Map.
+ *
+ * These tests cover the generator's hash logic, the save/regenerate/cleanup
+ * lifecycle, and the hook wiring. The tile fetcher is stubbed via an HTTP
+ * short-circuit filter so tests never make a real network call.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Core;
+
+use GatherPress\Core\Venue;
+use GatherPress\Core\Venue_Static_Map;
+use GatherPress\Tests\Base;
+use PMC\Unit_Test\Utility;
+
+/**
+ * Class Test_Venue_Static_Map.
+ *
+ * @group multisite
+ * @coversDefaultClass \GatherPress\Core\Venue_Static_Map
+ */
+class Test_Venue_Static_Map extends Base {
+	/**
+	 * Minimal valid 1×1 PNG used as a stand-in for every tile fetch.
+	 *
+	 * Keeping the payload small keeps tests fast and makes it obvious when
+	 * a code path accidentally hits the real network (which would time out).
+	 *
+	 * @var string
+	 */
+	private $tile_png;
+
+	/**
+	 * Installs the HTTP short-circuit on every test so no network is touched.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$png  = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42m';
+		$png .= 'NkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Fixed, trusted PNG payload for the tile-fetch stub.
+		$this->tile_png = base64_decode( $png );
+
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+	}
+
+	/**
+	 * Removes the filter and any leftover files on tear-down.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+
+		$dirs     = wp_get_upload_dir();
+		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Static_Map::UPLOADS_SUBDIR;
+
+		if ( is_dir( $base_dir ) ) {
+			foreach ( (array) glob( $base_dir . '/*.png' ) as $file ) {
+				if ( is_file( $file ) ) {
+					unlink( $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+				}
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Short-circuit every HTTP request by returning the canned tile response.
+	 *
+	 * @param mixed  $preempt Default false.
+	 * @param array  $args    HTTP args (unused).
+	 * @param string $url     Request URL (unused).
+	 * @return array Mocked WP HTTP response.
+	 */
+	public function short_circuit_tile_requests( $preempt, $args, $url ): array {
+		unset( $args, $url );
+
+		return array(
+			'headers'  => array(),
+			'body'     => $this->tile_png,
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+
+	/**
+	 * Coverage for setup_hooks.
+	 *
+	 * @covers ::__construct
+	 * @covers ::setup_hooks
+	 *
+	 * @return void
+	 */
+	public function test_setup_hooks(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$hooks    = array(
+			array(
+				'type'     => 'action',
+				'name'     => 'wp_after_insert_post',
+				'priority' => 20,
+				'callback' => array( $instance, 'maybe_generate' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'registered_post_type',
+				'priority' => 10,
+				'callback' => array( $instance, 'maybe_register_delete_hook' ),
+			),
+		);
+
+		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * Coverage for maybe_register_delete_hook when the post type is a venue.
+	 *
+	 * @covers ::maybe_register_delete_hook
+	 *
+	 * @return void
+	 */
+	public function test_maybe_register_delete_hook(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $post_type ) {
+			$instance->maybe_register_delete_hook( $post_type );
+
+			$this->assertSame(
+				10,
+				has_action(
+					sprintf( 'delete_post_%s', $post_type ),
+					array( $instance, 'delete_stored_image' )
+				),
+				sprintf( 'delete_post_%s should be wired to delete_stored_image.', $post_type )
+			);
+		}
+	}
+
+	/**
+	 * Bails silently when the post type does not support venue information.
+	 *
+	 * @covers ::maybe_register_delete_hook
+	 *
+	 * @return void
+	 */
+	public function test_maybe_register_delete_hook_skips_unsupported_post_type(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		$instance->maybe_register_delete_hook( 'post' );
+
+		$this->assertFalse(
+			has_action( 'delete_post_post', array( $instance, 'delete_stored_image' ) ),
+			'Expected no delete-cleanup hook to be registered for a non-venue post type.'
+		);
+	}
+
+	/**
+	 * The hash should change when inputs change and stay stable otherwise.
+	 *
+	 * @covers ::hash_for
+	 *
+	 * @return void
+	 */
+	public function test_hash_for_detects_relevant_input_changes(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$info     = array(
+			'fullAddress' => '1 Infinite Loop',
+			'latitude'    => '37.3318',
+			'longitude'   => '-122.0312',
+		);
+
+		$baseline = $instance->hash_for( $info, 15, 600, 400, Venue_Static_Map::DEFAULT_TILE_URL );
+
+		$this->assertSame(
+			$baseline,
+			$instance->hash_for( $info, 15, 600, 400, Venue_Static_Map::DEFAULT_TILE_URL ),
+			'Hash should be stable when every input is identical.'
+		);
+
+		$moved_info              = $info;
+		$moved_info['latitude']  = '37.3320';
+		$moved_info['longitude'] = '-122.0314';
+
+		$this->assertNotSame(
+			$baseline,
+			$instance->hash_for( $moved_info, 15, 600, 400, Venue_Static_Map::DEFAULT_TILE_URL ),
+			'Hash should change when coordinates change.'
+		);
+
+		$this->assertNotSame(
+			$baseline,
+			$instance->hash_for( $info, 14, 600, 400, Venue_Static_Map::DEFAULT_TILE_URL ),
+			'Hash should change when the zoom level changes.'
+		);
+
+		$this->assertNotSame(
+			$baseline,
+			$instance->hash_for( $info, 15, 800, 400, Venue_Static_Map::DEFAULT_TILE_URL ),
+			'Hash should change when the width changes.'
+		);
+	}
+
+	/**
+	 * Writes a PNG to the uploads subdir and stores its URL in post meta.
+	 *
+	 * @covers ::maybe_generate
+	 * @covers ::composite_image
+	 * @covers ::save_image
+	 * @covers ::stamp_marker
+	 * @covers ::fetch_tile
+	 * @covers ::get_stored_descriptor
+	 *
+	 * @return void
+	 */
+	public function test_maybe_generate_writes_image_and_descriptor(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop, Cupertino, CA',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$instance->maybe_generate( $post_id );
+
+		$descriptor = $instance->get_stored_descriptor( $post_id );
+
+		$this->assertIsArray( $descriptor, 'Expected a descriptor array after generation.' );
+		$this->assertNotEmpty( $descriptor['url'], 'Descriptor URL should be populated.' );
+		$this->assertSame( 40, strlen( $descriptor['hash'] ), 'Descriptor hash should be a SHA-1 hex string.' );
+
+		$path = $instance->url_to_path( $descriptor['url'] );
+
+		$this->assertNotNull( $path, 'Saved URL should map back to a filesystem path.' );
+		$this->assertFileExists( $path, 'The static-map PNG should exist on disk.' );
+	}
+
+	/**
+	 * A second save with identical inputs should no-op (no file mtime change).
+	 *
+	 * @covers ::maybe_generate
+	 *
+	 * @return void
+	 */
+	public function test_maybe_generate_is_idempotent_when_inputs_unchanged(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$instance->maybe_generate( $post_id );
+		$first_descriptor = $instance->get_stored_descriptor( $post_id );
+		$path             = $instance->url_to_path( $first_descriptor['url'] );
+		$mtime_first      = filemtime( $path );
+
+		// Force the filesystem mtime to change so a regeneration would be detectable.
+		sleep( 1 );
+
+		$instance->maybe_generate( $post_id );
+
+		$this->assertSame(
+			$mtime_first,
+			filemtime( $path ),
+			'Second save with unchanged inputs should not rewrite the PNG.'
+		);
+	}
+
+	/**
+	 * Changing the venue address regenerates the image with a new hash.
+	 *
+	 * @covers ::maybe_generate
+	 *
+	 * @return void
+	 */
+	public function test_maybe_generate_regenerates_when_coordinates_change(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		update_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+		$first = $instance->get_stored_descriptor( $post_id );
+
+		update_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1600 Amphitheatre Parkway',
+					'latitude'    => '37.4220',
+					'longitude'   => '-122.0841',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+		$second = $instance->get_stored_descriptor( $post_id );
+
+		$this->assertNotSame(
+			$first['hash'],
+			$second['hash'],
+			'Hash should change with new coordinates.'
+		);
+		$this->assertNotSame(
+			$first['url'],
+			$second['url'],
+			'URL should change because the filename includes the hash.'
+		);
+
+		$old_path = $instance->url_to_path( $first['url'] );
+
+		$this->assertFileDoesNotExist(
+			$old_path,
+			'The previous static-map PNG should be cleaned up when regenerating.'
+		);
+	}
+
+	/**
+	 * No image is written when the venue lacks usable coordinates.
+	 *
+	 * @covers ::maybe_generate
+	 *
+	 * @return void
+	 */
+	public function test_maybe_generate_bails_without_coordinates(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => 'Somewhere, somewhere',
+					'latitude'    => '',
+					'longitude'   => '',
+				)
+			)
+		);
+
+		$instance->maybe_generate( $post_id );
+
+		$this->assertNull(
+			$instance->get_stored_descriptor( $post_id ),
+			'Venues without numeric coords should not get a static map.'
+		);
+	}
+
+	/**
+	 * Short-circuits for revisions and autosaves.
+	 *
+	 * @covers ::maybe_generate
+	 *
+	 * @return void
+	 */
+	public function test_maybe_generate_skips_revisions_and_autosaves(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$venue_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		update_post_meta(
+			$venue_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$revision_id = wp_save_post_revision( $venue_id );
+
+		if ( $revision_id ) {
+			$instance->maybe_generate( (int) $revision_id );
+			$this->assertNull(
+				$instance->get_stored_descriptor( (int) $revision_id ),
+				'Revisions should not receive a static map.'
+			);
+		}
+	}
+
+	/**
+	 * Removes the PNG and the descriptor meta for the venue.
+	 *
+	 * @covers ::delete_stored_image
+	 *
+	 * @return void
+	 */
+	public function test_delete_stored_image_removes_file_and_meta(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+
+		$descriptor = $instance->get_stored_descriptor( $post_id );
+		$path       = $instance->url_to_path( $descriptor['url'] );
+
+		$this->assertFileExists( $path );
+
+		$instance->delete_stored_image( $post_id );
+
+		$this->assertFileDoesNotExist( $path, 'PNG should be removed by delete_stored_image.' );
+		$this->assertNull(
+			$instance->get_stored_descriptor( $post_id ),
+			'Descriptor meta should be cleared after delete_stored_image.'
+		);
+	}
+
+	/**
+	 * Rejects URLs that sit outside of the plugin's uploads subdir.
+	 *
+	 * @covers ::url_to_path
+	 *
+	 * @return void
+	 */
+	public function test_url_to_path_rejects_external_urls(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		$this->assertNull(
+			$instance->url_to_path( 'https://example.com/evil.png' ),
+			'External URLs must not resolve to a filesystem path.'
+		);
+	}
+
+	/**
+	 * get_all_descriptors returns an empty array for a venue with nothing stored.
+	 *
+	 * @covers ::get_all_descriptors
+	 *
+	 * @return void
+	 */
+	public function test_get_all_descriptors_empty_when_nothing_stored(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		$this->assertSame( array(), $instance->get_all_descriptors( $post_id ) );
+	}
+
+	/**
+	 * get_all_descriptors silently drops malformed entries.
+	 *
+	 * @covers ::get_all_descriptors
+	 *
+	 * @return void
+	 */
+	public function test_get_all_descriptors_filters_malformed_entries(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		update_post_meta(
+			$post_id,
+			Venue_Static_Map::META_KEY,
+			array(
+				'15' => array(
+					'url'  => 'https://example.test/a.png',
+					'hash' => 'abc',
+				),
+				'18' => 'not-an-array',
+				'20' => array( 'url' => 'https://example.test/b.png' ), // missing hash
+			)
+		);
+
+		$descriptors = $instance->get_all_descriptors( $post_id );
+
+		$this->assertArrayHasKey( 15, $descriptors );
+		$this->assertArrayNotHasKey( 18, $descriptors );
+		$this->assertArrayNotHasKey( 20, $descriptors );
+	}
+
+	/**
+	 * Requesting a previously-uncached zoom triggers synchronous generation
+	 * and caches the result for next time.
+	 *
+	 * @covers ::get_url_for_post
+	 * @covers ::ensure_descriptor_for_zoom
+	 *
+	 * @return void
+	 */
+	public function test_get_url_for_post_lazily_generates_new_zoom(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+
+		$descriptors_before = $instance->get_all_descriptors( $post_id );
+
+		$this->assertCount( 1, $descriptors_before, 'Initial save should seed only the default zoom.' );
+		$this->assertArrayHasKey( Venue_Static_Map::DEFAULT_ZOOM, $descriptors_before );
+
+		// Request a different zoom. This is the key user-facing flow: a block
+		// configured at zoom 18 gets its own cached image on first render.
+		$url = $instance->get_url_for_post( $post_id, Venue::POST_TYPE, 18 );
+
+		$this->assertNotEmpty( $url, 'Lazy generation should return a non-empty URL.' );
+
+		$descriptors_after = $instance->get_all_descriptors( $post_id );
+
+		$this->assertCount( 2, $descriptors_after, 'New zoom should have been cached.' );
+		$this->assertArrayHasKey( 18, $descriptors_after );
+		$this->assertSame( $url, $descriptors_after[18]['url'] );
+	}
+
+	/**
+	 * A content change (e.g. new coordinates) regenerates every known zoom.
+	 *
+	 * @covers ::maybe_generate
+	 * @covers ::ensure_descriptor_for_zoom
+	 *
+	 * @return void
+	 */
+	public function test_maybe_generate_cascades_content_changes_to_all_cached_zooms(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		update_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+		// Warm a second zoom so we have two cached variants.
+		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 18 );
+
+		$before = $instance->get_all_descriptors( $post_id );
+
+		$this->assertCount( 2, $before );
+
+		// Change the address. maybe_generate should regenerate both zooms.
+		update_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1600 Amphitheatre Parkway',
+					'latitude'    => '37.4220',
+					'longitude'   => '-122.0841',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+
+		$after = $instance->get_all_descriptors( $post_id );
+
+		$this->assertCount( 2, $after, 'Both zooms should still be present after regeneration.' );
+		$this->assertNotSame(
+			$before[ Venue_Static_Map::DEFAULT_ZOOM ]['hash'],
+			$after[ Venue_Static_Map::DEFAULT_ZOOM ]['hash'],
+			'Default-zoom hash should change with new coordinates.'
+		);
+		$this->assertNotSame(
+			$before[18]['hash'],
+			$after[18]['hash'],
+			'Zoom-18 hash should change with new coordinates.'
+		);
+
+		// Old files should be gone.
+		$this->assertFileDoesNotExist(
+			(string) $instance->url_to_path( $before[ Venue_Static_Map::DEFAULT_ZOOM ]['url'] )
+		);
+		$this->assertFileDoesNotExist(
+			(string) $instance->url_to_path( $before[18]['url'] )
+		);
+	}
+
+	/**
+	 * Direct coverage for delete_file_by_url — unlinks only when the URL
+	 * resolves to a path inside the plugin's uploads subdir.
+	 *
+	 * @covers ::delete_file_by_url
+	 *
+	 * @return void
+	 */
+	public function test_delete_file_by_url_unlinks_in_scope(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		// Create a fixture file the method is allowed to delete.
+		$dirs     = wp_get_upload_dir();
+		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Static_Map::UPLOADS_SUBDIR;
+		wp_mkdir_p( $base_dir );
+
+		$path = $base_dir . '/delete-me.png';
+		$url  = trailingslashit( $dirs['baseurl'] ) . Venue_Static_Map::UPLOADS_SUBDIR . '/delete-me.png';
+		file_put_contents( $path, 'stub' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations.file_put_contents
+
+		$this->assertFileExists( $path );
+
+		Utility::invoke_hidden_method( $instance, 'delete_file_by_url', array( $url ) );
+
+		$this->assertFileDoesNotExist( $path, 'In-scope file should be removed.' );
+
+		// Out-of-scope URL should no-op (url_to_path returns null).
+		Utility::invoke_hidden_method(
+			$instance,
+			'delete_file_by_url',
+			array( 'https://example.test/outside.png' )
+		);
+		// Terminal assertion to keep PHPUnit happy — the real guarantee is
+		// "no exception thrown, no unexpected side effects."
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Direct coverage for ensure_descriptor_for_zoom when save_image fails.
+	 *
+	 * Exercising it through the public API (maybe_generate) leaves this
+	 * branch uncredited by xdebug, so we invoke the protected method directly.
+	 *
+	 * @covers ::ensure_descriptor_for_zoom
+	 *
+	 * @return void
+	 */
+	public function test_ensure_descriptor_for_zoom_returns_null_when_save_fails(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		$force_error = static function ( $dirs ) {
+			$dirs['error'] = 'Simulated uploads failure.';
+			return $dirs;
+		};
+		add_filter( 'upload_dir', $force_error );
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'ensure_descriptor_for_zoom',
+			array(
+				42,
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				),
+				15,
+			)
+		);
+
+		remove_filter( 'upload_dir', $force_error );
+
+		$this->assertNull( $result, 'Null return when save_image cannot write the file.' );
+	}
+
+	/**
+	 * get_url_for_post on a second call for the same zoom is a cache hit
+	 * (no filesystem rewrite).
+	 *
+	 * @covers ::ensure_descriptor_for_zoom
+	 *
+	 * @return void
+	 */
+	public function test_get_url_for_post_is_cached_on_second_call(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$first  = $instance->get_url_for_post( $post_id, Venue::POST_TYPE, 17 );
+		$path   = (string) $instance->url_to_path( $first );
+		$mtime1 = filemtime( $path );
+
+		sleep( 1 );
+
+		$second = $instance->get_url_for_post( $post_id, Venue::POST_TYPE, 17 );
+
+		$this->assertSame( $first, $second, 'Second call should return the same URL.' );
+		$this->assertSame( $mtime1, filemtime( $path ), 'Second call must not rewrite the PNG.' );
+	}
+
+	/**
+	 * Returns the stored URL when given a venue post ID directly.
+	 *
+	 * @covers ::get_url_for_post
+	 *
+	 * @return void
+	 */
+	public function test_get_url_for_post_resolves_venue_directly(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+
+		$descriptor = $instance->get_stored_descriptor( $post_id );
+
+		$this->assertSame(
+			$descriptor['url'],
+			$instance->get_url_for_post( $post_id, Venue::POST_TYPE )
+		);
+	}
+
+	/**
+	 * Walks event → linked venue to resolve the static map URL.
+	 *
+	 * @covers ::get_url_for_post
+	 *
+	 * @return void
+	 */
+	public function test_get_url_for_post_resolves_event_via_linked_venue(): void {
+		$instance    = Venue_Static_Map::get_instance();
+		$venue_setup = \GatherPress\Core\Venue_Setup::get_instance();
+
+		$venue = $this->mock->post(
+			array(
+				'post_type'  => Venue::POST_TYPE,
+				'post_name'  => 'venue-for-url-helper',
+				'post_title' => 'Venue For URL Helper',
+			)
+		)->get();
+
+		$event = $this->mock->post(
+			array(
+				'post_type' => \GatherPress\Core\Event::POST_TYPE,
+				'post_name' => 'event-for-url-helper',
+			)
+		)->get();
+
+		$term_slug = $venue_setup->term_slug_from_post_name( $venue->post_name );
+		wp_set_post_terms( $event->ID, $term_slug, Venue::TAXONOMY );
+
+		update_post_meta(
+			$venue->ID,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $venue->ID );
+
+		$descriptor = $instance->get_stored_descriptor( $venue->ID );
+
+		$this->assertSame(
+			$descriptor['url'],
+			$instance->get_url_for_post( $event->ID, \GatherPress\Core\Event::POST_TYPE )
+		);
+	}
+
+	/**
+	 * Returns '' from get_url_for_post for posts unrelated to venues.
+	 *
+	 * @covers ::get_url_for_post
+	 *
+	 * @return void
+	 */
+	public function test_get_url_for_post_returns_empty_for_unrelated_post(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => 'post' ) );
+
+		$this->assertSame( '', $instance->get_url_for_post( $post_id, 'post' ) );
+	}
+
+	/**
+	 * Returns '' from get_url_for_post when a venue has no stored map yet.
+	 *
+	 * @covers ::get_url_for_post
+	 *
+	 * @return void
+	 */
+	public function test_get_url_for_post_returns_empty_when_no_map_generated(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		$this->assertSame( '', $instance->get_url_for_post( $post_id, Venue::POST_TYPE ) );
+	}
+
+	/**
+	 * Resolves a URL inside the plugin's uploads subdir back to a path.
+	 *
+	 * @covers ::url_to_path
+	 *
+	 * @return void
+	 */
+	public function test_url_to_path_resolves_plugin_subdir_url(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$dirs     = wp_get_upload_dir();
+		$url      = trailingslashit( $dirs['baseurl'] )
+			. Venue_Static_Map::UPLOADS_SUBDIR . '/42-abc.png';
+		$expected = trailingslashit( $dirs['basedir'] )
+			. Venue_Static_Map::UPLOADS_SUBDIR . '/42-abc.png';
+
+		$this->assertSame( $expected, $instance->url_to_path( $url ) );
+	}
+
+	/**
+	 * Bails silently when called on a non-venue post type.
+	 *
+	 * @covers ::maybe_generate
+	 *
+	 * @return void
+	 */
+	public function test_maybe_generate_skips_unsupported_post_type(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => 'post' ) );
+
+		$instance->maybe_generate( $post_id );
+
+		$this->assertNull(
+			$instance->get_stored_descriptor( $post_id ),
+			'Non-venue post types must not receive a static map.'
+		);
+	}
+
+	/**
+	 * Returns null from fetch_tile when the HTTP response is an error.
+	 *
+	 * @covers ::fetch_tile
+	 *
+	 * @return void
+	 */
+	public function test_fetch_tile_returns_null_on_http_error(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		// Replace the success stub with a WP_Error short-circuit just for this test.
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		$fail = static function () {
+			return new \WP_Error( 'boom', 'tile fetch failed' );
+		};
+		add_filter( 'pre_http_request', $fail, 10 );
+
+		$this->assertNull(
+			$instance->fetch_tile( 15, 1, 1, Venue_Static_Map::DEFAULT_TILE_URL )
+		);
+
+		remove_filter( 'pre_http_request', $fail, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+	}
+
+	/**
+	 * Returns null from fetch_tile when the HTTP response is not 200 OK.
+	 *
+	 * @covers ::fetch_tile
+	 *
+	 * @return void
+	 */
+	public function test_fetch_tile_returns_null_on_non_200_response(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		$not_found = static function () {
+			return array(
+				'headers'  => array(),
+				'body'     => '',
+				'response' => array(
+					'code'    => 404,
+					'message' => 'Not Found',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $not_found, 10 );
+
+		$this->assertNull(
+			$instance->fetch_tile( 15, 1, 1, Venue_Static_Map::DEFAULT_TILE_URL )
+		);
+
+		remove_filter( 'pre_http_request', $not_found, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+	}
+
+	/**
+	 * Returns PNG bytes from fetch_tile when the request succeeds.
+	 *
+	 * @covers ::fetch_tile
+	 *
+	 * @return void
+	 */
+	public function test_fetch_tile_returns_png_bytes(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		$this->assertSame(
+			$this->tile_png,
+			$instance->fetch_tile( 15, 1, 1, Venue_Static_Map::DEFAULT_TILE_URL )
+		);
+	}
+
+	/**
+	 * Directly exercise composite_image so coverage credits the method entry.
+	 *
+	 * @covers ::composite_image
+	 *
+	 * @return void
+	 */
+	public function test_composite_image_returns_gd_image(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		$image = $instance->composite_image(
+			37.3318,
+			-122.0312,
+			15,
+			256,
+			256,
+			Venue_Static_Map::DEFAULT_TILE_URL
+		);
+
+		$this->assertInstanceOf( \GdImage::class, $image );
+		$this->assertSame( 256, imagesx( $image ) );
+		$this->assertSame( 256, imagesy( $image ) );
+
+		imagedestroy( $image );
+	}
+
+	/**
+	 * Draws a marker into the provided canvas.
+	 *
+	 * @covers ::stamp_marker
+	 *
+	 * @return void
+	 */
+	public function test_stamp_marker_draws_on_canvas(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$canvas   = imagecreatetruecolor( 40, 40 );
+		$instance->stamp_marker( $canvas, 20, 20 );
+
+		// The marker center should be white (inner dot).
+		$index = imagecolorat( $canvas, 20, 20 );
+		$rgb   = imagecolorsforindex( $canvas, $index );
+
+		$this->assertSame( 255, $rgb['red'] );
+		$this->assertSame( 255, $rgb['green'] );
+		$this->assertSame( 255, $rgb['blue'] );
+
+		imagedestroy( $canvas );
+	}
+
+	/**
+	 * Writes the PNG and returns a URL inside the plugin uploads subdir.
+	 *
+	 * @covers ::save_image
+	 *
+	 * @return void
+	 */
+	public function test_save_image_writes_file_and_returns_url(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$canvas   = imagecreatetruecolor( 10, 10 );
+
+		$url = $instance->save_image( $canvas, 99, 'deadbeef' );
+		imagedestroy( $canvas );
+
+		$this->assertNotNull( $url, 'save_image should return a URL on success.' );
+		$this->assertStringContainsString( Venue_Static_Map::UPLOADS_SUBDIR, $url );
+
+		$path = $instance->url_to_path( $url );
+		$this->assertFileExists( $path );
+	}
+
+	/**
+	 * Coverage for parse_coord — numeric input → float, anything else → null.
+	 *
+	 * @covers ::parse_coord
+	 *
+	 * @return void
+	 */
+	public function test_parse_coord(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		$this->assertSame(
+			37.3318,
+			Utility::invoke_hidden_method( $instance, 'parse_coord', array( '37.3318' ) )
+		);
+		$this->assertNull(
+			Utility::invoke_hidden_method( $instance, 'parse_coord', array( 'not a number' ) )
+		);
+		$this->assertNull(
+			Utility::invoke_hidden_method( $instance, 'parse_coord', array( '' ) )
+		);
+	}
+
+	/**
+	 * Coverage for the filterable getters.
+	 *
+	 * @covers ::get_zoom
+	 * @covers ::get_width
+	 * @covers ::get_height
+	 * @covers ::get_tile_url_template
+	 *
+	 * @return void
+	 */
+	public function test_filterable_getters(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		$this->assertSame(
+			Venue_Static_Map::DEFAULT_ZOOM,
+			Utility::invoke_hidden_method( $instance, 'get_zoom' )
+		);
+		$this->assertSame(
+			Venue_Static_Map::DEFAULT_WIDTH,
+			Utility::invoke_hidden_method( $instance, 'get_width' )
+		);
+		$this->assertSame(
+			Venue_Static_Map::DEFAULT_HEIGHT,
+			Utility::invoke_hidden_method( $instance, 'get_height' )
+		);
+		$this->assertSame(
+			Venue_Static_Map::DEFAULT_TILE_URL,
+			Utility::invoke_hidden_method( $instance, 'get_tile_url_template' )
+		);
+	}
+
+	/**
+	 * Survives a tile that fails to fetch (falls through, blank area).
+	 *
+	 * @covers ::composite_image
+	 *
+	 * @return void
+	 */
+	public function test_composite_image_continues_past_failed_fetch(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		$fail = static function () {
+			return new \WP_Error( 'boom', 'tile fetch failed' );
+		};
+		add_filter( 'pre_http_request', $fail, 10 );
+
+		$image = $instance->composite_image(
+			37.3318,
+			-122.0312,
+			15,
+			256,
+			256,
+			Venue_Static_Map::DEFAULT_TILE_URL
+		);
+
+		remove_filter( 'pre_http_request', $fail, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+
+		$this->assertInstanceOf(
+			\GdImage::class,
+			$image,
+			'A failed tile fetch should leave the canvas intact rather than nulling the result.'
+		);
+
+		imagedestroy( $image );
+	}
+
+	/**
+	 * Survives a tile whose response body is not a valid PNG.
+	 *
+	 * @covers ::composite_image
+	 *
+	 * @return void
+	 */
+	public function test_composite_image_continues_past_invalid_png(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		$garbage = static function () {
+			return array(
+				'headers'  => array(),
+				'body'     => 'not a png',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $garbage, 10 );
+
+		$image = $instance->composite_image(
+			37.3318,
+			-122.0312,
+			15,
+			256,
+			256,
+			Venue_Static_Map::DEFAULT_TILE_URL
+		);
+
+		remove_filter( 'pre_http_request', $garbage, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+
+		$this->assertInstanceOf( \GdImage::class, $image );
+
+		imagedestroy( $image );
+	}
+
+	/**
+	 * Returns null from save_image when wp_get_upload_dir reports an error.
+	 *
+	 * @covers ::save_image
+	 *
+	 * @return void
+	 */
+	public function test_save_image_returns_null_when_uploads_report_error(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$canvas   = imagecreatetruecolor( 10, 10 );
+
+		$force_error = static function ( $dirs ) {
+			$dirs['error'] = 'Simulated uploads failure.';
+			return $dirs;
+		};
+		add_filter( 'upload_dir', $force_error );
+
+		$url = $instance->save_image( $canvas, 99, 'abc' );
+
+		remove_filter( 'upload_dir', $force_error );
+		imagedestroy( $canvas );
+
+		$this->assertNull(
+			$url,
+			'save_image must report failure when the uploads dir itself is unavailable.'
+		);
+	}
+
+	/**
+	 * Bails without writing meta when save_image fails.
+	 *
+	 * @covers ::maybe_generate
+	 *
+	 * @return void
+	 */
+	public function test_maybe_generate_bails_when_save_fails(): void {
+		$instance = Venue_Static_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$force_error = static function ( $dirs ) {
+			$dirs['error'] = 'Simulated uploads failure.';
+			return $dirs;
+		};
+		add_filter( 'upload_dir', $force_error );
+
+		$instance->maybe_generate( $post_id );
+
+		remove_filter( 'upload_dir', $force_error );
+
+		$this->assertNull(
+			$instance->get_stored_descriptor( $post_id ),
+			'No descriptor should be stored when save_image fails.'
+		);
+	}
+
+	/**
+	 * Coverage for the lng/lat → world-pixel conversions.
+	 *
+	 * Verifies the canonical slippy-map invariants: `lng = 0, zoom = 0` sits
+	 * at the middle of the 256-pixel world, and `lat = 0` likewise.
+	 *
+	 * @covers ::lng_to_world_pixel
+	 * @covers ::lat_to_world_pixel
+	 *
+	 * @return void
+	 */
+	public function test_world_pixel_conversions(): void {
+		$instance = Venue_Static_Map::get_instance();
+
+		$this->assertSame(
+			128.0,
+			Utility::invoke_hidden_method( $instance, 'lng_to_world_pixel', array( 0.0, 0 ) )
+		);
+		$this->assertEqualsWithDelta(
+			128.0,
+			Utility::invoke_hidden_method( $instance, 'lat_to_world_pixel', array( 0.0, 0 ) ),
+			0.000001
+		);
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
@@ -86,5 +86,25 @@ class Test_Venues extends Base {
 			$section['maps']['options']['map_platform']['field']['options']['default'],
 			'Failed to assert map_platform defaults to osm.'
 		);
+
+		// New block-default settings feed the venue-map block.json defaults
+		// via Venue_Map::apply_block_attribute_defaults().
+		foreach ( array(
+			'venue_map_default_render_mode' => 'interactive',
+			'venue_map_default_zoom'        => 18,
+			'venue_map_default_height'      => 300,
+			'venue_map_default_type'        => 'roadmap',
+		) as $key => $expected ) {
+			$this->assertArrayHasKey(
+				$key,
+				$section['maps']['options'],
+				sprintf( 'Failed to assert %s option is present.', $key )
+			);
+			$this->assertSame(
+				$expected,
+				$section['maps']['options'][ $key ]['field']['options']['default'],
+				sprintf( 'Failed to assert default value for %s.', $key )
+			);
+		}
 	}
 }


### PR DESCRIPTION
### Description of the Change

Adds a server-rendered static-map pipeline to the venue-map block. The block now exposes a **Render mode** toggle:

- **Interactive** (existing): Leaflet or Google Maps; requires JavaScript.
- **Static image**: a pre-rendered PNG composited from CartoDB/OpenStreetMap tiles and served from `wp-content/uploads/gatherpress/static-maps/`. No JS required on the front end.

Static PNGs are generated on `wp_after_insert_post` when the venue has usable lat/lng. The cache is keyed by `(zoom, height)` combo so each block configuration gets its own PNG at the exact pixel dimensions it will render at — Leaflet zoom equals static zoom visually. A content change (new address/coords) cascades a regenerate to every cached combo; uncached combos generate lazily on first front-end request and are reused from then on. CartoDB/OSM attribution is included in the static output as required by the tile provider.

Site-wide defaults land under **Settings → Venues → Maps** (render mode, zoom level, height, map type). Blocks read them via the `block_type_metadata` filter — existing blocks keep their explicit values, new inserts pick up the site defaults.

Editor integration:
- Shows the cached static PNG as the block preview when render mode is static and a PNG exists for the current `(zoom, height)`.
- Falls back to a "Static map preview appears after venue is saved" placeholder otherwise.
- While the venue is being edited, compares the edited address/lat/lng against the saved snapshot and forces the placeholder until the next save so a stale PNG doesn't linger after the user types a new address.

Geocoding race fix: locks post saving while a venue address geocode is pending (debounced 1 s). Previously, a quick save could persist a new address with the previous lat/lng, baking the static PNG at stale coords until a second save healed it.

Incidental: `Rsvp_Token::approve_comment()` now no-ops when the comment is already approved, so repeated page-loads of a magic-link URL don't re-fire `wp_transition_comment_status` unnecessarily (and don't re-trigger third-party listeners on that hook).

Closes #1177 

### How to test the Change

1. Activate the branch and visit **Settings → Venues → Maps**. Confirm the four defaults render (render mode, zoom, height, map type) and persist on save.
2. Create a new venue, enter an address, and save. Confirm a PNG lands under `wp-content/uploads/gatherpress/static-maps/` and that the venue-map block in the editor shows it.
3. In an event post, insert a venue-map block and switch Render mode to "Static image". Front end should render the PNG + attribution without JavaScript (disable JS in devtools to verify).
4. Change the venue address in the sidebar. The editor preview should immediately flip to the "Static map preview appears after venue is saved" placeholder, and the Save button should disable until the 1-second debounced geocode resolves.
5. Change just the block's zoom or height on the front-end–facing block. Saving the event should trigger a lazy generate on first front-end load for that new `(zoom, height)` combo; subsequent loads should hit the cache.
6. Edit the venue address a second time (changing coords) and re-save. Every previously-cached combo should regenerate and the old PNGs should be cleaned up from uploads.
7. Delete the venue post. All cached PNGs for that venue should be removed and the meta cleared.

### Changelog Entry

> Added - Server-rendered static maps on the venue-map block, with per-`(zoom, height)` caching, site-wide defaults under Settings → Venues → Maps, and a Render mode toggle that lets events serve maps without JavaScript.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.