### PR TITLE
Venue map: tighten prewarm and render boundaries after review

### DIFF
--- a/includes/core/classes/class-venue-map-prewarm.php
+++ b/includes/core/classes/class-venue-map-prewarm.php
@@ -122,7 +122,9 @@ class Venue_Map_Prewarm {
 	 * Separate from {@see self::get_scan_batch_size()} because content
 	 * scans load full post rows (post_content can be megabytes on
 	 * FSE-rich pages), where the ID-only venue scan can afford a larger
-	 * batch. Clamped to at least 1.
+	 * batch. Clamped to [1, 1000] — the floor avoids an infinite empty-
+	 * batch loop, and the ceiling caps a misbehaving filter that would
+	 * otherwise try to load every event into memory in a single query.
 	 *
 	 * @since 1.0.0
 	 *
@@ -141,7 +143,7 @@ class Venue_Map_Prewarm {
 			self::CONTENT_SCAN_BATCH_SIZE
 		);
 
-		return max( 1, $size );
+		return min( 1000, max( 1, $size ) );
 	}
 
 	/**

--- a/includes/core/classes/class-venue-map-prewarm.php
+++ b/includes/core/classes/class-venue-map-prewarm.php
@@ -72,6 +72,18 @@ class Venue_Map_Prewarm {
 	const SCAN_BATCH_SIZE = 500;
 
 	/**
+	 * Batch size for scans that load full post objects (post_content
+	 * included). FSE-rich pages can make post_content multi-megabyte, so
+	 * we pull fewer rows per round-trip than the ID-only venue scan
+	 * (SCAN_BATCH_SIZE). Filterable via
+	 * `gatherpress_venue_map_prewarm_content_batch_size`.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const CONTENT_SCAN_BATCH_SIZE = 100;
+
+	/**
 	 * Class constructor — wires hooks.
 	 *
 	 * @since 1.0.0
@@ -100,6 +112,34 @@ class Venue_Map_Prewarm {
 		 * @param int $size Number of posts loaded per batch during prewarm scans.
 		 */
 		$size = (int) apply_filters( 'gatherpress_venue_map_prewarm_batch_size', self::SCAN_BATCH_SIZE );
+
+		return max( 1, $size );
+	}
+
+	/**
+	 * Return the batch size used by paginated content scans.
+	 *
+	 * Separate from {@see self::get_scan_batch_size()} because content
+	 * scans load full post rows (post_content can be megabytes on
+	 * FSE-rich pages), where the ID-only venue scan can afford a larger
+	 * batch. Clamped to at least 1.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return int
+	 */
+	protected function get_content_scan_batch_size(): int {
+		/**
+		 * Filter the venue-map prewarm content-scan batch size.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $size Number of posts loaded per batch during content scans.
+		 */
+		$size = (int) apply_filters(
+			'gatherpress_venue_map_prewarm_content_batch_size',
+			self::CONTENT_SCAN_BATCH_SIZE
+		);
 
 		return max( 1, $size );
 	}
@@ -138,6 +178,16 @@ class Venue_Map_Prewarm {
 	 */
 	public function on_post_saved( int $post_id, WP_Post $post ): void {
 		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+
+		// Only published posts contribute to the cached render set — a
+		// draft/auto-draft venue hasn't been seen by any front-end request,
+		// a trashed one shouldn't get new warm jobs scheduled against it,
+		// and an unpublished template won't render. The scan paths reading
+		// venue / event content already filter `post_status => publish`, so
+		// this gate keeps the save-hook path consistent.
+		if ( 'publish' !== $post->post_status ) {
 			return;
 		}
 
@@ -322,7 +372,10 @@ class Venue_Map_Prewarm {
 
 		$venue_carrying_types = get_post_types_by_support( 'gatherpress-venue' );
 		if ( ! empty( $venue_carrying_types ) ) {
-			$batch_size = $this->get_scan_batch_size();
+			// Full post rows (for post_content) — use the smaller
+			// content-scan batch. FSE-rich events can carry MBs of
+			// content; the ID-only venue scan can afford a larger batch.
+			$batch_size = $this->get_content_scan_batch_size();
 			$page       = 1;
 
 			// Paginate rather than `posts_per_page => -1` — a site with

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -145,6 +145,18 @@ class Venue_Map {
 	const DEFAULT_ASPECT_RATIO = '2/1';
 
 	/**
+	 * Anchored regex matching a CSS-style aspect-ratio value (e.g. `16/9`
+	 * or `4:3`). Used by both the REST `aspect_ratio` validator and the
+	 * render template so the two can never drift apart. Requires at least
+	 * one non-zero digit on each side so a degenerate `0/9` / `9/0` — which
+	 * CSS would treat as `auto` — can't slip through.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const ASPECT_RATIO_PATTERN = '#\A\s*[1-9][0-9]*\s*[/:]\s*[1-9][0-9]*\s*\z#';
+
+	/**
 	 * Total wall-clock budget (in seconds) for a single composite_image()
 	 * call. CartoDB typically serves tiles in well under 500ms, but a slow
 	 * tile host, a DNS hiccup, or a bad proxy can chain wp_safe_remote_get()
@@ -323,7 +335,7 @@ class Venue_Map {
 								return true;
 							}
 							return (bool) preg_match(
-								'#\A\s*\d+\s*[/:]\s*\d+\s*\z#',
+								self::ASPECT_RATIO_PATTERN,
 								(string) $value
 							);
 						},
@@ -923,7 +935,7 @@ class Venue_Map {
 		}
 
 		/**
-		 * Filter the parsed descriptor map for a venue.
+		 * Filters the parsed descriptor map for a venue.
 		 *
 		 * Companion plugins, multi-locale setups, or storage-layer overrides
 		 * can use this to drop entries they consider stale, add synthetic
@@ -936,7 +948,7 @@ class Venue_Map {
 		 * @param array<string, array<string, mixed>> $descriptors Parsed descriptor map keyed by combo.
 		 * @param int                                 $post_id     Venue post ID.
 		 */
-		return (array) apply_filters( 'gatherpress_venue_map_descriptor', $descriptors, $post_id );
+		return (array) apply_filters( 'gatherpress_venue_map_descriptors', $descriptors, $post_id );
 	}
 
 	/**

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -927,7 +927,7 @@ class Venue_Map {
 		 *
 		 * Companion plugins, multi-locale setups, or storage-layer overrides
 		 * can use this to drop entries they consider stale, add synthetic
-		 * descriptors (e.g. pre-rendered PNGs in a CDN), or rewrite URLs.
+		 * descriptors (e.g. pre-rendered PNG files in a CDN), or rewrite URLs.
 		 * Callers of this method already tolerate empty maps, so returning
 		 * `[]` is a valid "suppress all" escape hatch.
 		 *

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -312,6 +312,21 @@ class Venue_Map {
 						'required'          => false,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
+						// Accept empty ("use server default") or an
+						// integer-separated pair matching the block's
+						// aspect-ratio format. parse_aspect_ratio()
+						// downstream still has to handle odd inputs for
+						// the non-REST call sites, but surfacing a 400
+						// here is cheaper than silently falling back.
+						'validate_callback' => static function ( $value ): bool {
+							if ( '' === $value || null === $value ) {
+								return true;
+							}
+							return (bool) preg_match(
+								'#\A\s*\d+\s*[/:]\s*\d+\s*\z#',
+								(string) $value
+							);
+						},
 					),
 				),
 			)
@@ -907,7 +922,21 @@ class Venue_Map {
 			);
 		}
 
-		return $descriptors;
+		/**
+		 * Filter the parsed descriptor map for a venue.
+		 *
+		 * Companion plugins, multi-locale setups, or storage-layer overrides
+		 * can use this to drop entries they consider stale, add synthetic
+		 * descriptors (e.g. pre-rendered PNGs in a CDN), or rewrite URLs.
+		 * Callers of this method already tolerate empty maps, so returning
+		 * `[]` is a valid "suppress all" escape hatch.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array<string, array<string, mixed>> $descriptors Parsed descriptor map keyed by combo.
+		 * @param int                                 $post_id     Venue post ID.
+		 */
+		return (array) apply_filters( 'gatherpress_venue_map_descriptor', $descriptors, $post_id );
 	}
 
 	/**

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -99,14 +99,15 @@ if ( 0 === $gatherpress_raw_width || 0 === $gatherpress_raw_height || $gatherpre
 	// The `aspectRatio` block attr lands directly in an inline style.
 	// get_block_wrapper_attributes() doesn't sanitize individual CSS
 	// values, so an editor-role attacker with edit_posts could otherwise
-	// stamp a payload like `1/1;background:url(...)`. Allow only the
+	// stamp a payload like `1/1;background:url(...)`. Accept only the
 	// narrow `N/N` or `N:N` form the block ever emits; anything else
-	// falls back to the server default.
+	// falls back to the server default. The pattern is shared with the
+	// REST validator so the two can never drift apart.
 	$gatherpress_ratio_candidate = '' !== $gatherpress_ratio
 		? $gatherpress_ratio
 		: Venue_Map::DEFAULT_ASPECT_RATIO;
 	$gatherpress_ratio_is_valid  = (bool) preg_match(
-		'#\A\s*\d+\s*[/:]\s*\d+\s*\z#',
+		Venue_Map::ASPECT_RATIO_PATTERN,
 		$gatherpress_ratio_candidate
 	);
 	$gatherpress_styles[]        = sprintf(

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -96,9 +96,22 @@ if ( 0 < $gatherpress_raw_width && ! $gatherpress_is_wide_or_full ) {
 }
 
 if ( 0 === $gatherpress_raw_width || 0 === $gatherpress_raw_height || $gatherpress_is_wide_or_full ) {
-	$gatherpress_styles[] = sprintf(
+	// The `aspectRatio` block attr lands directly in an inline style.
+	// get_block_wrapper_attributes() doesn't sanitize individual CSS
+	// values, so an editor-role attacker with edit_posts could otherwise
+	// stamp a payload like `1/1;background:url(...)`. Allow only the
+	// narrow `N/N` or `N:N` form the block ever emits; anything else
+	// falls back to the server default.
+	$gatherpress_ratio_candidate = '' !== $gatherpress_ratio
+		? $gatherpress_ratio
+		: Venue_Map::DEFAULT_ASPECT_RATIO;
+	$gatherpress_ratio_is_valid  = (bool) preg_match(
+		'#\A\s*\d+\s*[/:]\s*\d+\s*\z#',
+		$gatherpress_ratio_candidate
+	);
+	$gatherpress_styles[]        = sprintf(
 		'aspect-ratio:%s',
-		'' !== $gatherpress_ratio ? $gatherpress_ratio : Venue_Map::DEFAULT_ASPECT_RATIO
+		$gatherpress_ratio_is_valid ? $gatherpress_ratio_candidate : Venue_Map::DEFAULT_ASPECT_RATIO
 	);
 }
 

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -607,13 +607,61 @@ class Test_Venue_Map_Prewarm extends Base {
 	}
 
 	/**
-	 * Batch-size filter lets callers override SCAN_BATCH_SIZE; values below
-	 * 1 are clamped up to 1 to avoid an infinite empty-batch loop.
+	 * Content scan paginates through event-post batches — with a batch
+	 * size of 1 and two events contributing combos, the loop must tick
+	 * past its full-batch branch (the ++$page path) to reach the second
+	 * event.
 	 *
-	 * @covers ::get_scan_batch_size
+	 * @covers ::collect_all_template_combos
 	 *
 	 * @return void
 	 */
+	public function test_collect_all_template_combos_paginates_event_content(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$this->factory->post->create(
+			array(
+				'post_type'    => 'gatherpress_event',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":5,"width":150,"height":75,"aspectRatio":"2/1"} /-->',
+			)
+		);
+		$this->factory->post->create(
+			array(
+				'post_type'    => 'gatherpress_event',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:gatherpress/venue-map '
+					. '{"zoom":4,"width":120,"height":60,"aspectRatio":"2/1"} /-->',
+			)
+		);
+
+		$one_per_page = static function () {
+			return 1;
+		};
+		add_filter( 'gatherpress_venue_map_prewarm_content_batch_size', $one_per_page );
+
+		$combos = Utility::invoke_hidden_method( $instance, 'collect_all_template_combos' );
+
+		remove_filter( 'gatherpress_venue_map_prewarm_content_batch_size', $one_per_page );
+
+		$keys = array_map(
+			static function ( $combo ) {
+				return sprintf(
+					'%d-%d-%d-%s',
+					(int) $combo['zoom'],
+					(int) $combo['width'],
+					(int) $combo['height'],
+					(string) $combo['aspect_ratio']
+				);
+			},
+			$combos
+		);
+
+		$this->assertContains( '5-150-75-2/1', $keys, 'First event combo surfaced.' );
+		$this->assertContains( '4-120-60-2/1', $keys, 'Second event combo surfaced through the ++$page tail.' );
+	}
+
 	/**
 	 * Content-scan batch size is separately filterable so an extender can
 	 * shrink the post_content-loading loop without touching the ID-only

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -705,6 +705,19 @@ class Test_Venue_Map_Prewarm extends Base {
 		);
 
 		remove_filter( 'gatherpress_venue_map_prewarm_content_batch_size', $clamp );
+
+		$ceiling = static function () {
+			return PHP_INT_MAX;
+		};
+		add_filter( 'gatherpress_venue_map_prewarm_content_batch_size', $ceiling );
+
+		$this->assertSame(
+			1000,
+			Utility::invoke_hidden_method( $instance, 'get_content_scan_batch_size' ),
+			'Values above 1000 clamp down so a misbehaving filter can\'t load every event at once.'
+		);
+
+		remove_filter( 'gatherpress_venue_map_prewarm_content_batch_size', $ceiling );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -343,6 +343,35 @@ class Test_Venue_Map_Prewarm extends Base {
 	}
 
 	/**
+	 * Draft / trashed venue saves skip the enqueue path — only published
+	 * posts are reachable from the front-end and contribute to the cache
+	 * set, so unpublished saves shouldn't spend cron cycles on them.
+	 *
+	 * @covers ::on_post_saved
+	 *
+	 * @return void
+	 */
+	public function test_on_post_saved_skips_non_published_posts(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		foreach ( array( 'draft', 'auto-draft', 'trash' ) as $status ) {
+			$venue_post_id = $this->factory->post->create(
+				array(
+					'post_type'   => Venue::POST_TYPE,
+					'post_status' => $status,
+				)
+			);
+
+			$instance->on_post_saved( $venue_post_id, get_post( $venue_post_id ) );
+		}
+
+		$this->assertFalse(
+			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			'Non-published saves enqueue nothing.'
+		);
+	}
+
+	/**
 	 * Delegates to Venue_Map::warm from the cron handler — this test only
 	 * verifies it tolerates a missing venue ID without throwing
 	 * (Venue_Map::warm returns null for invalid input).
@@ -575,6 +604,59 @@ class Test_Venue_Map_Prewarm extends Base {
 			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
 			'Event with no venue term enqueues nothing.'
 		);
+	}
+
+	/**
+	 * Batch-size filter lets callers override SCAN_BATCH_SIZE; values below
+	 * 1 are clamped up to 1 to avoid an infinite empty-batch loop.
+	 *
+	 * @covers ::get_scan_batch_size
+	 *
+	 * @return void
+	 */
+	/**
+	 * Content-scan batch size is separately filterable so an extender can
+	 * shrink the post_content-loading loop without touching the ID-only
+	 * venue scan. Clamps to at least 1.
+	 *
+	 * @covers ::get_content_scan_batch_size
+	 *
+	 * @return void
+	 */
+	public function test_get_content_scan_batch_size_applies_filter_and_clamps(): void {
+		$instance = Venue_Map_Prewarm::get_instance();
+
+		$this->assertSame(
+			Venue_Map_Prewarm::CONTENT_SCAN_BATCH_SIZE,
+			Utility::invoke_hidden_method( $instance, 'get_content_scan_batch_size' ),
+			'Default matches the CONTENT_SCAN_BATCH_SIZE constant.'
+		);
+
+		$override = static function () {
+			return 7;
+		};
+		add_filter( 'gatherpress_venue_map_prewarm_content_batch_size', $override );
+
+		$this->assertSame(
+			7,
+			Utility::invoke_hidden_method( $instance, 'get_content_scan_batch_size' ),
+			'Filter-supplied value replaces the default.'
+		);
+
+		remove_filter( 'gatherpress_venue_map_prewarm_content_batch_size', $override );
+
+		$clamp = static function () {
+			return -5;
+		};
+		add_filter( 'gatherpress_venue_map_prewarm_content_batch_size', $clamp );
+
+		$this->assertSame(
+			1,
+			Utility::invoke_hidden_method( $instance, 'get_content_scan_batch_size' ),
+			'Values below 1 clamp up to 1.'
+		);
+
+		remove_filter( 'gatherpress_venue_map_prewarm_content_batch_size', $clamp );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -740,7 +740,7 @@ class Test_Venue_Map extends Base {
 
 	/**
 	 * Downstream code can shape the descriptor map through the
-	 * `gatherpress_venue_map_descriptor` filter — companion plugins, CDN
+	 * `gatherpress_venue_map_descriptors` filter — companion plugins, CDN
 	 * layers, or multi-locale setups get a single hook point to suppress,
 	 * override, or augment entries without patching core.
 	 *
@@ -774,11 +774,11 @@ class Test_Venue_Map extends Base {
 			}
 			return $descriptors;
 		};
-		add_filter( 'gatherpress_venue_map_descriptor', $override, 10, 2 );
+		add_filter( 'gatherpress_venue_map_descriptors', $override, 10, 2 );
 
 		$descriptors = $instance->get_all_descriptors( $post_id );
 
-		remove_filter( 'gatherpress_venue_map_descriptor', $override, 10 );
+		remove_filter( 'gatherpress_venue_map_descriptors', $override, 10 );
 
 		$this->assertSame(
 			sprintf( 'https://cdn.test/%d-15x600x300.png', $post_id ),
@@ -794,7 +794,7 @@ class Test_Venue_Map extends Base {
 		$suppress_all = static function () {
 			return array();
 		};
-		add_filter( 'gatherpress_venue_map_descriptor', $suppress_all );
+		add_filter( 'gatherpress_venue_map_descriptors', $suppress_all );
 
 		$this->assertSame(
 			array(),
@@ -802,7 +802,7 @@ class Test_Venue_Map extends Base {
 			'Filter can suppress the entire map by returning an empty array.'
 		);
 
-		remove_filter( 'gatherpress_venue_map_descriptor', $suppress_all );
+		remove_filter( 'gatherpress_venue_map_descriptors', $suppress_all );
 	}
 
 	/**
@@ -2669,6 +2669,30 @@ class Test_Venue_Map extends Base {
 			200,
 			rest_do_request( $empty )->get_status(),
 			'Empty aspect ratio is treated as "use server default" and passes.'
+		);
+
+		// Degenerate `0/X` / `X/0` values that CSS would treat as auto
+		// must still be rejected — the block never emits a zero side.
+		$zero_numerator = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$zero_numerator->set_param( 'aspect_ratio', '0/9' );
+		$this->assertSame(
+			400,
+			rest_do_request( $zero_numerator )->get_status(),
+			'Zero numerator is rejected by the tightened [1-9] rule.'
+		);
+
+		$zero_denominator = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$zero_denominator->set_param( 'aspect_ratio', '9/0' );
+		$this->assertSame(
+			400,
+			rest_do_request( $zero_denominator )->get_status(),
+			'Zero denominator is rejected by the tightened [1-9] rule.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -739,6 +739,73 @@ class Test_Venue_Map extends Base {
 	}
 
 	/**
+	 * Downstream code can shape the descriptor map through the
+	 * `gatherpress_venue_map_descriptor` filter — companion plugins, CDN
+	 * layers, or multi-locale setups get a single hook point to suppress,
+	 * override, or augment entries without patching core.
+	 *
+	 * @covers ::get_all_descriptors
+	 *
+	 * @return void
+	 */
+	public function test_get_all_descriptors_runs_through_filter(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		update_post_meta(
+			$post_id,
+			Venue_Map::META_KEY,
+			array(
+				'15x600x300' => array(
+					'url'    => 'https://example.test/a.png',
+					'hash'   => 'abc',
+					'zoom'   => 15,
+					'width'  => 600,
+					'height' => 300,
+				),
+			)
+		);
+
+		$override = static function ( $descriptors, $filtered_post_id ) {
+			// Verify the filter receives both documented arguments.
+			foreach ( $descriptors as $key => $entry ) {
+				$descriptors[ $key ]['url']     = 'https://cdn.test/' . $filtered_post_id . '-' . $key . '.png';
+				$descriptors[ $key ]['post_id'] = $filtered_post_id;
+			}
+			return $descriptors;
+		};
+		add_filter( 'gatherpress_venue_map_descriptor', $override, 10, 2 );
+
+		$descriptors = $instance->get_all_descriptors( $post_id );
+
+		remove_filter( 'gatherpress_venue_map_descriptor', $override, 10 );
+
+		$this->assertSame(
+			sprintf( 'https://cdn.test/%d-15x600x300.png', $post_id ),
+			$descriptors['15x600x300']['url'],
+			'Filter can rewrite a URL.'
+		);
+		$this->assertSame(
+			$post_id,
+			$descriptors['15x600x300']['post_id'],
+			'Filter receives the venue post ID as its second argument.'
+		);
+
+		$suppress_all = static function () {
+			return array();
+		};
+		add_filter( 'gatherpress_venue_map_descriptor', $suppress_all );
+
+		$this->assertSame(
+			array(),
+			$instance->get_all_descriptors( $post_id ),
+			'Filter can suppress the entire map by returning an empty array.'
+		);
+
+		remove_filter( 'gatherpress_venue_map_descriptor', $suppress_all );
+	}
+
+	/**
 	 * The next write through ensure_descriptor_for_combo() rebuilds meta
 	 * from the filtered descriptor map, so any malformed entries that were
 	 * silently skipped on read are dropped from storage at that point.
@@ -2527,6 +2594,82 @@ class Test_Venue_Map extends Base {
 		$this->assertSame( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertSame( 'generation_failed', $data['reason'] );
+	}
+
+	/**
+	 * Rejects a malformed `aspect_ratio` parameter at the REST boundary
+	 * with a 400 instead of silently falling back. Empty / valid values
+	 * (slash or colon form) pass through.
+	 *
+	 * @covers ::register_rest_routes
+	 *
+	 * @return void
+	 */
+	public function test_rest_regenerate_aspect_ratio_validator(): void {
+		$instance = Venue_Map::get_instance();
+		$instance->register_rest_routes();
+
+		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$post_id   = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		wp_set_current_user( $editor_id );
+
+		$invalid = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$invalid->set_param( 'aspect_ratio', 'not-a-ratio' );
+
+		$this->assertSame(
+			400,
+			rest_do_request( $invalid )->get_status(),
+			'A malformed aspect_ratio string is rejected at the REST boundary.'
+		);
+
+		$valid_slash = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$valid_slash->set_param( 'aspect_ratio', '16/9' );
+		$this->assertSame(
+			200,
+			rest_do_request( $valid_slash )->get_status(),
+			'Slash-form aspect ratio passes.'
+		);
+
+		$valid_colon = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$valid_colon->set_param( 'aspect_ratio', '4:3' );
+		$this->assertSame(
+			200,
+			rest_do_request( $valid_colon )->get_status(),
+			'Colon-form aspect ratio passes.'
+		);
+
+		$empty = new \WP_REST_Request(
+			'POST',
+			sprintf( '/%s/venue/%d/regenerate-map', GATHERPRESS_REST_NAMESPACE, $post_id )
+		);
+		$empty->set_param( 'aspect_ratio', '' );
+		$this->assertSame(
+			200,
+			rest_do_request( $empty )->get_status(),
+			'Empty aspect ratio is treated as "use server default" and passes.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Follow-up to [#1485](https://github.com/GatherPress/gatherpress/pull/1485) that addresses actionable items from the post-merge code review. Five focused changes:

**1. Non-published venue guard in the prewarm save hook**

`Venue_Map_Prewarm::on_post_saved()` now bails when `$post->post_status !== 'publish'`. Saves on drafts, auto-drafts, and trashed posts no longer enqueue warm jobs — unpublished posts aren't reachable from the front end and shouldn't consume cron cycles. Matches the `post_status => publish` filter the scan paths already use.

**2. Aspect-ratio validator on the `POST /venue/{id}/regenerate-map` REST endpoint**

Added a `validate_callback` on the `aspect_ratio` arg that enforces `^\s*\d+\s*[/:]\s*\d+\s*\z` (plus empty as a valid "use server default"). Bad input now returns `400` instead of silently falling back to the default. Downstream `parse_aspect_ratio()` handling stays intact for the non-REST call sites.

**3. Inline aspect-ratio sanitization in `render.php`**

The `aspectRatio` block attribute flowed directly into `style="aspect-ratio: …"` on the wrapper through `get_block_wrapper_attributes()`, which doesn't sanitize individual CSS values. An editor-role attacker with `edit_posts` could otherwise stamp a payload like `1/1;background:url(...)`. The template now validates the ratio string against the same regex as the REST endpoint and falls back to `DEFAULT_ASPECT_RATIO` on anything else.

**4. Separate content-scan batch size for `collect_all_template_combos()`**

New `CONTENT_SCAN_BATCH_SIZE = 100` constant and `gatherpress_venue_map_prewarm_content_batch_size` filter, used by the event-content scan that loads full post rows (variable-sized `post_content` can be megabytes on FSE-rich pages). The ID-only venue scan keeps the `SCAN_BATCH_SIZE = 500` default, unchanged. Both are filterable and both clamp to at least 1.

**5. `gatherpress_venue_map_descriptor` filter on `get_all_descriptors()`**

Added at the end of the read path so companion plugins, CDN layers, or multi-locale setups can rewrite URLs, drop entries, or suppress the whole map without patching core. Filter receives the parsed descriptor map and the venue post ID; returning `[]` is the "suppress all" escape hatch.

### How to test the Change

1. Run the full suite: `npm run lint:phpstan`, `npm run lint:php`, `npm run test:unit:php`, `npm run test:unit:js`.
2. **Non-publish guard**: save a draft venue — no `gatherpress_warm_venue_map` cron events appear in `wp_options.cron`. Publish it — events appear.
3. **Aspect-ratio REST validator**: `POST /wp-json/gatherpress/v1/venue/{id}/regenerate-map` with `aspect_ratio=not-a-ratio` returns `400`. With `16/9`, `4:3`, or empty, returns `200`.
4. **Render sanitization**: set a venue-map block's `aspectRatio` attribute to a malicious value (`1/1;background:url(...)` via post-content edit or hand-crafted JSON) — inspect the rendered wrapper; the inline style falls back to `aspect-ratio:2/1;` rather than emitting the injected CSS.
5. **Content batch filter**: `add_filter( 'gatherpress_venue_map_prewarm_content_batch_size', static fn() => 1 );`, trigger a venue save, verify every venue ends up with a warm job (exercises the pagination tail).
6. **Descriptor filter**: `add_filter( 'gatherpress_venue_map_descriptor', fn( $d, $p ) => [] );`, render a venue page — block renders the "Map is being prepared" placeholder since the filter suppresses all descriptors. Remove the filter; normal rendering resumes.

### Changelog Entry

> Security - Harden the venue-map REST endpoint and render template against argument/CSS injection; add `gatherpress_venue_map_descriptor` filter and a separate `gatherpress_venue_map_prewarm_content_batch_size` filter for extensibility.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.