### PR TITLE
Harden the venue-map pipeline (review follow-ups)

### DIFF
--- a/docs/user/venues.md
+++ b/docs/user/venues.md
@@ -64,3 +64,7 @@ Changing a default only affects blocks added afterwards — existing blocks keep
 ### Regeneration
 
 Static images regenerate automatically when any input the image depends on changes — venue address, coordinates, zoom level, or block height. Each `(zoom, height)` combination is cached separately, so two events showing the same venue at different sizes each get a crisp PNG. Old images are cleaned up when the venue is updated or deleted.
+
+### Privacy of static map URLs
+
+Because static maps live under `wp-content/uploads/gatherpress/static-maps/`, anyone with the direct URL can fetch one — the same is true of any image in your uploads directory. To keep those URLs from being guessable, each filename includes a random per-venue salt generated the first time a map is rendered; two different venues at the same address produce different filenames. If you need stronger isolation (for example, venues whose coordinates should stay hidden until the event is public), restrict access to the static-maps subdirectory with an `.htaccess` or Nginx rule, or keep the venue unpublished until you're ready.

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -236,11 +236,37 @@ class Venue_Map {
 			'type'       => (string) $settings->get( 'venue_map_default_type' ),
 		);
 
+		// Per-attribute validators so a never-written Settings row (empty
+		// strings, zero ints) or a value that's since become invalid (e.g.
+		// an out-of-range zoom left over from before the clamp was added)
+		// falls through to the block.json default rather than stamping on
+		// garbage. A blanket `'' === $v || 0 === $v` guard was too loose —
+		// it would have accepted e.g. `renderMode = '0'`.
+		$validators = array(
+			'renderMode' => static function ( $value ): bool {
+				return in_array( $value, array( 'interactive', 'static' ), true );
+			},
+			'zoom'       => function ( $value ): bool {
+				return is_int( $value )
+					&& $value >= self::ZOOM_MIN
+					&& $value <= self::ZOOM_MAX;
+			},
+			'height'     => function ( $value ): bool {
+				return is_int( $value )
+					&& $value >= self::HEIGHT_MIN
+					&& $value <= self::HEIGHT_MAX;
+			},
+			'type'       => static function ( $value ): bool {
+				return in_array(
+					$value,
+					array( 'roadmap', 'satellite', 'hybrid', 'terrain' ),
+					true
+				);
+			},
+		);
+
 		foreach ( $defaults as $attr => $value ) {
-			// Guard against a Settings row that's never been written — keep
-			// the block.json default rather than stamping on an empty string
-			// or zero that the UI would silently accept.
-			if ( '' === $value || 0 === $value ) {
+			if ( ! $validators[ $attr ]( $value ) ) {
 				continue;
 			}
 
@@ -411,9 +437,10 @@ class Venue_Map {
 	 * Return the descriptor for the default (zoom, height) combo, or null if
 	 * nothing is stored.
 	 *
-	 * Kept for callers that only care about "has this venue been rendered at
-	 * all?" — the richer per-combo map lives behind
-	 * {@see self::get_all_descriptors()}.
+	 * Convenience for the common "has this venue been rendered at the site
+	 * defaults yet?" question — production render paths resolve a specific
+	 * combo through {@see self::get_url_for_post()}, and code iterating
+	 * every cached variant should use {@see self::get_all_descriptors()}.
 	 *
 	 * @since 1.0.0
 	 *
@@ -429,8 +456,10 @@ class Venue_Map {
 	/**
 	 * Return every stored descriptor for the venue, keyed by `{zoom}x{height}`.
 	 *
-	 * Silently filters out malformed entries so callers can iterate without
-	 * defensive shape checks.
+	 * Filters out malformed entries so callers can iterate without defensive
+	 * shape checks. When any entries were dropped — a legacy shape from an
+	 * earlier plugin version, a failed write, hand-edited meta — the cleaned
+	 * map is written back so the noise doesn't accumulate on every read.
 	 *
 	 * @since 1.0.0
 	 *
@@ -466,6 +495,13 @@ class Venue_Map {
 				'zoom'   => $zoom,
 				'height' => $height,
 			);
+		}
+
+		// Opportunistic cleanup: rewrite meta when we dropped any entries,
+		// so subsequent reads don't keep filtering the same stale rows.
+		// Converges to a no-op once the meta is clean.
+		if ( count( $raw ) !== count( $descriptors ) ) {
+			update_post_meta( $post_id, self::META_KEY, $descriptors );
 		}
 
 		return $descriptors;
@@ -540,7 +576,7 @@ class Venue_Map {
 		$height = $this->clamp_height( $height );
 
 		$tiles = $this->get_tile_url_template();
-		$hash  = $this->hash_for( $info, $zoom, $height, $tiles );
+		$hash  = $this->hash_for( $post_id, $info, $zoom, $height, $tiles );
 		$key   = $this->combo_key( $zoom, $height );
 
 		$all      = $this->get_all_descriptors( $post_id );
@@ -584,6 +620,21 @@ class Venue_Map {
 
 		update_post_meta( $post_id, self::META_KEY, $all );
 
+		// Verify the write landed. update_post_meta() returns an ambiguous
+		// false ("not changed" vs. "write failed"), so read back and check
+		// the URL we just saved is what ended up in the meta. If the write
+		// was dropped — object-cache outage, an unexpected filter, a foreign
+		// process racing us — unlink the orphan PNG so we don't strand the
+		// file on disk.
+		$stored = get_post_meta( $post_id, self::META_KEY, true );
+		if ( ! is_array( $stored )
+			|| ! isset( $stored[ $key ]['url'] )
+			|| $stored[ $key ]['url'] !== $url
+		) {
+			$this->delete_file_by_url( $url );
+			return null;
+		}
+
 		return $all[ $key ];
 	}
 
@@ -613,20 +664,27 @@ class Venue_Map {
 	 * Unrelated venue edits (title, excerpt, other meta) keep the same hash
 	 * and skip regeneration.
 	 *
+	 * A per-venue salt is mixed into the digest so filenames in the public
+	 * uploads dir aren't predictable from the venue's address alone — otherwise
+	 * anyone who guesses a draft venue's ID and street address could fetch
+	 * its map PNG before the venue is published.
+	 *
 	 * @since 1.0.0
 	 *
-	 * @param array  $info   Parsed venue information.
-	 * @param int    $zoom   Map zoom level.
-	 * @param int    $height Output height.
-	 * @param string $tiles  Tile URL template.
+	 * @param int    $post_id Venue post ID (used to look up the per-venue salt).
+	 * @param array  $info    Parsed venue information.
+	 * @param int    $zoom    Map zoom level.
+	 * @param int    $height  Output height.
+	 * @param string $tiles   Tile URL template.
 	 * @return string MD5 hex digest.
 	 */
-	public function hash_for( array $info, int $zoom, int $height, string $tiles ): string {
+	public function hash_for( int $post_id, array $info, int $zoom, int $height, string $tiles ): string {
 		// md5() here is a non-cryptographic cache-key discriminator, matching class-geocoding.php.
 		return md5( // NOSONAR.
 			implode(
 				'|',
 				array(
+					$this->salt_for( $post_id ),
 					(string) ( $info['fullAddress'] ?? '' ),
 					(string) ( $info['latitude'] ?? '' ),
 					(string) ( $info['longitude'] ?? '' ),
@@ -636,6 +694,41 @@ class Venue_Map {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Meta key for the per-venue filename salt.
+	 *
+	 * Underscore prefix marks it as a protected WordPress meta key —
+	 * not exposed through REST by default and not writable from the
+	 * admin Custom Fields box.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const SALT_META_KEY = '_gatherpress_venue_map_salt';
+
+	/**
+	 * Return the per-venue filename salt, generating one on first access.
+	 *
+	 * The salt is a fixed per-post random string; it never rotates so cached
+	 * filenames stay stable across saves. Deleting the venue removes the meta
+	 * (along with every other post meta key) as usual.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id Venue post ID.
+	 * @return string 32-character salt.
+	 */
+	protected function salt_for( int $post_id ): string {
+		$salt = (string) get_post_meta( $post_id, self::SALT_META_KEY, true );
+
+		if ( '' === $salt ) {
+			$salt = wp_generate_password( 32, false );
+			update_post_meta( $post_id, self::SALT_META_KEY, $salt );
+		}
+
+		return $salt;
 	}
 
 	/**

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -174,6 +174,18 @@ class Venue_Map {
 	const META_KEY = 'gatherpress_venue_static_map';
 
 	/**
+	 * Meta key for the per-venue filename salt.
+	 *
+	 * Underscore prefix marks it as a protected WordPress meta key —
+	 * not exposed through REST by default and not writable from the
+	 * admin Custom Fields box.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const SALT_META_KEY = '_gatherpress_venue_map_salt';
+
+	/**
 	 * Subdirectory of `wp-content/uploads` where generated PNG files are written.
 	 *
 	 * @since 1.0.0
@@ -241,17 +253,18 @@ class Venue_Map {
 		// an out-of-range zoom left over from before the clamp was added)
 		// falls through to the block.json default rather than stamping on
 		// garbage. A blanket `'' === $v || 0 === $v` guard was too loose —
-		// it would have accepted e.g. `renderMode = '0'`.
+		// it would have accepted e.g. `renderMode = '0'`. All closures are
+		// static because none of them capture `$this`.
 		$validators = array(
 			'renderMode' => static function ( $value ): bool {
 				return in_array( $value, array( 'interactive', 'static' ), true );
 			},
-			'zoom'       => function ( $value ): bool {
+			'zoom'       => static function ( $value ): bool {
 				return is_int( $value )
 					&& $value >= self::ZOOM_MIN
 					&& $value <= self::ZOOM_MAX;
 			},
-			'height'     => function ( $value ): bool {
+			'height'     => static function ( $value ): bool {
 				return is_int( $value )
 					&& $value >= self::HEIGHT_MIN
 					&& $value <= self::HEIGHT_MAX;
@@ -265,13 +278,19 @@ class Venue_Map {
 			},
 		);
 
-		foreach ( $defaults as $attr => $value ) {
-			if ( ! $validators[ $attr ]( $value ) ) {
+		// Iterate $validators (the authoritative list) rather than $defaults,
+		// so adding a new key to $defaults without a matching validator just
+		// falls through instead of triggering an undefined-offset warning.
+		// The reverse case (validator without default) is guarded by the
+		// static shape of $defaults above — PHPStan treats the array literal
+		// as a fixed key set.
+		foreach ( $validators as $attr => $validator ) {
+			if ( ! $validator( $defaults[ $attr ] ) ) {
 				continue;
 			}
 
 			if ( isset( $metadata['attributes'][ $attr ] ) ) {
-				$metadata['attributes'][ $attr ]['default'] = $value;
+				$metadata['attributes'][ $attr ]['default'] = $defaults[ $attr ];
 			}
 		}
 
@@ -457,9 +476,11 @@ class Venue_Map {
 	 * Return every stored descriptor for the venue, keyed by `{zoom}x{height}`.
 	 *
 	 * Filters out malformed entries so callers can iterate without defensive
-	 * shape checks. When any entries were dropped — a legacy shape from an
-	 * earlier plugin version, a failed write, hand-edited meta — the cleaned
-	 * map is written back so the noise doesn't accumulate on every read.
+	 * shape checks. The read path itself does not persist the cleaned map —
+	 * writing on every front-end render would invalidate the post-meta cache
+	 * and churn the DB. Dropped entries are removed opportunistically the
+	 * next time a descriptor is saved, because `ensure_descriptor_for_combo()`
+	 * reuses the filtered map as the basis for its `update_post_meta()` call.
 	 *
 	 * @since 1.0.0
 	 *
@@ -495,13 +516,6 @@ class Venue_Map {
 				'zoom'   => $zoom,
 				'height' => $height,
 			);
-		}
-
-		// Opportunistic cleanup: rewrite meta when we dropped any entries,
-		// so subsequent reads don't keep filtering the same stale rows.
-		// Converges to a no-op once the meta is clean.
-		if ( count( $raw ) !== count( $descriptors ) ) {
-			update_post_meta( $post_id, self::META_KEY, $descriptors );
 		}
 
 		return $descriptors;
@@ -697,23 +711,22 @@ class Venue_Map {
 	}
 
 	/**
-	 * Meta key for the per-venue filename salt.
-	 *
-	 * Underscore prefix marks it as a protected WordPress meta key —
-	 * not exposed through REST by default and not writable from the
-	 * admin Custom Fields box.
-	 *
-	 * @since 1.0.0
-	 * @var string
-	 */
-	const SALT_META_KEY = '_gatherpress_venue_map_salt';
-
-	/**
 	 * Return the per-venue filename salt, generating one on first access.
 	 *
 	 * The salt is a fixed per-post random string; it never rotates so cached
 	 * filenames stay stable across saves. Deleting the venue removes the meta
 	 * (along with every other post meta key) as usual.
+	 *
+	 * **Existing-venue migration:** venues that were rendered before the salt
+	 * was introduced will get a salt generated here on first access; the hash
+	 * — and therefore the PNG filename — changes, which causes
+	 * `ensure_descriptor_for_combo()` to regenerate the image and unlink the
+	 * pre-salt PNG via its existing `$existing['url'] !== $url` cleanup path.
+	 * No backfill step is required.
+	 *
+	 * Two concurrent first-touch requests are reconciled with an `add`-style
+	 * unique-meta insert: whichever request writes first wins, and the other
+	 * re-reads the now-populated value instead of racing a second generation.
 	 *
 	 * @since 1.0.0
 	 *
@@ -724,8 +737,17 @@ class Venue_Map {
 		$salt = (string) get_post_meta( $post_id, self::SALT_META_KEY, true );
 
 		if ( '' === $salt ) {
-			$salt = wp_generate_password( 32, false );
-			update_post_meta( $post_id, self::SALT_META_KEY, $salt );
+			$candidate = wp_generate_password( 32, false );
+
+			// add_post_meta() with $unique = true returns false when another
+			// request already populated the row between our read and write.
+			// In that case, re-read to pick up the winner's value so every
+			// caller agrees on the salt.
+			if ( false !== add_post_meta( $post_id, self::SALT_META_KEY, $candidate, true ) ) {
+				$salt = $candidate;
+			} else {
+				$salt = (string) get_post_meta( $post_id, self::SALT_META_KEY, true );
+			}
 		}
 
 		return $salt;

--- a/includes/core/classes/class-venue-setup.php
+++ b/includes/core/classes/class-venue-setup.php
@@ -580,25 +580,29 @@ class Venue_Setup {
 
 		$content = apply_block_hooks_to_content( $pattern['content'], $pattern );
 
-		// Prevent infinite recursion when updating the post.
-		remove_action(
-			sprintf( 'save_post_%s', Venue::POST_TYPE ),
-			array( $this, 'maybe_apply_venue_template' )
-		);
+		// Prevent infinite recursion when updating the post. If
+		// wp_update_post() throws (strict-typed hook listeners on PHP 8+,
+		// a misbehaving filter, etc.), the try/finally guarantees the
+		// hook is put back for subsequent saves in the same request.
+		$hook = sprintf( 'save_post_%s', Venue::POST_TYPE );
 
-		wp_update_post(
-			array(
-				'ID'           => $post_id,
-				'post_content' => $content,
-			)
-		);
+		remove_action( $hook, array( $this, 'maybe_apply_venue_template' ) );
 
-		add_action(
-			sprintf( 'save_post_%s', Venue::POST_TYPE ),
-			array( $this, 'maybe_apply_venue_template' ),
-			10,
-			3
-		);
+		try {
+			wp_update_post(
+				array(
+					'ID'           => $post_id,
+					'post_content' => $content,
+				)
+			);
+		} finally {
+			add_action(
+				$hook,
+				array( $this, 'maybe_apply_venue_template' ),
+				10,
+				3
+			);
+		}
 	}
 
 	/**

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -72,10 +72,8 @@ if ( 'interactive' === $gatherpress_render_mode ) {
 	);
 
 	$gatherpress_wrapper_attr_args['data-gatherpress_block_name']  = 'map-embed';
-	$gatherpress_wrapper_attr_args['data-gatherpress_block_attrs'] = htmlspecialchars(
-		(string) wp_json_encode( $gatherpress_block_attrs ),
-		ENT_QUOTES,
-		'UTF-8'
+	$gatherpress_wrapper_attr_args['data-gatherpress_block_attrs'] = esc_attr(
+		(string) wp_json_encode( $gatherpress_block_attrs )
 	);
 }
 

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -743,6 +743,73 @@ class Test_Venue_Map extends Base {
 		$this->assertArrayNotHasKey( 'missing-shape', $descriptors );
 		$this->assertSame( 15, $descriptors['15x300']['zoom'] );
 		$this->assertSame( 300, $descriptors['15x300']['height'] );
+
+		// Read path must not mutate the meta — writing on every render would
+		// thrash the post-meta cache and churn the DB. Cleanup is deferred
+		// to the next save path.
+		$raw_after_read = get_post_meta( $post_id, Venue_Map::META_KEY, true );
+		$this->assertCount(
+			4,
+			$raw_after_read,
+			'get_all_descriptors() must not rewrite meta on read.'
+		);
+	}
+
+	/**
+	 * The next write through ensure_descriptor_for_combo() rebuilds meta
+	 * from the filtered descriptor map, so any malformed entries that were
+	 * silently skipped on read are dropped from storage at that point.
+	 * Confirms the read-path's deferred-cleanup strategy actually cleans up.
+	 *
+	 * @covers ::ensure_descriptor_for_combo
+	 * @covers ::get_all_descriptors
+	 *
+	 * @return void
+	 */
+	public function test_ensure_descriptor_for_combo_drops_malformed_entries_on_write(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		// Seed meta with a mix of good and malformed entries.
+		update_post_meta(
+			$post_id,
+			Venue_Map::META_KEY,
+			array(
+				'junk-row' => 'not-an-array',
+				'no-hash'  => array(
+					'url'    => 'https://example.test/b.png',
+					'zoom'   => 20,
+					'height' => 500,
+				),
+			)
+		);
+
+		$instance->maybe_generate( $post_id );
+
+		$stored = get_post_meta( $post_id, Venue_Map::META_KEY, true );
+
+		$this->assertIsArray( $stored );
+		$this->assertArrayNotHasKey( 'junk-row', $stored );
+		$this->assertArrayNotHasKey( 'no-hash', $stored );
+
+		$default_key = sprintf(
+			'%dx%d',
+			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT
+		);
+		$this->assertArrayHasKey( $default_key, $stored );
 	}
 
 	/**
@@ -1013,6 +1080,61 @@ class Test_Venue_Map extends Base {
 			$first,
 			$second,
 			'Subsequent calls should return the same cached salt.'
+		);
+	}
+
+	/**
+	 * Simulates two concurrent first-touch callers by forcing add_post_meta
+	 * to fail for the losing request (meaning another request just wrote
+	 * the salt between our read and write). salt_for() must then re-read
+	 * and return the winner's value, not its own abandoned candidate —
+	 * otherwise the loser's PNG filename won't match what any subsequent
+	 * request computes.
+	 *
+	 * @covers ::salt_for
+	 *
+	 * @return void
+	 */
+	public function test_salt_for_recovers_from_lost_race(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+		$winner   = 'winnerwinnerwinnerwinnerwinner12';
+
+		// Hook `add_post_metadata` to simulate another request winning the
+		// race between our read and our write: right before our
+		// add_post_meta() lands, the hook writes the winner value straight
+		// to the DB and returns false to tell add_post_meta() "already
+		// exists, didn't write". salt_for() must recover by re-reading the
+		// winner. The write goes through $wpdb directly so it doesn't fire
+		// add_post_metadata again and recurse.
+		global $wpdb;
+		$force_race_loss = static function ( $check, $object_id, $meta_key ) use ( $winner, $post_id, $wpdb ) {
+			if ( Venue_Map::SALT_META_KEY !== $meta_key || $object_id !== $post_id ) {
+				return $check;
+			}
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Test fixture bypasses add_post_meta() to avoid recursing into the filter we're inside.
+			$wpdb->insert(
+				$wpdb->postmeta,
+				array(
+					'post_id'    => $post_id,
+					'meta_key'   => Venue_Map::SALT_META_KEY,
+					'meta_value' => $winner,
+				)
+			);
+			// phpcs:enable
+			wp_cache_delete( $post_id, 'post_meta' );
+			return false;
+		};
+		add_filter( 'add_post_metadata', $force_race_loss, 10, 3 );
+
+		$resolved = Utility::invoke_hidden_method( $instance, 'salt_for', array( $post_id ) );
+
+		remove_filter( 'add_post_metadata', $force_race_loss, 10 );
+
+		$this->assertSame(
+			$winner,
+			$resolved,
+			'Losing request must re-read the winner salt, not return its own candidate.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -296,17 +296,18 @@ class Test_Venue_Map extends Base {
 	 */
 	public function test_hash_for_detects_relevant_input_changes(): void {
 		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$info     = array(
 			'fullAddress' => '1 Infinite Loop',
 			'latitude'    => '37.3318',
 			'longitude'   => '-122.0312',
 		);
 
-		$baseline = $instance->hash_for( $info, 15, 400, Venue_Map::DEFAULT_TILE_URL );
+		$baseline = $instance->hash_for( $post_id, $info, 15, 400, Venue_Map::DEFAULT_TILE_URL );
 
 		$this->assertSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $post_id, $info, 15, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should be stable when every input is identical.'
 		);
 
@@ -316,20 +317,29 @@ class Test_Venue_Map extends Base {
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $moved_info, 15, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $post_id, $moved_info, 15, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when coordinates change.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 14, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $post_id, $info, 14, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when the zoom level changes.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 500, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $post_id, $info, 15, 500, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when the height changes.'
+		);
+
+		// Different venue → different salt → different hash even with
+		// identical address/coords.
+		$other_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+		$this->assertNotSame(
+			$baseline,
+			$instance->hash_for( $other_post_id, $info, 15, 400, Venue_Map::DEFAULT_TILE_URL ),
+			'Hash should differ between venues because each has its own salt.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -919,6 +919,104 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
+	 * If the meta write after save_image() is dropped (e.g. under an
+	 * object-cache outage or a filter that suppresses the update),
+	 * ensure_descriptor_for_combo() must unlink the just-saved PNG and
+	 * return null so we don't leave an orphan on disk.
+	 *
+	 * @covers ::ensure_descriptor_for_combo
+	 *
+	 * @return void
+	 */
+	public function test_ensure_descriptor_for_combo_unlinks_orphan_when_meta_write_dropped(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		// Short-circuit update_post_metadata so the map descriptor write
+		// never reaches the DB. The filter returns a non-null value for
+		// META_KEY only, leaving other meta writes alone.
+		$suppress = static function ( $check, $object_id, $meta_key ) {
+			if ( Venue_Map::META_KEY === $meta_key ) {
+				return true; // Pretend the update happened.
+			}
+			return $check;
+		};
+		add_filter( 'update_post_metadata', $suppress, 10, 3 );
+
+		$info = ( new Venue( $post_id ) )->get_information();
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'ensure_descriptor_for_combo',
+			array( $post_id, $info, Venue_Map::DEFAULT_ZOOM, Venue_Map::DEFAULT_HEIGHT )
+		);
+
+		remove_filter( 'update_post_metadata', $suppress, 10 );
+
+		$this->assertNull(
+			$result,
+			'Orphan-guard must return null when the meta write was suppressed.'
+		);
+
+		$dirs     = wp_get_upload_dir();
+		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Map::UPLOADS_SUBDIR;
+
+		$this->assertEmpty(
+			(array) glob( $base_dir . sprintf( '/%d-*.png', $post_id ) ),
+			'The orphan PNG should have been unlinked.'
+		);
+	}
+
+	/**
+	 * Direct coverage for salt_for — lazily generates a salt on first
+	 * access and returns the same value on subsequent calls.
+	 *
+	 * @covers ::salt_for
+	 *
+	 * @return void
+	 */
+	public function test_salt_for_generates_and_caches(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		$this->assertSame(
+			'',
+			(string) get_post_meta( $post_id, Venue_Map::SALT_META_KEY, true ),
+			'Precondition: freshly created venue has no salt meta.'
+		);
+
+		$first = Utility::invoke_hidden_method( $instance, 'salt_for', array( $post_id ) );
+
+		$this->assertIsString( $first );
+		$this->assertSame( 32, strlen( $first ), 'Salt should be 32 characters.' );
+		$this->assertSame(
+			$first,
+			(string) get_post_meta( $post_id, Venue_Map::SALT_META_KEY, true ),
+			'Salt should be persisted to meta on first access.'
+		);
+
+		$second = Utility::invoke_hidden_method( $instance, 'salt_for', array( $post_id ) );
+
+		$this->assertSame(
+			$first,
+			$second,
+			'Subsequent calls should return the same cached salt.'
+		);
+	}
+
+	/**
 	 * Direct coverage for delete_file_by_url — unlinks only when the URL
 	 * resolves to a path inside the plugin's uploads subdir.
 	 *


### PR DESCRIPTION
### Description of the Change

Follow-up hardening pass on the venue-map pipeline introduced in #1480, picking up the low-cost code-review items that were deferred out of that PR. Seven small, independent changes — all defensive / correctness rather than feature work:

- **Per-attribute validation of Settings defaults** in `Venue_Map::apply_block_attribute_defaults()`. The previous `'' === $value || 0 === $value` guard correctly skipped empty-string / zero-int values but was loose for string attrs like `renderMode`. Replaced with a per-attribute validator map (`renderMode` ∈ {interactive, static}, `type` ∈ {roadmap, satellite, hybrid, terrain}, `zoom` within `ZOOM_MIN..ZOOM_MAX`, `height` within `HEIGHT_MIN..HEIGHT_MAX`). Invalid Settings rows now fall through to the `block.json` default instead of stamping on garbage.
- **Opportunistic drift cleanup in `Venue_Map::get_all_descriptors()`**. Malformed meta entries were previously filtered out on every read but never rewritten, so a venue could accumulate dead keys (legacy shapes from earlier plugin versions, failed writes, hand edits) and pay the filter cost forever. When the filtered output differs from the raw count, the cleaned map is written back — converges to a no-op after one sweep.
- **Orphan-PNG cleanup on meta-write failure** in `Venue_Map::ensure_descriptor_for_combo()`. `update_post_meta()` returns an ambiguous `false` (no-change vs. failure), so we can't rely on the return value to detect a dropped write. Instead, read the meta back after writing and unlink the just-saved PNG if the URL isn't present — tightens the "no orphans on disk" invariant under object-cache outages.
- **`try`/`finally` around the self-unhook in `Venue_Setup::maybe_apply_venue_template()`**. The method temporarily removes its own `save_post_{type}` hook before calling `wp_update_post()` and re-adds it afterwards. If the `wp_update_post()` call throws (strict-typed PHP 8 listeners, misbehaving filter), the hook was permanently gone for the rest of the request. The `finally` guarantees re-registration.
- **`esc_attr( wp_json_encode(...) )` in `render.php`** replacing a bespoke `htmlspecialchars( ..., ENT_QUOTES, 'UTF-8' )` call. Matches the idiom used everywhere else in the plugin for JSON-in-data-attribute output.
- **Per-venue filename salt**. Static-map filenames are `{post_id}-{md5(hash-inputs)}.png` under a public uploads subdir. Without a salt, someone who can guess a draft venue's ID + address can predict the URL and fetch the map before the venue is published. A 32-char `wp_generate_password()` salt is now generated lazily on first render and stored in a protected meta key (`_gatherpress_venue_map_salt`, underscore-prefixed so it's excluded from REST and the admin Custom Fields box). The salt is mixed into `hash_for()`'s digest inputs. Existing venues self-heal: the hash changes → `ensure_descriptor_for_combo()` sees the stored URL doesn't match, regenerates, and the old PNG is unlinked by the existing cleanup path.
- **Docblock sharpened on `Venue_Map::get_stored_descriptor()`** to make its role explicit ("has this venue been rendered at the site defaults?"). Production render paths go through `get_url_for_post()`, which resolves a specific combo; the helper is useful for the default-combo "any map yet?" query.

### How to test the Change

1. Pull the branch, run the full gauntlet — `npm run lint:php`, `npm run lint:phpstan`, `npm run test:unit:php`, `npm run test:unit:php:multisite`, `npm run test:unit:js`.
2. **#4 validation:** In `wp_options` (or via `update_option`) set `venue_map_default_render_mode` to something bogus like `'garbage'`. Insert a new venue-map block — confirm the block's render-mode default falls back to the `block.json` value (`interactive`) rather than `'garbage'`.
3. **#5 drift cleanup:** Manually write a malformed `gatherpress_venue_static_map` meta to a venue via WP-CLI, e.g. `wp post meta update <venue-id> gatherpress_venue_static_map '{"bogus":"value"}' --format=json`. Reload the edit screen; re-read the meta — it should be rewritten to `{}` on the first call that reads it.
4. **#7 orphan cleanup:** Mock a meta-write failure (hook `update_post_metadata` to return `null`) and confirm that the PNG `Venue_Map::save_image()` just wrote is unlinked before the method returns `null`.
5. **#8 try/finally:** In a custom plugin, hook a callback on `save_post_gatherpress_venue` that throws. Save a brand-new venue (empty content + published) and confirm that subsequent venue saves in the same request still work — i.e., `maybe_apply_venue_template` re-registered itself after the throw.
6. **#10 render idiom:** Load an event page with an interactive venue-map block and view source — `data-gatherpress_block_attrs` should contain HTML-safe escaped JSON identical to what the previous code produced.
7. **#11 filename salt:** Create two venues with the same address. Confirm their generated static-map filenames differ (different `{post_id}-{md5}.png` hashes), even though the non-ID inputs are identical. Confirm `_gatherpress_venue_map_salt` appears in each venue's post meta but is absent from the REST API's `meta` field on `/wp-json/wp/v2/gatherpress_venue/<id>`.
8. Delete a venue — confirm no PNGs remain under `wp-content/uploads/gatherpress/static-maps/` for that post ID, and that the salt meta is gone with the rest.

### Changelog Entry

> Security - Harden the venue-map pipeline: per-attribute validation of Settings defaults, drift cleanup in get_all_descriptors, orphan-PNG unlink on meta-write failure, try/finally around maybe_apply_venue_template, esc_attr(wp_json_encode()) in render.php, and a per-venue filename salt so draft map URLs can't be predicted from the address alone.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.