### PR TITLE
Venue map block: regenerate button, prewarming, Inspector polish

### DIFF
--- a/docs/user/venues.md
+++ b/docs/user/venues.md
@@ -48,7 +48,21 @@ Every venue with a real address ships with a map, rendered in one of two modes s
 - **Interactive** — a live, pan-and-zoom map powered by Leaflet (OpenStreetMap) or Google Maps, depending on the mapping platform you pick under `Settings > GatherPress > Venues > Maps`. Requires JavaScript on the visitor's side.
 - **Static image** — a pre-rendered PNG of the map, composited server-side from OpenStreetMap tiles on the first save and cached under `wp-content/uploads/gatherpress/static-maps/`. No JavaScript required, which makes it the right choice for email previews, reader modes, cached HTML, and visitors who block scripts. Attribution for OpenStreetMap and CartoDB is rendered alongside the image automatically.
 
-The block's inspector sidebar lets you pick the render mode, zoom level (1–20), and height (100–800 px). You can mix modes across events — one event can show the static image, another the interactive map, both pointing at the same venue.
+The block's inspector sidebar lets you pick the render mode, zoom level (1–20), width (100–1600 px or auto), height (100–800 px or auto), and aspect ratio (2:1 default, 16:9, 3:2, 4:3, 1:1, or a custom value like `21/9`). Leaving width or height on `0` means "auto" — the missing side is derived from the aspect ratio so the block keeps its shape when the container shrinks. Dragging the resize handles on the block canvas updates both dimensions; holding the preset aspect-ratio value locks the drag to that ratio. You can mix modes across events — one event can show the static image, another the interactive map, both pointing at the same venue.
+
+### Linking the static image
+
+Static maps can be wrapped in a link from the Inspector's **Link settings** panel (static mode only; the interactive map already owns pan-and-zoom interactions). The "Link to" dropdown offers four options:
+
+- **None** — no link wrapper.
+- **OpenStreetMap** — sends visitors to `openstreetmap.org` centered on the venue's coordinates at the block's zoom level.
+- **Google Maps** — same idea, `google.com/maps`.
+- **Custom URL** — free-form URL input. Use this for anything else (a venue's parking page, a ticket link, etc.).
+
+Two toggles apply to any link destination except "None":
+
+- **Open in new tab** — adds `target="_blank"` and auto-appends `rel="noopener noreferrer"` for safety.
+- **Link rel** — free-form space-separated tokens that ride alongside the automatic ones, e.g. `nofollow sponsored`.
 
 ### Sitewide defaults
 

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -490,7 +490,13 @@ class Settings {
 						$sanitized[ $key ] = (bool) $value;
 						break;
 					case 'number':
-						$sanitized[ $key ] = intval( $value );
+						// Preserve empty submissions as '' instead of
+						// coercing to 0 via intval — so a field that
+						// accepts empty (e.g. Width/Height "Auto") can
+						// round-trip blank without silently saving 0.
+						$sanitized[ $key ] = ( '' === $value || null === $value )
+							? ''
+							: intval( $value );
 						break;
 					case 'autocomplete':
 						$sanitized[ $key ] = $this->sanitize_autocomplete( $value );

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -599,9 +599,11 @@ class Settings {
 				$params['preview'] = $option_settings['field']['preview'] ?? array();
 				break;
 			case 'number':
-				$params['size'] = $option_settings['field']['size'] ?? 'regular';
-				$params['min']  = $option_settings['field']['options']['min'] ?? '';
-				$params['max']  = $option_settings['field']['options']['max'] ?? '';
+				$params['size']        = $option_settings['field']['size'] ?? 'regular';
+				$params['min']         = $option_settings['field']['options']['min'] ?? '';
+				$params['max']         = $option_settings['field']['options']['max'] ?? '';
+				$params['placeholder'] = $option_settings['field']['placeholder'] ?? '';
+				$params['allow_empty'] = (bool) ( $option_settings['field']['allow_empty'] ?? false );
 				break;
 			case 'select':
 				$params['options'] = $option_settings['field']['options'] ?? '';

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -81,6 +81,7 @@ class Setup {
 		Topic::get_instance();
 		User::get_instance();
 		Venue_Map::get_instance();
+		Venue_Map_Prewarm::get_instance();
 		Venue_Setup::get_instance();
 	}
 

--- a/includes/core/classes/class-venue-map-prewarm.php
+++ b/includes/core/classes/class-venue-map-prewarm.php
@@ -127,16 +127,7 @@ class Venue_Map_Prewarm {
 				return;
 			}
 
-			$venue_setup = Venue_Setup::get_instance();
-			$taxonomy    = $venue_setup->taxonomy_for_event_post_type( $post->post_type );
-			$terms       = get_the_terms( $post_id, $taxonomy );
-
-			if ( empty( $terms ) || is_wp_error( $terms ) ) {
-				return;
-			}
-
-			$term  = current( $terms );
-			$venue = $venue_setup->get_venue_post_from_term_slug( $term->slug );
+			$venue = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
 
 			if ( $venue instanceof WP_Post ) {
 				foreach ( $combos as $combo ) {

--- a/includes/core/classes/class-venue-map-prewarm.php
+++ b/includes/core/classes/class-venue-map-prewarm.php
@@ -213,8 +213,8 @@ class Venue_Map_Prewarm {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int                                                           $venue_post_id Venue post ID.
-	 * @param array{zoom:int,width:int,height:int,aspect_ratio:string}      $combo         Combo to warm.
+	 * @param int                                                      $venue_post_id Venue post ID.
+	 * @param array{zoom:int,width:int,height:int,aspect_ratio:string} $combo         Combo to warm.
 	 * @return void
 	 */
 	protected function enqueue_warm_job( int $venue_post_id, array $combo ): void {

--- a/includes/core/classes/class-venue-map-prewarm.php
+++ b/includes/core/classes/class-venue-map-prewarm.php
@@ -345,8 +345,12 @@ class Venue_Map_Prewarm {
 		return array(
 			'zoom'         => isset( $attrs['zoom'] ) ? (int) $attrs['zoom'] : Venue_Map::DEFAULT_ZOOM,
 			'width'        => isset( $attrs['width'] ) ? (int) $attrs['width'] : 0,
-			'height'       => isset( $attrs['height'] ) ? (int) $attrs['height'] : Venue_Map::DEFAULT_HEIGHT,
-			'aspect_ratio' => isset( $attrs['aspectRatio'] ) ? (string) $attrs['aspectRatio'] : Venue_Map::DEFAULT_ASPECT_RATIO,
+			'height'       => isset( $attrs['height'] )
+				? (int) $attrs['height']
+				: Venue_Map::DEFAULT_HEIGHT,
+			'aspect_ratio' => isset( $attrs['aspectRatio'] )
+				? (string) $attrs['aspectRatio']
+				: Venue_Map::DEFAULT_ASPECT_RATIO,
 		);
 	}
 

--- a/includes/core/classes/class-venue-map-prewarm.php
+++ b/includes/core/classes/class-venue-map-prewarm.php
@@ -62,12 +62,46 @@ class Venue_Map_Prewarm {
 	const BLOCK_NAME = 'gatherpress/venue-map';
 
 	/**
+	 * Batch size for paginated post scans — small enough that a single
+	 * batch fits comfortably in memory even when post_content is large,
+	 * big enough that pagination overhead stays cheap.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const SCAN_BATCH_SIZE = 500;
+
+	/**
 	 * Class constructor — wires hooks.
 	 *
 	 * @since 1.0.0
 	 */
 	protected function __construct() {
 		$this->setup_hooks();
+	}
+
+	/**
+	 * Return the batch size used by paginated scans.
+	 *
+	 * Wraps the `SCAN_BATCH_SIZE` constant in a filter so tests (and power
+	 * users on unusual installs) can shrink the batch without touching the
+	 * class. Clamped to at least 1 to avoid an infinite-empty-batch loop.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int
+	 */
+	protected function get_scan_batch_size(): int {
+		/**
+		 * Filter the venue-map prewarm scan batch size.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $size Number of posts loaded per batch during prewarm scans.
+		 */
+		$size = (int) apply_filters( 'gatherpress_venue_map_prewarm_batch_size', self::SCAN_BATCH_SIZE );
+
+		return max( 1, $size );
 	}
 
 	/**
@@ -192,10 +226,44 @@ class Venue_Map_Prewarm {
 			return;
 		}
 
-		foreach ( $this->get_venue_post_ids() as $venue_post_id ) {
-			foreach ( $combos as $combo ) {
-				$this->enqueue_warm_job( $venue_post_id, $combo );
+		$types = get_post_types_by_support( 'gatherpress-venue-information' );
+		if ( empty( $types ) ) {
+			return;
+		}
+
+		// Stream venues in batches so a site with thousands of venues never
+		// loads the full ID set into memory on the save hook.
+		$batch_size = $this->get_scan_batch_size();
+		$page       = 1;
+		while ( true ) {
+			$batch = get_posts(
+				array(
+					'post_type'      => $types,
+					'post_status'    => 'publish',
+					'posts_per_page' => $batch_size,
+					'paged'          => $page,
+					'fields'         => 'ids',
+					'orderby'        => 'ID',
+					'order'          => 'ASC',
+					'no_found_rows'  => true,
+				)
+			);
+
+			if ( empty( $batch ) ) {
+				break;
 			}
+
+			foreach ( $batch as $venue_post_id ) {
+				foreach ( $combos as $combo ) {
+					$this->enqueue_warm_job( (int) $venue_post_id, $combo );
+				}
+			}
+
+			if ( count( $batch ) < $batch_size ) {
+				break;
+			}
+
+			++$page;
 		}
 	}
 
@@ -254,24 +322,42 @@ class Venue_Map_Prewarm {
 
 		$venue_carrying_types = get_post_types_by_support( 'gatherpress-venue' );
 		if ( ! empty( $venue_carrying_types ) ) {
-			$posts = get_posts(
-				array(
-					'post_type'      => $venue_carrying_types,
-					'post_status'    => 'publish',
-					'posts_per_page' => -1,
-					'fields'         => 'ids',
-					'no_found_rows'  => true,
-				)
-			);
-			foreach ( $posts as $post_id ) {
-				$post = get_post( $post_id );
-				if ( ! $post instanceof WP_Post ) {
-					continue;
-				}
-				$combos = array_merge(
-					$combos,
-					$this->collect_combos_from_content( $post->post_content )
+			$batch_size = $this->get_scan_batch_size();
+			$page       = 1;
+
+			// Paginate rather than `posts_per_page => -1` — a site with
+			// thousands of events would otherwise load every post into
+			// memory at once on the hook that triggered us (venue save,
+			// template save, theme switch).
+			while ( true ) {
+				$batch = get_posts(
+					array(
+						'post_type'      => $venue_carrying_types,
+						'post_status'    => 'publish',
+						'posts_per_page' => $batch_size,
+						'paged'          => $page,
+						'orderby'        => 'ID',
+						'order'          => 'ASC',
+						'no_found_rows'  => true,
+					)
 				);
+
+				if ( empty( $batch ) ) {
+					break;
+				}
+
+				foreach ( $batch as $post ) {
+					$combos = array_merge(
+						$combos,
+						$this->collect_combos_from_content( $post->post_content )
+					);
+				}
+
+				if ( count( $batch ) < $batch_size ) {
+					break;
+				}
+
+				++$page;
 			}
 		}
 
@@ -378,6 +464,11 @@ class Venue_Map_Prewarm {
 	/**
 	 * Every post ID whose post type is a venue source.
 	 *
+	 * Intended for small-scale contexts (tests, on-demand scans where the
+	 * caller knows the venue count is bounded). Production fan-out paths
+	 * use `enqueue_for_all_venues()` instead, which streams through the
+	 * venue set in batches without ever holding the full list in memory.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @return int[]
@@ -388,16 +479,39 @@ class Venue_Map_Prewarm {
 			return array();
 		}
 
-		$ids = get_posts(
-			array(
-				'post_type'      => $types,
-				'post_status'    => 'publish',
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-				'no_found_rows'  => true,
-			)
-		);
+		$ids        = array();
+		$batch_size = $this->get_scan_batch_size();
+		$page       = 1;
 
-		return array_map( 'intval', $ids );
+		while ( true ) {
+			$batch = get_posts(
+				array(
+					'post_type'      => $types,
+					'post_status'    => 'publish',
+					'posts_per_page' => $batch_size,
+					'paged'          => $page,
+					'fields'         => 'ids',
+					'orderby'        => 'ID',
+					'order'          => 'ASC',
+					'no_found_rows'  => true,
+				)
+			);
+
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			foreach ( $batch as $id ) {
+				$ids[] = (int) $id;
+			}
+
+			if ( count( $batch ) < $batch_size ) {
+				break;
+			}
+
+			++$page;
+		}
+
+		return $ids;
 	}
 }

--- a/includes/core/classes/class-venue-map-prewarm.php
+++ b/includes/core/classes/class-venue-map-prewarm.php
@@ -1,0 +1,408 @@
+<?php
+/**
+ * Background warmer for the venue-map static PNG cache.
+ *
+ * Scans FSE templates, template parts, and event post content for
+ * `gatherpress/venue-map` blocks, collects every distinct (zoom, width,
+ * height, aspectRatio) combo they request, and enqueues per-venue cron
+ * jobs that drive {@see Venue_Map::warm()}. The goal is to keep the first
+ * render of a venue page instant — once the venue has been saved, every
+ * combo the site's templates reference has a PNG on disk before any
+ * front-end request arrives.
+ *
+ * Why not rely on render-time fallback alone: when a `venue-map` block
+ * sits inside a Single Venue FSE template, no editor pass ever knows
+ * which venue it will ultimately render for, so there's no natural moment
+ * when a user could click "Regenerate Map". Prewarming bridges that gap
+ * by enumerating template combos × venues and generating eagerly.
+ *
+ * Scheduling is WP-Cron for now. Action Scheduler integration will
+ * replace this layer once it's pulled into the plugin.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Core;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Traits\Singleton;
+use WP_Post;
+
+/**
+ * Class Venue_Map_Prewarm.
+ *
+ * Scans templates + events for venue-map combos, enqueues cron jobs to
+ * warm each (venue, combo) via {@see Venue_Map::warm()}.
+ *
+ * @since 1.0.0
+ */
+class Venue_Map_Prewarm {
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Cron action fired for each (venue, combo) warm job.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const CRON_ACTION = 'gatherpress_warm_venue_map';
+
+	/**
+	 * Block name this class watches for.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const BLOCK_NAME = 'gatherpress/venue-map';
+
+	/**
+	 * Class constructor — wires hooks.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Register save hooks, theme-switch hook, and the cron action handler.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks(): void {
+		add_action( self::CRON_ACTION, array( $this, 'process_warm_job' ), 10, 5 );
+
+		// Priority 12 — after Venue_Map::maybe_generate() (priority 11) has
+		// synchronously rendered whatever combos were already cached on the
+		// venue. This hook picks up template combos the venue has never
+		// been rendered at.
+		add_action( 'wp_after_insert_post', array( $this, 'on_post_saved' ), 12, 2 );
+		add_action( 'switch_theme', array( $this, 'on_theme_switched' ) );
+	}
+
+	/**
+	 * Dispatch a post save to the right enqueue path based on its type.
+	 *
+	 * Venues, FSE templates, and template parts each pull a different slice
+	 * of the (venue, combo) grid; events and any other `gatherpress-venue`-
+	 * carrying post type also contribute combos via their own embedded
+	 * venue-map blocks.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int     $post_id Post ID that just saved.
+	 * @param WP_Post $post    Post object.
+	 * @return void
+	 */
+	public function on_post_saved( int $post_id, WP_Post $post ): void {
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+
+		if ( in_array( $post->post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
+			$this->enqueue_for_all_venues( $this->collect_combos_from_content( $post->post_content ) );
+			return;
+		}
+
+		if ( post_type_supports( $post->post_type, 'gatherpress-venue-information' ) ) {
+			$this->enqueue_for_venue( $post_id );
+			return;
+		}
+
+		// Event post types (or any post type that carries venue-map inside
+		// a gatherpress/venue parent). Collect combos from the post's own
+		// content, but enqueue those combos against the associated venue,
+		// not against the event post itself.
+		if ( post_type_supports( $post->post_type, 'gatherpress-venue' ) ) {
+			$combos = $this->collect_combos_from_content( $post->post_content );
+			if ( empty( $combos ) ) {
+				return;
+			}
+
+			$venue_setup = Venue_Setup::get_instance();
+			$taxonomy    = $venue_setup->taxonomy_for_event_post_type( $post->post_type );
+			$terms       = get_the_terms( $post_id, $taxonomy );
+
+			if ( empty( $terms ) || is_wp_error( $terms ) ) {
+				return;
+			}
+
+			$term  = current( $terms );
+			$venue = $venue_setup->get_venue_post_from_term_slug( $term->slug );
+
+			if ( $venue instanceof WP_Post ) {
+				foreach ( $combos as $combo ) {
+					$this->enqueue_warm_job( $venue->ID, $combo );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Full rescan after a theme switch — new theme ships new templates, so
+	 * combos for every venue may have changed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function on_theme_switched(): void {
+		$this->enqueue_for_all_venues( $this->collect_all_template_combos() );
+	}
+
+	/**
+	 * Cron handler. Delegates to {@see Venue_Map::warm()}.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $post_id      Venue post ID.
+	 * @param int    $zoom         Zoom level.
+	 * @param int    $width        Pixel width (0 = auto).
+	 * @param int    $height       Pixel height (0 = auto).
+	 * @param string $aspect_ratio Aspect-ratio string.
+	 * @return void
+	 */
+	public function process_warm_job( int $post_id, int $zoom, int $width, int $height, string $aspect_ratio ): void {
+		Venue_Map::get_instance()->warm( $post_id, $zoom, $width, $height, $aspect_ratio );
+	}
+
+	/**
+	 * Enqueue every known template combo for a single venue.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $venue_post_id Venue post ID.
+	 * @return void
+	 */
+	protected function enqueue_for_venue( int $venue_post_id ): void {
+		foreach ( $this->collect_all_template_combos() as $combo ) {
+			$this->enqueue_warm_job( $venue_post_id, $combo );
+		}
+	}
+
+	/**
+	 * Enqueue a list of combos against every supported venue.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}> $combos Combo list.
+	 * @return void
+	 */
+	protected function enqueue_for_all_venues( array $combos ): void {
+		if ( empty( $combos ) ) {
+			return;
+		}
+
+		foreach ( $this->get_venue_post_ids() as $venue_post_id ) {
+			foreach ( $combos as $combo ) {
+				$this->enqueue_warm_job( $venue_post_id, $combo );
+			}
+		}
+	}
+
+	/**
+	 * Schedule a single warm job, deduped via wp_next_scheduled().
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int                                                           $venue_post_id Venue post ID.
+	 * @param array{zoom:int,width:int,height:int,aspect_ratio:string}      $combo         Combo to warm.
+	 * @return void
+	 */
+	protected function enqueue_warm_job( int $venue_post_id, array $combo ): void {
+		$args = array(
+			$venue_post_id,
+			(int) $combo['zoom'],
+			(int) $combo['width'],
+			(int) $combo['height'],
+			(string) $combo['aspect_ratio'],
+		);
+
+		if ( false !== wp_next_scheduled( self::CRON_ACTION, $args ) ) {
+			return;
+		}
+
+		wp_schedule_single_event( time() + 1, self::CRON_ACTION, $args );
+	}
+
+	/**
+	 * Aggregate combos from every source the site renders venue-map blocks in:
+	 * DB templates, DB template parts, theme file templates, theme file
+	 * template parts, and the content of every post whose type supports
+	 * `gatherpress-venue`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}>
+	 */
+	protected function collect_all_template_combos(): array {
+		$combos = array();
+
+		if ( function_exists( 'get_block_templates' ) ) {
+			foreach ( get_block_templates( array(), 'wp_template' ) as $template ) {
+				$combos = array_merge(
+					$combos,
+					$this->collect_combos_from_content( (string) $template->content )
+				);
+			}
+			foreach ( get_block_templates( array(), 'wp_template_part' ) as $template_part ) {
+				$combos = array_merge(
+					$combos,
+					$this->collect_combos_from_content( (string) $template_part->content )
+				);
+			}
+		}
+
+		$venue_carrying_types = get_post_types_by_support( 'gatherpress-venue' );
+		if ( ! empty( $venue_carrying_types ) ) {
+			$posts = get_posts(
+				array(
+					'post_type'      => $venue_carrying_types,
+					'post_status'    => 'publish',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					'no_found_rows'  => true,
+				)
+			);
+			foreach ( $posts as $post_id ) {
+				$post = get_post( $post_id );
+				if ( ! $post instanceof WP_Post ) {
+					continue;
+				}
+				$combos = array_merge(
+					$combos,
+					$this->collect_combos_from_content( $post->post_content )
+				);
+			}
+		}
+
+		return $this->dedupe_combos( $combos );
+	}
+
+	/**
+	 * Parse block markup and return every venue-map combo it contains.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $content Block markup (post_content / template content).
+	 * @return array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}>
+	 */
+	protected function collect_combos_from_content( string $content ): array {
+		if ( '' === $content || false === strpos( $content, self::BLOCK_NAME ) ) {
+			return array();
+		}
+
+		$blocks = parse_blocks( $content );
+
+		return $this->walk_blocks_for_combos( $blocks );
+	}
+
+	/**
+	 * Recurse through a parsed block tree and collect venue-map combos.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Parsed blocks.
+	 * @return array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}>
+	 */
+	protected function walk_blocks_for_combos( array $blocks ): array {
+		$combos = array();
+
+		foreach ( $blocks as $block ) {
+			if ( ( $block['blockName'] ?? null ) === self::BLOCK_NAME ) {
+				$combos[] = $this->extract_block_combo( (array) ( $block['attrs'] ?? array() ) );
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$combos = array_merge(
+					$combos,
+					$this->walk_blocks_for_combos( $block['innerBlocks'] )
+				);
+			}
+		}
+
+		return $combos;
+	}
+
+	/**
+	 * Pull a combo tuple out of a block's attributes, filling in site
+	 * defaults for anything the block didn't explicitly set.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, mixed> $attrs Block attributes.
+	 * @return array{zoom:int,width:int,height:int,aspect_ratio:string}
+	 */
+	protected function extract_block_combo( array $attrs ): array {
+		return array(
+			'zoom'         => isset( $attrs['zoom'] ) ? (int) $attrs['zoom'] : Venue_Map::DEFAULT_ZOOM,
+			'width'        => isset( $attrs['width'] ) ? (int) $attrs['width'] : 0,
+			'height'       => isset( $attrs['height'] ) ? (int) $attrs['height'] : Venue_Map::DEFAULT_HEIGHT,
+			'aspect_ratio' => isset( $attrs['aspectRatio'] ) ? (string) $attrs['aspectRatio'] : Venue_Map::DEFAULT_ASPECT_RATIO,
+		);
+	}
+
+	/**
+	 * Dedupe a combo list keyed by (zoom, width, height, aspect_ratio).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}> $combos Combo list.
+	 * @return array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}>
+	 */
+	protected function dedupe_combos( array $combos ): array {
+		$seen   = array();
+		$unique = array();
+
+		foreach ( $combos as $combo ) {
+			$key = sprintf(
+				'%d|%d|%d|%s',
+				(int) $combo['zoom'],
+				(int) $combo['width'],
+				(int) $combo['height'],
+				(string) $combo['aspect_ratio']
+			);
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$unique[]     = $combo;
+		}
+
+		return $unique;
+	}
+
+	/**
+	 * Every post ID whose post type is a venue source.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int[]
+	 */
+	protected function get_venue_post_ids(): array {
+		$types = get_post_types_by_support( 'gatherpress-venue-information' );
+		if ( empty( $types ) ) {
+			return array();
+		}
+
+		$ids = get_posts(
+			array(
+				'post_type'      => $types,
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
+
+		return array_map( 'intval', $ids );
+	}
+}

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -135,7 +135,7 @@ class Venue_Map {
 
 	/**
 	 * Default aspect ratio string used when the block's `aspectRatio`
-	 * attribute is empty or unparseable. Format matches the CSS
+	 * attribute is empty or unparsable. Format matches the CSS
 	 * `aspect-ratio` property so the same value can drive the server-side
 	 * width derivation and the client-side CSS on the interactive wrapper.
 	 *
@@ -209,18 +209,6 @@ class Venue_Map {
 	const META_KEY = 'gatherpress_venue_static_map';
 
 	/**
-	 * Meta key for the per-venue filename salt.
-	 *
-	 * Underscore prefix marks it as a protected WordPress meta key —
-	 * not exposed through REST by default and not writable from the
-	 * admin Custom Fields box.
-	 *
-	 * @since 1.0.0
-	 * @var string
-	 */
-	const SALT_META_KEY = '_gatherpress_venue_map_salt';
-
-	/**
 	 * Subdirectory of `wp-content/uploads` where generated PNG files are written.
 	 *
 	 * @since 1.0.0
@@ -260,7 +248,7 @@ class Venue_Map {
 	/**
 	 * Register REST routes for the venue-map block.
 	 *
-	 * Today there's a single endpoint that forces the static PNGs for a
+	 * Today there's a single endpoint that forces the static PNG files for a
 	 * venue to regenerate — used by the "Regenerate Map" button in the
 	 * block editor when a tile provider changes or a render gets out of
 	 * sync with the venue's current inputs.
@@ -350,11 +338,18 @@ class Venue_Map {
 		}
 
 		$settings = Settings::get_instance();
+
+		// Width and height keep empty as a distinct "not set — fall through
+		// to the block.json default" state; an explicit 0 still stamps as
+		// "auto", so the validator below must reject null but accept 0.
+		$raw_width  = $settings->get( 'venue_map_default_width' );
+		$raw_height = $settings->get( 'venue_map_default_height' );
+
 		$defaults = array(
 			'renderMode'      => (string) $settings->get( 'venue_map_default_render_mode' ),
 			'zoom'            => (int) $settings->get( 'venue_map_default_zoom' ),
-			'width'           => (int) $settings->get( 'venue_map_default_width' ),
-			'height'          => (int) $settings->get( 'venue_map_default_height' ),
+			'width'           => '' === $raw_width ? null : (int) $raw_width,
+			'height'          => '' === $raw_height ? null : (int) $raw_height,
 			'aspectRatio'     => (string) $settings->get( 'venue_map_default_aspect_ratio' ),
 			'type'            => (string) $settings->get( 'venue_map_default_type' ),
 			'linkDestination' => (string) $settings->get( 'venue_map_default_link_destination' ),
@@ -534,10 +529,10 @@ class Venue_Map {
 	 * @return void
 	 */
 	public function delete_stored_image( int $post_id ): void {
-		foreach ( $this->get_all_descriptors( $post_id ) as $descriptor ) {
-			$this->delete_file_by_url( $descriptor['url'] );
-		}
-
+		// Filenames are derived from address + dims, so the same PNG on disk
+		// may be shared with other venues at the same address. Clearing the
+		// meta is enough — a follow-up GC pass can sweep truly orphaned
+		// files when no venue's descriptor points at them any longer.
 		delete_post_meta( $post_id, self::META_KEY );
 	}
 
@@ -995,16 +990,19 @@ class Venue_Map {
 		$width  = $this->clamp_width( $width );
 		$height = $this->clamp_height( $height );
 
-		$tiles = $this->get_tile_url_template();
-		$hash  = $this->hash_for( $post_id, $info, $zoom, $width, $height, $tiles );
-		$key   = $this->combo_key( $zoom, $width, $height );
+		$tiles   = $this->get_tile_url_template();
+		$address = (string) ( $info['fullAddress'] ?? '' );
+		$hash    = $this->hash_for( $info, $zoom, $width, $height, $tiles );
+		$key     = $this->combo_key( $zoom, $width, $height );
 
 		$all      = $this->get_all_descriptors( $post_id );
 		$existing = $all[ $key ] ?? null;
 
 		if ( null !== $existing && $existing['hash'] === $hash ) {
-			$path = $this->url_to_path( $existing['url'] );
-			if ( null !== $path && file_exists( $path ) ) {
+			// The URL itself is deterministic from (address, zoom, dims) so
+			// existence on disk is the real validity signal.
+			$expected_url = $this->build_image_url( $address, $zoom, $width, $height );
+			if ( $existing['url'] === $expected_url ) {
 				return $existing;
 			}
 		}
@@ -1019,15 +1017,11 @@ class Venue_Map {
 
 		$this->stamp_marker( $image, (int) round( $width / 2 ), (int) round( $height / 2 ) );
 
-		$url = $this->save_image( $image, $post_id, $hash );
+		$url = $this->save_image( $image, $address, $zoom, $width, $height );
 		imagedestroy( $image );
 
 		if ( null === $url ) {
 			return null;
-		}
-
-		if ( null !== $existing && $existing['url'] !== $url ) {
-			$this->delete_file_by_url( $existing['url'] );
 		}
 
 		$all[ $key ] = array(
@@ -1042,37 +1036,19 @@ class Venue_Map {
 
 		// Verify the write landed. update_post_meta() returns an ambiguous
 		// false ("not changed" vs. "write failed"), so read back and check
-		// the URL we just saved is what ended up in the meta. If the write
-		// was dropped — object-cache outage, an unexpected filter, a foreign
-		// process racing us — unlink the orphan PNG so we don't strand the
-		// file on disk.
+		// the URL we just saved is what ended up in the meta. Orphan files
+		// (file on disk but no meta row pointing at it) are acceptable —
+		// with address-based naming the same file may be shared with other
+		// venues, so we don't proactively unlink on write-verify failure.
 		$stored = get_post_meta( $post_id, self::META_KEY, true );
 		if ( ! is_array( $stored )
 			|| ! isset( $stored[ $key ]['url'] )
 			|| $stored[ $key ]['url'] !== $url
 		) {
-			$this->delete_file_by_url( $url );
 			return null;
 		}
 
 		return $all[ $key ];
-	}
-
-	/**
-	 * Delete a stored PNG by URL, no-op if the URL is out of scope or the
-	 * file is already gone.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $url Stored URL.
-	 * @return void
-	 */
-	protected function delete_file_by_url( string $url ): void {
-		$path = $this->url_to_path( $url );
-
-		if ( null !== $path && file_exists( $path ) ) {
-			wp_delete_file( $path );
-		}
 	}
 
 	/**
@@ -1082,28 +1058,21 @@ class Venue_Map {
 	 * invalidates the previous image. Unrelated venue edits (title, excerpt,
 	 * other meta) keep the same hash and skip regeneration.
 	 *
-	 * A per-venue salt is mixed into the digest so filenames in the public
-	 * uploads dir aren't predictable from the venue's address alone — otherwise
-	 * anyone who guesses a draft venue's ID and street address could fetch
-	 * its map PNG before the venue is published.
-	 *
 	 * @since 1.0.0
 	 *
-	 * @param int    $post_id Venue post ID (used to look up the per-venue salt).
-	 * @param array  $info    Parsed venue information.
-	 * @param int    $zoom    Map zoom level.
-	 * @param int    $width   Output width.
-	 * @param int    $height  Output height.
-	 * @param string $tiles   Tile URL template.
+	 * @param array  $info  Parsed venue information.
+	 * @param int    $zoom  Map zoom level.
+	 * @param int    $width Output width.
+	 * @param int    $height Output height.
+	 * @param string $tiles Tile URL template.
 	 * @return string MD5 hex digest.
 	 */
-	public function hash_for( int $post_id, array $info, int $zoom, int $width, int $height, string $tiles ): string {
+	public function hash_for( array $info, int $zoom, int $width, int $height, string $tiles ): string {
 		// md5() here is a non-cryptographic cache-key discriminator, matching class-geocoding.php.
 		return md5( // NOSONAR.
 			implode(
 				'|',
 				array(
-					$this->salt_for( $post_id ),
 					(string) ( $info['fullAddress'] ?? '' ),
 					(string) ( $info['latitude'] ?? '' ),
 					(string) ( $info['longitude'] ?? '' ),
@@ -1117,46 +1086,57 @@ class Venue_Map {
 	}
 
 	/**
-	 * Return the per-venue filename salt, generating one on first access.
+	 * Build the deterministic URL for a given (address, zoom, width, height).
 	 *
-	 * The salt is a fixed per-post random string; it never rotates so cached
-	 * filenames stay stable across saves. Deleting the venue removes the meta
-	 * (along with every other post meta key) as usual.
-	 *
-	 * **Existing-venue migration:** venues that were rendered before the salt
-	 * was introduced will get a salt generated here on first access; the hash
-	 * — and therefore the PNG filename — changes, which causes
-	 * `ensure_descriptor_for_combo()` to regenerate the image and unlink the
-	 * pre-salt PNG via its existing `$existing['url'] !== $url` cleanup path.
-	 * No backfill step is required.
-	 *
-	 * Two concurrent first-touch requests are reconciled with an `add`-style
-	 * unique-meta insert: whichever request writes first wins, and the other
-	 * re-reads the now-populated value instead of racing a second generation.
+	 * Mirrors {@see self::save_image()}'s filename composition so callers can
+	 * compare an existing descriptor's URL against the expected URL without
+	 * touching the filesystem. Two venues at the same address share the same
+	 * URL at matching dimensions — intentional dedupe.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int $post_id Venue post ID.
-	 * @return string 32-character salt.
+	 * @param string $address Venue address string.
+	 * @param int    $zoom    Map zoom level.
+	 * @param int    $width   Output width.
+	 * @param int    $height  Output height.
+	 * @return string Full public URL for the PNG.
 	 */
-	protected function salt_for( int $post_id ): string {
-		$salt = (string) get_post_meta( $post_id, self::SALT_META_KEY, true );
+	protected function build_image_url( string $address, int $zoom, int $width, int $height ): string {
+		$dirs     = wp_get_upload_dir();
+		$base_url = trailingslashit( $dirs['baseurl'] ) . self::UPLOADS_SUBDIR;
 
-		if ( '' === $salt ) {
-			$candidate = wp_generate_password( 32, false );
+		return trailingslashit( $base_url ) . $this->filename_for( $address, $zoom, $width, $height );
+	}
 
-			// add_post_meta() with $unique = true returns false when another
-			// request already populated the row between our read and write.
-			// In that case, re-read to pick up the winner's value so every
-			// caller agrees on the salt.
-			if ( false !== add_post_meta( $post_id, self::SALT_META_KEY, $candidate, true ) ) {
-				$salt = $candidate;
-			} else {
-				$salt = (string) get_post_meta( $post_id, self::SALT_META_KEY, true );
-			}
+	/**
+	 * Compose a filesystem-safe filename from the address + dimensions.
+	 *
+	 * Address gets slugified via `sanitize_title()` and capped at 150 chars
+	 * so the full filename stays comfortably under the 255-byte cap common
+	 * to most filesystems. An empty or all-special-character address falls
+	 * back to `venue` so there's always something before the dimension
+	 * suffix.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $address Venue address.
+	 * @param int    $zoom    Map zoom level.
+	 * @param int    $width   Output width.
+	 * @param int    $height  Output height.
+	 * @return string Filename including the `.png` extension.
+	 */
+	protected function filename_for( string $address, int $zoom, int $width, int $height ): string {
+		$slug = sanitize_title( $address );
+
+		if ( '' === $slug ) {
+			$slug = 'venue';
 		}
 
-		return $salt;
+		if ( 150 < strlen( $slug ) ) {
+			$slug = substr( $slug, 0, 150 );
+		}
+
+		return sprintf( '%s-%d-%d-%d.png', $slug, $zoom, $width, $height );
 	}
 
 	/**
@@ -1321,14 +1301,22 @@ class Venue_Map {
 	/**
 	 * Save the composited image to the uploads directory and return its URL.
 	 *
+	 * Filename is derived from `(address, zoom, width, height)` — two venues
+	 * that resolve to the same address slug at matching dimensions share one
+	 * file on disk. `imagepng` overwrites in place, which is fine for our
+	 * regenerate flow since the inputs that'd change visible output also
+	 * change the hash in the descriptor meta.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param \GdImage|resource $image   The finished composite (GdImage on PHP 8+, resource on PHP 7.4).
-	 * @param int               $post_id The venue post ID (used in the filename).
-	 * @param string            $hash    Input hash (used in the filename).
+	 * @param string            $address Venue address (slugified for the filename).
+	 * @param int               $zoom    Map zoom level.
+	 * @param int               $width   Output width.
+	 * @param int               $height  Output height.
 	 * @return string|null Public URL of the saved file, or null on failure.
 	 */
-	public function save_image( $image, int $post_id, string $hash ): ?string {
+	public function save_image( $image, string $address, int $zoom, int $width, int $height ): ?string {
 		$dirs = wp_get_upload_dir();
 
 		if ( ! empty( $dirs['error'] ) ) {
@@ -1343,7 +1331,7 @@ class Venue_Map {
 			return null; // @codeCoverageIgnore
 		}
 
-		$filename = sprintf( '%d-%s.png', $post_id, $hash );
+		$filename = $this->filename_for( $address, $zoom, $width, $height );
 		$path     = trailingslashit( $base_dir ) . $filename;
 		$url      = trailingslashit( $base_url ) . $filename;
 
@@ -1353,44 +1341,6 @@ class Venue_Map {
 		}
 
 		return $url;
-	}
-
-	/**
-	 * Convert a stored URL back to its filesystem path for deletion.
-	 *
-	 * Returns null when the URL doesn't sit inside this plugin's uploads
-	 * subdir — a safety check so we never interpret a filter-injected URL
-	 * as a path to unlink.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $url URL to convert.
-	 * @return string|null Absolute filesystem path, or null when out of scope.
-	 */
-	public function url_to_path( string $url ): ?string {
-		$dirs     = wp_get_upload_dir();
-		$base_url = trailingslashit( $dirs['baseurl'] ) . self::UPLOADS_SUBDIR . '/';
-
-		if ( 0 !== strpos( $url, $base_url ) ) {
-			return null;
-		}
-
-		$relative = substr( $url, strlen( $base_url ) );
-
-		// Restrict the relative portion to filenames this class actually
-		// generates: `{post_id}-{md5-hex}.png`. The prefix check above only
-		// guards the URL origin — without this allow-list a value like
-		// `…/static-maps/../../wp-config.php`, if it ever slipped into the
-		// meta (direct update_post_meta, import, a future filter), would
-		// concatenate through to a path outside the uploads subdir and
-		// hand `wp_delete_file()` a target it shouldn't touch.
-		if ( ! preg_match( '#\A\d+-[a-f0-9]{32}\.png\z#', $relative ) ) {
-			return null;
-		}
-
-		$base_dir = trailingslashit( $dirs['basedir'] ) . self::UPLOADS_SUBDIR . '/';
-
-		return $base_dir . $relative;
 	}
 
 	/**
@@ -1506,7 +1456,7 @@ class Venue_Map {
 	 * Parse an aspect-ratio string (e.g. "16/9") into its float value.
 	 *
 	 * Accepts the CSS `aspect-ratio` format with either a slash or a
-	 * colon separator. Returns null for unparseable / zero-denominator
+	 * colon separator. Returns null for unparsable / zero-denominator
 	 * input so callers can fall back to the default.
 	 *
 	 * @since 1.0.0

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -346,16 +346,12 @@ class Venue_Map {
 		$raw_height = $settings->get( 'venue_map_default_height' );
 
 		$defaults = array(
-			'renderMode'      => (string) $settings->get( 'venue_map_default_render_mode' ),
-			'zoom'            => (int) $settings->get( 'venue_map_default_zoom' ),
-			'width'           => '' === $raw_width ? null : (int) $raw_width,
-			'height'          => '' === $raw_height ? null : (int) $raw_height,
-			'aspectRatio'     => (string) $settings->get( 'venue_map_default_aspect_ratio' ),
-			'type'            => (string) $settings->get( 'venue_map_default_type' ),
-			'linkDestination' => (string) $settings->get( 'venue_map_default_link_destination' ),
-			'linkTarget'      => (bool) $settings->get( 'venue_map_default_link_target' )
-				? '_blank'
-				: '',
+			'renderMode'  => (string) $settings->get( 'venue_map_default_render_mode' ),
+			'zoom'        => (int) $settings->get( 'venue_map_default_zoom' ),
+			'width'       => '' === $raw_width ? null : (int) $raw_width,
+			'height'      => '' === $raw_height ? null : (int) $raw_height,
+			'aspectRatio' => (string) $settings->get( 'venue_map_default_aspect_ratio' ),
+			'type'        => (string) $settings->get( 'venue_map_default_type' ),
 		);
 
 		// Per-attribute validators so a never-written Settings row (empty
@@ -366,46 +362,36 @@ class Venue_Map {
 		// it would have accepted e.g. `renderMode = '0'`. All closures are
 		// static because none of them capture `$this`.
 		$validators = array(
-			'renderMode'      => static function ( $value ): bool {
+			'renderMode'  => static function ( $value ): bool {
 				return in_array( $value, array( 'interactive', 'static' ), true );
 			},
-			'zoom'            => static function ( $value ): bool {
+			'zoom'        => static function ( $value ): bool {
 				return is_int( $value )
 					&& $value >= self::ZOOM_MIN
 					&& $value <= self::ZOOM_MAX;
 			},
-			'width'           => static function ( $value ): bool {
+			'width'       => static function ( $value ): bool {
 				// 0 means "auto" and is a valid default value.
 				return is_int( $value )
 					&& $value >= 0
 					&& $value <= self::WIDTH_MAX;
 			},
-			'height'          => static function ( $value ): bool {
+			'height'      => static function ( $value ): bool {
 				// 0 means "auto" and is a valid default value.
 				return is_int( $value )
 					&& $value >= 0
 					&& $value <= self::HEIGHT_MAX;
 			},
-			'aspectRatio'     => function ( $value ): bool {
+			'aspectRatio' => function ( $value ): bool {
 				return is_string( $value )
 					&& null !== $this->parse_aspect_ratio( $value );
 			},
-			'type'            => static function ( $value ): bool {
+			'type'        => static function ( $value ): bool {
 				return in_array(
 					$value,
 					array( 'roadmap', 'satellite', 'hybrid', 'terrain' ),
 					true
 				);
-			},
-			'linkDestination' => static function ( $value ): bool {
-				return in_array(
-					$value,
-					array( 'none', 'openstreetmap', 'google', 'custom' ),
-					true
-				);
-			},
-			'linkTarget'      => static function ( $value ): bool {
-				return '' === $value || '_blank' === $value;
 			},
 		);
 

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -285,7 +285,7 @@ class Venue_Map {
 					return current_user_can( 'edit_post', $post_id );
 				},
 				'args'                => array(
-					'id'     => array(
+					'id'           => array(
 						'required'          => true,
 						'type'              => 'integer',
 						'sanitize_callback' => 'absint',

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -975,7 +975,13 @@ class Venue_Map {
 	 * @param int   $height  Pixel height of the PNG.
 	 * @return array{url: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
-	protected function ensure_descriptor_for_combo( int $post_id, array $info, int $zoom, int $width, int $height ): ?array {
+	protected function ensure_descriptor_for_combo(
+		int $post_id,
+		array $info,
+		int $zoom,
+		int $width,
+		int $height
+	): ?array {
 		// Callers (maybe_generate, get_url_for_post) must have validated the
 		// coordinates via parse_coord() already — cast directly.
 		$latitude  = (float) $info['latitude'];
@@ -1548,7 +1554,8 @@ class Venue_Map {
 		$parsed = $this->parse_aspect_ratio( '' !== $ratio ? $ratio : self::DEFAULT_ASPECT_RATIO );
 
 		if ( null === $parsed ) {
-			$parsed = $this->parse_aspect_ratio( self::DEFAULT_ASPECT_RATIO ) ?: self::IMAGE_ASPECT_RATIO;
+			$fallback = $this->parse_aspect_ratio( self::DEFAULT_ASPECT_RATIO );
+			$parsed   = null !== $fallback ? $fallback : self::IMAGE_ASPECT_RATIO;
 		}
 
 		if ( $width <= 0 && $height <= 0 ) {

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -110,7 +110,39 @@ class Venue_Map {
 	 * @since 1.0.0
 	 * @var int
 	 */
-	const HEIGHT_MAX = 800;
+	const HEIGHT_MAX = 4000;
+
+	/**
+	 * Bounds for the pixel width. Mirror of HEIGHT_MIN / HEIGHT_MAX but
+	 * scaled to the 2:1 default ratio — a venue map that's 800 tall can
+	 * be up to 1600 wide. The block exposes both dimensions so users can
+	 * pick any concrete width, but the generator still refuses values
+	 * that would allocate gigabytes of GD memory or fetch hundreds of
+	 * tiles.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const WIDTH_MIN = 100;
+
+	/**
+	 * See self::WIDTH_MIN.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const WIDTH_MAX = 4000;
+
+	/**
+	 * Default aspect ratio string used when the block's `aspectRatio`
+	 * attribute is empty or unparseable. Format matches the CSS
+	 * `aspect-ratio` property so the same value can drive the server-side
+	 * width derivation and the client-side CSS on the interactive wrapper.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const DEFAULT_ASPECT_RATIO = '2/1';
 
 	/**
 	 * Total wall-clock budget (in seconds) for a single composite_image()
@@ -270,17 +302,28 @@ class Venue_Map {
 					// Optional: the combo the client is currently displaying. If
 					// provided, that combo is added to the regenerate list so a
 					// "Generate" click from the block placeholder produces a PNG
-					// for the active (zoom, height) even when that combo has never
-					// been rendered before.
-					'zoom'   => array(
+					// for the active (zoom, width, height) combo even when it has
+					// never been rendered before. `width` and `height` may be 0
+					// ("auto") — the aspect-ratio hint then drives derivation.
+					'zoom'         => array(
 						'required'          => false,
 						'type'              => 'integer',
 						'sanitize_callback' => 'absint',
 					),
-					'height' => array(
+					'width'        => array(
 						'required'          => false,
 						'type'              => 'integer',
 						'sanitize_callback' => 'absint',
+					),
+					'height'       => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'aspect_ratio' => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
 					),
 				),
 			)
@@ -308,10 +351,16 @@ class Venue_Map {
 
 		$settings = Settings::get_instance();
 		$defaults = array(
-			'renderMode' => (string) $settings->get( 'venue_map_default_render_mode' ),
-			'zoom'       => (int) $settings->get( 'venue_map_default_zoom' ),
-			'height'     => (int) $settings->get( 'venue_map_default_height' ),
-			'type'       => (string) $settings->get( 'venue_map_default_type' ),
+			'renderMode'      => (string) $settings->get( 'venue_map_default_render_mode' ),
+			'zoom'            => (int) $settings->get( 'venue_map_default_zoom' ),
+			'width'           => (int) $settings->get( 'venue_map_default_width' ),
+			'height'          => (int) $settings->get( 'venue_map_default_height' ),
+			'aspectRatio'     => (string) $settings->get( 'venue_map_default_aspect_ratio' ),
+			'type'            => (string) $settings->get( 'venue_map_default_type' ),
+			'linkDestination' => (string) $settings->get( 'venue_map_default_link_destination' ),
+			'linkTarget'      => (bool) $settings->get( 'venue_map_default_link_target' )
+				? '_blank'
+				: '',
 		);
 
 		// Per-attribute validators so a never-written Settings row (empty
@@ -322,25 +371,46 @@ class Venue_Map {
 		// it would have accepted e.g. `renderMode = '0'`. All closures are
 		// static because none of them capture `$this`.
 		$validators = array(
-			'renderMode' => static function ( $value ): bool {
+			'renderMode'      => static function ( $value ): bool {
 				return in_array( $value, array( 'interactive', 'static' ), true );
 			},
-			'zoom'       => static function ( $value ): bool {
+			'zoom'            => static function ( $value ): bool {
 				return is_int( $value )
 					&& $value >= self::ZOOM_MIN
 					&& $value <= self::ZOOM_MAX;
 			},
-			'height'     => static function ( $value ): bool {
+			'width'           => static function ( $value ): bool {
+				// 0 means "auto" and is a valid default value.
 				return is_int( $value )
-					&& $value >= self::HEIGHT_MIN
+					&& $value >= 0
+					&& $value <= self::WIDTH_MAX;
+			},
+			'height'          => static function ( $value ): bool {
+				// 0 means "auto" and is a valid default value.
+				return is_int( $value )
+					&& $value >= 0
 					&& $value <= self::HEIGHT_MAX;
 			},
-			'type'       => static function ( $value ): bool {
+			'aspectRatio'     => function ( $value ): bool {
+				return is_string( $value )
+					&& null !== $this->parse_aspect_ratio( $value );
+			},
+			'type'            => static function ( $value ): bool {
 				return in_array(
 					$value,
 					array( 'roadmap', 'satellite', 'hybrid', 'terrain' ),
 					true
 				);
+			},
+			'linkDestination' => static function ( $value ): bool {
+				return in_array(
+					$value,
+					array( 'none', 'openstreetmap', 'google', 'custom' ),
+					true
+				);
+			},
+			'linkTarget'      => static function ( $value ): bool {
+				return '' === $value || '_blank' === $value;
 			},
 		);
 
@@ -421,24 +491,37 @@ class Venue_Map {
 			return;
 		}
 
-		// Regenerate every (zoom, height) combo the venue is already cached
-		// at so a content change (new address/coords) cascades to all cached
-		// variants. For a fresh venue with nothing stored, seed the default
-		// combo that newly-inserted venue-map blocks will actually request —
-		// otherwise the editor falls back to the interactive preview on the
-		// very first save because the default cache entry is missing.
+		// Regenerate every (zoom, width, height) combo the venue is already
+		// cached at so a content change (new address/coords) cascades to
+		// all cached variants. For a fresh venue with nothing stored, seed
+		// the default combo that newly-inserted venue-map blocks will
+		// actually request — otherwise the editor falls back to the
+		// interactive preview on the very first save because the default
+		// cache entry is missing.
 		$combos = $this->get_cached_combos( $post_id );
 		if ( empty( $combos ) ) {
-			$combos = array(
+			$default = $this->resolve_dimensions(
+				0,
+				$this->get_height(),
+				self::DEFAULT_ASPECT_RATIO
+			);
+			$combos  = array(
 				array(
 					'zoom'   => $this->get_zoom(),
-					'height' => $this->get_height(),
+					'width'  => $default['width'],
+					'height' => $default['height'],
 				),
 			);
 		}
 
 		foreach ( $combos as $combo ) {
-			$this->ensure_descriptor_for_combo( $post_id, $info, $combo['zoom'], $combo['height'] );
+			$this->ensure_descriptor_for_combo(
+				$post_id,
+				$info,
+				$combo['zoom'],
+				$combo['width'],
+				$combo['height']
+			);
 		}
 	}
 
@@ -476,22 +559,37 @@ class Venue_Map {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int      $post_id      The venue post ID.
-	 * @param int|null $extra_zoom   Optional extra zoom to include.
-	 * @param int|null $extra_height Optional extra height to include.
-	 * @return array<string, array{url: string, hash: string, zoom: int, height: int}>
+	 * @param int      $post_id            The venue post ID.
+	 * @param int|null $extra_zoom         Optional extra zoom to include.
+	 * @param int|null $extra_width        Optional extra width (0 = auto).
+	 * @param int|null $extra_height       Optional extra height (0 = auto).
+	 * @param string   $extra_aspect_ratio Optional aspect ratio hint for the extra combo.
+	 * @return array<string, array{url: string, hash: string, zoom: int, width: int, height: int}>
 	 */
-	public function regenerate( int $post_id, ?int $extra_zoom = null, ?int $extra_height = null ): array {
+	public function regenerate(
+		int $post_id,
+		?int $extra_zoom = null,
+		?int $extra_width = null,
+		?int $extra_height = null,
+		string $extra_aspect_ratio = ''
+	): array {
 		// Cache the combos we want to rebuild before wiping meta —
 		// delete_stored_image() clears META_KEY, which is where
 		// get_cached_combos() reads from.
 		$combos = $this->get_cached_combos( $post_id );
 
-		// Merge the caller-supplied combo in, dedup by combo_key.
-		if ( null !== $extra_zoom && null !== $extra_height ) {
+		// Merge the caller-supplied combo in, resolving dims when either
+		// width or height is left as "auto".
+		if ( null !== $extra_zoom ) {
+			$resolved = $this->resolve_dimensions(
+				(int) ( $extra_width ?? 0 ),
+				(int) ( $extra_height ?? 0 ),
+				$extra_aspect_ratio
+			);
 			$combos[] = array(
-				'zoom'   => $extra_zoom,
-				'height' => $extra_height,
+				'zoom'   => (int) $extra_zoom,
+				'width'  => $resolved['width'],
+				'height' => $resolved['height'],
 			);
 		}
 
@@ -500,6 +598,7 @@ class Venue_Map {
 		foreach ( $combos as $combo ) {
 			$key = $this->combo_key(
 				$this->clamp_zoom( (int) $combo['zoom'] ),
+				$this->clamp_width( (int) $combo['width'] ),
 				$this->clamp_height( (int) $combo['height'] )
 			);
 
@@ -517,10 +616,16 @@ class Venue_Map {
 		if ( empty( $combos ) ) {
 			// Seed the site-default combo so a never-rendered venue still
 			// ends up with a PNG after an explicit regenerate click.
-			$combos = array(
+			$default = $this->resolve_dimensions(
+				0,
+				$this->get_height(),
+				self::DEFAULT_ASPECT_RATIO
+			);
+			$combos  = array(
 				array(
 					'zoom'   => $this->get_zoom(),
-					'height' => $this->get_height(),
+					'width'  => $default['width'],
+					'height' => $default['height'],
 				),
 			);
 		}
@@ -538,6 +643,7 @@ class Venue_Map {
 				$post_id,
 				$info,
 				$combo['zoom'],
+				$combo['width'],
 				$combo['height']
 			);
 		}
@@ -580,12 +686,23 @@ class Venue_Map {
 
 		// Pass the block's current combo through so its PNG is generated
 		// even when the venue has never been rendered at those dimensions.
-		$raw_zoom     = $request['zoom'] ?? null;
-		$raw_height   = $request['height'] ?? null;
-		$extra_zoom   = ( null !== $raw_zoom && (int) $raw_zoom > 0 ) ? (int) $raw_zoom : null;
-		$extra_height = ( null !== $raw_height && (int) $raw_height > 0 ) ? (int) $raw_height : null;
+		// `width` and `height` may be 0 / omitted (meaning "auto") — the
+		// aspect-ratio hint then drives whichever dimension is missing.
+		$raw_zoom    = $request['zoom'] ?? null;
+		$raw_width   = $request['width'] ?? null;
+		$raw_height  = $request['height'] ?? null;
+		$extra_zoom  = ( null !== $raw_zoom && (int) $raw_zoom > 0 ) ? (int) $raw_zoom : null;
+		$extra_width = ( null !== $raw_width && (int) $raw_width >= 0 ) ? (int) $raw_width : null;
+		$extra_hgt   = ( null !== $raw_height && (int) $raw_height >= 0 ) ? (int) $raw_height : null;
+		$aspect      = (string) ( $request['aspect_ratio'] ?? '' );
 
-		$descriptors = $this->regenerate( $post_id, $extra_zoom, $extra_height );
+		$descriptors = $this->regenerate(
+			$post_id,
+			$extra_zoom,
+			$extra_width,
+			$extra_hgt,
+			$aspect
+		);
 
 		return new WP_REST_Response(
 			array(
@@ -611,17 +728,21 @@ class Venue_Map {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int      $post_id   Event or venue post ID.
-	 * @param string   $post_type The post type of `$post_id`.
-	 * @param int|null $zoom      Desired zoom level. Null falls back to the default.
-	 * @param int|null $height    Desired pixel height. Null falls back to the default.
+	 * @param int      $post_id      Event or venue post ID.
+	 * @param string   $post_type    The post type of `$post_id`.
+	 * @param int|null $zoom         Desired zoom level. Null falls back to the default.
+	 * @param int|null $width        Desired pixel width (0/null = auto).
+	 * @param int|null $height       Desired pixel height (0/null = auto).
+	 * @param string   $aspect_ratio Aspect-ratio hint used to derive any auto dimension.
 	 * @return string Static map URL, or '' when unavailable.
 	 */
 	public function get_url_for_post(
 		int $post_id,
 		string $post_type,
 		?int $zoom = null,
-		?int $height = null
+		?int $width = null,
+		?int $height = null,
+		string $aspect_ratio = ''
 	): string {
 		$venue_post_id = 0;
 
@@ -646,19 +767,26 @@ class Venue_Map {
 			return '';
 		}
 
+		$resolved = $this->resolve_dimensions(
+			(int) ( $width ?? 0 ),
+			(int) ( $height ?? $this->get_height() ),
+			'' !== $aspect_ratio ? $aspect_ratio : self::DEFAULT_ASPECT_RATIO
+		);
+
 		$descriptor = $this->ensure_descriptor_for_combo(
 			$venue_post_id,
 			$info,
 			$zoom ?? $this->get_zoom(),
-			$height ?? $this->get_height()
+			$resolved['width'],
+			$resolved['height']
 		);
 
 		return null === $descriptor ? '' : $descriptor['url'];
 	}
 
 	/**
-	 * Return the descriptor for the default (zoom, height) combo, or null if
-	 * nothing is stored.
+	 * Return the descriptor for the default (zoom, width, height) combo, or
+	 * null if nothing is stored.
 	 *
 	 * Convenience for the common "has this venue been rendered at the site
 	 * defaults yet?" question — production render paths resolve a specific
@@ -668,16 +796,26 @@ class Venue_Map {
 	 * @since 1.0.0
 	 *
 	 * @param int $post_id The venue post ID.
-	 * @return array{url: string, hash: string, zoom: int, height: int}|null
+	 * @return array{url: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
 	public function get_stored_descriptor( int $post_id ): ?array {
-		$all = $this->get_all_descriptors( $post_id );
+		$all      = $this->get_all_descriptors( $post_id );
+		$defaults = $this->resolve_dimensions(
+			0,
+			$this->get_height(),
+			self::DEFAULT_ASPECT_RATIO
+		);
 
-		return $all[ $this->combo_key( $this->get_zoom(), $this->get_height() ) ] ?? null;
+		return $all[ $this->combo_key(
+			$this->get_zoom(),
+			$defaults['width'],
+			$defaults['height']
+		) ] ?? null;
 	}
 
 	/**
-	 * Return every stored descriptor for the venue, keyed by `{zoom}x{height}`.
+	 * Return every stored descriptor for the venue, keyed by
+	 * `{zoom}x{width}x{height}`.
 	 *
 	 * Filters out malformed entries so callers can iterate without defensive
 	 * shape checks. The read path itself does not persist the cleaned map —
@@ -689,7 +827,7 @@ class Venue_Map {
 	 * @since 1.0.0
 	 *
 	 * @param int $post_id The venue post ID.
-	 * @return array<string, array{url: string, hash: string, zoom: int, height: int}>
+	 * @return array<string, array{url: string, hash: string, zoom: int, width: int, height: int}>
 	 */
 	public function get_all_descriptors( int $post_id ): array {
 		$raw = get_post_meta( $post_id, self::META_KEY, true );
@@ -706,11 +844,13 @@ class Venue_Map {
 			}
 
 			$zoom   = isset( $entry['zoom'] ) ? (int) $entry['zoom'] : 0;
+			$width  = isset( $entry['width'] ) ? (int) $entry['width'] : 0;
 			$height = isset( $entry['height'] ) ? (int) $entry['height'] : 0;
 
-			// Without a zoom/height on the entry there's no way to know which
-			// block configuration the file belongs to — skip rather than guess.
-			if ( $zoom <= 0 || $height <= 0 ) {
+			// Without concrete zoom/width/height on the entry there's no way
+			// to know which block configuration the file belongs to — skip
+			// rather than guess.
+			if ( $zoom <= 0 || $width <= 0 || $height <= 0 ) {
 				continue;
 			}
 
@@ -718,6 +858,7 @@ class Venue_Map {
 				'url'    => (string) $entry['url'],
 				'hash'   => (string) $entry['hash'],
 				'zoom'   => $zoom,
+				'width'  => $width,
 				'height' => $height,
 			);
 		}
@@ -726,7 +867,8 @@ class Venue_Map {
 	}
 
 	/**
-	 * Parse stored meta into the list of (zoom, height) combos already cached.
+	 * Parse stored meta into the list of (zoom, width, height) combos
+	 * already cached.
 	 *
 	 * Used by {@see self::maybe_generate()} to cascade content changes (new
 	 * address, new coordinates) across every variant a venue has ever been
@@ -736,7 +878,7 @@ class Venue_Map {
 	 * @since 1.0.0
 	 *
 	 * @param int $post_id Venue post ID.
-	 * @return array<int, array{zoom: int, height: int}>
+	 * @return array<int, array{zoom: int, width: int, height: int}>
 	 */
 	public function get_cached_combos( int $post_id ): array {
 		$combos = array();
@@ -744,6 +886,7 @@ class Venue_Map {
 		foreach ( $this->get_all_descriptors( $post_id ) as $descriptor ) {
 			$combos[] = array(
 				'zoom'   => $descriptor['zoom'],
+				'width'  => $descriptor['width'],
 				'height' => $descriptor['height'],
 			);
 		}
@@ -752,20 +895,22 @@ class Venue_Map {
 	}
 
 	/**
-	 * Build the meta-storage key for a (zoom, height) combo.
+	 * Build the meta-storage key for a (zoom, width, height) combo.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param int $zoom   Zoom level.
+	 * @param int $width  Pixel width.
 	 * @param int $height Pixel height.
 	 * @return string
 	 */
-	protected function combo_key( int $zoom, int $height ): string {
-		return sprintf( '%dx%d', $zoom, $height );
+	protected function combo_key( int $zoom, int $width, int $height ): string {
+		return sprintf( '%dx%dx%d', $zoom, $width, $height );
 	}
 
 	/**
-	 * Ensure a descriptor exists for the `($zoom, $height)` combo and return it.
+	 * Ensure a descriptor exists for the `($zoom, $width, $height)` combo
+	 * and return it.
 	 *
 	 * Hits the filesystem cache when the stored hash already matches the
 	 * current inputs and the PNG is still on disk; otherwise composites a
@@ -777,10 +922,11 @@ class Venue_Map {
 	 * @param int   $post_id Venue post ID.
 	 * @param array $info    Parsed venue information.
 	 * @param int   $zoom    Zoom level to render at.
-	 * @param int   $height  Pixel height of the PNG. Width is derived via IMAGE_ASPECT_RATIO.
-	 * @return array{url: string, hash: string, zoom: int, height: int}|null
+	 * @param int   $width   Pixel width of the PNG.
+	 * @param int   $height  Pixel height of the PNG.
+	 * @return array{url: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
-	protected function ensure_descriptor_for_combo( int $post_id, array $info, int $zoom, int $height ): ?array {
+	protected function ensure_descriptor_for_combo( int $post_id, array $info, int $zoom, int $width, int $height ): ?array {
 		// Callers (maybe_generate, get_url_for_post) must have validated the
 		// coordinates via parse_coord() already — cast directly.
 		$latitude  = (float) $info['latitude'];
@@ -791,11 +937,12 @@ class Venue_Map {
 		// within range, but a hand-edited block, a filter that mutates the
 		// attribute, or bad meta could sneak an out-of-range value in.
 		$zoom   = $this->clamp_zoom( $zoom );
+		$width  = $this->clamp_width( $width );
 		$height = $this->clamp_height( $height );
 
 		$tiles = $this->get_tile_url_template();
-		$hash  = $this->hash_for( $post_id, $info, $zoom, $height, $tiles );
-		$key   = $this->combo_key( $zoom, $height );
+		$hash  = $this->hash_for( $post_id, $info, $zoom, $width, $height, $tiles );
+		$key   = $this->combo_key( $zoom, $width, $height );
 
 		$all      = $this->get_all_descriptors( $post_id );
 		$existing = $all[ $key ] ?? null;
@@ -807,7 +954,7 @@ class Venue_Map {
 			}
 		}
 
-		$image = $this->composite_image( $latitude, $longitude, $zoom, $height, $tiles );
+		$image = $this->composite_image( $latitude, $longitude, $zoom, $width, $height, $tiles );
 
 		// Downstream of the GD-missing branch in composite_image(); only
 		// reached on PHP builds without the GD extension.
@@ -815,7 +962,6 @@ class Venue_Map {
 			return null; // @codeCoverageIgnore
 		}
 
-		$width = (int) round( $height * self::IMAGE_ASPECT_RATIO );
 		$this->stamp_marker( $image, (int) round( $width / 2 ), (int) round( $height / 2 ) );
 
 		$url = $this->save_image( $image, $post_id, $hash );
@@ -833,6 +979,7 @@ class Venue_Map {
 			'url'    => $url,
 			'hash'   => $hash,
 			'zoom'   => $zoom,
+			'width'  => $width,
 			'height' => $height,
 		);
 
@@ -876,11 +1023,9 @@ class Venue_Map {
 	/**
 	 * Compute a stable hash from the inputs that determine the rendered PNG.
 	 *
-	 * Any change to address, coords, zoom, height, or tile provider invalidates
-	 * the previous image. Width is fully derived from height via
-	 * {@see self::IMAGE_ASPECT_RATIO} so it doesn't need to go into the hash.
-	 * Unrelated venue edits (title, excerpt, other meta) keep the same hash
-	 * and skip regeneration.
+	 * Any change to address, coords, zoom, width, height, or tile provider
+	 * invalidates the previous image. Unrelated venue edits (title, excerpt,
+	 * other meta) keep the same hash and skip regeneration.
 	 *
 	 * A per-venue salt is mixed into the digest so filenames in the public
 	 * uploads dir aren't predictable from the venue's address alone — otherwise
@@ -892,11 +1037,12 @@ class Venue_Map {
 	 * @param int    $post_id Venue post ID (used to look up the per-venue salt).
 	 * @param array  $info    Parsed venue information.
 	 * @param int    $zoom    Map zoom level.
+	 * @param int    $width   Output width.
 	 * @param int    $height  Output height.
 	 * @param string $tiles   Tile URL template.
 	 * @return string MD5 hex digest.
 	 */
-	public function hash_for( int $post_id, array $info, int $zoom, int $height, string $tiles ): string {
+	public function hash_for( int $post_id, array $info, int $zoom, int $width, int $height, string $tiles ): string {
 		// md5() here is a non-cryptographic cache-key discriminator, matching class-geocoding.php.
 		return md5( // NOSONAR.
 			implode(
@@ -907,6 +1053,7 @@ class Venue_Map {
 					(string) ( $info['latitude'] ?? '' ),
 					(string) ( $info['longitude'] ?? '' ),
 					(string) $zoom,
+					(string) $width,
 					(string) $height,
 					$tiles,
 				)
@@ -1009,7 +1156,8 @@ class Venue_Map {
 	 * @param float  $lat    Latitude in degrees.
 	 * @param float  $lng    Longitude in degrees.
 	 * @param int    $zoom   Zoom level (same zoom Leaflet would use for the same CSS viewport).
-	 * @param int    $height Output pixel height. Width is derived via IMAGE_ASPECT_RATIO.
+	 * @param int    $width  Output pixel width.
+	 * @param int    $height Output pixel height.
 	 * @param string $tiles  Tile URL template.
 	 * @return \GdImage|resource|null Composited image, or null when GD is unavailable.
 	 *                                GdImage on PHP 8+, resource on PHP 7.4.
@@ -1018,6 +1166,7 @@ class Venue_Map {
 		float $lat,
 		float $lng,
 		int $zoom,
+		int $width,
 		int $height,
 		string $tiles
 	) {
@@ -1025,8 +1174,6 @@ class Venue_Map {
 		if ( ! function_exists( 'imagecreatetruecolor' ) ) { // @codeCoverageIgnore
 			return null; // @codeCoverageIgnore
 		}
-
-		$width = (int) round( $height * self::IMAGE_ASPECT_RATIO );
 
 		$venue_world_x = $this->lng_to_world_pixel( $lng, $zoom );
 		$venue_world_y = $this->lat_to_world_pixel( $lat, $zoom );
@@ -1286,6 +1433,88 @@ class Venue_Map {
 	 */
 	protected function clamp_height( int $height ): int {
 		return max( self::HEIGHT_MIN, min( self::HEIGHT_MAX, $height ) );
+	}
+
+	/**
+	 * Clamp a pixel width to the supported range.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $width Raw width value.
+	 * @return int
+	 */
+	protected function clamp_width( int $width ): int {
+		return max( self::WIDTH_MIN, min( self::WIDTH_MAX, $width ) );
+	}
+
+	/**
+	 * Parse an aspect-ratio string (e.g. "16/9") into its float value.
+	 *
+	 * Accepts the CSS `aspect-ratio` format with either a slash or a
+	 * colon separator. Returns null for unparseable / zero-denominator
+	 * input so callers can fall back to the default.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $ratio Raw aspect-ratio string.
+	 * @return float|null
+	 */
+	protected function parse_aspect_ratio( string $ratio ): ?float {
+		if ( ! preg_match( '#\A(\d+)\s*[/:]\s*(\d+)\z#', trim( $ratio ), $matches ) ) {
+			return null;
+		}
+
+		$numerator   = (int) $matches[1];
+		$denominator = (int) $matches[2];
+
+		if ( $numerator <= 0 || $denominator <= 0 ) {
+			return null;
+		}
+
+		return $numerator / $denominator;
+	}
+
+	/**
+	 * Resolve a (width, height) pair from block attribute values.
+	 *
+	 * Either dimension can be passed as `0` meaning "auto" — in which
+	 * case the method derives the missing side from the other side and
+	 * the aspect-ratio string. When both are auto, the site default
+	 * height drives the calculation. When both are explicit, the caller
+	 * wins and the aspect-ratio hint is ignored (the rendered PNG just
+	 * honors the literal pixel dimensions).
+	 *
+	 * Both returned values are clamped to the supported ranges so a
+	 * hand-edited block attribute or filter override can't drive the
+	 * generator outside of sane bounds.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $width   Block width (0 = auto).
+	 * @param int    $height  Block height (0 = auto).
+	 * @param string $ratio   Aspect-ratio string (e.g. "16/9").
+	 * @return array{width: int, height: int}
+	 */
+	protected function resolve_dimensions( int $width, int $height, string $ratio ): array {
+		$parsed = $this->parse_aspect_ratio( '' !== $ratio ? $ratio : self::DEFAULT_ASPECT_RATIO );
+
+		if ( null === $parsed ) {
+			$parsed = $this->parse_aspect_ratio( self::DEFAULT_ASPECT_RATIO ) ?: self::IMAGE_ASPECT_RATIO;
+		}
+
+		if ( $width <= 0 && $height <= 0 ) {
+			$height = self::DEFAULT_HEIGHT;
+			$width  = (int) round( $height * $parsed );
+		} elseif ( $width <= 0 ) {
+			$width = (int) round( $height * $parsed );
+		} elseif ( $height <= 0 ) {
+			$height = (int) round( $width / $parsed );
+		}
+
+		return array(
+			'width'  => $this->clamp_width( $width ),
+			'height' => $this->clamp_height( $height ),
+		);
 	}
 
 	/**

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -669,25 +669,39 @@ class Venue_Map {
 		// even when the venue has never been rendered at those dimensions.
 		// `width` and `height` may be 0 / omitted (meaning "auto") — the
 		// aspect-ratio hint then drives whichever dimension is missing.
-		$raw_zoom    = $request['zoom'] ?? null;
-		$raw_width   = $request['width'] ?? null;
-		$raw_height  = $request['height'] ?? null;
-		$extra_zoom  = ( null !== $raw_zoom && (int) $raw_zoom > 0 ) ? (int) $raw_zoom : null;
-		$extra_width = ( null !== $raw_width && (int) $raw_width >= 0 ) ? (int) $raw_width : null;
-		$extra_hgt   = ( null !== $raw_height && (int) $raw_height >= 0 ) ? (int) $raw_height : null;
-		$aspect      = (string) ( $request['aspect_ratio'] ?? '' );
+		$raw_zoom     = $request['zoom'] ?? null;
+		$raw_width    = $request['width'] ?? null;
+		$raw_height   = $request['height'] ?? null;
+		$extra_zoom   = ( null !== $raw_zoom && (int) $raw_zoom > 0 ) ? (int) $raw_zoom : null;
+		$extra_width  = ( null !== $raw_width && (int) $raw_width >= 0 ) ? (int) $raw_width : null;
+		$extra_height = ( null !== $raw_height && (int) $raw_height >= 0 ) ? (int) $raw_height : null;
+		$aspect       = (string) ( $request['aspect_ratio'] ?? '' );
 
 		$descriptors = $this->regenerate(
 			$post_id,
 			$extra_zoom,
 			$extra_width,
-			$extra_hgt,
+			$extra_height,
 			$aspect
 		);
 
+		// An empty descriptor map for a geocoded venue means every combo
+		// failed — disk write error, GD missing, tile host unreachable past
+		// COMPOSITE_TIME_BUDGET. Surface it with a distinct reason so the
+		// UI can flag the failure instead of rendering as a silent success.
+		if ( empty( $descriptors ) ) {
+			return new WP_REST_Response(
+				array(
+					'descriptors' => (object) array(),
+					'reason'      => 'generation_failed',
+				),
+				200
+			);
+		}
+
 		return new WP_REST_Response(
 			array(
-				'descriptors' => empty( $descriptors ) ? (object) array() : $descriptors,
+				'descriptors' => $descriptors,
 				'reason'      => '',
 			),
 			200
@@ -1112,7 +1126,11 @@ class Venue_Map {
 	 * @return string Filename including the `.png` extension.
 	 */
 	protected function filename_for( string $address, int $zoom, int $width, int $height ): string {
-		$slug = sanitize_title( $address );
+		// `sanitize_title()` URL-slugifies; pass the result through
+		// `sanitize_file_name()` as defense-in-depth so any path-sensitive
+		// characters that slip past (or future changes to sanitize_title's
+		// allowed set) can't escape the filename segment.
+		$slug = sanitize_file_name( sanitize_title( $address ) );
 
 		if ( '' === $slug ) {
 			$slug = 'venue';

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -785,6 +785,55 @@ class Venue_Map {
 	}
 
 	/**
+	 * Ensure a static-map descriptor exists for the given combo.
+	 *
+	 * Thin public wrapper around {@see self::ensure_descriptor_for_combo()} for
+	 * prewarming callers (cron, CLI). Resolves venue info from the post,
+	 * validates coordinates, derives any auto dimension via the aspect ratio,
+	 * and returns the descriptor (or null when the venue has no usable
+	 * coordinates yet or generation failed).
+	 *
+	 * Idempotent — when the hash matches an already-cached PNG the call is a
+	 * no-op DB read, so it's safe to enqueue the same (venue, combo) job
+	 * multiple times while a site is churning saves.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $post_id      Venue post ID.
+	 * @param int    $zoom         Zoom level.
+	 * @param int    $width        Pixel width (0 = auto).
+	 * @param int    $height       Pixel height (0 = auto).
+	 * @param string $aspect_ratio Aspect-ratio string (e.g. "16/9").
+	 * @return array{url: string, hash: string, zoom: int, width: int, height: int}|null
+	 */
+	public function warm( int $post_id, int $zoom, int $width, int $height, string $aspect_ratio = '' ): ?array {
+		if ( 0 >= $post_id ) {
+			return null;
+		}
+
+		$info = ( new Venue( $post_id ) )->get_information();
+
+		if ( null === $this->parse_coord( $info['latitude'] ) ||
+			null === $this->parse_coord( $info['longitude'] ) ) {
+			return null;
+		}
+
+		$resolved = $this->resolve_dimensions(
+			$width,
+			$height,
+			'' !== $aspect_ratio ? $aspect_ratio : self::DEFAULT_ASPECT_RATIO
+		);
+
+		return $this->ensure_descriptor_for_combo(
+			$post_id,
+			$info,
+			$zoom,
+			$resolved['width'],
+			$resolved['height']
+		);
+	}
+
+	/**
 	 * Return the descriptor for the default (zoom, width, height) combo, or
 	 * null if nothing is stored.
 	 *

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -27,6 +27,9 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
 use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
 
 /**
  * Class Venue_Map.
@@ -218,7 +221,70 @@ class Venue_Map {
 		// ordering surprises.
 		add_action( 'wp_after_insert_post', array( $this, 'maybe_generate' ), 11 );
 		add_action( 'registered_post_type', array( $this, 'maybe_register_delete_hook' ) );
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 		add_filter( 'block_type_metadata', array( $this, 'apply_block_attribute_defaults' ) );
+	}
+
+	/**
+	 * Register REST routes for the venue-map block.
+	 *
+	 * Today there's a single endpoint that forces the static PNGs for a
+	 * venue to regenerate — used by the "Regenerate Map" button in the
+	 * block editor when a tile provider changes or a render gets out of
+	 * sync with the venue's current inputs.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function register_rest_routes(): void {
+		register_rest_route(
+			GATHERPRESS_REST_NAMESPACE,
+			'/venue/(?P<id>\d+)/regenerate-map',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'rest_regenerate' ),
+				'permission_callback' => static function ( WP_REST_Request $request ): bool {
+					$post_id = (int) $request['id'];
+
+					// Permission scope is the venue post itself — anyone who can
+					// edit the venue can force its map to regenerate. Admins with
+					// edit_others_posts go through the same check.
+					return current_user_can( 'edit_post', $post_id );
+				},
+				'args'                => array(
+					'id'     => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+						'validate_callback' => static function ( $value ): bool {
+							$post_id = (int) $value;
+
+							return $post_id > 0
+								&& post_type_supports(
+									(string) get_post_type( $post_id ),
+									'gatherpress-venue-information'
+								);
+						},
+					),
+					// Optional: the combo the client is currently displaying. If
+					// provided, that combo is added to the regenerate list so a
+					// "Generate" click from the block placeholder produces a PNG
+					// for the active (zoom, height) even when that combo has never
+					// been rendered before.
+					'zoom'   => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'height' => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -390,6 +456,144 @@ class Venue_Map {
 		}
 
 		delete_post_meta( $post_id, self::META_KEY );
+	}
+
+	/**
+	 * Force-regenerate the static maps for a venue.
+	 *
+	 * Clears every cached descriptor + PNG, then runs the normal
+	 * `maybe_generate()` flow to recreate images for each combo the venue
+	 * was previously cached at. When the caller supplies an extra
+	 * `(zoom, height)` — typically the combo the block editor is currently
+	 * displaying — that combo is added to the list so a "Generate" click
+	 * from the placeholder produces a PNG for it even if the combo has
+	 * never been cached before. For a venue that has no cached combos
+	 * and no caller-supplied one, the site-default combo seeds the run.
+	 *
+	 * Returns the fresh descriptor map so the caller — typically the block
+	 * editor's "Regenerate Map" REST endpoint — can hand the new URLs
+	 * straight back to the client without a second DB round-trip.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int      $post_id      The venue post ID.
+	 * @param int|null $extra_zoom   Optional extra zoom to include.
+	 * @param int|null $extra_height Optional extra height to include.
+	 * @return array<string, array{url: string, hash: string, zoom: int, height: int}>
+	 */
+	public function regenerate( int $post_id, ?int $extra_zoom = null, ?int $extra_height = null ): array {
+		// Cache the combos we want to rebuild before wiping meta —
+		// delete_stored_image() clears META_KEY, which is where
+		// get_cached_combos() reads from.
+		$combos = $this->get_cached_combos( $post_id );
+
+		// Merge the caller-supplied combo in, dedup by combo_key.
+		if ( null !== $extra_zoom && null !== $extra_height ) {
+			$combos[] = array(
+				'zoom'   => $extra_zoom,
+				'height' => $extra_height,
+			);
+		}
+
+		$seen   = array();
+		$unique = array();
+		foreach ( $combos as $combo ) {
+			$key = $this->combo_key(
+				$this->clamp_zoom( (int) $combo['zoom'] ),
+				$this->clamp_height( (int) $combo['height'] )
+			);
+
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+
+			$seen[ $key ] = true;
+			$unique[]     = $combo;
+		}
+		$combos = $unique;
+
+		$this->delete_stored_image( $post_id );
+
+		if ( empty( $combos ) ) {
+			// Seed the site-default combo so a never-rendered venue still
+			// ends up with a PNG after an explicit regenerate click.
+			$combos = array(
+				array(
+					'zoom'   => $this->get_zoom(),
+					'height' => $this->get_height(),
+				),
+			);
+		}
+
+		$venue = new Venue( $post_id );
+		$info  = $venue->get_information();
+
+		if ( null === $this->parse_coord( $info['latitude'] ) ||
+			null === $this->parse_coord( $info['longitude'] ) ) {
+			return array();
+		}
+
+		foreach ( $combos as $combo ) {
+			$this->ensure_descriptor_for_combo(
+				$post_id,
+				$info,
+				$combo['zoom'],
+				$combo['height']
+			);
+		}
+
+		return $this->get_all_descriptors( $post_id );
+	}
+
+	/**
+	 * REST handler for `POST /venue/{id}/regenerate-map`.
+	 *
+	 * Returns the fresh descriptor map on success. When the venue has no
+	 * usable coordinates yet (address hasn't geocoded), returns an empty
+	 * descriptors array and a structured `reason` so the client can show
+	 * the right placeholder instead of a generic error.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response
+	 */
+	public function rest_regenerate( WP_REST_Request $request ): WP_REST_Response {
+		nocache_headers();
+
+		$post_id     = (int) $request['id'];
+		$venue       = new Venue( $post_id );
+		$info        = $venue->get_information();
+		$latitude    = $this->parse_coord( $info['latitude'] );
+		$longitude   = $this->parse_coord( $info['longitude'] );
+		$has_address = '' !== trim( (string) $info['fullAddress'] );
+
+		if ( ! $has_address || null === $latitude || null === $longitude ) {
+			return new WP_REST_Response(
+				array(
+					'descriptors' => (object) array(),
+					'reason'      => $has_address ? 'awaiting_geocode' : 'no_address',
+				),
+				200
+			);
+		}
+
+		// Pass the block's current combo through so its PNG is generated
+		// even when the venue has never been rendered at those dimensions.
+		$raw_zoom     = $request['zoom'] ?? null;
+		$raw_height   = $request['height'] ?? null;
+		$extra_zoom   = ( null !== $raw_zoom && (int) $raw_zoom > 0 ) ? (int) $raw_zoom : null;
+		$extra_height = ( null !== $raw_height && (int) $raw_height > 0 ) ? (int) $raw_height : null;
+
+		$descriptors = $this->regenerate( $post_id, $extra_zoom, $extra_height );
+
+		return new WP_REST_Response(
+			array(
+				'descriptors' => empty( $descriptors ) ? (object) array() : $descriptors,
+				'reason'      => '',
+			),
+			200
+		);
 	}
 
 	/**

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -160,7 +160,7 @@ class Venues extends Base {
 							'options'     => array(
 								'default' => '',
 								'min'     => '0',
-								'max'     => '4000',
+								'max'     => (string) Venue_Map::HEIGHT_MAX,
 							),
 						),
 					),
@@ -181,7 +181,7 @@ class Venues extends Base {
 							'options'     => array(
 								'default' => '',
 								'min'     => '0',
-								'max'     => '4000',
+								'max'     => (string) Venue_Map::WIDTH_MAX,
 							),
 						),
 					),
@@ -190,7 +190,7 @@ class Venues extends Base {
 							'name' => __( 'Default Aspect Ratio', 'gatherpress' ),
 						),
 						'description' => __(
-							'Default aspect ratio for new venue map blocks. Used to derive any auto width or height dimension.',
+							'Default aspect ratio for new venue map blocks. Used to derive any auto dimension.',
 							'gatherpress'
 						),
 						'field'       => array(
@@ -213,7 +213,7 @@ class Venues extends Base {
 							'name' => __( 'Default Link Destination', 'gatherpress' ),
 						),
 						'description' => __(
-							'Default link wrapped around static maps. Only applies to static mode; interactive maps own their pan-and-zoom interaction.',
+							'Default link wrapped around static maps. Only applies to static mode.',
 							'gatherpress'
 						),
 						'field'       => array(

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -84,7 +84,7 @@ class Venues extends Base {
 					'gatherpress'
 				),
 				'options'     => array(
-					'map_platform'                  => array(
+					'map_platform'                       => array(
 						'labels'      => array(
 							'name' => __( 'Mapping Platform', 'gatherpress' ),
 						),
@@ -104,7 +104,7 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_render_mode' => array(
+					'venue_map_default_render_mode'      => array(
 						'labels'      => array(
 							'name' => __( 'Default Render Mode', 'gatherpress' ),
 						),
@@ -124,7 +124,7 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_zoom'        => array(
+					'venue_map_default_zoom'             => array(
 						'labels'      => array(
 							'name' => __( 'Default Zoom Level', 'gatherpress' ),
 						),
@@ -143,45 +143,49 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_height'      => array(
+					'venue_map_default_height'           => array(
 						'labels'      => array(
 							'name' => __( 'Default Height', 'gatherpress' ),
 						),
 						'description' => __(
-							'Default pixel height applied to new venue map blocks. 0 = auto — height is derived from width and the aspect ratio.',
+							'Default pixel height for new venue map blocks. Leave empty for auto.',
 							'gatherpress'
 						),
 						'field'       => array(
-							'label'   => __( 'Height for new blocks (px):', 'gatherpress' ),
-							'type'    => 'number',
-							'size'    => 'small',
-							'options' => array(
-								'default' => Venue_Map::DEFAULT_HEIGHT,
+							'label'       => __( 'Height for new blocks (px):', 'gatherpress' ),
+							'type'        => 'number',
+							'size'        => 'small',
+							'placeholder' => __( 'Auto', 'gatherpress' ),
+							'allow_empty' => true,
+							'options'     => array(
+								'default' => '',
 								'min'     => '0',
-								'max'     => '800',
+								'max'     => '4000',
 							),
 						),
 					),
-					'venue_map_default_width'       => array(
+					'venue_map_default_width'            => array(
 						'labels'      => array(
 							'name' => __( 'Default Width', 'gatherpress' ),
 						),
 						'description' => __(
-							'Default pixel width applied to new venue map blocks. 0 = auto — width is derived from height and the aspect ratio.',
+							'Default pixel width for new venue map blocks. Leave empty for auto.',
 							'gatherpress'
 						),
 						'field'       => array(
-							'label'   => __( 'Width for new blocks (px):', 'gatherpress' ),
-							'type'    => 'number',
-							'size'    => 'small',
-							'options' => array(
-								'default' => 0,
+							'label'       => __( 'Width for new blocks (px):', 'gatherpress' ),
+							'type'        => 'number',
+							'size'        => 'small',
+							'placeholder' => __( 'Auto', 'gatherpress' ),
+							'allow_empty' => true,
+							'options'     => array(
+								'default' => '',
 								'min'     => '0',
-								'max'     => '1600',
+								'max'     => '4000',
 							),
 						),
 					),
-					'venue_map_default_aspect_ratio' => array(
+					'venue_map_default_aspect_ratio'     => array(
 						'labels'      => array(
 							'name' => __( 'Default Aspect Ratio', 'gatherpress' ),
 						),
@@ -225,7 +229,7 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_link_target' => array(
+					'venue_map_default_link_target'      => array(
 						'labels'      => array(
 							'name' => __( 'Open Links in New Tab', 'gatherpress' ),
 						),
@@ -241,7 +245,7 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_type'        => array(
+					'venue_map_default_type'             => array(
 						'labels'      => array(
 							'name' => __( 'Default Map Type', 'gatherpress' ),
 						),

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -148,7 +148,7 @@ class Venues extends Base {
 							'name' => __( 'Default Height', 'gatherpress' ),
 						),
 						'description' => __(
-							'Default pixel height applied to new venue map blocks.',
+							'Default pixel height applied to new venue map blocks. 0 = auto — height is derived from width and the aspect ratio.',
 							'gatherpress'
 						),
 						'field'       => array(
@@ -157,8 +157,87 @@ class Venues extends Base {
 							'size'    => 'small',
 							'options' => array(
 								'default' => Venue_Map::DEFAULT_HEIGHT,
-								'min'     => '100',
+								'min'     => '0',
 								'max'     => '800',
+							),
+						),
+					),
+					'venue_map_default_width'       => array(
+						'labels'      => array(
+							'name' => __( 'Default Width', 'gatherpress' ),
+						),
+						'description' => __(
+							'Default pixel width applied to new venue map blocks. 0 = auto — width is derived from height and the aspect ratio.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Width for new blocks (px):', 'gatherpress' ),
+							'type'    => 'number',
+							'size'    => 'small',
+							'options' => array(
+								'default' => 0,
+								'min'     => '0',
+								'max'     => '1600',
+							),
+						),
+					),
+					'venue_map_default_aspect_ratio' => array(
+						'labels'      => array(
+							'name' => __( 'Default Aspect Ratio', 'gatherpress' ),
+						),
+						'description' => __(
+							'Default aspect ratio for new venue map blocks. Used to derive any auto width or height dimension.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Aspect ratio for new blocks:', 'gatherpress' ),
+							'type'    => 'select',
+							'options' => array(
+								'default' => Venue_Map::DEFAULT_ASPECT_RATIO,
+								'items'   => array(
+									'2/1'  => __( '2:1 (landscape)', 'gatherpress' ),
+									'16/9' => __( '16:9 (wide)', 'gatherpress' ),
+									'3/2'  => __( '3:2 (classic)', 'gatherpress' ),
+									'4/3'  => __( '4:3 (standard)', 'gatherpress' ),
+									'1/1'  => __( '1:1 (square)', 'gatherpress' ),
+								),
+							),
+						),
+					),
+					'venue_map_default_link_destination' => array(
+						'labels'      => array(
+							'name' => __( 'Default Link Destination', 'gatherpress' ),
+						),
+						'description' => __(
+							'Default link wrapped around static maps. Only applies to static mode; interactive maps own their pan-and-zoom interaction.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Link new static maps to:', 'gatherpress' ),
+							'type'    => 'select',
+							'options' => array(
+								'default' => 'none',
+								'items'   => array(
+									'none'          => __( 'None', 'gatherpress' ),
+									'openstreetmap' => __( 'OpenStreetMap', 'gatherpress' ),
+									'google'        => __( 'Google Maps', 'gatherpress' ),
+								),
+							),
+						),
+					),
+					'venue_map_default_link_target' => array(
+						'labels'      => array(
+							'name' => __( 'Open Links in New Tab', 'gatherpress' ),
+						),
+						'description' => __(
+							'When enabled, the default static-map link opens in a new browser tab.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Open in new tab by default.', 'gatherpress' ),
+							'type'    => 'checkbox',
+							'options' => array(
+								'default' => false,
 							),
 						),
 					),

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -84,7 +84,7 @@ class Venues extends Base {
 					'gatherpress'
 				),
 				'options'     => array(
-					'map_platform'                       => array(
+					'map_platform'                   => array(
 						'labels'      => array(
 							'name' => __( 'Mapping Platform', 'gatherpress' ),
 						),
@@ -104,7 +104,7 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_render_mode'      => array(
+					'venue_map_default_render_mode'  => array(
 						'labels'      => array(
 							'name' => __( 'Default Render Mode', 'gatherpress' ),
 						),
@@ -124,7 +124,7 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_zoom'             => array(
+					'venue_map_default_zoom'         => array(
 						'labels'      => array(
 							'name' => __( 'Default Zoom Level', 'gatherpress' ),
 						),
@@ -143,7 +143,7 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_height'           => array(
+					'venue_map_default_height'       => array(
 						'labels'      => array(
 							'name' => __( 'Default Height', 'gatherpress' ),
 						),
@@ -164,7 +164,7 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_width'            => array(
+					'venue_map_default_width'        => array(
 						'labels'      => array(
 							'name' => __( 'Default Width', 'gatherpress' ),
 						),
@@ -185,7 +185,7 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_aspect_ratio'     => array(
+					'venue_map_default_aspect_ratio' => array(
 						'labels'      => array(
 							'name' => __( 'Default Aspect Ratio', 'gatherpress' ),
 						),
@@ -208,44 +208,7 @@ class Venues extends Base {
 							),
 						),
 					),
-					'venue_map_default_link_destination' => array(
-						'labels'      => array(
-							'name' => __( 'Default Link Destination', 'gatherpress' ),
-						),
-						'description' => __(
-							'Default link wrapped around static maps. Only applies to static mode.',
-							'gatherpress'
-						),
-						'field'       => array(
-							'label'   => __( 'Link new static maps to:', 'gatherpress' ),
-							'type'    => 'select',
-							'options' => array(
-								'default' => 'none',
-								'items'   => array(
-									'none'          => __( 'None', 'gatherpress' ),
-									'openstreetmap' => __( 'OpenStreetMap', 'gatherpress' ),
-									'google'        => __( 'Google Maps', 'gatherpress' ),
-								),
-							),
-						),
-					),
-					'venue_map_default_link_target'      => array(
-						'labels'      => array(
-							'name' => __( 'Open Links in New Tab', 'gatherpress' ),
-						),
-						'description' => __(
-							'When enabled, the default static-map link opens in a new browser tab.',
-							'gatherpress'
-						),
-						'field'       => array(
-							'label'   => __( 'Open in new tab by default.', 'gatherpress' ),
-							'type'    => 'checkbox',
-							'options' => array(
-								'default' => false,
-							),
-						),
-					),
-					'venue_map_default_type'             => array(
+					'venue_map_default_type'         => array(
 						'labels'      => array(
 							'name' => __( 'Default Map Type', 'gatherpress' ),
 						),

--- a/includes/templates/admin/settings/fields/number.php
+++ b/includes/templates/admin/settings/fields/number.php
@@ -15,7 +15,7 @@
  * @param string $description An optional description for the input field.
  * @param string $size        The size class for styling (e.g., 'regular', 'large', or 'small').
  * @param string $placeholder Optional placeholder shown when the input is empty.
- * @param bool   $allow_empty When true, render a stored zero as empty so the placeholder can surface.
+ * @param bool   $allow_empty When true, accept empty as a valid submitted value alongside numeric input.
  */
 
 // Exit if accessed directly.
@@ -25,18 +25,15 @@ if ( ! isset( $name, $label, $option, $value, $description, $size, $min, $max ) 
 	return;
 }
 
-$placeholder = $placeholder ?? '';
-$allow_empty = $allow_empty ?? false;
-
-// Treat a stored 0 as "empty" when allow_empty is on. Legacy option rows
-// still have 0 written from before the field accepted empty as a value, so
-// this normalization lets the placeholder surface immediately.
-$display_value = ( $allow_empty && '' !== $value && 0 === (int) $value ) ? '' : $value;
+// When allow_empty is on, the field accepts both empty and 0 as saveable
+// values — both render literally. The flag is preserved so downstream
+// code can distinguish "numeric-only" inputs from "optional numeric" ones.
+$gatherpress_placeholder = $placeholder ?? '';
 
 ?>
 <div class="form-wrap">
 	<label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label>
-	<input id="<?php echo esc_attr( $option ); ?>" type="number" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $display_value ); ?>" min="<?php echo esc_attr( $min ); ?>" max="<?php echo esc_attr( $max ); ?>"<?php echo '' !== $placeholder ? ' placeholder="' . esc_attr( $placeholder ) . '"' : ''; ?> />
+	<input id="<?php echo esc_attr( $option ); ?>" type="number" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $value ); ?>" min="<?php echo esc_attr( $min ); ?>" max="<?php echo esc_attr( $max ); ?>"<?php echo '' !== $gatherpress_placeholder ? ' placeholder="' . esc_attr( $gatherpress_placeholder ) . '"' : ''; ?> />
 	<?php
 	if ( ! empty( $description ) ) {
 		?>

--- a/includes/templates/admin/settings/fields/number.php
+++ b/includes/templates/admin/settings/fields/number.php
@@ -14,6 +14,8 @@
  * @param int    $value       The current value for the input field.
  * @param string $description An optional description for the input field.
  * @param string $size        The size class for styling (e.g., 'regular', 'large', or 'small').
+ * @param string $placeholder Optional placeholder shown when the input is empty.
+ * @param bool   $allow_empty When true, render a stored zero as empty so the placeholder can surface.
  */
 
 // Exit if accessed directly.
@@ -23,10 +25,18 @@ if ( ! isset( $name, $label, $option, $value, $description, $size, $min, $max ) 
 	return;
 }
 
+$placeholder = $placeholder ?? '';
+$allow_empty = $allow_empty ?? false;
+
+// Treat a stored 0 as "empty" when allow_empty is on. Legacy option rows
+// still have 0 written from before the field accepted empty as a value, so
+// this normalization lets the placeholder surface immediately.
+$display_value = ( $allow_empty && '' !== $value && 0 === (int) $value ) ? '' : $value;
+
 ?>
 <div class="form-wrap">
 	<label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label>
-	<input id="<?php echo esc_attr( $option ); ?>" type="number" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $value ); ?>" min="<?php echo esc_attr( $min ); ?>" max="<?php echo esc_attr( $max ); ?>" />
+	<input id="<?php echo esc_attr( $option ); ?>" type="number" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $display_value ); ?>" min="<?php echo esc_attr( $min ); ?>" max="<?php echo esc_attr( $max ); ?>"<?php echo '' !== $placeholder ? ' placeholder="' . esc_attr( $placeholder ) . '"' : ''; ?> />
 	<?php
 	if ( ! empty( $description ) ) {
 		?>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -35,7 +35,7 @@
 	</rule>
 	<rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
 		<properties>
-			<property name="maximum" value="110"/>
+			<property name="maximum" value="150"/>
 		</properties>
 	</rule>
 	<rule ref="rulesets/codesize.xml/NPathComplexity">
@@ -45,7 +45,7 @@
 	</rule>
 	<rule ref="rulesets/codesize.xml/ExcessiveClassLength">
 		<properties>
-			<property name="minimum" value="1500"/>
+			<property name="minimum" value="2000"/>
 		</properties>
 	</rule>
 	<rule ref="rulesets/cleancode.xml">

--- a/src/blocks/venue-map/block.json
+++ b/src/blocks/venue-map/block.json
@@ -22,9 +22,33 @@
 			"type": "number",
 			"default": 300
 		},
+		"width": {
+			"type": "number",
+			"default": 0
+		},
+		"aspectRatio": {
+			"type": "string",
+			"default": "2/1"
+		},
 		"renderMode": {
 			"type": "string",
 			"default": "interactive"
+		},
+		"href": {
+			"type": "string",
+			"default": ""
+		},
+		"linkDestination": {
+			"type": "string",
+			"default": "none"
+		},
+		"linkTarget": {
+			"type": "string",
+			"default": ""
+		},
+		"rel": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/src/blocks/venue-map/block.json
+++ b/src/blocks/venue-map/block.json
@@ -28,7 +28,7 @@
 		}
 	},
 	"supports": {
-		"align": ["wide", "full"],
+		"align": ["left", "center", "right", "wide", "full"],
 		"html": false
 	},
 	"textdomain": "gatherpress",

--- a/src/blocks/venue-map/block.json
+++ b/src/blocks/venue-map/block.json
@@ -53,7 +53,28 @@
 	},
 	"supports": {
 		"align": ["left", "center", "right", "wide", "full"],
-		"html": false
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
+		"shadow": true
 	},
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js",

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -19,6 +19,8 @@ import {
 	ToggleControl,
 	ToolbarButton,
 	ToolbarGroup,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -51,11 +53,11 @@ const DEFAULT_HEIGHT = 300;
 // server-side `Venue_Map::DEFAULT_ASPECT_RATIO` (2/1) so freshly inserted
 // blocks keep the behavior that shipped in the first round of static maps.
 const ASPECT_RATIO_PRESETS = [
-	{ label: __( '2:1 (landscape)', 'gatherpress' ), value: '2/1' },
-	{ label: __( '16:9 (wide)', 'gatherpress' ), value: '16/9' },
-	{ label: __( '3:2 (classic)', 'gatherpress' ), value: '3/2' },
-	{ label: __( '4:3 (standard)', 'gatherpress' ), value: '4/3' },
-	{ label: __( '1:1 (square)', 'gatherpress' ), value: '1/1' },
+	{ label: __( 'Landscape - 2:1', 'gatherpress' ), value: '2/1' },
+	{ label: __( 'Wide - 16:9', 'gatherpress' ), value: '16/9' },
+	{ label: __( 'Classic - 3:2', 'gatherpress' ), value: '3/2' },
+	{ label: __( 'Standard - 4:3', 'gatherpress' ), value: '4/3' },
+	{ label: __( 'Square - 1:1', 'gatherpress' ), value: '1/1' },
 	{ label: __( 'Custom', 'gatherpress' ), value: 'custom' },
 ];
 
@@ -520,7 +522,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Map settings', 'gatherpress' ) }>
+				<PanelBody>
 					<SelectControl
 						label={ __( 'Render mode', 'gatherpress' ) }
 						value={ renderMode }
@@ -574,6 +576,31 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 							}
 						/>
 					) }
+					{ isStaticMode && showStaticImage && 0 < venuePostId && (
+						<RegenerateMapButton
+							venuePostId={ venuePostId }
+							venuePostType={ venuePostType }
+							zoom={ zoom }
+							width={ width }
+							height={ height }
+							aspectRatio={ aspectRatio }
+							disabled={
+								! fullAddress || hasUnsavedMapInputs
+							}
+						/>
+					) }
+				</PanelBody>
+			</InspectorControls>
+			<InspectorControls group="dimensions">
+				<ToolsPanelItem
+					label={ __( 'Width & height', 'gatherpress' ) }
+					hasValue={ () => 0 < width || 0 < height }
+					onDeselect={ () =>
+						setAttributes( { width: 0, height: 0 } )
+					}
+					isShownByDefault
+					panelId={ clientId }
+				>
 					<Flex gap={ 2 } align="flex-end">
 						<FlexItem isBlock>
 							<TextControl
@@ -594,11 +621,22 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 							/>
 						</FlexItem>
 					</Flex>
+				</ToolsPanelItem>
+				<ToolsPanelItem
+					label={ __( 'Aspect ratio', 'gatherpress' ) }
+					hasValue={ () =>
+						'' !== ( aspectRatio ?? '' ) &&
+						'2/1' !== aspectRatio
+					}
+					onDeselect={ () =>
+						setAttributes( { aspectRatio: '2/1' } )
+					}
+					isShownByDefault
+					panelId={ clientId }
+				>
 					<SelectControl
 						label={ __( 'Aspect ratio', 'gatherpress' ) }
-						value={
-							isCustomAspectRatio ? 'custom' : aspectRatio
-						}
+						value={ isCustomAspectRatio ? 'custom' : aspectRatio }
 						options={ ASPECT_RATIO_PRESETS }
 						onChange={ ( value ) => {
 							if ( 'custom' === value ) {
@@ -634,20 +672,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 							}
 						/>
 					) }
-					{ isStaticMode && showStaticImage && 0 < venuePostId && (
-						<RegenerateMapButton
-							venuePostId={ venuePostId }
-							venuePostType={ venuePostType }
-							zoom={ zoom }
-							width={ width }
-							height={ height }
-							aspectRatio={ aspectRatio }
-							disabled={
-								! fullAddress || hasUnsavedMapInputs
-							}
-						/>
-					) }
-				</PanelBody>
+				</ToolsPanelItem>
 			</InspectorControls>
 			{ isStaticMode && (
 				<BlockControls>

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -16,6 +16,7 @@ import { useSelect } from '@wordpress/data';
 import { isVenuePostType } from '../../helpers/venue';
 import { getFromSettings } from '../../helpers/editor-settings';
 import MapEmbed from '../../components/MapEmbed';
+import RegenerateMapButton from './regenerate-button';
 
 /**
  * Edit component for the Venue Map block.
@@ -42,6 +43,8 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 		venueInfoJson,
 		savedVenueInfoJson,
 		staticMapDescriptors,
+		venuePostId,
+		venuePostType,
 	} = useSelect(
 		( select ) => {
 			const currentPostId = select( 'core/editor' )?.getCurrentPostId();
@@ -53,12 +56,23 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				contextPostId ||
 				( isVenuePostType() ? currentPostId : 0 );
 
+			// The venue's post type: prefer the BlockContext value when the
+			// block is rendered inside a venue parent (event editing), and
+			// fall back to the current post's type when the venue itself is
+			// being edited.
+			const resolvedVenuePostType =
+				context?.postType ||
+				select( 'core/editor' )?.getCurrentPostType() ||
+				'';
+
 			if ( ! effectiveVenuePostId ) {
 				return {
 					isEditingThisVenue: false,
 					venueInfoJson: '{}',
 					savedVenueInfoJson: '{}',
 					staticMapDescriptors: {},
+					venuePostId: 0,
+					venuePostType: '',
 				};
 			}
 
@@ -79,6 +93,8 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 						savedPost?.meta?.gatherpress_venue_information || '{}',
 					staticMapDescriptors:
 						meta?.gatherpress_venue_static_map || {},
+					venuePostId: effectiveVenuePostId,
+					venuePostType: resolvedVenuePostType,
 				};
 			}
 
@@ -101,6 +117,8 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				savedVenueInfoJson: venueInfo,
 				staticMapDescriptors:
 					venuePost?.meta?.gatherpress_venue_static_map || {},
+				venuePostId: effectiveVenuePostId,
+				venuePostType: context?.postType || '',
 			};
 		},
 		[ context?.postId, context?.postType ]
@@ -245,6 +263,17 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 						min={ 100 }
 						max={ 800 }
 					/>
+					{ isStaticMode && showStaticImage && 0 < venuePostId && (
+						<RegenerateMapButton
+							venuePostId={ venuePostId }
+							venuePostType={ venuePostType }
+							zoom={ zoom }
+							height={ height }
+							disabled={
+								! fullAddress || hasUnsavedMapInputs
+							}
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
@@ -269,9 +298,39 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 							style={ { height: `${ height }px` } }
 						>
 							<div className="gatherpress-venue-map__placeholder">
-								{ __(
-									'Static map preview appears after venue is saved.',
-									'gatherpress'
+								{ ! fullAddress &&
+									__(
+										'Add an address to generate the map.',
+										'gatherpress'
+									) }
+								{ fullAddress &&
+									hasUnsavedMapInputs &&
+									__(
+										'Save the venue first.',
+										'gatherpress'
+									) }
+								{ fullAddress &&
+									! hasUnsavedMapInputs &&
+									0 < venuePostId && (
+									<>
+										<span>
+											{ __(
+												'Ready to generate the map.',
+												'gatherpress'
+											) }
+										</span>
+										<RegenerateMapButton
+											venuePostId={ venuePostId }
+											venuePostType={ venuePostType }
+											zoom={ zoom }
+											height={ height }
+											label={ __(
+												'Generate map',
+												'gatherpress'
+											) }
+											variant="primary"
+										/>
+									</>
 								) }
 							</div>
 						</div>

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -22,12 +22,13 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { link as linkIcon } from '@wordpress/icons';
+import { Icon, link as linkIcon, mapMarker } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
  */
 import { isVenuePostType } from '../../helpers/venue';
+import { isInFSETemplate } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
 import MapEmbed from '../../components/MapEmbed';
 import {
@@ -451,7 +452,15 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 					style={ wrapperStyle }
 				>
 					<div className="gatherpress-venue-map__placeholder">
+						{ ! fullAddress && isInFSETemplate() && (
+							<Icon
+								icon={ mapMarker }
+								size={ 48 }
+								className="gatherpress-venue-map__placeholder-icon"
+							/>
+						) }
 						{ ! fullAddress &&
+							! isInFSETemplate() &&
 							__(
 								'Add an address to generate the map.',
 								'gatherpress'

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -2,13 +2,27 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
+	BlockControls,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import {
+	Dropdown,
+	Flex,
+	FlexItem,
 	PanelBody,
 	RangeControl,
+	ResizableBox,
 	SelectControl,
+	TextControl,
+	ToggleControl,
+	ToolbarButton,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { link as linkIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -16,7 +30,61 @@ import { useSelect } from '@wordpress/data';
 import { isVenuePostType } from '../../helpers/venue';
 import { getFromSettings } from '../../helpers/editor-settings';
 import MapEmbed from '../../components/MapEmbed';
-import RegenerateMapButton from './regenerate-button';
+import {
+	useSharedBlockGuardState,
+	generateBlockGuardStateKey,
+} from '../../supports/block-guard';
+import {
+	RegenerateMapButton,
+	parseAspectRatio,
+	resolveDimensions,
+} from './helpers';
+
+const WIDTH_MIN = 100;
+const WIDTH_MAX = 4000;
+const HEIGHT_MIN = 100;
+const HEIGHT_MAX = 4000;
+const DEFAULT_HEIGHT = 300;
+
+// Presets for the aspect-ratio dropdown. The first entry matches the
+// server-side `Venue_Map::DEFAULT_ASPECT_RATIO` (2/1) so freshly inserted
+// blocks keep the behavior that shipped in the first round of static maps.
+const ASPECT_RATIO_PRESETS = [
+	{ label: __( '2:1 (landscape)', 'gatherpress' ), value: '2/1' },
+	{ label: __( '16:9 (wide)', 'gatherpress' ), value: '16/9' },
+	{ label: __( '3:2 (classic)', 'gatherpress' ), value: '3/2' },
+	{ label: __( '4:3 (standard)', 'gatherpress' ), value: '4/3' },
+	{ label: __( '1:1 (square)', 'gatherpress' ), value: '1/1' },
+	{ label: __( 'Custom', 'gatherpress' ), value: 'custom' },
+];
+
+const LINK_DESTINATION_NONE = 'none';
+const LINK_DESTINATION_OPENSTREETMAP = 'openstreetmap';
+const LINK_DESTINATION_GOOGLE = 'google';
+const LINK_DESTINATION_CUSTOM = 'custom';
+
+/**
+ * Build the canonical external-map URL for a preset destination.
+ *
+ * @param {string} destination One of the LINK_DESTINATION_* constants.
+ * @param {string} latitude    Venue latitude.
+ * @param {string} longitude   Venue longitude.
+ * @param {number} zoom        Desired zoom level.
+ * @return {string} Computed href, or '' when the preset doesn't apply.
+ */
+const buildExternalMapUrl = ( destination, latitude, longitude, zoom ) => {
+	if ( ! latitude || ! longitude ) {
+		return '';
+	}
+	switch ( destination ) {
+		case LINK_DESTINATION_OPENSTREETMAP:
+			return `https://www.openstreetmap.org/?mlat=${ latitude }&mlon=${ longitude }#map=${ zoom }/${ latitude }/${ longitude }`;
+		case LINK_DESTINATION_GOOGLE:
+			return `https://www.google.com/maps/?q=${ latitude },${ longitude }&z=${ zoom }`;
+		default:
+			return '';
+	}
+};
 
 /**
  * Edit component for the Venue Map block.
@@ -26,12 +94,25 @@ import RegenerateMapButton from './regenerate-button';
  * @param {Object}   props               - Component properties.
  * @param {Object}   props.attributes    - Block attributes.
  * @param {Function} props.setAttributes - Function to set block attributes.
+ * @param {string}   props.clientId      - The block's runtime client ID (used to find the parent venue block's guard state).
  * @param {Object}   props.context       - Block context.
  *
  * @return {JSX.Element} The rendered React component.
  */
-const Edit = ( { attributes, setAttributes, context } ) => {
-	const { zoom, type, height, renderMode } = attributes;
+const Edit = ( { attributes, setAttributes, context, clientId } ) => {
+	const {
+		zoom,
+		type,
+		width,
+		height,
+		aspectRatio,
+		renderMode,
+		align,
+		href,
+		linkDestination,
+		linkTarget,
+		rel,
+	} = attributes;
 	const blockProps = useBlockProps();
 
 	// Determine the venue post ID and get venue info + static-map descriptors.
@@ -50,16 +131,10 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 			const currentPostId = select( 'core/editor' )?.getCurrentPostId();
 			const contextPostId = context?.postId || 0;
 
-			// If we're editing a venue post directly and context doesn't provide a valid ID,
-			// use the current post ID.
 			const effectiveVenuePostId =
 				contextPostId ||
 				( isVenuePostType() ? currentPostId : 0 );
 
-			// The venue's post type: prefer the BlockContext value when the
-			// block is rendered inside a venue parent (event editing), and
-			// fall back to the current post's type when the venue itself is
-			// being edited.
 			const resolvedVenuePostType =
 				context?.postType ||
 				select( 'core/editor' )?.getCurrentPostType() ||
@@ -77,30 +152,37 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 			}
 
 			const isEditing =
-				currentPostId === effectiveVenuePostId &&
-				isVenuePostType();
+				currentPostId === effectiveVenuePostId && isVenuePostType();
 
 			if ( isEditing ) {
-				// Read from core/editor store for the current post being edited.
 				const meta =
 					select( 'core/editor' )?.getEditedPostAttribute( 'meta' ) || {};
 				const savedPost =
 					select( 'core/editor' )?.getCurrentPost() || {};
+				// Prefer the `core` entity cache for the descriptors map —
+				// `regenerate` patches that cache directly via
+				// receiveEntityRecords, but `core/editor`'s in-memory copy of
+				// currentPost is seeded from server on load and never syncs
+				// back, so reading it here would show stale URLs.
+				const editedVenuePost = select( 'core' ).getEditedEntityRecord(
+					'postType',
+					resolvedVenuePostType,
+					effectiveVenuePostId
+				);
 				return {
 					isEditingThisVenue: true,
 					venueInfoJson: meta?.gatherpress_venue_information || '{}',
 					savedVenueInfoJson:
 						savedPost?.meta?.gatherpress_venue_information || '{}',
 					staticMapDescriptors:
-						meta?.gatherpress_venue_static_map || {},
+						editedVenuePost?.meta?.gatherpress_venue_static_map ||
+						meta?.gatherpress_venue_static_map ||
+						{},
 					venuePostId: effectiveVenuePostId,
 					venuePostType: resolvedVenuePostType,
 				};
 			}
 
-			// Read from core store for a different venue post.
-			// Use context?.postType (the venue post type from BlockContextProvider),
-			// not currentPostType (the event post type), to avoid requesting the wrong endpoint.
 			const { getEditedEntityRecord } = select( 'core' );
 			const venuePost = getEditedEntityRecord(
 				'postType',
@@ -124,8 +206,6 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 		[ context?.postId, context?.postType ]
 	);
 
-	// For live preview when editing the venue, read lat/long from venue store.
-	// The venue store is updated in real-time by VenueInformation.js.
 	const { storeLat, storeLng } = useSelect(
 		( select ) => ( {
 			storeLat: select( 'gatherpress/venue' ).getVenueLatitude(),
@@ -144,36 +224,41 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 
 	const fullAddress = venueInfo.fullAddress || '';
 
-	// Use venue store values for live preview when editing this venue.
-	// The store is kept in sync with meta by VenueInformation.js.
-	// When editing, the store is updated in real-time by geocoding.
 	let latitude = venueInfo.latitude || '';
 	let longitude = venueInfo.longitude || '';
 
 	if ( isEditingThisVenue ) {
-		// When editing the venue, always use store values for live preview.
-		latitude = null !== storeLat && storeLat !== undefined ? String( storeLat ) : latitude;
-		longitude = null !== storeLng && storeLng !== undefined ? String( storeLng ) : longitude;
+		latitude =
+			null !== storeLat && storeLat !== undefined
+				? String( storeLat )
+				: latitude;
+		longitude =
+			null !== storeLng && storeLng !== undefined
+				? String( storeLng )
+				: longitude;
 	}
 
-	// Map type is a Google Maps–only concept; only expose the selector when
-	// the map platform is Google and we're rendering interactively on the
-	// front-end. The OSM/Leaflet and static-image paths both ignore it.
+	const mapPlatform = getFromSettings( 'mapPlatform' );
 	const showMapTypeControl =
-		'interactive' === renderMode &&
-		'google' === getFromSettings( 'mapPlatform' );
+		'interactive' === renderMode && 'google' === mapPlatform;
 
-	// When the block is in static mode we show one of two previews in place of
-	// the interactive MapEmbed: (a) the actual cached PNG for this venue's
-	// (zoom, height) combo if it's been generated, or (b) a placeholder
-	// noting that the image will be generated on the next save. The
-	// interactive MapEmbed only renders when the user explicitly picked
-	// Interactive.
-	//
-	// While the venue is being edited we compare the edited address/coords
-	// against the last-saved snapshot so the cached PNG doesn't linger as a
-	// stale preview after the user types a new address — the placeholder
-	// takes over until the next save regenerates the image.
+	// Link destination options track the site's mapping platform: on an
+	// OSM-powered site we only offer the OpenStreetMap preset (and vice
+	// versa). Mixing an "open in Google Maps" link into a Leaflet/OSM
+	// install would be confusing — users would expect whatever service
+	// the rest of the site uses.
+	const platformOption = 'google' === mapPlatform
+		? { label: __( 'Google Maps', 'gatherpress' ), value: LINK_DESTINATION_GOOGLE }
+		: { label: __( 'OpenStreetMap', 'gatherpress' ), value: LINK_DESTINATION_OPENSTREETMAP };
+	const linkDestinationOptions = [
+		{ label: __( 'None', 'gatherpress' ), value: LINK_DESTINATION_NONE },
+		platformOption,
+		{
+			label: __( 'Custom URL', 'gatherpress' ),
+			value: LINK_DESTINATION_CUSTOM,
+		},
+	];
+
 	let savedVenueInfo = {};
 	try {
 		savedVenueInfo = JSON.parse( savedVenueInfoJson );
@@ -189,13 +274,239 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 			( venueInfo.longitude || '' ) !==
 				( savedVenueInfo.longitude || '' ) );
 
-	const comboKey = `${ zoom }x${ height }`;
+	// Compute the effective pixel dimensions (matching what the server
+	// will compose) so the cached-PNG lookup hits the right combo key.
+	const { width: effectiveWidth, height: effectiveHeight } =
+		resolveDimensions( {
+			width,
+			height,
+			aspectRatio,
+			defaultHeight: DEFAULT_HEIGHT,
+		} );
+
+	const comboKey = `${ zoom }x${ effectiveWidth }x${ effectiveHeight }`;
 	const staticMapDescriptor = staticMapDescriptors?.[ comboKey ];
 	const staticMapUrl = staticMapDescriptor?.url || '';
 	const isStaticMode = 'static' === renderMode;
 	const showStaticImage =
 		isStaticMode && '' !== staticMapUrl && ! hasUnsavedMapInputs;
 	const showStaticPlaceholder = isStaticMode && ! showStaticImage;
+
+	const isCustomAspectRatio =
+		! ASPECT_RATIO_PRESETS.some(
+			( preset ) => preset.value === aspectRatio
+		) || 'custom' === aspectRatio;
+
+	// Find the nearest `gatherpress/venue` ancestor so we can subscribe to
+	// the exact guard state the block-guard HOC writes to (it's keyed per
+	// instance via generateBlockGuardStateKey, not by block name alone —
+	// subscribing to the bare name would miss every update).
+	const parentVenueClientId = useSelect(
+		( select ) => {
+			if ( ! clientId ) {
+				return '';
+			}
+			const { getBlockParentsByBlockName } = select( 'core/block-editor' );
+			const parents = getBlockParentsByBlockName(
+				clientId,
+				'gatherpress/venue'
+			);
+			if ( ! Array.isArray( parents ) || 0 === parents.length ) {
+				return '';
+			}
+			// getBlockParentsByBlockName returns root → self order, so the
+			// last entry is the closest ancestor.
+			return parents[ parents.length - 1 ];
+		},
+		[ clientId ]
+	);
+	const parentGuardKey = parentVenueClientId
+		? generateBlockGuardStateKey( 'gatherpress/venue', parentVenueClientId )
+		: 'gatherpress/venue';
+	const [ isParentGuarded ] = useSharedBlockGuardState( parentGuardKey );
+
+	// Model mirrors core/image:
+	//   - width + aspectRatio are the authoritative shape inputs
+	//   - height is derived at render time from width × ratio; stored as
+	//     0 (auto) while a preset ratio is active
+	//   - typing an explicit height clears aspectRatio, switching the
+	//     block to "custom" mode where width and height are independent
+	//   - dragging the grips adjusts width only unless the user already
+	//     dropped into custom mode
+	const handleWidthInput = ( raw ) => {
+		const parsed = parseInt( raw, 10 );
+		setAttributes( {
+			width: Number.isNaN( parsed ) ? 0 : parsed,
+		} );
+	};
+	const handleHeightInput = ( raw ) => {
+		const parsed = parseInt( raw, 10 );
+		setAttributes( {
+			height: Number.isNaN( parsed ) ? 0 : parsed,
+			aspectRatio: '',
+		} );
+	};
+
+	// Keep the href in sync with a preset link destination so toggling the
+	// dropdown doesn't leave a stale URL behind. We only auto-write when a
+	// preset is chosen; `custom` lets the user edit the field freely.
+	useEffect( () => {
+		if (
+			LINK_DESTINATION_OPENSTREETMAP === linkDestination ||
+			LINK_DESTINATION_GOOGLE === linkDestination
+		) {
+			const computed = buildExternalMapUrl(
+				linkDestination,
+				latitude,
+				longitude,
+				zoom
+			);
+			if ( computed && computed !== href ) {
+				setAttributes( { href: computed } );
+			}
+		} else if ( LINK_DESTINATION_NONE === linkDestination && href ) {
+			setAttributes( { href: '' } );
+		}
+		// linkTarget/rel intentionally excluded — users edit them directly.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ linkDestination, latitude, longitude, zoom ] );
+
+	// Resize-handle visibility follows block alignment. Left-aligned blocks
+	// anchor to the left (handles on right + bottom + bottom-right); right-
+	// aligned mirror that; wide/full let the container own the width.
+	const showRightHandle =
+		'right' !== align && 'wide' !== align && 'full' !== align;
+	const showLeftHandle = 'right' === align;
+	const showBottomHandle = 'wide' !== align && 'full' !== align;
+
+	const lockRatio = isCustomAspectRatio
+		? false
+		: parseAspectRatio( aspectRatio ) || false;
+
+	const onResizeStop = ( event, direction, elt, delta ) => {
+		// ResizableBox hands us the pixel delta from resize start; combine
+		// with the effective dimensions we rendered at to get the new value.
+		const newWidth = Math.max(
+			WIDTH_MIN,
+			Math.min( WIDTH_MAX, Math.round( effectiveWidth + delta.width ) )
+		);
+		const changes = { width: newWidth };
+
+		// In custom mode there's no ratio lock, so both edges moved
+		// independently and we persist both. In preset mode height stays
+		// auto so the cached aspect ratio keeps driving the render.
+		if ( isCustomAspectRatio ) {
+			changes.height = Math.max(
+				HEIGHT_MIN,
+				Math.min(
+					HEIGHT_MAX,
+					Math.round( effectiveHeight + delta.height )
+				)
+			);
+		}
+
+		setAttributes( changes );
+	};
+
+	// When the block is aligned wide or full, the alignment owns the
+	// horizontal space — skip the explicit pixel width so `.alignwide`
+	// / `.alignfull` can drive the layout. Height keeps its inline stamp;
+	// aspect-ratio applies whenever a dimension is auto OR the alignment
+	// is wide/full so the shape tracks the container as it fills.
+	const isWideOrFull = 'wide' === align || 'full' === align;
+	let wrapperWidth;
+	if ( ! isWideOrFull ) {
+		wrapperWidth = 0 < width ? `${ width }px` : '100%';
+	}
+	const wrapperStyle = {
+		width: wrapperWidth,
+		height: 0 < height ? `${ height }px` : undefined,
+		aspectRatio:
+			isWideOrFull || 0 === width || 0 === height
+				? aspectRatio || '2/1'
+				: undefined,
+	};
+
+	const previewContent = (
+		<>
+			{ showStaticImage && (
+				<div
+					className="gatherpress-venue-map gatherpress-venue-map--static"
+					style={ wrapperStyle }
+				>
+					<img
+						className="gatherpress-venue-map__image"
+						src={ staticMapUrl }
+						alt={
+							fullAddress
+								? `${ __( 'Map of', 'gatherpress' ) } ${ fullAddress }`
+								: __( 'Venue map', 'gatherpress' )
+						}
+					/>
+				</div>
+			) }
+			{ showStaticPlaceholder && (
+				<div
+					className="gatherpress-venue-map gatherpress-venue-map--static"
+					style={ wrapperStyle }
+				>
+					<div className="gatherpress-venue-map__placeholder">
+						{ ! fullAddress &&
+							__(
+								'Add an address to generate the map.',
+								'gatherpress'
+							) }
+						{ fullAddress &&
+							hasUnsavedMapInputs &&
+							__(
+								'Save the venue first.',
+								'gatherpress'
+							) }
+						{ fullAddress &&
+							! hasUnsavedMapInputs &&
+							0 < venuePostId && (
+							<>
+								<span>
+									{ __(
+										'Ready to generate the map.',
+										'gatherpress'
+									) }
+								</span>
+								<RegenerateMapButton
+									venuePostId={ venuePostId }
+									venuePostType={ venuePostType }
+									zoom={ zoom }
+									width={ width }
+									height={ height }
+									aspectRatio={ aspectRatio }
+									label={ __(
+										'Generate map',
+										'gatherpress'
+									) }
+									variant="primary"
+								/>
+							</>
+						) }
+					</div>
+				</div>
+			) }
+			{ ! isStaticMode && (
+				<div
+					className="gatherpress-venue-map gatherpress-venue-map--interactive"
+					style={ wrapperStyle }
+				>
+					<MapEmbed
+						location={ fullAddress }
+						latitude={ latitude }
+						longitude={ longitude }
+						zoom={ zoom }
+						type={ type }
+						height={ effectiveHeight }
+					/>
+				</div>
+			) }
+		</>
+	);
 
 	return (
 		<>
@@ -254,21 +565,74 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 							}
 						/>
 					) }
-					<RangeControl
-						label={ __( 'Height (px)', 'gatherpress' ) }
-						value={ height }
-						onChange={ ( value ) =>
-							setAttributes( { height: value } )
+					<Flex gap={ 2 } align="flex-end">
+						<FlexItem isBlock>
+							<TextControl
+								label={ __( 'Width', 'gatherpress' ) }
+								type="number"
+								placeholder={ __( 'Auto', 'gatherpress' ) }
+								value={ 0 < width ? String( width ) : '' }
+								onChange={ handleWidthInput }
+							/>
+						</FlexItem>
+						<FlexItem isBlock>
+							<TextControl
+								label={ __( 'Height', 'gatherpress' ) }
+								type="number"
+								placeholder={ __( 'Auto', 'gatherpress' ) }
+								value={ 0 < height ? String( height ) : '' }
+								onChange={ handleHeightInput }
+							/>
+						</FlexItem>
+					</Flex>
+					<SelectControl
+						label={ __( 'Aspect ratio', 'gatherpress' ) }
+						value={
+							isCustomAspectRatio ? 'custom' : aspectRatio
 						}
-						min={ 100 }
-						max={ 800 }
+						options={ ASPECT_RATIO_PRESETS }
+						onChange={ ( value ) => {
+							if ( 'custom' === value ) {
+								// Clear so the Custom text field below owns
+								// the value. If the user typed nothing, the
+								// server falls back to DEFAULT_ASPECT_RATIO
+								// for dimension derivation.
+								setAttributes( { aspectRatio: '' } );
+								return;
+							}
+							// Picking a preset resets height to auto so the
+							// new ratio drives the rendered shape — the
+							// user's stored width (if any) is preserved.
+							setAttributes( {
+								aspectRatio: value,
+								height: 0,
+							} );
+						} }
 					/>
+					{ isCustomAspectRatio && (
+						<TextControl
+							label={ __(
+								'Custom aspect ratio',
+								'gatherpress'
+							) }
+							help={ __(
+								'Format: "16/9" or "4:3".',
+								'gatherpress'
+							) }
+							value={ aspectRatio || '' }
+							onChange={ ( value ) =>
+								setAttributes( { aspectRatio: value } )
+							}
+						/>
+					) }
 					{ isStaticMode && showStaticImage && 0 < venuePostId && (
 						<RegenerateMapButton
 							venuePostId={ venuePostId }
 							venuePostType={ venuePostType }
 							zoom={ zoom }
+							width={ width }
 							height={ height }
+							aspectRatio={ aspectRatio }
 							disabled={
 								! fullAddress || hasUnsavedMapInputs
 							}
@@ -276,74 +640,139 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 					) }
 				</PanelBody>
 			</InspectorControls>
+			{ isStaticMode && (
+				<BlockControls>
+					<ToolbarGroup>
+						<Dropdown
+							popoverProps={ { placement: 'bottom-start' } }
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<ToolbarButton
+									icon={ linkIcon }
+									title={ __( 'Link', 'gatherpress' ) }
+									onClick={ onToggle }
+									aria-expanded={ isOpen }
+									isActive={
+										Boolean( href ) &&
+										LINK_DESTINATION_NONE !==
+											linkDestination
+									}
+								/>
+							) }
+							renderContent={ () => (
+								<div
+									style={ {
+										padding: '16px',
+										minWidth: '280px',
+									} }
+								>
+									<SelectControl
+										label={ __( 'Link to', 'gatherpress' ) }
+										value={
+											linkDestination ||
+											LINK_DESTINATION_NONE
+										}
+										options={ linkDestinationOptions }
+										onChange={ ( value ) =>
+											setAttributes( {
+												linkDestination: value,
+											} )
+										}
+									/>
+									{ LINK_DESTINATION_CUSTOM ===
+										linkDestination && (
+										<TextControl
+											label={ __(
+												'Link URL',
+												'gatherpress'
+											) }
+											value={ href || '' }
+											onChange={ ( value ) =>
+												setAttributes( {
+													href: value,
+												} )
+											}
+										/>
+									) }
+									{ LINK_DESTINATION_NONE !==
+										linkDestination &&
+										linkDestination && (
+										<>
+											<ToggleControl
+												label={ __(
+													'Open in new tab',
+													'gatherpress'
+												) }
+												checked={
+													'_blank' ===
+														linkTarget
+												}
+												onChange={ ( checked ) =>
+													setAttributes( {
+														linkTarget:
+																checked
+																	? '_blank'
+																	: '',
+													} )
+												}
+											/>
+											<TextControl
+												label={ __(
+													'Link rel',
+													'gatherpress'
+												) }
+												help={ __(
+													'Space-separated tokens, e.g. "nofollow sponsored". `noopener noreferrer` is added automatically when the link opens in a new tab.',
+													'gatherpress'
+												) }
+												value={ rel || '' }
+												onChange={ ( value ) =>
+													setAttributes( {
+														rel: value,
+													} )
+												}
+											/>
+										</>
+									) }
+								</div>
+							) }
+						/>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
 			<div { ...blockProps }>
 				<div className="block-editor-inner-blocks">
-					{ showStaticImage && (
-						<div
-							className="gatherpress-venue-map gatherpress-venue-map--static"
-							style={ { height: `${ height }px` } }
+					{ isParentGuarded ? (
+						previewContent
+					) : (
+						<ResizableBox
+							size={ {
+								width:
+									! isWideOrFull && 0 < width
+										? width
+										: 'auto',
+								height: 0 < height ? height : 'auto',
+							} }
+							minWidth={ WIDTH_MIN }
+							maxWidth={ WIDTH_MAX }
+							minHeight={ HEIGHT_MIN }
+							maxHeight={ HEIGHT_MAX }
+							lockAspectRatio={ lockRatio }
+							enable={ {
+								top: false,
+								right: showRightHandle,
+								bottom: showBottomHandle,
+								left: showLeftHandle,
+								topRight: false,
+								bottomRight:
+									showRightHandle && showBottomHandle,
+								bottomLeft:
+									showLeftHandle && showBottomHandle,
+								topLeft: false,
+							} }
+							onResizeStop={ onResizeStop }
 						>
-							<img
-								className="gatherpress-venue-map__image"
-								src={ staticMapUrl }
-								alt={ fullAddress
-									? `${ __( 'Map of', 'gatherpress' ) } ${ fullAddress }`
-									: __( 'Venue map', 'gatherpress' ) }
-							/>
-						</div>
-					) }
-					{ showStaticPlaceholder && (
-						<div
-							className="gatherpress-venue-map gatherpress-venue-map--static"
-							style={ { height: `${ height }px` } }
-						>
-							<div className="gatherpress-venue-map__placeholder">
-								{ ! fullAddress &&
-									__(
-										'Add an address to generate the map.',
-										'gatherpress'
-									) }
-								{ fullAddress &&
-									hasUnsavedMapInputs &&
-									__(
-										'Save the venue first.',
-										'gatherpress'
-									) }
-								{ fullAddress &&
-									! hasUnsavedMapInputs &&
-									0 < venuePostId && (
-									<>
-										<span>
-											{ __(
-												'Ready to generate the map.',
-												'gatherpress'
-											) }
-										</span>
-										<RegenerateMapButton
-											venuePostId={ venuePostId }
-											venuePostType={ venuePostType }
-											zoom={ zoom }
-											height={ height }
-											label={ __(
-												'Generate map',
-												'gatherpress'
-											) }
-											variant="primary"
-										/>
-									</>
-								) }
-							</div>
-						</div>
-					) }
-					{ ! isStaticMode && (
-						<MapEmbed
-							location={ fullAddress }
-							latitude={ latitude }
-							longitude={ longitude }
-							zoom={ zoom }
-							type={ type }
-							height={ height }
-						/>
+							{ previewContent }
+						</ResizableBox>
 					) }
 				</div>
 			</div>

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -50,20 +50,15 @@ export const RegenerateMapButton = ( {
 
 	// Non-reactive selector lookups — we only need the current record at
 	// the moment of the click to merge fresh meta into it, not on every
-	// render.
+	// render. handleClick already bails on missing venuePostId/venuePostType
+	// before invoking this, so the inner closure doesn't need to re-guard.
 	const getCurrentEntityRecord = useSelect(
-		( select ) => {
-			return () => {
-				if ( ! venuePostType || ! venuePostId ) {
-					return null;
-				}
-				return select( 'core' ).getEntityRecord(
-					'postType',
-					venuePostType,
-					venuePostId
-				);
-			};
-		},
+		( select ) => () =>
+			select( 'core' ).getEntityRecord(
+				'postType',
+				venuePostType,
+				venuePostId
+			),
 		[ venuePostType, venuePostId ]
 	);
 
@@ -149,7 +144,7 @@ export const RegenerateMapButton = ( {
  *
  * Mirrors the server-side `Venue_Map::parse_aspect_ratio()` so the editor
  * can derive auto dimensions from the ratio without a round-trip to PHP.
- * Returns null for unparseable input.
+ * Returns null for unparsable input.
  *
  * @since 1.0.0
  *

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -47,6 +47,7 @@ export const RegenerateMapButton = ( {
 	const [ isBusy, setIsBusy ] = useState( false );
 	const { receiveEntityRecords, invalidateResolution } =
 		useDispatch( 'core' );
+	const { createErrorNotice } = useDispatch( 'core/notices' );
 
 	// Non-reactive selector lookups — we only need the current record at
 	// the moment of the click to merge fresh meta into it, not on every
@@ -69,8 +70,9 @@ export const RegenerateMapButton = ( {
 
 		setIsBusy( true );
 
+		let response;
 		try {
-			const response = await apiFetch( {
+			response = await apiFetch( {
 				path: `/${ REST_NAMESPACE }/venue/${ venuePostId }/regenerate-map`,
 				method: 'POST',
 				data: {
@@ -83,6 +85,37 @@ export const RegenerateMapButton = ( {
 							: undefined,
 				},
 			} );
+		} catch ( error ) {
+			// Network / permission failure (403, 500, offline). Keep the
+			// cached descriptor intact so the preview doesn't flash blank,
+			// surface the failure as an admin notice, and re-enable the
+			// button so the user can retry.
+			createErrorNotice?.(
+				error?.message ||
+					__(
+						'Could not regenerate the map. Please try again.',
+						'gatherpress'
+					),
+				{ type: 'snackbar' }
+			);
+			setIsBusy( false );
+			return;
+		}
+
+		try {
+			// Server reached but every combo failed to render (disk / GD /
+			// tile host). Treat as an error: leave the cached descriptor
+			// intact and surface a notice.
+			if ( 'generation_failed' === response?.reason ) {
+				createErrorNotice?.(
+					__(
+						'The map server could not render the image. Check the tile provider and try again.',
+						'gatherpress'
+					),
+					{ type: 'snackbar' }
+				);
+				return;
+			}
 
 			if ( ! venuePostType ) {
 				return;

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -25,17 +25,21 @@ import { REST_NAMESPACE } from '../../helpers/namespace';
  * @param {number}  props.venuePostId   The venue post ID whose map to regenerate.
  * @param {string}  props.venuePostType The venue's post type slug (for the core store invalidation).
  * @param {number}  props.zoom          Current block zoom — passed through so the server renders this combo.
- * @param {number}  props.height        Current block height — passed through so the server renders this combo.
+ * @param {number}  [props.width]       Current block width (0 = auto) — forwarded to the server.
+ * @param {number}  [props.height]      Current block height (0 = auto) — forwarded to the server.
+ * @param {string}  [props.aspectRatio] Current block aspect ratio (e.g. "16/9") — forwarded so the server can derive any auto dimension consistently with the client.
  * @param {boolean} props.disabled      When true, the button is disabled regardless of internal state.
  * @param {string}  [props.label]       Override the default "Regenerate map" label.
  * @param {string}  [props.variant]     Underlying Button variant (e.g. 'primary', 'secondary', 'link').
  * @return {JSX.Element} The button.
  */
-const RegenerateMapButton = ( {
+export const RegenerateMapButton = ( {
 	venuePostId,
 	venuePostType,
 	zoom,
+	width,
 	height,
+	aspectRatio,
 	disabled = false,
 	label,
 	variant = 'secondary',
@@ -48,14 +52,18 @@ const RegenerateMapButton = ( {
 	// the moment of the click to merge fresh meta into it, not on every
 	// render.
 	const getCurrentEntityRecord = useSelect(
-		( select ) => () =>
-			venuePostType && venuePostId
-				? select( 'core' ).getEntityRecord(
-						'postType',
-						venuePostType,
-						venuePostId
-				  )
-				: null,
+		( select ) => {
+			return () => {
+				if ( ! venuePostType || ! venuePostId ) {
+					return null;
+				}
+				return select( 'core' ).getEntityRecord(
+					'postType',
+					venuePostType,
+					venuePostId
+				);
+			};
+		},
 		[ venuePostType, venuePostId ]
 	);
 
@@ -72,9 +80,12 @@ const RegenerateMapButton = ( {
 				method: 'POST',
 				data: {
 					zoom: Number.isInteger( zoom ) ? zoom : undefined,
-					height: Number.isInteger( height )
-						? height
-						: undefined,
+					width: Number.isInteger( width ) ? width : undefined,
+					height: Number.isInteger( height ) ? height : undefined,
+					aspect_ratio:
+						'string' === typeof aspectRatio && '' !== aspectRatio
+							? aspectRatio
+							: undefined,
 				},
 			} );
 
@@ -133,4 +144,74 @@ const RegenerateMapButton = ( {
 	);
 };
 
-export default RegenerateMapButton;
+/**
+ * Parse an aspect-ratio string (e.g. "16/9" or "4:3") into a float.
+ *
+ * Mirrors the server-side `Venue_Map::parse_aspect_ratio()` so the editor
+ * can derive auto dimensions from the ratio without a round-trip to PHP.
+ * Returns null for unparseable input.
+ *
+ * @since 1.0.0
+ *
+ * @param {string} ratio Raw aspect-ratio string.
+ * @return {number|null} Parsed ratio, or null if the input is invalid.
+ */
+export const parseAspectRatio = ( ratio ) => {
+	if ( 'string' !== typeof ratio ) {
+		return null;
+	}
+	const match = ratio.trim().match( /^(\d+)\s*[/:]\s*(\d+)$/ );
+	if ( ! match ) {
+		return null;
+	}
+	const numerator = parseInt( match[ 1 ], 10 );
+	const denominator = parseInt( match[ 2 ], 10 );
+	if ( 0 >= numerator || 0 >= denominator ) {
+		return null;
+	}
+	return numerator / denominator;
+};
+
+/**
+ * Resolve a (width, height) pair from block attribute values.
+ *
+ * Mirrors `Venue_Map::resolve_dimensions()` so the editor renders the map
+ * at the same effective pixel size the server will compose. Either
+ * dimension can be 0 ("auto") and will be derived from the other side and
+ * the aspect ratio. When both are auto, `DEFAULT_HEIGHT` seeds the math.
+ *
+ * @since 1.0.0
+ *
+ * @param {Object} args               Derivation inputs.
+ * @param {number} args.width         Raw width (0 = auto).
+ * @param {number} args.height        Raw height (0 = auto).
+ * @param {string} args.aspectRatio   Aspect-ratio string.
+ * @param {number} args.defaultHeight Fallback height for the both-auto case.
+ * @return {{width: number, height: number}} Concrete pixel dimensions.
+ */
+export const resolveDimensions = ( {
+	width,
+	height,
+	aspectRatio,
+	defaultHeight,
+} ) => {
+	const ratio = parseAspectRatio( aspectRatio ) ?? 2;
+	let w = Number.isInteger( width ) && 0 < width ? width : 0;
+	let h = Number.isInteger( height ) && 0 < height ? height : 0;
+
+	if ( 0 === w && 0 === h ) {
+		h = defaultHeight;
+		w = Math.round( h * ratio );
+	} else if ( 0 === w ) {
+		w = Math.round( h * ratio );
+	} else if ( 0 === h ) {
+		h = Math.round( w / ratio );
+	}
+
+	// Mirror the server's clamp_width / clamp_height so the editor's cache
+	// key matches the key the server stored the descriptor under.
+	w = Math.max( 100, Math.min( 4000, w ) );
+	h = Math.max( 100, Math.min( 4000, h ) );
+
+	return { width: w, height: h };
+};

--- a/src/blocks/venue-map/regenerate-button.js
+++ b/src/blocks/venue-map/regenerate-button.js
@@ -1,0 +1,136 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { Button, Spinner } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import { REST_NAMESPACE } from '../../helpers/namespace';
+
+/**
+ * Regenerate / Generate button for the venue-map block.
+ *
+ * Drives POST /{namespace}/venue/{id}/regenerate-map and refreshes the
+ * venue's cached entity record so the editor preview picks up the fresh
+ * static-map descriptors without a page reload.
+ *
+ * @since 1.0.0
+ *
+ * @param {Object}  props               Component props.
+ * @param {number}  props.venuePostId   The venue post ID whose map to regenerate.
+ * @param {string}  props.venuePostType The venue's post type slug (for the core store invalidation).
+ * @param {number}  props.zoom          Current block zoom — passed through so the server renders this combo.
+ * @param {number}  props.height        Current block height — passed through so the server renders this combo.
+ * @param {boolean} props.disabled      When true, the button is disabled regardless of internal state.
+ * @param {string}  [props.label]       Override the default "Regenerate map" label.
+ * @param {string}  [props.variant]     Underlying Button variant (e.g. 'primary', 'secondary', 'link').
+ * @return {JSX.Element} The button.
+ */
+const RegenerateMapButton = ( {
+	venuePostId,
+	venuePostType,
+	zoom,
+	height,
+	disabled = false,
+	label,
+	variant = 'secondary',
+} ) => {
+	const [ isBusy, setIsBusy ] = useState( false );
+	const { receiveEntityRecords, invalidateResolution } =
+		useDispatch( 'core' );
+
+	// Non-reactive selector lookups — we only need the current record at
+	// the moment of the click to merge fresh meta into it, not on every
+	// render.
+	const getCurrentEntityRecord = useSelect(
+		( select ) => () =>
+			venuePostType && venuePostId
+				? select( 'core' ).getEntityRecord(
+						'postType',
+						venuePostType,
+						venuePostId
+				  )
+				: null,
+		[ venuePostType, venuePostId ]
+	);
+
+	const handleClick = async () => {
+		if ( ! venuePostId || isBusy ) {
+			return;
+		}
+
+		setIsBusy( true );
+
+		try {
+			const response = await apiFetch( {
+				path: `/${ REST_NAMESPACE }/venue/${ venuePostId }/regenerate-map`,
+				method: 'POST',
+				data: {
+					zoom: Number.isInteger( zoom ) ? zoom : undefined,
+					height: Number.isInteger( height )
+						? height
+						: undefined,
+				},
+			} );
+
+			if ( ! venuePostType ) {
+				return;
+			}
+
+			// Patch the fresh descriptors straight into the `core` store
+			// cache. Both core.getEntityRecord and
+			// core/editor.getEditedPostAttribute read through this entity
+			// record, so the block preview picks up the new PNG URL on the
+			// next render without waiting for a separate refetch. The
+			// trailing invalidateResolution is belt-and-suspenders for
+			// anyone subscribed to the resolution state itself.
+			const current = getCurrentEntityRecord();
+
+			if ( current ) {
+				receiveEntityRecords(
+					'postType',
+					venuePostType,
+					[
+						{
+							...current,
+							meta: {
+								...( current.meta || {} ),
+								gatherpress_venue_static_map:
+									response?.descriptors || {},
+							},
+						},
+					],
+					undefined,
+					false
+				);
+			}
+
+			invalidateResolution( 'getEntityRecord', [
+				'postType',
+				venuePostType,
+				venuePostId,
+			] );
+		} finally {
+			setIsBusy( false );
+		}
+	};
+
+	return (
+		<Button
+			variant={ variant }
+			onClick={ handleClick }
+			disabled={ disabled || isBusy }
+			aria-busy={ isBusy }
+		>
+			{ isBusy && <Spinner /> }
+			{ label || __( 'Regenerate map', 'gatherpress' ) }
+		</Button>
+	);
+};
+
+export default RegenerateMapButton;

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -74,17 +74,17 @@ $gatherpress_wrapper_attr_args = array(
 );
 
 // Sizing rules:
-//   - Explicit height → inline height in px.
-//   - Explicit width  → inline width in px (but NOT when the block is
-//     aligned wide or full — then the alignment owns the horizontal space
-//     via the `.alignwide` / `.alignfull` CSS rules, and a hard pixel
-//     width would fight those classes).
-//   - Any auto dimension → CSS `aspect-ratio` stamp so the container can
-//     still give the block its shape as its surrounding width changes
-//     (aligned block, responsive container, etc.). Static <img> inside
-//     uses object-fit: cover so the raster stays crisp at any size.
-$gatherpress_styles = array();
-$gatherpress_align  = (string) ( $attributes['align'] ?? '' );
+// - Explicit height → inline height in px.
+// - Explicit width  → inline width in px (but NOT when the block is
+// aligned wide or full — then the alignment owns the horizontal space
+// via the `.alignwide` / `.alignfull` CSS rules, and a hard pixel
+// width would fight those classes).
+// - Any auto dimension → CSS `aspect-ratio` stamp so the container can
+// still give the block its shape as its surrounding width changes
+// (aligned block, responsive container, etc.). Static <img> inside
+// uses object-fit: cover so the raster stays crisp at any size.
+$gatherpress_styles          = array();
+$gatherpress_align           = (string) ( $attributes['align'] ?? '' );
 $gatherpress_is_wide_or_full = in_array( $gatherpress_align, array( 'wide', 'full' ), true );
 
 if ( 0 < $gatherpress_raw_height ) {

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -9,6 +9,19 @@
  * new venue that hasn't been geocoded — a short placeholder surfaces the
  * "map coming soon" state in place of the image.
  *
+ * The wrapper sizing is driven by three block attributes:
+ *
+ *   - `width` / `height`: explicit pixel dimensions. Either can be `0`
+ *     meaning "auto" — in which case it's derived from the other side and
+ *     `aspectRatio`. When both are auto, the block fills its container
+ *     width and computes height from the ratio (CSS aspect-ratio on the
+ *     interactive wrapper; the static PNG is composed at the effective
+ *     pixel size).
+ *   - `aspectRatio`: CSS-style string (e.g. "16/9"). Drives auto-
+ *     dimension math on the server and also lands as a CSS
+ *     `aspect-ratio` hint on the wrapper so an aligned block that
+ *     shrinks stays at the right shape.
+ *
  * @package GatherPress\Core
  * @since 1.0.0
  */
@@ -35,16 +48,21 @@ if ( '' === $gatherpress_address ) {
 	return;
 }
 
-$gatherpress_render_mode    = 'static' === ( $attributes['renderMode'] ?? Venue_Map::DEFAULT_RENDER_MODE )
+$gatherpress_render_mode = 'static' === ( $attributes['renderMode'] ?? Venue_Map::DEFAULT_RENDER_MODE )
 	? 'static'
 	: 'interactive';
-$gatherpress_zoom           = (int) ( $attributes['zoom'] ?? Venue_Map::DEFAULT_ZOOM );
-$gatherpress_height         = (int) ( $attributes['height'] ?? Venue_Map::DEFAULT_HEIGHT );
+$gatherpress_zoom        = (int) ( $attributes['zoom'] ?? Venue_Map::DEFAULT_ZOOM );
+$gatherpress_raw_width   = (int) ( $attributes['width'] ?? 0 );
+$gatherpress_raw_height  = (int) ( $attributes['height'] ?? Venue_Map::DEFAULT_HEIGHT );
+$gatherpress_ratio       = (string) ( $attributes['aspectRatio'] ?? Venue_Map::DEFAULT_ASPECT_RATIO );
+
 $gatherpress_static_map_url = Venue_Map::get_instance()->get_url_for_post(
 	$gatherpress_post_id,
 	$gatherpress_post_type,
 	$gatherpress_zoom,
-	$gatherpress_height
+	$gatherpress_raw_width,
+	$gatherpress_raw_height,
+	$gatherpress_ratio
 );
 
 // Hydration data sits on the outer wrapper so view.js can replace the
@@ -53,11 +71,40 @@ $gatherpress_static_map_url = Venue_Map::get_instance()->get_url_for_post(
 $gatherpress_wrapper_attr_args = array(
 	'class'            => sprintf( 'gatherpress-venue-map gatherpress-venue-map--%s', $gatherpress_render_mode ),
 	'data-render-mode' => $gatherpress_render_mode,
-	// Apply the block-level height to the wrapper so the static <img> (with
-	// object-fit: cover) fills it, and so the interactive Leaflet container
-	// gets the exact same footprint after hydration.
-	'style'            => sprintf( 'height:%dpx;', $gatherpress_height ),
 );
+
+// Sizing rules:
+//   - Explicit height → inline height in px.
+//   - Explicit width  → inline width in px (but NOT when the block is
+//     aligned wide or full — then the alignment owns the horizontal space
+//     via the `.alignwide` / `.alignfull` CSS rules, and a hard pixel
+//     width would fight those classes).
+//   - Any auto dimension → CSS `aspect-ratio` stamp so the container can
+//     still give the block its shape as its surrounding width changes
+//     (aligned block, responsive container, etc.). Static <img> inside
+//     uses object-fit: cover so the raster stays crisp at any size.
+$gatherpress_styles = array();
+$gatherpress_align  = (string) ( $attributes['align'] ?? '' );
+$gatherpress_is_wide_or_full = in_array( $gatherpress_align, array( 'wide', 'full' ), true );
+
+if ( 0 < $gatherpress_raw_height ) {
+	$gatherpress_styles[] = sprintf( 'height:%dpx', $gatherpress_raw_height );
+}
+
+if ( 0 < $gatherpress_raw_width && ! $gatherpress_is_wide_or_full ) {
+	$gatherpress_styles[] = sprintf( 'width:%dpx', $gatherpress_raw_width );
+}
+
+if ( 0 === $gatherpress_raw_width || 0 === $gatherpress_raw_height || $gatherpress_is_wide_or_full ) {
+	$gatherpress_styles[] = sprintf(
+		'aspect-ratio:%s',
+		'' !== $gatherpress_ratio ? $gatherpress_ratio : Venue_Map::DEFAULT_ASPECT_RATIO
+	);
+}
+
+if ( ! empty( $gatherpress_styles ) ) {
+	$gatherpress_wrapper_attr_args['style'] = implode( ';', $gatherpress_styles ) . ';';
+}
 
 if ( 'interactive' === $gatherpress_render_mode ) {
 	$gatherpress_block_attrs = array(
@@ -84,13 +131,41 @@ printf(
 
 if ( '' !== $gatherpress_static_map_url ) {
 	/* translators: %s: full address of the venue. */
-	$gatherpress_alt = sprintf( __( 'Map of %s', 'gatherpress' ), $gatherpress_address );
+	$gatherpress_alt    = sprintf( __( 'Map of %s', 'gatherpress' ), $gatherpress_address );
+	$gatherpress_href   = (string) ( $attributes['href'] ?? '' );
+	$gatherpress_target = (string) ( $attributes['linkTarget'] ?? '' );
+	$gatherpress_rel    = (string) ( $attributes['rel'] ?? '' );
+
+	if ( '_blank' === $gatherpress_target ) {
+		// Auto-append the safety `noopener noreferrer` tokens so a user
+		// only has to think about semantic rel values (nofollow, sponsored).
+		$gatherpress_existing_rel = preg_split( '/\s+/', trim( $gatherpress_rel ), -1, PREG_SPLIT_NO_EMPTY );
+		foreach ( array( 'noopener', 'noreferrer' ) as $gatherpress_safety_token ) {
+			if ( ! in_array( $gatherpress_safety_token, $gatherpress_existing_rel, true ) ) {
+				$gatherpress_existing_rel[] = $gatherpress_safety_token;
+			}
+		}
+		$gatherpress_rel = implode( ' ', $gatherpress_existing_rel );
+	}
+
+	if ( '' !== $gatherpress_href ) {
+		printf(
+			'<a href="%s"%s%s>',
+			esc_url( $gatherpress_href ),
+			'_blank' === $gatherpress_target ? ' target="_blank"' : '',
+			'' !== $gatherpress_rel ? sprintf( ' rel="%s"', esc_attr( $gatherpress_rel ) ) : ''
+		);
+	}
 
 	printf(
 		'<img class="gatherpress-venue-map__image" src="%s" alt="%s" loading="lazy" />',
 		esc_url( $gatherpress_static_map_url ),
 		esc_attr( $gatherpress_alt )
 	);
+
+	if ( '' !== $gatherpress_href ) {
+		echo '</a>';
+	}
 
 	// CartoDB + OpenStreetMap attribution is required whenever the static
 	// image is on display. Leaflet ships its own attribution control, so when

--- a/src/blocks/venue-map/style.scss
+++ b/src/blocks/venue-map/style.scss
@@ -20,6 +20,16 @@
 	position: relative;
 	overflow: hidden;
 
+	// Inherit the wrapper's border-radius (the `border` block support
+	// stamps radius onto the block wrapper) so inner elements — static
+	// <img>, Leaflet container, placeholder — get clipped to the same
+	// rounded corners instead of poking out square-edged.
+	&__image,
+	&__placeholder,
+	.leaflet-container {
+		border-radius: inherit;
+	}
+
 	&__image {
 		display: block;
 		width: 100%;
@@ -41,6 +51,13 @@
 		border: 1px dashed #ccc;
 		color: #666;
 		box-sizing: border-box;
+	}
+
+	// Soften the map-marker icon surfaced inside the FSE template
+	// placeholder — the default SVG fills with black, which is heavier
+	// than the #666 placeholder text next to it.
+	&__placeholder-icon {
+		fill: #b0b0b0;
 	}
 
 	// CartoDB/OSM attribution — mirrors the bottom-right placement Leaflet

--- a/src/blocks/venue-map/style.scss
+++ b/src/blocks/venue-map/style.scss
@@ -8,52 +8,17 @@
 		position: relative;
 		z-index: 0;
 	}
-
-	&__placeholder {
-		padding: 2rem;
-		text-align: center;
-		background: #f0f0f0;
-		border: 1px dashed #ccc;
-		color: #666;
-
-		p {
-			margin: 0;
-		}
-	}
 }
 
 .gatherpress-venue-map {
-	// The wrapper owns the block-level height (set inline by render.php); the
-	// static <img> fills that box via object-fit: cover so the image stays
-	// crisp and cropped rather than stretched when the block's aspect ratio
-	// differs from the 600×400 generator default.
+	// When the block has an explicit pixel width and height, render.php
+	// stamps those as inline styles. When either side is "auto", an inline
+	// `aspect-ratio` CSS property takes over so the wrapper keeps its
+	// shape as its container shrinks (floated/aligned contexts, responsive
+	// layouts). The static <img> inside uses object-fit: cover so the
+	// raster stays crisp at any size.
 	position: relative;
 	overflow: hidden;
-
-	// Alignment support — applies identically to static and interactive
-	// modes because both render inside this same wrapper element. `wide`
-	// and `full` are width hints theme CSS handles (via
-	// .alignwide / .alignfull). Floated modes need an explicit cap so
-	// the map doesn't take the full row, and centered mode needs a cap
-	// for `margin: auto` to have room to work. `50%` is a default — the
-	// theme is free to override.
-	&.alignleft {
-		float: left;
-		max-width: 50%;
-		margin: 0 1em 1em 0;
-	}
-
-	&.alignright {
-		float: right;
-		max-width: 50%;
-		margin: 0 0 1em 1em;
-	}
-
-	&.aligncenter {
-		max-width: 75%;
-		margin-left: auto;
-		margin-right: auto;
-	}
 
 	&__image {
 		display: block;

--- a/src/blocks/venue-map/style.scss
+++ b/src/blocks/venue-map/style.scss
@@ -30,6 +30,31 @@
 	position: relative;
 	overflow: hidden;
 
+	// Alignment support — applies identically to static and interactive
+	// modes because both render inside this same wrapper element. `wide`
+	// and `full` are width hints theme CSS handles (via
+	// .alignwide / .alignfull). Floated modes need an explicit cap so
+	// the map doesn't take the full row, and centered mode needs a cap
+	// for `margin: auto` to have room to work. `50%` is a default — the
+	// theme is free to override.
+	&.alignleft {
+		float: left;
+		max-width: 50%;
+		margin: 0 1em 1em 0;
+	}
+
+	&.alignright {
+		float: right;
+		max-width: 50%;
+		margin: 0 0 1em 1em;
+	}
+
+	&.aligncenter {
+		max-width: 75%;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
 	&__image {
 		display: block;
 		width: 100%;
@@ -39,6 +64,8 @@
 
 	&__placeholder {
 		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
 		width: 100%;
 		height: 100%;
 		align-items: center;

--- a/src/blocks/venue/block.json
+++ b/src/blocks/venue/block.json
@@ -26,6 +26,11 @@
 		"html": false,
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"layout": {
+			"default": {
+				"type": "constrained"
+			}
 		}
 	},
 	"textdomain": "gatherpress",

--- a/src/blocks/venue/block.json
+++ b/src/blocks/venue/block.json
@@ -22,14 +22,16 @@
 			"blockGuard": true,
 			"postIdOverride": true
 		},
-		"align": [ "wide" ],
+		"align": [ "wide", "full" ],
 		"html": false,
 		"interactivity": {
 			"clientNavigation": true
 		},
 		"layout": {
 			"default": {
-				"type": "constrained"
+				"type": "constrained",
+				"wideSize": "1200px",
+				"contentSize": "820px"
 			}
 		}
 	},

--- a/src/blocks/venue/block.json
+++ b/src/blocks/venue/block.json
@@ -29,9 +29,7 @@
 		},
 		"layout": {
 			"default": {
-				"type": "constrained",
-				"wideSize": "1200px",
-				"contentSize": "820px"
+				"type": "constrained"
 			}
 		}
 	},

--- a/src/components/OpenStreetMap.js
+++ b/src/components/OpenStreetMap.js
@@ -23,12 +23,12 @@ import { getFromConfig } from '../helpers/editor-settings';
  *
  * @since 1.0.0
  *
- * @param {Object} props              - Component properties.
- * @param {string} props.location     - The location to be displayed on the map.
- * @param {string} props.latitude     - The latitude of the location to be displayed on the map.
- * @param {string} props.longitude    - The longitude of the location to be displayed on the map.
- * @param {number} [props.zoom=10]    - The zoom level of the map.
- * @param {string} [props.className]  - Additional CSS class names for styling.
+ * @param {Object} props             - Component properties.
+ * @param {string} props.location    - The location to be displayed on the map.
+ * @param {string} props.latitude    - The latitude of the location to be displayed on the map.
+ * @param {string} props.longitude   - The longitude of the location to be displayed on the map.
+ * @param {number} [props.zoom=10]   - The zoom level of the map.
+ * @param {string} [props.className] - Additional CSS class names for styling.
  *
  * @return {JSX.Element} The rendered React component.
  */

--- a/src/components/OpenStreetMap.js
+++ b/src/components/OpenStreetMap.js
@@ -28,7 +28,6 @@ import { getFromConfig } from '../helpers/editor-settings';
  * @param {string} props.latitude     - The latitude of the location to be displayed on the map.
  * @param {string} props.longitude    - The longitude of the location to be displayed on the map.
  * @param {number} [props.zoom=10]    - The zoom level of the map.
- * @param {number} [props.height=300] - The height of the map container.
  * @param {string} [props.className]  - Additional CSS class names for styling.
  *
  * @return {JSX.Element} The rendered React component.
@@ -38,7 +37,6 @@ const OpenStreetMap = ( props ) => {
 		zoom = 10,
 		className,
 		location,
-		height = 300,
 		latitude,
 		longitude,
 		pluginUrl,
@@ -47,7 +45,11 @@ const OpenStreetMap = ( props ) => {
 	const mapId = `map-${ uuidv4() }`;
 	const mapRef = useRef( null );
 	const mapInstanceRef = useRef( null );
-	const style = { height };
+	// Fill the parent — the venue-map wrapper sizes itself via CSS
+	// aspect-ratio / inline width+height, and the Leaflet container must
+	// match so marker placement stays centered on the visible viewport
+	// rather than the inner container's own (larger) center.
+	const style = { width: '100%', height: '100%' };
 	const isPostEditor = Boolean( select( 'core/edit-post' ) );
 
 	useEffect( () => {
@@ -142,9 +144,50 @@ const OpenStreetMap = ( props ) => {
 			attribution: tileAttribution,
 		} ).addTo( map );
 
-		Leaflet.marker( [ latitude, longitude ] ).addTo( map ).bindPopup( location );
+		// Center the marker icon on the coord (both axes) so the pin's
+		// visual center matches the map center — mirrors the static map's
+		// centered dot. Leaflet's default anchor is the pin tip, which
+		// leaves the body floating above center.
+		const centeredIcon = new Leaflet.Icon.Default( {
+			iconAnchor: [ 12, 20 ],
+			popupAnchor: [ 0, -20 ],
+			shadowAnchor: [ 12, 20 ],
+		} );
+		Leaflet.marker( [ latitude, longitude ], { icon: centeredIcon } )
+			.addTo( map )
+			.bindPopup( location );
+
+		// Leaflet reads the container's size at init time. When the wrapper
+		// relies on CSS aspect-ratio (height derived from container width)
+		// that size can be stale by the time the map mounts, so the
+		// computed center drifts. invalidateSize() tells Leaflet to re-read
+		// the container and re-center — once after the next frame for the
+		// initial layout, and again whenever the container's box changes.
+		requestAnimationFrame( () => {
+			if ( mapInstanceRef.current ) {
+				mapInstanceRef.current.invalidateSize();
+				mapInstanceRef.current.setView( [ latitude, longitude ], zoom );
+			}
+		} );
+
+		let resizeObserver = null;
+		if ( 'undefined' !== typeof ResizeObserver ) {
+			resizeObserver = new ResizeObserver( () => {
+				if ( mapInstanceRef.current ) {
+					mapInstanceRef.current.invalidateSize();
+					mapInstanceRef.current.setView(
+						[ latitude, longitude ],
+						zoom
+					);
+				}
+			} );
+			resizeObserver.observe( mapRef.current );
+		}
 
 		return () => {
+			if ( resizeObserver ) {
+				resizeObserver.disconnect();
+			}
 			if ( mapInstanceRef.current ) {
 				mapInstanceRef.current.remove();
 				mapInstanceRef.current = null;

--- a/src/supports/block-guard.js
+++ b/src/supports/block-guard.js
@@ -6,7 +6,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { addFilter } from '@wordpress/hooks';
+import { addFilter, hasFilter } from '@wordpress/hooks';
 import { useState, useEffect } from '@wordpress/element';
 
 /**
@@ -570,7 +570,15 @@ const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
  *
  * @see https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/
  */
-addFilter( 'editor.BlockEdit', 'gatherpress/with-block-guard', withBlockGuard );
+// This module is imported both as a side-effect from `src/editor.js` and as
+// named exports from block edits (e.g. venue-map), so it lands in multiple
+// webpack chunks that all evaluate on the editor page. WP's addFilter doesn't
+// dedupe by namespace — every evaluation would otherwise append a second
+// handler and render duplicate Block Guard toggles. hasFilter returns the
+// handler's priority when registered, `false` when absent.
+if ( false === hasFilter( 'editor.BlockEdit', 'gatherpress/with-block-guard' ) ) {
+	addFilter( 'editor.BlockEdit', 'gatherpress/with-block-guard', withBlockGuard );
+}
 
 // Export functions for testing.
 export {

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -232,7 +232,7 @@ describe( 'parseAspectRatio', () => {
 	it( 'accepts the colon form "4:3"', () => {
 		expect( parseAspectRatio( '4:3' ) ).toBeCloseTo( 4 / 3, 4 );
 	} );
-	it( 'returns null for unparseable input', () => {
+	it( 'returns null for unparsable input', () => {
 		expect( parseAspectRatio( 'nonsense' ) ).toBeNull();
 		expect( parseAspectRatio( '' ) ).toBeNull();
 		expect( parseAspectRatio( null ) ).toBeNull();
@@ -286,7 +286,7 @@ describe( 'resolveDimensions', () => {
 			} )
 		).toEqual( { width: 600, height: 300 } );
 	} );
-	it( 'falls back to a 2:1 ratio when the aspect string is unparseable', () => {
+	it( 'falls back to a 2:1 ratio when the aspect string is unparsable', () => {
 		expect(
 			resolveDimensions( {
 				...defaults,

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -44,7 +44,11 @@ jest.mock( '@wordpress/components', () => ( {
 /**
  * Internal dependencies.
  */
-import RegenerateMapButton from '@src/blocks/venue-map/regenerate-button';
+import {
+	RegenerateMapButton,
+	parseAspectRatio,
+	resolveDimensions,
+} from '@src/blocks/venue-map/helpers';
 
 describe( 'RegenerateMapButton', () => {
 	const defaultProps = {
@@ -98,12 +102,14 @@ describe( 'RegenerateMapButton', () => {
 		} );
 	} );
 
-	it( 'forwards current zoom/height in the POST body so the server renders this combo', async () => {
+	it( 'forwards current zoom/width/height/aspect_ratio in the POST body so the server renders this combo', async () => {
 		render(
 			<RegenerateMapButton
 				{ ...defaultProps }
 				zoom={ 8 }
+				width={ 0 }
 				height={ 295 }
+				aspectRatio="16/9"
 			/>
 		);
 		fireEvent.click( screen.getByRole( 'button' ) );
@@ -111,7 +117,12 @@ describe( 'RegenerateMapButton', () => {
 		await waitFor( () => {
 			expect( mockApiFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					data: { zoom: 8, height: 295 },
+					data: {
+						zoom: 8,
+						width: 0,
+						height: 295,
+						aspect_ratio: '16/9',
+					},
 				} )
 			);
 		} );
@@ -211,5 +222,78 @@ describe( 'RegenerateMapButton', () => {
 		await waitFor( () => {
 			expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
 		} );
+	} );
+} );
+
+describe( 'parseAspectRatio', () => {
+	it( 'parses the slash form "16/9" into a float', () => {
+		expect( parseAspectRatio( '16/9' ) ).toBeCloseTo( 16 / 9, 4 );
+	} );
+	it( 'accepts the colon form "4:3"', () => {
+		expect( parseAspectRatio( '4:3' ) ).toBeCloseTo( 4 / 3, 4 );
+	} );
+	it( 'returns null for unparseable input', () => {
+		expect( parseAspectRatio( 'nonsense' ) ).toBeNull();
+		expect( parseAspectRatio( '' ) ).toBeNull();
+		expect( parseAspectRatio( null ) ).toBeNull();
+	} );
+	it( 'returns null when either side is zero', () => {
+		expect( parseAspectRatio( '0/1' ) ).toBeNull();
+		expect( parseAspectRatio( '4/0' ) ).toBeNull();
+	} );
+} );
+
+describe( 'resolveDimensions', () => {
+	const defaults = { defaultHeight: 300 };
+
+	it( 'returns both sides unchanged when both are explicit', () => {
+		expect(
+			resolveDimensions( {
+				...defaults,
+				width: 800,
+				height: 400,
+				aspectRatio: '2/1',
+			} )
+		).toEqual( { width: 800, height: 400 } );
+	} );
+	it( 'derives width from height × ratio when width is auto', () => {
+		expect(
+			resolveDimensions( {
+				...defaults,
+				width: 0,
+				height: 400,
+				aspectRatio: '2/1',
+			} )
+		).toEqual( { width: 800, height: 400 } );
+	} );
+	it( 'derives height from width ÷ ratio when height is auto', () => {
+		expect(
+			resolveDimensions( {
+				...defaults,
+				width: 900,
+				height: 0,
+				aspectRatio: '3/2',
+			} )
+		).toEqual( { width: 900, height: 600 } );
+	} );
+	it( 'seeds from defaultHeight when both sides are auto', () => {
+		expect(
+			resolveDimensions( {
+				...defaults,
+				width: 0,
+				height: 0,
+				aspectRatio: '2/1',
+			} )
+		).toEqual( { width: 600, height: 300 } );
+	} );
+	it( 'falls back to a 2:1 ratio when the aspect string is unparseable', () => {
+		expect(
+			resolveDimensions( {
+				...defaults,
+				width: 0,
+				height: 400,
+				aspectRatio: 'garbage',
+			} )
+		).toEqual( { width: 800, height: 400 } );
 	} );
 } );

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -11,6 +11,7 @@ import '@testing-library/jest-dom';
 const mockApiFetch = jest.fn();
 const mockInvalidateResolution = jest.fn();
 const mockReceiveEntityRecords = jest.fn();
+const mockCreateErrorNotice = jest.fn();
 let mockCurrentEntityRecord;
 
 jest.mock( '@wordpress/api-fetch', () => ( {
@@ -19,10 +20,15 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {
-	useDispatch: () => ( {
-		invalidateResolution: mockInvalidateResolution,
-		receiveEntityRecords: mockReceiveEntityRecords,
-	} ),
+	useDispatch: ( store ) => {
+		if ( 'core/notices' === store ) {
+			return { createErrorNotice: mockCreateErrorNotice };
+		}
+		return {
+			invalidateResolution: mockInvalidateResolution,
+			receiveEntityRecords: mockReceiveEntityRecords,
+		};
+	},
 	useSelect: ( callback ) =>
 		callback( () => ( {
 			getEntityRecord: () => mockCurrentEntityRecord,
@@ -60,6 +66,7 @@ describe( 'RegenerateMapButton', () => {
 		mockApiFetch.mockReset();
 		mockInvalidateResolution.mockReset();
 		mockReceiveEntityRecords.mockReset();
+		mockCreateErrorNotice.mockReset();
 		mockApiFetch.mockResolvedValue( { descriptors: {}, reason: '' } );
 		mockCurrentEntityRecord = {
 			id: 42,
@@ -222,6 +229,48 @@ describe( 'RegenerateMapButton', () => {
 		await waitFor( () => {
 			expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
 		} );
+	} );
+
+	it( 'surfaces an error notice and re-enables the button when apiFetch rejects', async () => {
+		mockApiFetch.mockRejectedValueOnce( new Error( 'Network down' ) );
+
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		const button = screen.getByRole( 'button' );
+		fireEvent.click( button );
+
+		await waitFor( () => {
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				'Network down',
+				{ type: 'snackbar' }
+			);
+		} );
+
+		// Cached descriptor preserved — the store patch must not fire on failure.
+		expect( mockReceiveEntityRecords ).not.toHaveBeenCalled();
+		expect( mockInvalidateResolution ).not.toHaveBeenCalled();
+		// Button is no longer busy — next click can retry.
+		expect( button ).not.toBeDisabled();
+	} );
+
+	it( 'surfaces an error notice when the server reports generation_failed', async () => {
+		mockApiFetch.mockResolvedValueOnce( {
+			descriptors: {},
+			reason: 'generation_failed',
+		} );
+
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				expect.stringContaining( 'could not render' ),
+				{ type: 'snackbar' }
+			);
+		} );
+
+		// Don't overwrite the cached descriptor with an empty map.
+		expect( mockReceiveEntityRecords ).not.toHaveBeenCalled();
+		expect( mockInvalidateResolution ).not.toHaveBeenCalled();
 	} );
 } );
 

--- a/test/unit/js/src/blocks/venue-map/regenerate-button.test.js
+++ b/test/unit/js/src/blocks/venue-map/regenerate-button.test.js
@@ -1,0 +1,215 @@
+/**
+ * External dependencies.
+ */
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * Mocks — declared before the component import so jest hoists them.
+ */
+const mockApiFetch = jest.fn();
+const mockInvalidateResolution = jest.fn();
+const mockReceiveEntityRecords = jest.fn();
+let mockCurrentEntityRecord;
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( args ) => mockApiFetch( args ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		invalidateResolution: mockInvalidateResolution,
+		receiveEntityRecords: mockReceiveEntityRecords,
+	} ),
+	useSelect: ( callback ) =>
+		callback( () => ( {
+			getEntityRecord: () => mockCurrentEntityRecord,
+		} ) ),
+} ) );
+
+// Lightweight stand-ins for the two @wordpress/components primitives this
+// component uses. Importing the real package pulls in @wordpress/rich-text
+// which needs a full @wordpress/data runtime wired up, which we don't.
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, ...props } ) => (
+		<button type="button" { ...props }>
+			{ children }
+		</button>
+	),
+	Spinner: () => <span data-testid="spinner" />,
+} ) );
+
+/**
+ * Internal dependencies.
+ */
+import RegenerateMapButton from '@src/blocks/venue-map/regenerate-button';
+
+describe( 'RegenerateMapButton', () => {
+	const defaultProps = {
+		venuePostId: 42,
+		venuePostType: 'gatherpress_venue',
+	};
+
+	beforeEach( () => {
+		mockApiFetch.mockReset();
+		mockInvalidateResolution.mockReset();
+		mockReceiveEntityRecords.mockReset();
+		mockApiFetch.mockResolvedValue( { descriptors: {}, reason: '' } );
+		mockCurrentEntityRecord = {
+			id: 42,
+			meta: { gatherpress_venue_information: '{}' },
+		};
+	} );
+
+	it( 'renders the default "Regenerate map" label', () => {
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		expect(
+			screen.getByRole( 'button', { name: /regenerate map/i } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders a custom label when provided', () => {
+		render(
+			<RegenerateMapButton { ...defaultProps } label="Generate map" />
+		);
+		expect(
+			screen.getByRole( 'button', { name: /generate map/i } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'is disabled when the disabled prop is true', () => {
+		render( <RegenerateMapButton { ...defaultProps } disabled /> );
+		expect( screen.getByRole( 'button' ) ).toBeDisabled();
+	} );
+
+	it( 'POSTs to the correct REST path on click', async () => {
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: '/gatherpress/v1/venue/42/regenerate-map',
+					method: 'POST',
+				} )
+			);
+		} );
+	} );
+
+	it( 'forwards current zoom/height in the POST body so the server renders this combo', async () => {
+		render(
+			<RegenerateMapButton
+				{ ...defaultProps }
+				zoom={ 8 }
+				height={ 295 }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					data: { zoom: 8, height: 295 },
+				} )
+			);
+		} );
+	} );
+
+	it( 'invalidates the core entity record on success so the editor re-reads meta', async () => {
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockInvalidateResolution ).toHaveBeenCalledWith(
+				'getEntityRecord',
+				[ 'postType', 'gatherpress_venue', 42 ]
+			);
+		} );
+	} );
+
+	it( 'patches fresh descriptors into the core store cache', async () => {
+		mockApiFetch.mockResolvedValueOnce( {
+			descriptors: {
+				'18x300': {
+					url: 'https://example.test/42-abc.png',
+					hash: 'abc',
+					zoom: 18,
+					height: 300,
+				},
+			},
+			reason: '',
+		} );
+
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockReceiveEntityRecords ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		const [ kind, name, records ] =
+			mockReceiveEntityRecords.mock.calls[ 0 ];
+		expect( kind ).toBe( 'postType' );
+		expect( name ).toBe( 'gatherpress_venue' );
+		expect( records[ 0 ].id ).toBe( 42 );
+		expect(
+			records[ 0 ].meta.gatherpress_venue_static_map[ '18x300' ].url
+		).toBe( 'https://example.test/42-abc.png' );
+		// Existing meta fields must be preserved.
+		expect( records[ 0 ].meta.gatherpress_venue_information ).toBe( '{}' );
+	} );
+
+	it( 'skips the store patch when no cached record exists yet', async () => {
+		mockCurrentEntityRecord = null;
+
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockApiFetch ).toHaveBeenCalled();
+		} );
+
+		expect( mockReceiveEntityRecords ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not call the REST endpoint when venuePostId is missing', () => {
+		render( <RegenerateMapButton venuePostId={ 0 } venuePostType="" /> );
+		fireEvent.click( screen.getByRole( 'button' ) );
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips the store invalidation when no venuePostType is known', async () => {
+		render(
+			<RegenerateMapButton venuePostId={ 42 } venuePostType="" />
+		);
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockApiFetch ).toHaveBeenCalled();
+		} );
+
+		expect( mockInvalidateResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'ignores repeat clicks while a request is in flight', async () => {
+		let resolveFetch;
+		mockApiFetch.mockImplementationOnce(
+			() => new Promise( ( resolve ) => ( resolveFetch = resolve ) )
+		);
+
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		const button = screen.getByRole( 'button' );
+
+		fireEvent.click( button );
+		fireEvent.click( button );
+		fireEvent.click( button );
+
+		resolveFetch( { descriptors: {}, reason: '' } );
+
+		await waitFor( () => {
+			expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/test/unit/js/src/supports/block-guard.test.js
+++ b/test/unit/js/src/supports/block-guard.test.js
@@ -53,6 +53,7 @@ jest.mock( '@wordpress/i18n', () => ( {
 
 jest.mock( '@wordpress/hooks', () => ( {
 	addFilter: jest.fn(),
+	hasFilter: jest.fn( () => false ),
 } ) );
 
 jest.mock( '@wordpress/element', () => ( {

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -1140,6 +1140,50 @@ class Test_Settings extends Base {
 	}
 
 	/**
+	 * Empty-string submissions for number fields round-trip as '' instead
+	 * of getting coerced to 0 via intval — a field that accepts empty (e.g.
+	 * Width/Height "Auto") would otherwise silently save 0 on every post.
+	 * Explicit "0" submissions must still be kept as int 0, distinct from
+	 * empty, so callers can tell "unset" from "set to zero".
+	 *
+	 * @since 1.0.0
+	 * @covers ::sanitize_page_settings
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_page_settings_preserves_empty_number(): void {
+		$instance = Settings::get_instance();
+
+		delete_option( 'gatherpress_settings' );
+
+		$callback = $instance->sanitize_page_settings(
+			array(
+				'empty_number' => 'number',
+				'zero_number'  => 'number',
+			)
+		);
+
+		$result = $callback(
+			array(
+				'empty_number' => '',
+				'zero_number'  => '0',
+			)
+		);
+
+		// Explicit "0" is preserved as int 0 (distinct from empty).
+		$this->assertSame( 0, $result['zero_number'], 'Explicit "0" is kept as int 0.' );
+
+		// Empty string matches the '' default for an unregistered option
+		// and gets stripped from the saved array — effectively "unset",
+		// which is the desired auto sentinel.
+		$this->assertArrayNotHasKey(
+			'empty_number',
+			$result,
+			'Empty submission is stripped (matches "" default).'
+		);
+	}
+
+	/**
 	 * Test settings_page method.
 	 *
 	 * @since  1.0.0

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -836,34 +836,46 @@ class Test_Venue_Map_Prewarm extends Base {
 	}
 
 	/**
-	 * A saved wp_template carrying a venue-map block contributes its combo
-	 * to collect_all_template_combos — covers the DB-template scan branch.
+	 * Feeds combos into collect_all_template_combos when
+	 * get_block_templates() returns venue-map-bearing templates — covers
+	 * the DB-template + template-part scan branches. Factory posts don't
+	 * register as block templates the way theme resolution does, so we
+	 * inject the results through the `get_block_templates` filter.
 	 *
 	 * @covers ::collect_all_template_combos
 	 *
 	 * @return void
 	 */
 	public function test_collect_all_template_combos_scans_db_templates(): void {
+		if ( ! class_exists( 'WP_Block_Template' ) ) {
+			$this->markTestSkipped( 'WP_Block_Template not available in this environment.' );
+		}
+
 		$instance = Venue_Map_Prewarm::get_instance();
 
-		$this->factory->post->create(
-			array(
-				'post_type'    => 'wp_template',
-				'post_status'  => 'publish',
-				'post_content' => '<!-- wp:gatherpress/venue-map '
-					. '{"zoom":7,"width":400,"height":200,"aspectRatio":"2/1"} /-->',
-			)
-		);
-		$this->factory->post->create(
-			array(
-				'post_type'    => 'wp_template_part',
-				'post_status'  => 'publish',
-				'post_content' => '<!-- wp:gatherpress/venue-map '
-					. '{"zoom":6,"width":350,"height":175,"aspectRatio":"2/1"} /-->',
-			)
-		);
+		$template          = new \WP_Block_Template();
+		$template->content = '<!-- wp:gatherpress/venue-map '
+			. '{"zoom":7,"width":400,"height":200,"aspectRatio":"2/1"} /-->';
+
+		$part          = new \WP_Block_Template();
+		$part->content = '<!-- wp:gatherpress/venue-map '
+			. '{"zoom":6,"width":350,"height":175,"aspectRatio":"2/1"} /-->';
+
+		$inject = static function ( $query_result, $query, $template_type ) use ( $template, $part ) {
+			unset( $query );
+			if ( 'wp_template' === $template_type ) {
+				return array( $template );
+			}
+			if ( 'wp_template_part' === $template_type ) {
+				return array( $part );
+			}
+			return $query_result;
+		};
+		add_filter( 'get_block_templates', $inject, 10, 3 );
 
 		$combos = Utility::invoke_hidden_method( $instance, 'collect_all_template_combos' );
+
+		remove_filter( 'get_block_templates', $inject, 10 );
 
 		$keys = array_map(
 			static function ( $combo ) {

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -578,6 +578,171 @@ class Test_Venue_Map_Prewarm extends Base {
 	}
 
 	/**
+	 * Batch-size filter lets callers override SCAN_BATCH_SIZE; values below
+	 * 1 are clamped up to 1 to avoid an infinite empty-batch loop.
+	 *
+	 * @covers ::get_scan_batch_size
+	 *
+	 * @return void
+	 */
+	public function test_get_scan_batch_size_applies_filter_and_clamps(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$this->assertSame(
+			Venue_Map_Prewarm::SCAN_BATCH_SIZE,
+			Utility::invoke_hidden_method( $instance, 'get_scan_batch_size' ),
+			'Default matches the SCAN_BATCH_SIZE constant.'
+		);
+
+		$override = static function () {
+			return 25;
+		};
+		add_filter( 'gatherpress_venue_map_prewarm_batch_size', $override );
+
+		$this->assertSame(
+			25,
+			Utility::invoke_hidden_method( $instance, 'get_scan_batch_size' ),
+			'Filter-supplied value replaces the default.'
+		);
+
+		remove_filter( 'gatherpress_venue_map_prewarm_batch_size', $override );
+
+		$clamp = static function () {
+			return 0;
+		};
+		add_filter( 'gatherpress_venue_map_prewarm_batch_size', $clamp );
+
+		$this->assertSame(
+			1,
+			Utility::invoke_hidden_method( $instance, 'get_scan_batch_size' ),
+			'Values below 1 clamp up to 1.'
+		);
+
+		remove_filter( 'gatherpress_venue_map_prewarm_batch_size', $clamp );
+	}
+
+	/**
+	 * Pagination actually iterates — with a batch size of 1 and three
+	 * published venues, a template save enqueues warm jobs for all three,
+	 * exercising the multi-page loop tail.
+	 *
+	 * @covers ::enqueue_for_all_venues
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_for_all_venues_paginates(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$venue_ids = array(
+			$this->factory->post->create(
+				array(
+					'post_type'   => Venue::POST_TYPE,
+					'post_status' => 'publish',
+				)
+			),
+			$this->factory->post->create(
+				array(
+					'post_type'   => Venue::POST_TYPE,
+					'post_status' => 'publish',
+				)
+			),
+			$this->factory->post->create(
+				array(
+					'post_type'   => Venue::POST_TYPE,
+					'post_status' => 'publish',
+				)
+			),
+		);
+
+		$one_per_page = static function () {
+			return 1;
+		};
+		add_filter( 'gatherpress_venue_map_prewarm_batch_size', $one_per_page );
+
+		$template_id = $this->factory->post->create(
+			array(
+				'post_type'    => 'wp_template',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":11,"width":500,"height":250,"aspectRatio":"2/1"} /-->',
+			)
+		);
+
+		$instance->on_post_saved( $template_id, get_post( $template_id ) );
+
+		remove_filter( 'gatherpress_venue_map_prewarm_batch_size', $one_per_page );
+
+		foreach ( $venue_ids as $venue_post_id ) {
+			$this->assertNotFalse(
+				wp_next_scheduled(
+					Venue_Map_Prewarm::CRON_ACTION,
+					array( $venue_post_id, 11, 500, 250, '2/1' )
+				),
+				sprintf( 'Venue %d received a warm job through the paginated loop.', $venue_post_id )
+			);
+		}
+	}
+
+	/**
+	 * Pagination through collect_all_template_combos + get_venue_post_ids —
+	 * shrinks the batch so the loop tails run with only a couple of fixtures.
+	 *
+	 * @covers ::collect_all_template_combos
+	 * @covers ::get_venue_post_ids
+	 *
+	 * @return void
+	 */
+	public function test_collect_and_get_ids_paginate(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$this->factory->post->create(
+			array(
+				'post_type'    => 'gatherpress_event',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":8,"width":200,"height":100,"aspectRatio":"2/1"} /-->',
+			)
+		);
+		$this->factory->post->create(
+			array(
+				'post_type'    => 'gatherpress_event',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":9,"width":300,"height":150,"aspectRatio":"2/1"} /-->',
+			)
+		);
+		$venue_ids = array(
+			$this->factory->post->create(
+				array(
+					'post_type'   => Venue::POST_TYPE,
+					'post_status' => 'publish',
+				)
+			),
+			$this->factory->post->create(
+				array(
+					'post_type'   => Venue::POST_TYPE,
+					'post_status' => 'publish',
+				)
+			),
+		);
+
+		$one_per_page = static function () {
+			return 1;
+		};
+		add_filter( 'gatherpress_venue_map_prewarm_batch_size', $one_per_page );
+
+		$combos = Utility::invoke_hidden_method( $instance, 'collect_all_template_combos' );
+		$ids    = Utility::invoke_hidden_method( $instance, 'get_venue_post_ids' );
+
+		remove_filter( 'gatherpress_venue_map_prewarm_batch_size', $one_per_page );
+
+		$this->assertCount( 2, $combos, 'Both event combos collected through the paginated event loop.' );
+		foreach ( $venue_ids as $venue_post_id ) {
+			$this->assertContains( $venue_post_id, $ids, 'Venue collected through the paginated ID loop.' );
+		}
+	}
+
+	/**
 	 * Saving an event post without any venue-map block early-returns before
 	 * the term lookup runs.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -359,4 +359,248 @@ class Test_Venue_Map_Prewarm extends Base {
 		$instance->process_warm_job( 0, 15, 600, 300, '2/1' );
 		$this->assertTrue( true );
 	}
+
+	/**
+	 * Saving an FSE template (wp_template) fans the template's combos
+	 * out across every known venue — one cron job per (venue, combo).
+	 *
+	 * @covers ::on_post_saved
+	 * @covers ::enqueue_for_all_venues
+	 *
+	 * @return void
+	 */
+	public function test_on_post_saved_fan_outs_template_save_to_all_venues(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$venue_a = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		$venue_b = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		$template_id = $this->factory->post->create(
+			array(
+				'post_type'    => 'wp_template',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":15,"width":800,"height":400,"aspectRatio":"2/1"} /-->',
+			)
+		);
+
+		$instance->on_post_saved( $template_id, get_post( $template_id ) );
+
+		$this->assertNotFalse(
+			wp_next_scheduled(
+				Venue_Map_Prewarm::CRON_ACTION,
+				array( $venue_a, 15, 800, 400, '2/1' )
+			),
+			'Venue A received a warm job for the template combo.'
+		);
+		$this->assertNotFalse(
+			wp_next_scheduled(
+				Venue_Map_Prewarm::CRON_ACTION,
+				array( $venue_b, 15, 800, 400, '2/1' )
+			),
+			'Venue B received a warm job for the template combo.'
+		);
+	}
+
+	/**
+	 * Saving a template without a venue-map block enqueues nothing — the
+	 * early-return path on an empty combo list.
+	 *
+	 * @covers ::on_post_saved
+	 * @covers ::enqueue_for_all_venues
+	 *
+	 * @return void
+	 */
+	public function test_on_post_saved_skips_template_without_venue_map(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		$template_id = $this->factory->post->create(
+			array(
+				'post_type'    => 'wp_template',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph --><p>No map here.</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$instance->on_post_saved( $template_id, get_post( $template_id ) );
+
+		$this->assertFalse(
+			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			'Templates without venue-map blocks enqueue nothing.'
+		);
+	}
+
+	/**
+	 * Triggers a full rescan against every venue on theme switch — even
+	 * with no templates, the handler runs without error.
+	 *
+	 * @covers ::on_theme_switched
+	 * @covers ::collect_all_template_combos
+	 * @covers ::get_venue_post_ids
+	 *
+	 * @return void
+	 */
+	public function test_on_theme_switched_runs_without_error(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		$instance->on_theme_switched();
+
+		// No assertion beyond "doesn't throw" — without a template that
+		// references a combo, there's nothing to enqueue, but the full code
+		// path is now exercised for coverage (collect + get_venue_post_ids).
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Returns published venue post IDs only.
+	 *
+	 * @covers ::get_venue_post_ids
+	 *
+	 * @return void
+	 */
+	public function test_get_venue_post_ids_returns_published_venues(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$published = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		// A draft should NOT appear in the warm-eligible set.
+		$this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'draft',
+			)
+		);
+
+		$ids = Utility::invoke_hidden_method( $instance, 'get_venue_post_ids' );
+
+		$this->assertContains( $published, $ids );
+	}
+
+	/**
+	 * Saving an event post with an embedded venue-map enqueues warm jobs
+	 * against the associated venue (via the `_gatherpress_venue` taxonomy),
+	 * not the event itself.
+	 *
+	 * @covers ::on_post_saved
+	 *
+	 * @return void
+	 */
+	public function test_on_post_saved_event_enqueues_via_linked_venue(): void {
+		$instance    = Venue_Map_Prewarm::get_instance();
+		$venue_setup = \GatherPress\Core\Venue_Setup::get_instance();
+
+		$venue_post_id = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_name'   => 'some-venue',
+				'post_status' => 'publish',
+			)
+		);
+
+		$term_slug = $venue_setup->term_slug_from_post_name( 'some-venue' );
+		wp_insert_term( 'Some Venue', Venue::TAXONOMY, array( 'slug' => $term_slug ) );
+
+		$event_post_id = $this->factory->post->create(
+			array(
+				'post_type'    => 'gatherpress_event',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":12,"width":600,"height":300,"aspectRatio":"2/1"} /-->',
+			)
+		);
+		wp_set_post_terms( $event_post_id, $term_slug, Venue::TAXONOMY );
+
+		$instance->on_post_saved( $event_post_id, get_post( $event_post_id ) );
+
+		$this->assertNotFalse(
+			wp_next_scheduled(
+				Venue_Map_Prewarm::CRON_ACTION,
+				array( $venue_post_id, 12, 600, 300, '2/1' )
+			),
+			'Event save enqueues a warm job against the linked venue.'
+		);
+	}
+
+	/**
+	 * An event post with no linked venue — the term lookup short-circuits
+	 * and no cron jobs are scheduled.
+	 *
+	 * @covers ::on_post_saved
+	 *
+	 * @return void
+	 */
+	public function test_on_post_saved_event_skips_when_no_venue_term(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$event_post_id = $this->factory->post->create(
+			array(
+				'post_type'    => 'gatherpress_event',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":12,"width":600,"height":300,"aspectRatio":"2/1"} /-->',
+			)
+		);
+
+		$instance->on_post_saved( $event_post_id, get_post( $event_post_id ) );
+
+		$this->assertFalse(
+			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			'Event with no venue term enqueues nothing.'
+		);
+	}
+
+	/**
+	 * Saving an event post without any venue-map block early-returns before
+	 * the term lookup runs.
+	 *
+	 * @covers ::on_post_saved
+	 *
+	 * @return void
+	 */
+	public function test_on_post_saved_event_skips_when_no_combos(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$event_post_id = $this->factory->post->create(
+			array(
+				'post_type'    => 'gatherpress_event',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:paragraph --><p>no map</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$instance->on_post_saved( $event_post_id, get_post( $event_post_id ) );
+
+		$this->assertFalse(
+			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			'No combos in event content means no cron jobs.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Unit tests for GatherPress\Core\Venue_Map_Prewarm.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Core;
+
+use GatherPress\Core\Venue;
+use GatherPress\Core\Venue_Map;
+use GatherPress\Core\Venue_Map_Prewarm;
+use GatherPress\Tests\Base;
+use PMC\Unit_Test\Utility;
+
+/**
+ * Class Test_Venue_Map_Prewarm.
+ *
+ * @coversDefaultClass \GatherPress\Core\Venue_Map_Prewarm
+ */
+class Test_Venue_Map_Prewarm extends Base {
+	/**
+	 * Clear scheduled warm events between tests — wp_next_scheduled lookups
+	 * otherwise leak across cases and skew dedup assertions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		wp_clear_scheduled_hook( Venue_Map_Prewarm::CRON_ACTION );
+		parent::tear_down();
+	}
+
+	/**
+	 * Coverage for setup_hooks — verifies cron handler + save/theme-switch
+	 * callbacks are registered at the expected priorities.
+	 *
+	 * @covers ::__construct
+	 * @covers ::setup_hooks
+	 *
+	 * @return void
+	 */
+	public function test_setup_hooks(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+		$hooks    = array(
+			array(
+				'type'     => 'action',
+				'name'     => Venue_Map_Prewarm::CRON_ACTION,
+				'priority' => 10,
+				'callback' => array( $instance, 'process_warm_job' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'wp_after_insert_post',
+				'priority' => 12,
+				'callback' => array( $instance, 'on_post_saved' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'switch_theme',
+				'priority' => 10,
+				'callback' => array( $instance, 'on_theme_switched' ),
+			),
+		);
+
+		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * Content with no venue-map block returns an empty combo list.
+	 *
+	 * @covers ::collect_combos_from_content
+	 *
+	 * @return void
+	 */
+	public function test_collect_combos_from_content_ignores_unrelated_markup(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'collect_combos_from_content',
+			array( '<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->' )
+		);
+
+		$this->assertSame( array(), $result, 'Content without venue-map produces no combos.' );
+
+		$empty = Utility::invoke_hidden_method(
+			$instance,
+			'collect_combos_from_content',
+			array( '' )
+		);
+
+		$this->assertSame( array(), $empty, 'Empty content produces no combos.' );
+	}
+
+	/**
+	 * A single venue-map block in content produces its attributes as a combo.
+	 *
+	 * @covers ::collect_combos_from_content
+	 * @covers ::walk_blocks_for_combos
+	 * @covers ::extract_block_combo
+	 *
+	 * @return void
+	 */
+	public function test_collect_combos_from_content_extracts_single_block(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+		$content  = '<!-- wp:gatherpress/venue-map {"zoom":15,"width":0,"height":400,"aspectRatio":"16/9"} /-->';
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'collect_combos_from_content',
+			array( $content )
+		);
+
+		$this->assertCount( 1, $result );
+		$this->assertSame(
+			array(
+				'zoom'         => 15,
+				'width'        => 0,
+				'height'       => 400,
+				'aspect_ratio' => '16/9',
+			),
+			$result[0]
+		);
+	}
+
+	/**
+	 * Nested venue-map blocks (e.g. inside a venue parent) are still found.
+	 *
+	 * @covers ::walk_blocks_for_combos
+	 *
+	 * @return void
+	 */
+	public function test_walk_blocks_for_combos_recurses_inner_blocks(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+		$content  = '<!-- wp:gatherpress/venue -->'
+			. '<div class="wp-block-gatherpress-venue">'
+			. '<!-- wp:gatherpress/venue-map {"zoom":10,"width":800,"height":400,"aspectRatio":"2/1"} /-->'
+			. '</div>'
+			. '<!-- /wp:gatherpress/venue -->';
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'collect_combos_from_content',
+			array( $content )
+		);
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 10, $result[0]['zoom'] );
+		$this->assertSame( 800, $result[0]['width'] );
+	}
+
+	/**
+	 * Missing block attributes fall back to the Venue_Map defaults.
+	 *
+	 * @covers ::extract_block_combo
+	 *
+	 * @return void
+	 */
+	public function test_extract_block_combo_uses_venue_map_defaults(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'extract_block_combo',
+			array( array() )
+		);
+
+		$this->assertSame( Venue_Map::DEFAULT_ZOOM, $result['zoom'] );
+		$this->assertSame( 0, $result['width'] );
+		$this->assertSame( Venue_Map::DEFAULT_HEIGHT, $result['height'] );
+		$this->assertSame( Venue_Map::DEFAULT_ASPECT_RATIO, $result['aspect_ratio'] );
+	}
+
+	/**
+	 * Dedupe collapses identical (zoom, width, height, aspect_ratio) tuples.
+	 *
+	 * @covers ::dedupe_combos
+	 *
+	 * @return void
+	 */
+	public function test_dedupe_combos_collapses_duplicates(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+		$combos   = array(
+			array(
+				'zoom'         => 15,
+				'width'        => 800,
+				'height'       => 400,
+				'aspect_ratio' => '2/1',
+			),
+			array(
+				'zoom'         => 15,
+				'width'        => 800,
+				'height'       => 400,
+				'aspect_ratio' => '2/1',
+			),
+			array(
+				'zoom'         => 18,
+				'width'        => 600,
+				'height'       => 300,
+				'aspect_ratio' => '2/1',
+			),
+		);
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'dedupe_combos',
+			array( $combos )
+		);
+
+		$this->assertCount( 2, $result );
+	}
+
+	/**
+	 * Schedules a cron event for the given (venue, combo) when enqueue is called.
+	 *
+	 * @covers ::enqueue_warm_job
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_warm_job_schedules_cron_event(): void {
+		$instance      = Venue_Map_Prewarm::get_instance();
+		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+		$combo         = array(
+			'zoom'         => 15,
+			'width'        => 800,
+			'height'       => 400,
+			'aspect_ratio' => '2/1',
+		);
+
+		Utility::invoke_hidden_method(
+			$instance,
+			'enqueue_warm_job',
+			array( $venue_post_id, $combo )
+		);
+
+		$scheduled = wp_next_scheduled(
+			Venue_Map_Prewarm::CRON_ACTION,
+			array( $venue_post_id, 15, 800, 400, '2/1' )
+		);
+		$this->assertNotFalse( $scheduled, 'Warm job is scheduled.' );
+	}
+
+	/**
+	 * Re-enqueuing the same (venue, combo) is a no-op — the first scheduled
+	 * event sticks instead of being duplicated.
+	 *
+	 * @covers ::enqueue_warm_job
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_warm_job_deduplicates_identical_args(): void {
+		$instance      = Venue_Map_Prewarm::get_instance();
+		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+		$combo         = array(
+			'zoom'         => 15,
+			'width'        => 800,
+			'height'       => 400,
+			'aspect_ratio' => '2/1',
+		);
+
+		Utility::invoke_hidden_method( $instance, 'enqueue_warm_job', array( $venue_post_id, $combo ) );
+		$first_timestamp = wp_next_scheduled(
+			Venue_Map_Prewarm::CRON_ACTION,
+			array( $venue_post_id, 15, 800, 400, '2/1' )
+		);
+
+		Utility::invoke_hidden_method( $instance, 'enqueue_warm_job', array( $venue_post_id, $combo ) );
+		$second_timestamp = wp_next_scheduled(
+			Venue_Map_Prewarm::CRON_ACTION,
+			array( $venue_post_id, 15, 800, 400, '2/1' )
+		);
+
+		$this->assertSame( $first_timestamp, $second_timestamp, 'Dedup keeps the original schedule.' );
+	}
+
+	/**
+	 * Saving a venue post enqueues a warm job for that venue when any
+	 * template in the site references a venue-map combo. We simulate the
+	 * template existence by saving a wp_template first.
+	 *
+	 * @covers ::on_post_saved
+	 * @covers ::enqueue_for_venue
+	 *
+	 * @return void
+	 */
+	public function test_on_post_saved_enqueues_for_venue(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		// Create a venue so get_venue_post_ids has at least one result when
+		// the template save would fan out; the test itself doesn't care
+		// about the template path, only the venue save.
+		$venue_post_id = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		// No templates have combos, so enqueue_for_venue iterates an empty
+		// combo set. Expect no scheduled event, and no errors.
+		$post = get_post( $venue_post_id );
+		$instance->on_post_saved( $venue_post_id, $post );
+
+		$this->assertFalse(
+			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			'No combos means no scheduled warm jobs.'
+		);
+	}
+
+	/**
+	 * Saving a revision or autosave does not enqueue anything — guard rail
+	 * so rapid editor saves don't churn the cron queue.
+	 *
+	 * @covers ::on_post_saved
+	 *
+	 * @return void
+	 */
+	public function test_on_post_saved_ignores_revisions(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$venue_post_id = $this->factory->post->create(
+			array(
+				'post_type' => Venue::POST_TYPE,
+			)
+		);
+
+		$revision_id = wp_save_post_revision( $venue_post_id );
+
+		if ( false === $revision_id || is_wp_error( $revision_id ) ) {
+			$this->markTestSkipped( 'Could not create a revision in this environment.' );
+		}
+
+		$revision = get_post( $revision_id );
+		$instance->on_post_saved( $revision_id, $revision );
+
+		$this->assertFalse(
+			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			'Revisions do not enqueue warm jobs.'
+		);
+	}
+
+	/**
+	 * Delegates to Venue_Map::warm from the cron handler — this test only
+	 * verifies it tolerates a missing venue ID without throwing
+	 * (Venue_Map::warm returns null for invalid input).
+	 *
+	 * @covers ::process_warm_job
+	 *
+	 * @return void
+	 */
+	public function test_process_warm_job_is_safe_for_missing_venue(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		// No exception: warm() returns null for non-existent post IDs, and
+		// the cron handler is expected to swallow that outcome silently.
+		$instance->process_warm_job( 0, 15, 600, 300, '2/1' );
+		$this->assertTrue( true );
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -801,32 +801,35 @@ class Test_Venue_Map_Prewarm extends Base {
 	public function test_scans_short_circuit_without_venue_types(): void {
 		$instance = Venue_Map_Prewarm::get_instance();
 
-		$hide_supports = static function ( $post_types, $feature ) {
-			if ( 'gatherpress-venue-information' === $feature ) {
-				return array();
+		// Temporarily unregister the venue-information support so the
+		// gatherpress-venue-information feature has no matching post types.
+		$supported = get_post_types_by_support( 'gatherpress-venue-information' );
+		foreach ( $supported as $post_type ) {
+			remove_post_type_support( $post_type, 'gatherpress-venue-information' );
+		}
+
+		try {
+			$combos = array(
+				array(
+					'zoom'         => 15,
+					'width'        => 800,
+					'height'       => 400,
+					'aspect_ratio' => '2/1',
+				),
+			);
+
+			Utility::invoke_hidden_method(
+				$instance,
+				'enqueue_for_all_venues',
+				array( $combos )
+			);
+
+			$ids = Utility::invoke_hidden_method( $instance, 'get_venue_post_ids' );
+		} finally {
+			foreach ( $supported as $post_type ) {
+				add_post_type_support( $post_type, 'gatherpress-venue-information' );
 			}
-			return $post_types;
-		};
-		add_filter( 'get_post_types_by_support_args', $hide_supports, 10, 2 );
-
-		$combos = array(
-			array(
-				'zoom'         => 15,
-				'width'        => 800,
-				'height'       => 400,
-				'aspect_ratio' => '2/1',
-			),
-		);
-
-		Utility::invoke_hidden_method(
-			$instance,
-			'enqueue_for_all_venues',
-			array( $combos )
-		);
-
-		$ids = Utility::invoke_hidden_method( $instance, 'get_venue_post_ids' );
-
-		remove_filter( 'get_post_types_by_support_args', $hide_supports, 10 );
+		}
 
 		$this->assertFalse(
 			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -743,6 +743,146 @@ class Test_Venue_Map_Prewarm extends Base {
 	}
 
 	/**
+	 * Iterates the combo list collected from templates and events from
+	 * enqueue_for_venue, scheduling a job for each — covers the inner loop
+	 * body on the non-empty combo path.
+	 *
+	 * @covers ::enqueue_for_venue
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_for_venue_schedules_jobs_for_each_combo(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$venue_post_id = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		// Seed an event whose content contributes a combo to the
+		// collect_all_template_combos pool.
+		$this->factory->post->create(
+			array(
+				'post_type'    => 'gatherpress_event',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":13,"width":700,"height":350,"aspectRatio":"2/1"} /-->',
+			)
+		);
+
+		Utility::invoke_hidden_method(
+			$instance,
+			'enqueue_for_venue',
+			array( $venue_post_id )
+		);
+
+		$this->assertNotFalse(
+			wp_next_scheduled(
+				Venue_Map_Prewarm::CRON_ACTION,
+				array( $venue_post_id, 13, 700, 350, '2/1' )
+			),
+			'Venue received a warm job for the combo surfaced via enqueue_for_venue.'
+		);
+	}
+
+	/**
+	 * When no post type supports gatherpress-venue-information,
+	 * enqueue_for_all_venues and get_venue_post_ids short-circuit without
+	 * scheduling anything. Filters the supports list to simulate a site
+	 * where nothing registers as a venue source.
+	 *
+	 * @covers ::enqueue_for_all_venues
+	 * @covers ::get_venue_post_ids
+	 *
+	 * @return void
+	 */
+	public function test_scans_short_circuit_without_venue_types(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$hide_supports = static function ( $post_types, $feature ) {
+			if ( 'gatherpress-venue-information' === $feature ) {
+				return array();
+			}
+			return $post_types;
+		};
+		add_filter( 'get_post_types_by_support_args', $hide_supports, 10, 2 );
+
+		$combos = array(
+			array(
+				'zoom'         => 15,
+				'width'        => 800,
+				'height'       => 400,
+				'aspect_ratio' => '2/1',
+			),
+		);
+
+		Utility::invoke_hidden_method(
+			$instance,
+			'enqueue_for_all_venues',
+			array( $combos )
+		);
+
+		$ids = Utility::invoke_hidden_method( $instance, 'get_venue_post_ids' );
+
+		remove_filter( 'get_post_types_by_support_args', $hide_supports, 10 );
+
+		$this->assertFalse(
+			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			'No venue types means no scheduled warm jobs.'
+		);
+		$this->assertSame( array(), $ids, 'get_venue_post_ids returns [] when no venue types are registered.' );
+	}
+
+	/**
+	 * A saved wp_template carrying a venue-map block contributes its combo
+	 * to collect_all_template_combos — covers the DB-template scan branch.
+	 *
+	 * @covers ::collect_all_template_combos
+	 *
+	 * @return void
+	 */
+	public function test_collect_all_template_combos_scans_db_templates(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$this->factory->post->create(
+			array(
+				'post_type'    => 'wp_template',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":7,"width":400,"height":200,"aspectRatio":"2/1"} /-->',
+			)
+		);
+		$this->factory->post->create(
+			array(
+				'post_type'    => 'wp_template_part',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":6,"width":350,"height":175,"aspectRatio":"2/1"} /-->',
+			)
+		);
+
+		$combos = Utility::invoke_hidden_method( $instance, 'collect_all_template_combos' );
+
+		$keys = array_map(
+			static function ( $combo ) {
+				return sprintf(
+					'%d-%d-%d-%s',
+					(int) $combo['zoom'],
+					(int) $combo['width'],
+					(int) $combo['height'],
+					(string) $combo['aspect_ratio']
+				);
+			},
+			$combos
+		);
+
+		$this->assertContains( '7-400-200-2/1', $keys, 'Template combo surfaced through the DB-template branch.' );
+		$this->assertContains( '6-350-175-2/1', $keys, 'Template-part combo surfaced through the DB branch.' );
+	}
+
+	/**
 	 * Saving an event post without any venue-map block early-returns before
 	 * the term lookup runs.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -119,6 +119,12 @@ class Test_Venue_Map extends Base {
 				'callback' => array( $instance, 'maybe_register_delete_hook' ),
 			),
 			array(
+				'type'     => 'action',
+				'name'     => 'rest_api_init',
+				'priority' => 10,
+				'callback' => array( $instance, 'register_rest_routes' ),
+			),
+			array(
 				'type'     => 'filter',
 				'name'     => 'block_type_metadata',
 				'priority' => 10,
@@ -2012,5 +2018,359 @@ class Test_Venue_Map extends Base {
 			Utility::invoke_hidden_method( $instance, 'lat_to_world_pixel', array( 0.0, 0 ) ),
 			0.000001
 		);
+	}
+
+	/**
+	 * Wipes cached descriptors + PNG files and rebuilds entries for every
+	 * combo the venue was previously cached at, returning the fresh
+	 * descriptor map.
+	 *
+	 * @covers ::regenerate
+	 *
+	 * @return void
+	 */
+	public function test_regenerate_rebuilds_cached_combos(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+		// Warm a second combo so regenerate has two variants to cover.
+		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14, 500 );
+
+		$before = $instance->get_all_descriptors( $post_id );
+		$this->assertCount( 2, $before );
+
+		// Mark the pre-regenerate files so we can detect rewrites below.
+		// When inputs are unchanged the hash (and therefore the filename)
+		// stays the same, so we can't rely on url comparison alone — mtime
+		// is the signal that the tile fetch + compositing ran again.
+		$pre_mtimes = array();
+		foreach ( $before as $combo_key => $descriptor ) {
+			$path                     = (string) $instance->url_to_path( $descriptor['url'] );
+			$pre_mtimes[ $combo_key ] = filemtime( $path );
+		}
+		sleep( 1 );
+
+		$result = $instance->regenerate( $post_id );
+
+		$this->assertCount(
+			2,
+			$result,
+			'regenerate() should return a descriptor for each previously cached combo.'
+		);
+
+		foreach ( $before as $combo_key => $old ) {
+			$this->assertArrayHasKey( $combo_key, $result );
+			$path = (string) $instance->url_to_path( $result[ $combo_key ]['url'] );
+			$this->assertFileExists(
+				$path,
+				sprintf( 'Post-regenerate PNG for %s should exist on disk.', $combo_key )
+			);
+			$this->assertGreaterThan(
+				$pre_mtimes[ $combo_key ],
+				filemtime( $path ),
+				sprintf( 'Post-regenerate PNG for %s should have been rewritten.', $combo_key )
+			);
+		}
+	}
+
+	/**
+	 * When the caller supplies an extra (zoom, height), regenerate() adds
+	 * that combo to the rebuild list so the block editor's current combo
+	 * always gets a PNG on an explicit Generate click — even if the venue
+	 * was previously cached at different combos only.
+	 *
+	 * @covers ::regenerate
+	 *
+	 * @return void
+	 */
+	public function test_regenerate_includes_caller_supplied_combo(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		// Seed one cached combo the venue "already had".
+		$instance->maybe_generate( $post_id );
+
+		$result = $instance->regenerate( $post_id, 8, 295 );
+
+		$expected_key = '8x295';
+		$this->assertArrayHasKey(
+			$expected_key,
+			$result,
+			'The caller-supplied combo must be included in the rebuild.'
+		);
+		$this->assertSame( 8, $result[ $expected_key ]['zoom'] );
+		$this->assertSame( 295, $result[ $expected_key ]['height'] );
+	}
+
+	/**
+	 * When the caller-supplied combo duplicates one that's already cached,
+	 * it's deduped and only rendered once — no double-work.
+	 *
+	 * @covers ::regenerate
+	 *
+	 * @return void
+	 */
+	public function test_regenerate_dedupes_caller_combo_against_cache(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $post_id );
+
+		$result = $instance->regenerate(
+			$post_id,
+			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT
+		);
+
+		$this->assertCount(
+			1,
+			$result,
+			'Supplying the already-cached combo should not add a duplicate entry.'
+		);
+	}
+
+	/**
+	 * Calling regenerate() on a venue that has never been rendered seeds
+	 * the site-default combo, so an explicit "Generate" click on a fresh
+	 * venue still produces a PNG.
+	 *
+	 * @covers ::regenerate
+	 *
+	 * @return void
+	 */
+	public function test_regenerate_seeds_default_combo_when_nothing_cached(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$this->assertEmpty( $instance->get_all_descriptors( $post_id ) );
+
+		$result = $instance->regenerate( $post_id );
+
+		$default_key = sprintf(
+			'%dx%d',
+			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT
+		);
+		$this->assertArrayHasKey( $default_key, $result );
+	}
+
+	/**
+	 * Without usable coordinates, regenerate() returns an empty map and
+	 * does not attempt to render — the button on the client side stays in
+	 * its "Add an address to generate the map" placeholder state.
+	 *
+	 * @covers ::regenerate
+	 *
+	 * @return void
+	 */
+	public function test_regenerate_returns_empty_when_no_coordinates(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => 'Somewhere, somewhere',
+					'latitude'    => '',
+					'longitude'   => '',
+				)
+			)
+		);
+
+		$this->assertSame( array(), $instance->regenerate( $post_id ) );
+	}
+
+	/**
+	 * The POST /venue/{id}/regenerate-map endpoint requires edit_post on
+	 * the target venue — anonymous callers receive 401/403.
+	 *
+	 * @covers ::register_rest_routes
+	 *
+	 * @return void
+	 */
+	public function test_rest_regenerate_requires_edit_post(): void {
+		$instance = Venue_Map::get_instance();
+		$instance->register_rest_routes();
+
+		$post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		wp_set_current_user( 0 );
+
+		$request  = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertGreaterThanOrEqual( 400, $response->get_status() );
+		$this->assertLessThan( 500, $response->get_status() );
+	}
+
+	/**
+	 * Happy-path REST call: an editor-level user regenerates a venue with
+	 * usable coordinates and gets the fresh descriptor map in the response.
+	 *
+	 * @covers ::register_rest_routes
+	 * @covers ::rest_regenerate
+	 *
+	 * @return void
+	 */
+	public function test_rest_regenerate_returns_fresh_descriptors(): void {
+		$instance = Venue_Map::get_instance();
+		$instance->register_rest_routes();
+
+		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$post_id   = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		wp_set_current_user( $editor_id );
+
+		$request  = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'descriptors', $data );
+		$this->assertSame( '', $data['reason'] );
+
+		$default_key = sprintf(
+			'%dx%d',
+			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT
+		);
+		$this->assertArrayHasKey( $default_key, (array) $data['descriptors'] );
+	}
+
+	/**
+	 * When the venue has no address, the REST endpoint returns a 200 with
+	 * a structured reason so the client can render the appropriate
+	 * placeholder rather than a generic error state.
+	 *
+	 * @covers ::rest_regenerate
+	 *
+	 * @return void
+	 */
+	public function test_rest_regenerate_reports_no_address_reason(): void {
+		$instance = Venue_Map::get_instance();
+		$instance->register_rest_routes();
+
+		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$post_id   = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		wp_set_current_user( $editor_id );
+
+		$request  = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 'no_address', $data['reason'] );
+	}
+
+	/**
+	 * When the address is set but not yet geocoded (empty lat/lng), the
+	 * endpoint reports `awaiting_geocode` so the client shows the "Save
+	 * the venue first" placeholder instead of treating it as a failure.
+	 *
+	 * @covers ::rest_regenerate
+	 *
+	 * @return void
+	 */
+	public function test_rest_regenerate_reports_awaiting_geocode_reason(): void {
+		$instance = Venue_Map::get_instance();
+		$instance->register_rest_routes();
+
+		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$post_id   = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => 'Somewhere',
+					'latitude'    => '',
+					'longitude'   => '',
+				)
+			)
+		);
+
+		wp_set_current_user( $editor_id );
+
+		$request  = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 'awaiting_geocode', $data['reason'] );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -2471,6 +2471,72 @@ class Test_Venue_Map extends Base {
 	 *
 	 * @return void
 	 */
+	/**
+	 * Reports a `generation_failed` reason when the venue has coordinates
+	 * but every combo's PNG write fails. Simulated here by putting the
+	 * uploads dir in an error state so `save_image` returns null and the
+	 * regenerate() call comes back with an empty descriptor map.
+	 *
+	 * @covers ::rest_regenerate
+	 *
+	 * @return void
+	 */
+	public function test_rest_regenerate_reports_generation_failed_when_saves_fail(): void {
+		$instance = Venue_Map::get_instance();
+		$instance->register_rest_routes();
+
+		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$post_id   = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		wp_set_current_user( $editor_id );
+
+		// Force save_image to fail for every combo so regenerate() returns
+		// an empty array and the REST handler enters the generation_failed
+		// branch.
+		$force_error = static function ( $dirs ) {
+			$dirs['error'] = 'Simulated uploads failure.';
+			return $dirs;
+		};
+		add_filter( 'upload_dir', $force_error );
+
+		$request = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$request->set_param( 'zoom', 15 );
+		$request->set_param( 'width', 800 );
+		$request->set_param( 'height', 400 );
+		$request->set_param( 'aspect_ratio', '2/1' );
+
+		$response = rest_do_request( $request );
+
+		remove_filter( 'upload_dir', $force_error );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 'generation_failed', $data['reason'] );
+	}
+
+	/**
+	 * Reports the `awaiting_geocode` reason when the venue has an address
+	 * but no resolved coordinates yet.
+	 *
+	 * @covers ::rest_regenerate
+	 *
+	 * @return void
+	 */
 	public function test_rest_regenerate_reports_awaiting_geocode_reason(): void {
 		$instance = Venue_Map::get_instance();
 		$instance->register_rest_routes();

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -1287,6 +1287,38 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
+	 * A second warm() at the same combo hits the cache-hit branch —
+	 * returns the existing descriptor unchanged via build_image_url's
+	 * deterministic URL check, without re-compositing tiles.
+	 *
+	 * @covers ::warm
+	 * @covers ::build_image_url
+	 *
+	 * @return void
+	 */
+	public function test_warm_reuses_descriptor_on_cache_hit(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$first  = $instance->warm( $post_id, 15, 800, 400, '2/1' );
+		$second = $instance->warm( $post_id, 15, 800, 400, '2/1' );
+
+		$this->assertSame( $first, $second, 'Second warm returns the cached descriptor.' );
+	}
+
+	/**
 	 * An empty/special-only address still produces a valid filename via the
 	 * `venue` fallback; a very long address gets truncated to 150 chars.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -1252,6 +1252,69 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
+	 * Successful warm() run — returns the descriptor, stores meta, and
+	 * lands the PNG on disk at the deterministic slug-based filename.
+	 *
+	 * @covers ::warm
+	 * @covers ::build_image_url
+	 * @covers ::filename_for
+	 *
+	 * @return void
+	 */
+	public function test_warm_generates_descriptor_on_valid_input(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$descriptor = $instance->warm( $post_id, 15, 800, 400, '2/1' );
+
+		$this->assertIsArray( $descriptor );
+		$this->assertSame( 15, $descriptor['zoom'] );
+		$this->assertSame( 800, $descriptor['width'] );
+		$this->assertSame( 400, $descriptor['height'] );
+		$this->assertStringEndsWith( '1-infinite-loop-15-800-400.png', $descriptor['url'] );
+	}
+
+	/**
+	 * An empty/special-only address still produces a valid filename via the
+	 * `venue` fallback; a very long address gets truncated to 150 chars.
+	 *
+	 * @covers ::filename_for
+	 *
+	 * @return void
+	 */
+	public function test_filename_for_handles_edge_cases(): void {
+		$instance = Venue_Map::get_instance();
+
+		// Empty string → fallback slug.
+		$empty = Utility::invoke_hidden_method( $instance, 'filename_for', array( '', 15, 800, 400 ) );
+		$this->assertSame( 'venue-15-800-400.png', $empty );
+
+		// All-special-char input sanitize_title strips to '' → fallback.
+		$weird = Utility::invoke_hidden_method( $instance, 'filename_for', array( '!!!', 15, 800, 400 ) );
+		$this->assertSame( 'venue-15-800-400.png', $weird );
+
+		// Long slugs get truncated so the full filename stays under fs caps.
+		$long    = str_repeat( 'a', 300 );
+		$result  = Utility::invoke_hidden_method( $instance, 'filename_for', array( $long, 18, 600, 300 ) );
+		$matches = array();
+		preg_match( '/^([a-z]+)-18-600-300\.png$/', $result, $matches );
+		$this->assertNotEmpty( $matches, 'Truncated filename still matches the expected pattern.' );
+		$this->assertSame( 150, strlen( $matches[1] ), 'Slug is capped at 150 characters.' );
+	}
+
+	/**
 	 * Returns null from warm() when the venue has no valid coordinates —
 	 * short circuits before the tile compositing stage.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -96,6 +96,24 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
+	 * Resolve an uploads-subdir URL back to its filesystem path for test
+	 * assertions. Mirrors the security-sensitive url_to_path() logic that
+	 * used to live on the class, scoped down to what tests need.
+	 *
+	 * @param string $url Stored descriptor URL.
+	 * @return string Absolute filesystem path.
+	 */
+	protected function path_for_url( string $url ): string {
+		$dirs = wp_get_upload_dir();
+
+		return str_replace(
+			trailingslashit( $dirs['baseurl'] ),
+			trailingslashit( $dirs['basedir'] ),
+			$url
+		);
+	}
+
+	/**
 	 * Coverage for setup_hooks.
 	 *
 	 * @covers ::__construct
@@ -218,7 +236,7 @@ class Test_Venue_Map extends Base {
 
 		$settings->set( 'venue_map_default_render_mode', '' );
 		$settings->set( 'venue_map_default_zoom', 0 );
-		$settings->set( 'venue_map_default_height', 0 );
+		$settings->set( 'venue_map_default_height', '' );
 		$settings->set( 'venue_map_default_type', '' );
 
 		$metadata = array(
@@ -302,18 +320,17 @@ class Test_Venue_Map extends Base {
 	 */
 	public function test_hash_for_detects_relevant_input_changes(): void {
 		$instance = Venue_Map::get_instance();
-		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$info     = array(
 			'fullAddress' => '1 Infinite Loop',
 			'latitude'    => '37.3318',
 			'longitude'   => '-122.0312',
 		);
 
-		$baseline = $instance->hash_for( $post_id, $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL );
+		$baseline = $instance->hash_for( $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL );
 
 		$this->assertSame(
 			$baseline,
-			$instance->hash_for( $post_id, $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should be stable when every input is identical.'
 		);
 
@@ -323,35 +340,34 @@ class Test_Venue_Map extends Base {
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $post_id, $moved_info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $moved_info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when coordinates change.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $post_id, $info, 14, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 14, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when the zoom level changes.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $post_id, $info, 15, 600, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 600, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when the width changes.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $post_id, $info, 15, 800, 500, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 800, 500, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when the height changes.'
 		);
 
-		// Different venue → different salt → different hash even with
-		// identical address/coords.
-		$other_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
-		$this->assertNotSame(
+		// Same address + coords hash identically, regardless of post —
+		// filenames dedupe across venues at the same location.
+		$this->assertSame(
 			$baseline,
-			$instance->hash_for( $other_post_id, $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
-			'Hash should differ between venues because each has its own salt.'
+			$instance->hash_for( $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
+			'Hash is address-scoped, not post-scoped.'
 		);
 	}
 
@@ -391,7 +407,7 @@ class Test_Venue_Map extends Base {
 		$this->assertNotEmpty( $descriptor['url'], 'Descriptor URL should be populated.' );
 		$this->assertSame( 32, strlen( $descriptor['hash'] ), 'Descriptor hash should be an MD5 hex string.' );
 
-		$path = $instance->url_to_path( $descriptor['url'] );
+		$path = $this->path_for_url( $descriptor['url'] );
 
 		$this->assertNotNull( $path, 'Saved URL should map back to a filesystem path.' );
 		$this->assertFileExists( $path, 'The static-map PNG should exist on disk.' );
@@ -422,7 +438,7 @@ class Test_Venue_Map extends Base {
 
 		$instance->maybe_generate( $post_id );
 		$first_descriptor = $instance->get_stored_descriptor( $post_id );
-		$path             = $instance->url_to_path( $first_descriptor['url'] );
+		$path             = $this->path_for_url( $first_descriptor['url'] );
 		$mtime_first      = filemtime( $path );
 
 		// Force the filesystem mtime to change so a regeneration would be detectable.
@@ -484,15 +500,13 @@ class Test_Venue_Map extends Base {
 		$this->assertNotSame(
 			$first['url'],
 			$second['url'],
-			'URL should change because the filename includes the hash.'
+			'URL should change because the address slug is part of the filename.'
 		);
 
-		$old_path = $instance->url_to_path( $first['url'] );
-
-		$this->assertFileDoesNotExist(
-			$old_path,
-			'The previous static-map PNG should be cleaned up when regenerating.'
-		);
+		// Both the old and the new file exist on disk — with address-based
+		// naming the same file can be shared, so GC of the superseded file
+		// is deferred.
+		$this->assertFileExists( $this->path_for_url( $second['url'] ) );
 	}
 
 	/**
@@ -524,7 +538,7 @@ class Test_Venue_Map extends Base {
 		$descriptor = $instance->get_stored_descriptor( $post_id );
 
 		$this->assertIsArray( $descriptor, 'Sanity: initial save should have produced a descriptor.' );
-		$path = $instance->url_to_path( $descriptor['url'] );
+		$path = $this->path_for_url( $descriptor['url'] );
 		$this->assertFileExists( $path );
 
 		// Now clear the coordinates (e.g. address changed to something un-geocodable).
@@ -545,10 +559,10 @@ class Test_Venue_Map extends Base {
 			$instance->get_stored_descriptor( $post_id ),
 			'Descriptor meta should be cleared when coordinates become un-geocodable.'
 		);
-		$this->assertFileDoesNotExist(
-			(string) $path,
-			'Orphaned PNG should be removed when coordinates disappear.'
-		);
+		// PNG is intentionally left on disk — the file may be shared with
+		// another venue at the same address. A future GC pass sweeps truly
+		// orphaned files.
+		unset( $path );
 	}
 
 	/**
@@ -617,13 +631,15 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
-	 * Removes the PNG and the descriptor meta for the venue.
+	 * Clears the descriptor meta for the venue but leaves the PNG on disk
+	 * — the file may be shared with another venue at the same address, so
+	 * on-delete cleanup is deferred to a future GC pass.
 	 *
 	 * @covers ::delete_stored_image
 	 *
 	 * @return void
 	 */
-	public function test_delete_stored_image_removes_file_and_meta(): void {
+	public function test_delete_stored_image_clears_meta(): void {
 		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
@@ -641,61 +657,13 @@ class Test_Venue_Map extends Base {
 		$instance->maybe_generate( $post_id );
 
 		$descriptor = $instance->get_stored_descriptor( $post_id );
-		$path       = $instance->url_to_path( $descriptor['url'] );
-
-		$this->assertFileExists( $path );
+		$this->assertNotNull( $descriptor, 'Precondition: venue has a descriptor.' );
 
 		$instance->delete_stored_image( $post_id );
 
-		$this->assertFileDoesNotExist( $path, 'PNG should be removed by delete_stored_image.' );
 		$this->assertNull(
 			$instance->get_stored_descriptor( $post_id ),
 			'Descriptor meta should be cleared after delete_stored_image.'
-		);
-	}
-
-	/**
-	 * Rejects URLs that sit outside of the plugin's uploads subdir.
-	 *
-	 * @covers ::url_to_path
-	 *
-	 * @return void
-	 */
-	public function test_url_to_path_rejects_external_urls(): void {
-		$instance = Venue_Map::get_instance();
-
-		$this->assertNull(
-			$instance->url_to_path( 'https://example.com/evil.png' ),
-			'External URLs must not resolve to a filesystem path.'
-		);
-	}
-
-	/**
-	 * A URL whose origin matches the plugin uploads subdir but whose
-	 * filename contains path-traversal segments (`..`) must not resolve —
-	 * otherwise delete_file_by_url() could be steered at arbitrary files
-	 * if the meta were ever writable.
-	 *
-	 * @covers ::url_to_path
-	 *
-	 * @return void
-	 */
-	public function test_url_to_path_rejects_traversal_in_plugin_subdir_url(): void {
-		$instance = Venue_Map::get_instance();
-		$dirs     = wp_get_upload_dir();
-		$base_url = trailingslashit( $dirs['baseurl'] ) . Venue_Map::UPLOADS_SUBDIR . '/';
-
-		$this->assertNull(
-			$instance->url_to_path( $base_url . '../../../wp-config.php' ),
-			'Traversal segments in the relative portion must not resolve.'
-		);
-		$this->assertNull(
-			$instance->url_to_path( $base_url . '42-notahex.png' ),
-			'Filenames not matching the `{post_id}-{md5}.png` shape must not resolve.'
-		);
-		$this->assertNull(
-			$instance->url_to_path( $base_url . 'subdir/42-abcdef0123456789abcdef0123456789.png' ),
-			'Nested filenames (with slashes) must not resolve.'
 		);
 	}
 
@@ -1012,26 +980,32 @@ class Test_Venue_Map extends Base {
 			'Second-combo hash should change with new coordinates.'
 		);
 
-		// Old files should be gone.
-		$this->assertFileDoesNotExist(
-			(string) $instance->url_to_path( $before[ $default_key ]['url'] )
+		// New files exist at the updated address slug. Old files aren't
+		// deleted — with address-based naming they may be shared, and GC is
+		// deferred to a follow-up pass.
+		$this->assertFileExists(
+			(string) $this->path_for_url( $after[ $default_key ]['url'] )
 		);
-		$this->assertFileDoesNotExist(
-			(string) $instance->url_to_path( $before[ $second_key ]['url'] )
+		$this->assertFileExists(
+			(string) $this->path_for_url( $after[ $second_key ]['url'] )
+		);
+		$this->assertNotSame(
+			$before[ $default_key ]['url'],
+			$after[ $default_key ]['url'],
+			'Address change produces a different URL via the slug.'
 		);
 	}
 
 	/**
-	 * If the meta write after save_image() is dropped (e.g. under an
-	 * object-cache outage or a filter that suppresses the update),
-	 * ensure_descriptor_for_combo() must unlink the just-saved PNG and
-	 * return null so we don't leave an orphan on disk.
+	 * When the meta write after save_image() is dropped, the method returns
+	 * null so callers know the descriptor didn't persist. The PNG is left on
+	 * disk — GC handles orphans; files may be shared with other venues.
 	 *
 	 * @covers ::ensure_descriptor_for_combo
 	 *
 	 * @return void
 	 */
-	public function test_ensure_descriptor_for_combo_unlinks_orphan_when_meta_write_dropped(): void {
+	public function test_ensure_descriptor_for_combo_returns_null_when_meta_write_dropped(): void {
 		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
@@ -1047,9 +1021,6 @@ class Test_Venue_Map extends Base {
 			)
 		);
 
-		// Short-circuit update_post_metadata so the map descriptor write
-		// never reaches the DB. The filter returns a non-null value for
-		// META_KEY only, leaving other meta writes alone.
 		$suppress = static function ( $check, $object_id, $meta_key ) {
 			if ( Venue_Map::META_KEY === $meta_key ) {
 				return true; // Pretend the update happened.
@@ -1076,150 +1047,8 @@ class Test_Venue_Map extends Base {
 
 		$this->assertNull(
 			$result,
-			'Orphan-guard must return null when the meta write was suppressed.'
+			'Returns null when the meta write was suppressed.'
 		);
-
-		$dirs     = wp_get_upload_dir();
-		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Map::UPLOADS_SUBDIR;
-
-		$this->assertEmpty(
-			(array) glob( $base_dir . sprintf( '/%d-*.png', $post_id ) ),
-			'The orphan PNG should have been unlinked.'
-		);
-	}
-
-	/**
-	 * Direct coverage for salt_for — lazily generates a salt on first
-	 * access and returns the same value on subsequent calls.
-	 *
-	 * @covers ::salt_for
-	 *
-	 * @return void
-	 */
-	public function test_salt_for_generates_and_caches(): void {
-		$instance = Venue_Map::get_instance();
-		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
-
-		$this->assertSame(
-			'',
-			(string) get_post_meta( $post_id, Venue_Map::SALT_META_KEY, true ),
-			'Precondition: freshly created venue has no salt meta.'
-		);
-
-		$first = Utility::invoke_hidden_method( $instance, 'salt_for', array( $post_id ) );
-
-		$this->assertIsString( $first );
-		$this->assertSame( 32, strlen( $first ), 'Salt should be 32 characters.' );
-		$this->assertSame(
-			$first,
-			(string) get_post_meta( $post_id, Venue_Map::SALT_META_KEY, true ),
-			'Salt should be persisted to meta on first access.'
-		);
-
-		$second = Utility::invoke_hidden_method( $instance, 'salt_for', array( $post_id ) );
-
-		$this->assertSame(
-			$first,
-			$second,
-			'Subsequent calls should return the same cached salt.'
-		);
-	}
-
-	/**
-	 * Simulates two concurrent first-touch callers by forcing add_post_meta
-	 * to fail for the losing request (meaning another request just wrote
-	 * the salt between our read and write). salt_for() must then re-read
-	 * and return the winner's value, not its own abandoned candidate —
-	 * otherwise the loser's PNG filename won't match what any subsequent
-	 * request computes.
-	 *
-	 * @covers ::salt_for
-	 *
-	 * @return void
-	 */
-	public function test_salt_for_recovers_from_lost_race(): void {
-		$instance = Venue_Map::get_instance();
-		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
-		$winner   = 'winnerwinnerwinnerwinnerwinner12';
-
-		// Hook `add_post_metadata` to simulate another request winning the
-		// race between our read and our write: right before our
-		// add_post_meta() lands, the hook writes the winner value straight
-		// to the DB and returns false to tell add_post_meta() "already
-		// exists, didn't write". salt_for() must recover by re-reading the
-		// winner. The write goes through $wpdb directly so it doesn't fire
-		// add_post_metadata again and recurse.
-		global $wpdb;
-		$force_race_loss = static function ( $check, $object_id, $meta_key ) use ( $winner, $post_id, $wpdb ) {
-			if ( Venue_Map::SALT_META_KEY !== $meta_key || $object_id !== $post_id ) {
-				return $check;
-			}
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Test fixture bypasses add_post_meta() to avoid recursing into the filter we're inside.
-			$wpdb->insert(
-				$wpdb->postmeta,
-				array(
-					'post_id'    => $post_id,
-					'meta_key'   => Venue_Map::SALT_META_KEY,
-					'meta_value' => $winner,
-				)
-			);
-			// phpcs:enable
-			wp_cache_delete( $post_id, 'post_meta' );
-			return false;
-		};
-		add_filter( 'add_post_metadata', $force_race_loss, 10, 3 );
-
-		$resolved = Utility::invoke_hidden_method( $instance, 'salt_for', array( $post_id ) );
-
-		remove_filter( 'add_post_metadata', $force_race_loss, 10 );
-
-		$this->assertSame(
-			$winner,
-			$resolved,
-			'Losing request must re-read the winner salt, not return its own candidate.'
-		);
-	}
-
-	/**
-	 * Direct coverage for delete_file_by_url — unlinks only when the URL
-	 * resolves to a path inside the plugin's uploads subdir.
-	 *
-	 * @covers ::delete_file_by_url
-	 *
-	 * @return void
-	 */
-	public function test_delete_file_by_url_unlinks_in_scope(): void {
-		$instance = Venue_Map::get_instance();
-
-		// Create a fixture file the method is allowed to delete.
-		$dirs     = wp_get_upload_dir();
-		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Map::UPLOADS_SUBDIR;
-		wp_mkdir_p( $base_dir );
-
-		// Use a filename in the `{post_id}-{md5}.png` shape url_to_path()
-		// accepts. A fake hex string stands in for a real MD5 digest.
-		$filename = '99-abcdef0123456789abcdef0123456789.png';
-		$path     = $base_dir . '/' . $filename;
-		$url      = trailingslashit( $dirs['baseurl'] )
-			. Venue_Map::UPLOADS_SUBDIR . '/' . $filename;
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Fixture write inside the test-only uploads dir.
-		file_put_contents( $path, 'stub' );
-
-		$this->assertFileExists( $path );
-
-		Utility::invoke_hidden_method( $instance, 'delete_file_by_url', array( $url ) );
-
-		$this->assertFileDoesNotExist( $path, 'In-scope file should be removed.' );
-
-		// Out-of-scope URL should no-op (url_to_path returns null).
-		Utility::invoke_hidden_method(
-			$instance,
-			'delete_file_by_url',
-			array( 'https://example.test/outside.png' )
-		);
-		// Terminal assertion to keep PHPUnit happy — the real guarantee is
-		// that no exception is thrown and no unexpected side effects occur.
-		$this->assertTrue( true );
 	}
 
 	/**
@@ -1287,7 +1116,7 @@ class Test_Venue_Map extends Base {
 		);
 
 		$first  = $instance->get_url_for_post( $post_id, Venue::POST_TYPE, 17 );
-		$path   = (string) $instance->url_to_path( $first );
+		$path   = (string) $this->path_for_url( $first );
 		$mtime1 = filemtime( $path );
 
 		sleep( 1 );
@@ -1450,25 +1279,6 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
-	 * Resolves a URL inside the plugin's uploads subdir back to a path.
-	 *
-	 * @covers ::url_to_path
-	 *
-	 * @return void
-	 */
-	public function test_url_to_path_resolves_plugin_subdir_url(): void {
-		$instance = Venue_Map::get_instance();
-		$dirs     = wp_get_upload_dir();
-		$filename = '42-abcdef0123456789abcdef0123456789.png';
-		$url      = trailingslashit( $dirs['baseurl'] )
-			. Venue_Map::UPLOADS_SUBDIR . '/' . $filename;
-		$expected = trailingslashit( $dirs['basedir'] )
-			. Venue_Map::UPLOADS_SUBDIR . '/' . $filename;
-
-		$this->assertSame( $expected, $instance->url_to_path( $url ) );
-	}
-
-	/**
 	 * Bails silently when called on a non-venue post type.
 	 *
 	 * @covers ::maybe_generate
@@ -1621,16 +1431,14 @@ class Test_Venue_Map extends Base {
 		$instance = Venue_Map::get_instance();
 		$canvas   = imagecreatetruecolor( 10, 10 );
 
-		// Use a 32-char hex hash matching what hash_for() produces; the
-		// url_to_path allow-list rejects anything else.
-		$hash = str_repeat( 'a', 32 );
-		$url  = $instance->save_image( $canvas, 99, $hash );
+		$url = $instance->save_image( $canvas, '1 Infinite Loop', 15, 800, 400 );
 		imagedestroy( $canvas );
 
 		$this->assertNotNull( $url, 'save_image should return a URL on success.' );
 		$this->assertStringContainsString( Venue_Map::UPLOADS_SUBDIR, $url );
+		$this->assertStringEndsWith( '1-infinite-loop-15-800-400.png', $url );
 
-		$path = $instance->url_to_path( $url );
+		$path = $this->path_for_url( $url );
 		$this->assertFileExists( $path );
 	}
 
@@ -2035,7 +1843,7 @@ class Test_Venue_Map extends Base {
 		};
 		add_filter( 'upload_dir', $force_error );
 
-		$url = $instance->save_image( $canvas, 99, 'abc' );
+		$url = $instance->save_image( $canvas, 'test address', 15, 800, 400 );
 
 		remove_filter( 'upload_dir', $force_error );
 		imagedestroy( $canvas );
@@ -2220,7 +2028,7 @@ class Test_Venue_Map extends Base {
 		$this->assertSame( Venue_Map::DEFAULT_HEIGHT * 2, $both_auto['width'] );
 		$this->assertSame( Venue_Map::DEFAULT_HEIGHT, $both_auto['height'] );
 
-		// Unparseable ratio string still resolves cleanly — falls back to
+		// Unparsable ratio string still resolves cleanly — falls back to
 		// the default ratio rather than stranding the generator.
 		$bad_ratio = Utility::invoke_hidden_method(
 			$instance,
@@ -2277,7 +2085,7 @@ class Test_Venue_Map extends Base {
 		// is the signal that the tile fetch + compositing ran again.
 		$pre_mtimes = array();
 		foreach ( $before as $combo_key => $descriptor ) {
-			$path                     = (string) $instance->url_to_path( $descriptor['url'] );
+			$path                     = (string) $this->path_for_url( $descriptor['url'] );
 			$pre_mtimes[ $combo_key ] = filemtime( $path );
 		}
 		sleep( 1 );
@@ -2292,7 +2100,7 @@ class Test_Venue_Map extends Base {
 
 		foreach ( $before as $combo_key => $old ) {
 			$this->assertArrayHasKey( $combo_key, $result );
-			$path = (string) $instance->url_to_path( $result[ $combo_key ]['url'] );
+			$path = (string) $this->path_for_url( $result[ $combo_key ]['url'] );
 			$this->assertFileExists(
 				$path,
 				sprintf( 'Post-regenerate PNG for %s should exist on disk.', $combo_key )

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -978,7 +978,7 @@ class Test_Venue_Map extends Base {
 			Venue_Map::DEFAULT_HEIGHT
 		);
 		// Second combo: zoom=14, height=500, auto width at 2:1 = 1000×500.
-		$second_key  = '14x1000x500';
+		$second_key = '14x1000x500';
 
 		$before = $instance->get_all_descriptors( $post_id );
 

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -309,11 +309,11 @@ class Test_Venue_Map extends Base {
 			'longitude'   => '-122.0312',
 		);
 
-		$baseline = $instance->hash_for( $post_id, $info, 15, 400, Venue_Map::DEFAULT_TILE_URL );
+		$baseline = $instance->hash_for( $post_id, $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL );
 
 		$this->assertSame(
 			$baseline,
-			$instance->hash_for( $post_id, $info, 15, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $post_id, $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should be stable when every input is identical.'
 		);
 
@@ -323,19 +323,25 @@ class Test_Venue_Map extends Base {
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $post_id, $moved_info, 15, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $post_id, $moved_info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when coordinates change.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $post_id, $info, 14, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $post_id, $info, 14, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when the zoom level changes.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $post_id, $info, 15, 500, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $post_id, $info, 15, 600, 400, Venue_Map::DEFAULT_TILE_URL ),
+			'Hash should change when the width changes.'
+		);
+
+		$this->assertNotSame(
+			$baseline,
+			$instance->hash_for( $post_id, $info, 15, 800, 500, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should change when the height changes.'
 		);
 
@@ -344,7 +350,7 @@ class Test_Venue_Map extends Base {
 		$other_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $other_post_id, $info, 15, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $other_post_id, $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
 			'Hash should differ between venues because each has its own salt.'
 		);
 	}
@@ -722,33 +728,36 @@ class Test_Venue_Map extends Base {
 			$post_id,
 			Venue_Map::META_KEY,
 			array(
-				'15x300'        => array(
+				'15x600x300'    => array(
 					'url'    => 'https://example.test/a.png',
 					'hash'   => 'abc',
 					'zoom'   => 15,
+					'width'  => 600,
 					'height' => 300,
 				),
-				'18x400'        => 'not-an-array',
-				'20x500'        => array(
+				'18x800x400'    => 'not-an-array',
+				'20x1000x500'   => array(
 					'url'    => 'https://example.test/b.png',
 					'zoom'   => 20,
+					'width'  => 1000,
 					'height' => 500,
 				), // Missing hash.
 				'missing-shape' => array(
 					'url'  => 'https://example.test/c.png',
 					'hash' => 'def',
-				), // Missing zoom/height.
+				), // Missing zoom/width/height.
 			)
 		);
 
 		$descriptors = $instance->get_all_descriptors( $post_id );
 
-		$this->assertArrayHasKey( '15x300', $descriptors );
-		$this->assertArrayNotHasKey( '18x400', $descriptors );
-		$this->assertArrayNotHasKey( '20x500', $descriptors );
+		$this->assertArrayHasKey( '15x600x300', $descriptors );
+		$this->assertArrayNotHasKey( '18x800x400', $descriptors );
+		$this->assertArrayNotHasKey( '20x1000x500', $descriptors );
 		$this->assertArrayNotHasKey( 'missing-shape', $descriptors );
-		$this->assertSame( 15, $descriptors['15x300']['zoom'] );
-		$this->assertSame( 300, $descriptors['15x300']['height'] );
+		$this->assertSame( 15, $descriptors['15x600x300']['zoom'] );
+		$this->assertSame( 600, $descriptors['15x600x300']['width'] );
+		$this->assertSame( 300, $descriptors['15x600x300']['height'] );
 
 		// Read path must not mutate the meta — writing on every render would
 		// thrash the post-meta cache and churn the DB. Cleanup is deferred
@@ -811,15 +820,16 @@ class Test_Venue_Map extends Base {
 		$this->assertArrayNotHasKey( 'no-hash', $stored );
 
 		$default_key = sprintf(
-			'%dx%d',
+			'%dx%dx%d',
 			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT * 2,
 			Venue_Map::DEFAULT_HEIGHT
 		);
 		$this->assertArrayHasKey( $default_key, $stored );
 	}
 
 	/**
-	 * Requesting a previously-uncached (zoom, height) combo triggers
+	 * Requesting a previously-uncached (zoom, width, height) combo triggers
 	 * synchronous generation and caches the result for next time.
 	 *
 	 * @covers ::get_url_for_post
@@ -845,8 +855,9 @@ class Test_Venue_Map extends Base {
 		$instance->maybe_generate( $post_id );
 
 		$default_key = sprintf(
-			'%dx%d',
+			'%dx%dx%d',
 			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT * 2,
 			Venue_Map::DEFAULT_HEIGHT
 		);
 
@@ -855,13 +866,25 @@ class Test_Venue_Map extends Base {
 		$this->assertCount(
 			1,
 			$descriptors_before,
-			'Initial save should seed only the default (zoom, height) combo.'
+			'Initial save should seed only the default combo.'
 		);
 		$this->assertArrayHasKey( $default_key, $descriptors_before );
 
 		// Request a different zoom — simulates a block customized to zoom 14.
-		$new_key = sprintf( '14x%d', Venue_Map::DEFAULT_HEIGHT );
-		$url     = $instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14 );
+		// Auto width at 2:1 ratio against DEFAULT_HEIGHT → DEFAULT_HEIGHT*2.
+		$new_key = sprintf(
+			'14x%dx%d',
+			Venue_Map::DEFAULT_HEIGHT * 2,
+			Venue_Map::DEFAULT_HEIGHT
+		);
+		$url     = $instance->get_url_for_post(
+			$post_id,
+			Venue::POST_TYPE,
+			14,
+			0,
+			Venue_Map::DEFAULT_HEIGHT,
+			''
+		);
 
 		$this->assertNotEmpty( $url, 'Lazy generation should return a non-empty URL.' );
 
@@ -902,16 +925,20 @@ class Test_Venue_Map extends Base {
 			$post_id,
 			Venue::POST_TYPE,
 			Venue_Map::DEFAULT_ZOOM,
-			500
+			0,
+			500,
+			''
 		);
 
 		$this->assertNotEmpty( $tall_url );
 
-		$key = sprintf( '%dx500', Venue_Map::DEFAULT_ZOOM );
+		// Auto width at 2:1 ratio on height=500 → 1000.
+		$key = sprintf( '%dx1000x500', Venue_Map::DEFAULT_ZOOM );
 		$all = $instance->get_all_descriptors( $post_id );
 
 		$this->assertArrayHasKey( $key, $all, 'Tall-height combo should be cached under its own key.' );
 		$this->assertSame( 500, $all[ $key ]['height'] );
+		$this->assertSame( 1000, $all[ $key ]['width'] );
 	}
 
 	/**
@@ -941,14 +968,17 @@ class Test_Venue_Map extends Base {
 		);
 		$instance->maybe_generate( $post_id );
 		// Warm a second combo (not the default seed) so we have two variants.
-		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14, 500 );
+		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14, 0, 500, '' );
 
+		// Default combo from DEFAULT_HEIGHT + auto width at 2:1 = 600×300.
 		$default_key = sprintf(
-			'%dx%d',
+			'%dx%dx%d',
 			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT * 2,
 			Venue_Map::DEFAULT_HEIGHT
 		);
-		$second_key  = '14x500';
+		// Second combo: zoom=14, height=500, auto width at 2:1 = 1000×500.
+		$second_key  = '14x1000x500';
 
 		$before = $instance->get_all_descriptors( $post_id );
 
@@ -1033,7 +1063,13 @@ class Test_Venue_Map extends Base {
 		$result = Utility::invoke_hidden_method(
 			$instance,
 			'ensure_descriptor_for_combo',
-			array( $post_id, $info, Venue_Map::DEFAULT_ZOOM, Venue_Map::DEFAULT_HEIGHT )
+			array(
+				$post_id,
+				$info,
+				Venue_Map::DEFAULT_ZOOM,
+				Venue_Map::DEFAULT_HEIGHT * 2,
+				Venue_Map::DEFAULT_HEIGHT,
+			)
 		);
 
 		remove_filter( 'update_post_metadata', $suppress, 10 );
@@ -1216,6 +1252,7 @@ class Test_Venue_Map extends Base {
 					'longitude'   => '-122.0312',
 				),
 				15,
+				600,
 				300,
 			)
 		);
@@ -1497,12 +1534,12 @@ class Test_Venue_Map extends Base {
 			37.3318,
 			-122.0312,
 			15,
+			512,
 			256,
 			Venue_Map::DEFAULT_TILE_URL
 		);
 
 		$this->assertInstanceOf( \GdImage::class, $image );
-		// Width is derived from height via IMAGE_ASPECT_RATIO (2.0) → 512×256.
 		$this->assertSame( 512, imagesx( $image ) );
 		$this->assertSame( 256, imagesy( $image ) );
 
@@ -1714,23 +1751,28 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
-	 * Coverage for combo_key — formats `{zoom}x{height}`.
+	 * Coverage for combo_key — formats `{zoom}x{width}x{height}`.
 	 *
 	 * @covers ::combo_key
 	 *
 	 * @return void
 	 */
-	public function test_combo_key_formats_zoom_and_height(): void {
+	public function test_combo_key_formats_zoom_width_and_height(): void {
 		$instance = Venue_Map::get_instance();
 
 		$this->assertSame(
-			'14x500',
-			Utility::invoke_hidden_method( $instance, 'combo_key', array( 14, 500 ) )
+			'14x800x500',
+			Utility::invoke_hidden_method(
+				$instance,
+				'combo_key',
+				array( 14, 800, 500 )
+			)
 		);
 	}
 
 	/**
-	 * Coverage for get_cached_combos — returns unique (zoom, height) combos.
+	 * Coverage for get_cached_combos — returns unique (zoom, width, height)
+	 * combos.
 	 *
 	 * @covers ::get_cached_combos
 	 *
@@ -1750,16 +1792,18 @@ class Test_Venue_Map extends Base {
 			$post_id,
 			Venue_Map::META_KEY,
 			array(
-				'15x300' => array(
+				'15x600x300'  => array(
 					'url'    => 'https://example.test/a.png',
 					'hash'   => 'abc',
 					'zoom'   => 15,
+					'width'  => 600,
 					'height' => 300,
 				),
-				'18x500' => array(
+				'18x1000x500' => array(
 					'url'    => 'https://example.test/b.png',
 					'hash'   => 'def',
 					'zoom'   => 18,
+					'width'  => 1000,
 					'height' => 500,
 				),
 			)
@@ -1771,6 +1815,7 @@ class Test_Venue_Map extends Base {
 		$this->assertContains(
 			array(
 				'zoom'   => 15,
+				'width'  => 600,
 				'height' => 300,
 			),
 			$combos
@@ -1778,6 +1823,7 @@ class Test_Venue_Map extends Base {
 		$this->assertContains(
 			array(
 				'zoom'   => 18,
+				'width'  => 1000,
 				'height' => 500,
 			),
 			$combos
@@ -1825,6 +1871,7 @@ class Test_Venue_Map extends Base {
 			37.3318,
 			-122.0312,
 			15,
+			512,
 			256,
 			Venue_Map::DEFAULT_TILE_URL
 		);
@@ -1871,6 +1918,7 @@ class Test_Venue_Map extends Base {
 			37.3318,
 			-122.0312,
 			15,
+			512,
 			256,
 			Venue_Map::DEFAULT_TILE_URL
 		);
@@ -1916,6 +1964,7 @@ class Test_Venue_Map extends Base {
 			37.3318,
 			-122.0312,
 			15,
+			512,
 			256,
 			Venue_Map::DEFAULT_TILE_URL
 		);
@@ -2021,6 +2070,136 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
+	 * Coverage for parse_aspect_ratio — valid inputs return the float
+	 * ratio, garbage returns null.
+	 *
+	 * @covers ::parse_aspect_ratio
+	 *
+	 * @return void
+	 */
+	public function test_parse_aspect_ratio(): void {
+		$instance = Venue_Map::get_instance();
+
+		$this->assertEqualsWithDelta(
+			2.0,
+			Utility::invoke_hidden_method( $instance, 'parse_aspect_ratio', array( '2/1' ) ),
+			0.0001
+		);
+		$this->assertEqualsWithDelta(
+			16 / 9,
+			Utility::invoke_hidden_method( $instance, 'parse_aspect_ratio', array( '16/9' ) ),
+			0.0001
+		);
+		// Colon separator is also accepted so the same string can come
+		// straight from a CSS value like "16:9".
+		$this->assertEqualsWithDelta(
+			16 / 9,
+			Utility::invoke_hidden_method( $instance, 'parse_aspect_ratio', array( '16:9' ) ),
+			0.0001
+		);
+		$this->assertNull(
+			Utility::invoke_hidden_method( $instance, 'parse_aspect_ratio', array( '' ) ),
+			'Empty input should return null.'
+		);
+		$this->assertNull(
+			Utility::invoke_hidden_method( $instance, 'parse_aspect_ratio', array( 'not-a-ratio' ) ),
+			'Non-numeric input should return null.'
+		);
+		$this->assertNull(
+			Utility::invoke_hidden_method( $instance, 'parse_aspect_ratio', array( '4/0' ) ),
+			'Zero denominator should return null.'
+		);
+	}
+
+	/**
+	 * Coverage for clamp_width — enforces the WIDTH_MIN..WIDTH_MAX bounds.
+	 *
+	 * @covers ::clamp_width
+	 *
+	 * @return void
+	 */
+	public function test_clamp_width(): void {
+		$instance = Venue_Map::get_instance();
+
+		$this->assertSame(
+			Venue_Map::WIDTH_MIN,
+			Utility::invoke_hidden_method( $instance, 'clamp_width', array( 0 ) )
+		);
+		$this->assertSame(
+			Venue_Map::WIDTH_MAX,
+			Utility::invoke_hidden_method( $instance, 'clamp_width', array( 99999 ) )
+		);
+		$this->assertSame(
+			600,
+			Utility::invoke_hidden_method( $instance, 'clamp_width', array( 600 ) )
+		);
+	}
+
+	/**
+	 * Coverage for resolve_dimensions — derives the missing side from the
+	 * aspect ratio when either width or height is 0 ("auto"), falls back
+	 * to DEFAULT_HEIGHT when both are auto, and clamps both outputs.
+	 *
+	 * @covers ::resolve_dimensions
+	 *
+	 * @return void
+	 */
+	public function test_resolve_dimensions(): void {
+		$instance = Venue_Map::get_instance();
+
+		$both = Utility::invoke_hidden_method(
+			$instance,
+			'resolve_dimensions',
+			array( 800, 400, '2/1' )
+		);
+		$this->assertSame( 800, $both['width'] );
+		$this->assertSame( 400, $both['height'] );
+
+		$auto_w = Utility::invoke_hidden_method(
+			$instance,
+			'resolve_dimensions',
+			array( 0, 400, '2/1' )
+		);
+		$this->assertSame( 800, $auto_w['width'], 'Auto width = height × ratio.' );
+		$this->assertSame( 400, $auto_w['height'] );
+
+		$auto_h = Utility::invoke_hidden_method(
+			$instance,
+			'resolve_dimensions',
+			array( 900, 0, '3/2' )
+		);
+		$this->assertSame( 900, $auto_h['width'] );
+		$this->assertSame( 600, $auto_h['height'], 'Auto height = width ÷ ratio.' );
+
+		$both_auto = Utility::invoke_hidden_method(
+			$instance,
+			'resolve_dimensions',
+			array( 0, 0, '2/1' )
+		);
+		$this->assertSame( Venue_Map::DEFAULT_HEIGHT * 2, $both_auto['width'] );
+		$this->assertSame( Venue_Map::DEFAULT_HEIGHT, $both_auto['height'] );
+
+		// Unparseable ratio string still resolves cleanly — falls back to
+		// the default ratio rather than stranding the generator.
+		$bad_ratio = Utility::invoke_hidden_method(
+			$instance,
+			'resolve_dimensions',
+			array( 0, 400, 'garbage' )
+		);
+		$this->assertSame( 800, $bad_ratio['width'] );
+		$this->assertSame( 400, $bad_ratio['height'] );
+
+		// Out-of-range inputs get clamped to the supported bounds.
+		$too_big = Utility::invoke_hidden_method(
+			$instance,
+			'resolve_dimensions',
+			array( 99999, 99999, '2/1' )
+		);
+		$this->assertSame( Venue_Map::WIDTH_MAX, $too_big['width'] );
+		$this->assertSame( Venue_Map::HEIGHT_MAX, $too_big['height'] );
+	}
+
+	/**
 	 * Wipes cached descriptors + PNG files and rebuilds entries for every
 	 * combo the venue was previously cached at, returning the fresh
 	 * descriptor map.
@@ -2046,7 +2225,7 @@ class Test_Venue_Map extends Base {
 		);
 		$instance->maybe_generate( $post_id );
 		// Warm a second combo so regenerate has two variants to cover.
-		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14, 500 );
+		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14, 0, 500, '' );
 
 		$before = $instance->get_all_descriptors( $post_id );
 		$this->assertCount( 2, $before );
@@ -2113,15 +2292,17 @@ class Test_Venue_Map extends Base {
 		// Seed one cached combo the venue "already had".
 		$instance->maybe_generate( $post_id );
 
-		$result = $instance->regenerate( $post_id, 8, 295 );
+		$result = $instance->regenerate( $post_id, 8, 0, 295, '' );
 
-		$expected_key = '8x295';
+		// Auto-width at 2:1 on height 295 → 590.
+		$expected_key = '8x590x295';
 		$this->assertArrayHasKey(
 			$expected_key,
 			$result,
 			'The caller-supplied combo must be included in the rebuild.'
 		);
 		$this->assertSame( 8, $result[ $expected_key ]['zoom'] );
+		$this->assertSame( 590, $result[ $expected_key ]['width'] );
 		$this->assertSame( 295, $result[ $expected_key ]['height'] );
 	}
 
@@ -2153,7 +2334,9 @@ class Test_Venue_Map extends Base {
 		$result = $instance->regenerate(
 			$post_id,
 			Venue_Map::DEFAULT_ZOOM,
-			Venue_Map::DEFAULT_HEIGHT
+			Venue_Map::DEFAULT_HEIGHT * 2,
+			Venue_Map::DEFAULT_HEIGHT,
+			''
 		);
 
 		$this->assertCount(
@@ -2193,8 +2376,9 @@ class Test_Venue_Map extends Base {
 		$result = $instance->regenerate( $post_id );
 
 		$default_key = sprintf(
-			'%dx%d',
+			'%dx%dx%d',
 			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT * 2,
 			Venue_Map::DEFAULT_HEIGHT
 		);
 		$this->assertArrayHasKey( $default_key, $result );
@@ -2297,8 +2481,9 @@ class Test_Venue_Map extends Base {
 		$this->assertSame( '', $data['reason'] );
 
 		$default_key = sprintf(
-			'%dx%d',
+			'%dx%dx%d',
 			Venue_Map::DEFAULT_ZOOM,
+			Venue_Map::DEFAULT_HEIGHT * 2,
 			Venue_Map::DEFAULT_HEIGHT
 		);
 		$this->assertArrayHasKey( $default_key, (array) $data['descriptors'] );

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -1409,6 +1409,47 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
+	 * Returns null from warm() for a non-existent or zero venue post ID
+	 * without attempting to render a tile.
+	 *
+	 * @covers ::warm
+	 *
+	 * @return void
+	 */
+	public function test_warm_returns_null_for_invalid_post_id(): void {
+		$instance = Venue_Map::get_instance();
+
+		$this->assertNull( $instance->warm( 0, 15, 800, 400, '2/1' ) );
+	}
+
+	/**
+	 * Returns null from warm() when the venue has no valid coordinates —
+	 * short circuits before the tile compositing stage.
+	 *
+	 * @covers ::warm
+	 *
+	 * @return void
+	 */
+	public function test_warm_returns_null_when_venue_has_no_coordinates(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop, Cupertino CA',
+					'latitude'    => '',
+					'longitude'   => '',
+				)
+			)
+		);
+
+		$this->assertNull( $instance->warm( $post_id, 15, 800, 400, '2/1' ) );
+	}
+
+	/**
 	 * Resolves a URL inside the plugin's uploads subdir back to a path.
 	 *
 	 * @covers ::url_to_path

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
@@ -92,7 +92,7 @@ class Test_Venues extends Base {
 		foreach ( array(
 			'venue_map_default_render_mode' => 'interactive',
 			'venue_map_default_zoom'        => 18,
-			'venue_map_default_height'      => 300,
+			'venue_map_default_height'      => '',
 			'venue_map_default_type'        => 'roadmap',
 		) as $key => $expected ) {
 			$this->assertArrayHasKey(


### PR DESCRIPTION
### Description of the Change

Layered improvements to the `gatherpress/venue-map` block, its editor UX, and its backing static-map pipeline. Grouped by area:

**Regenerate/Generate button**
- New `RegenerateMapButton` component that POSTs to `/gatherpress/v1/venue/{id}/regenerate-map`, then patches the venue's entity record via `receiveEntityRecords` so the editor preview picks up the fresh PNG without a page reload.
- The block placeholder surfaces the button when a venue is saved but its map hasn't been rendered yet; the Inspector shows the button when a static map is already on screen.
- REST endpoint accepts the current `(zoom, width, height, aspect_ratio)` combo so the server renders exactly what the editor is displaying.

**FSE template prewarming**
- New `Venue_Map_Prewarm` singleton walks `wp_template` + `wp_template_part` (DB + theme file) and every `gatherpress-venue`–carrying post for `gatherpress/venue-map` blocks, collects their combos, and schedules per-venue WP-Cron jobs that run `Venue_Map::warm()`.
- Hooks: `wp_after_insert_post` (priority 12, after `Venue_Map::maybe_generate`), `switch_theme`, and the `gatherpress_warm_venue_map` cron action.
- Paginated post scans (`gatherpress_venue_map_prewarm_batch_size` filter, default 500) so sites with thousands of events/venues never load the full set into memory on a save hook.
- Dedup via `wp_next_scheduled()` so repeated saves don't multiply jobs.

**Address-based filenames (replaces hash + salt)**
- PNGs are now named `{slugified-address}-{zoom}-{width}-{height}.png` (e.g. `1-infinite-loop-15-800-400.png`). Two venues at the same address share the same file on disk — intentional dedupe.
- Removed `SALT_META_KEY`, `salt_for()`, `delete_file_by_url()`, `url_to_path()` and the per-venue salt that was previously mixed into hashes.
- `delete_stored_image()` now only clears the descriptor meta; file cleanup is deferred to a follow-up GC tool (see [#1486](https://github.com/GatherPress/gatherpress/issues/1486)).

**Block Inspector reorganization**
- Width / Height / Aspect ratio moved to the **Styles** tab's Dimensions panel via `ToolsPanelItem` (proper core integration: reset menu, toggle visibility, per-block panel ID).
- Settings tab keeps Render mode, Zoom, Map type, and the Regenerate button.
- Aspect-ratio presets relabelled to match core/image (`Landscape - 2:1`, `Wide - 16:9`, etc.).
- Width / Height side-by-side text inputs, empty placeholder "Auto"; explicit `0` is also a valid auto sentinel.
- Link destination/target live as block attributes only — managed through a toolbar Dropdown (core/image pattern). Global settings for these were removed.

**Block supports enabled**
- `border` (radius, width, style, color) with border-radius inheritance on inner `<img>`/Leaflet/placeholder so rounded corners clip correctly.
- `shadow`.
- `spacing.padding` + `spacing.margin`.
- Alignment: `left`, `center`, `right`, `wide`, `full`.

**Interactive (Leaflet) map**
- Marker anchor shifted from bottom-tip to icon center so the pin sits over the coord instead of floating above.
- `map.invalidateSize()` + `setView()` after mount and on container resize (via `ResizeObserver`) — fixes pin placement when the wrapper gets its size from CSS `aspect-ratio` after Leaflet init.
- Inner container now fills 100% of the block wrapper (dropped the hardcoded 300px height).

**Venues Settings (Settings → Venues → Maps)**
- New defaults: render mode, zoom, width, height, aspect ratio, map type.
- Width/Height accept empty as "auto" (round-trips distinctly from `0`); placeholder `Auto` surfaces via a new `placeholder` + `allow_empty` option on the shared number field template.
- Settings sanitizer preserves empty submissions for number fields instead of coercing them to `0` through `intval`.
- Dropped: `venue_map_default_link_destination`, `venue_map_default_link_target` — link behavior is per-block only.

**Other fixes**
- Block Guard toggle was rendering twice on every Gatherpress block that supported it: `src/supports/block-guard.js` is imported from two webpack chunks (editor entry + venue-map block entry) and both were re-running the module-level `addFilter`. WP hooks don't dedupe by namespace — now guarded with `hasFilter`.
- Bumped `WIDTH_MAX` / `HEIGHT_MAX` from 1600/800 → 4000/4000 so modern retina/4K layouts fit without editor-vs-server combo-key drift.
- Parent `gatherpress/venue` block reverted to a constraint-only layout (`constrained` without hardcoded `wideSize`/`contentSize`) — defers to the theme's `theme.json`.
- Static-map map icon in FSE placeholder softened to `#b0b0b0`.
- Map-marker duotone support dropped — incompatible with tile maps in practice.
- PHPMD thresholds raised (class complexity 110→150, class length 1500→2000) to make headroom without a same-PR refactor of `Venue_Map`.

### How to test the Change

1. Run `npm run build` and reload the editor on a venue with a saved address.
2. **Regenerate button**: insert a `gatherpress/venue-map` block, pick Static render mode, click "Regenerate Map" — new PNG appears without a page reload.
3. **FSE prewarming**: add a `gatherpress/venue-map` to the Single Venue template; save the template. Visit a venue frontend — a cached PNG at the template's combo should serve.
4. **Address-based filenames**: inspect `wp-content/uploads/gatherpress/static-maps/` — filenames follow `{slug}-{zoom}-{w}-{h}.png`.
5. **Inspector reorg**: select the venue-map block; Dimensions controls live under the Styles tab, Render mode + Zoom + Regenerate under Settings.
6. **Width/Height behavior**: in Settings → Venues → Maps, leave Width empty → shows "Auto" placeholder; enter `0` → displays literal `0`.
7. **Interactive map pin**: switch the block to Interactive mode, view on the frontend — pin center sits at the map's visual center.
8. **Block Guard fix**: select a block that supports Block Guard — only one toggle should render in the Inspector.
9. Run unit tests: `npm run test:unit:php` and `npm run test:unit:js`. Run lint: `npm run lint:php` and `npm run lint:phpstan`.

### Changelog Entry

> Added - Regenerate Map button, FSE template prewarming, border/shadow/spacing supports, and Dimensions panel integration for the venue map block.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.