### PR TITLE
Venue map: add scale attribute, move Dimensions to Settings

### DIFF
--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -145,6 +145,27 @@ class Venue_Map {
 	const DEFAULT_ASPECT_RATIO = '2/1';
 
 	/**
+	 * Default `scale` (CSS `object-fit`) applied to the static map image.
+	 * `cover` crops the PNG to fill the wrapper without distortion — same
+	 * behavior the block shipped with before the attribute was exposed.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const DEFAULT_SCALE = 'cover';
+
+	/**
+	 * Allow-listed values for the `scale` block attribute — mirrors the
+	 * three `object-fit` keywords the block's Inspector exposes. Any other
+	 * value falls back to `DEFAULT_SCALE` at render time so a hand-edited
+	 * block attribute can't smuggle arbitrary CSS into the inline style.
+	 *
+	 * @since 1.0.0
+	 * @var string[]
+	 */
+	const SCALE_OPTIONS = array( 'cover', 'contain', 'fill' );
+
+	/**
 	 * Anchored regex matching a CSS-style aspect-ratio value (e.g. `16/9`
 	 * or `4:3`). Used by both the REST `aspect_ratio` validator and the
 	 * render template so the two can never drift apart. Requires at least
@@ -378,6 +399,7 @@ class Venue_Map {
 			'width'       => '' === $raw_width ? null : (int) $raw_width,
 			'height'      => '' === $raw_height ? null : (int) $raw_height,
 			'aspectRatio' => (string) $settings->get( 'venue_map_default_aspect_ratio' ),
+			'scale'       => (string) $settings->get( 'venue_map_default_scale' ),
 			'type'        => (string) $settings->get( 'venue_map_default_type' ),
 		);
 
@@ -412,6 +434,9 @@ class Venue_Map {
 			'aspectRatio' => function ( $value ): bool {
 				return is_string( $value )
 					&& null !== $this->parse_aspect_ratio( $value );
+			},
+			'scale'       => static function ( $value ): bool {
+				return in_array( $value, self::SCALE_OPTIONS, true );
 			},
 			'type'        => static function ( $value ): bool {
 				return in_array(

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -208,6 +208,27 @@ class Venues extends Base {
 							),
 						),
 					),
+					'venue_map_default_scale'        => array(
+						'labels'      => array(
+							'name' => __( 'Default Scale', 'gatherpress' ),
+						),
+						'description' => __(
+							'Default fit for static map images. Interactive maps fill their container automatically.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Scale for new blocks:', 'gatherpress' ),
+							'type'    => 'select',
+							'options' => array(
+								'default' => Venue_Map::DEFAULT_SCALE,
+								'items'   => array(
+									'cover'   => __( 'Cover', 'gatherpress' ),
+									'contain' => __( 'Contain', 'gatherpress' ),
+									'fill'    => __( 'Fill', 'gatherpress' ),
+								),
+							),
+						),
+					),
 					'venue_map_default_type'         => array(
 						'labels'      => array(
 							'name' => __( 'Default Map Type', 'gatherpress' ),

--- a/src/blocks/venue-map/block.json
+++ b/src/blocks/venue-map/block.json
@@ -30,6 +30,10 @@
 			"type": "string",
 			"default": "2/1"
 		},
+		"scale": {
+			"type": "string",
+			"default": "cover"
+		},
 		"renderMode": {
 			"type": "string",
 			"default": "interactive"

--- a/src/blocks/venue-map/block.json
+++ b/src/blocks/venue-map/block.json
@@ -32,6 +32,7 @@
 		},
 		"scale": {
 			"type": "string",
+			"enum": ["cover", "contain", "fill"],
 			"default": "cover"
 		},
 		"renderMode": {

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -63,6 +63,18 @@ const ASPECT_RATIO_PRESETS = [
 	{ label: __( 'Custom', 'gatherpress' ), value: 'custom' },
 ];
 
+// Allow-list for the `scale` block attribute — mirrors
+// `Venue_Map::SCALE_OPTIONS` so JS and PHP can't drift. The Scale
+// SelectControl options are derived from this list; the guard that
+// hides the control when render mode is interactive reads from it too.
+const SCALE_OPTIONS = [ 'cover', 'contain', 'fill' ];
+const SCALE_DEFAULT = 'cover';
+const SCALE_LABELS = {
+	cover: __( 'Cover', 'gatherpress' ),
+	contain: __( 'Contain', 'gatherpress' ),
+	fill: __( 'Fill', 'gatherpress' ),
+};
+
 const LINK_DESTINATION_NONE = 'none';
 const LINK_DESTINATION_OPENSTREETMAP = 'openstreetmap';
 const LINK_DESTINATION_GOOGLE = 'google';
@@ -245,6 +257,15 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 	}
 
 	const mapPlatform = getFromSettings( 'mapPlatform' );
+
+	// Resolve the site-wide scale default from Settings so "Reset all"
+	// and the "has value" check on the Scale ToolsPanelItem mirror what
+	// apply_block_attribute_defaults() stamps on the block. Fall back to
+	// SCALE_DEFAULT if Settings carries anything outside the allow-list.
+	const rawSiteScale = getFromSettings( 'venueMapDefaultScale' );
+	const siteScaleDefault = SCALE_OPTIONS.includes( rawSiteScale )
+		? rawSiteScale
+		: SCALE_DEFAULT;
 	const showMapTypeControl =
 		'interactive' === renderMode && 'google' === mapPlatform;
 
@@ -449,13 +470,9 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 								: __( 'Venue map', 'gatherpress' )
 						}
 						style={ {
-							objectFit: [
-								'cover',
-								'contain',
-								'fill',
-							].includes( scale )
+							objectFit: SCALE_OPTIONS.includes( scale )
 								? scale
-								: 'cover',
+								: siteScaleDefault,
 						} }
 					/>
 				</div>
@@ -611,7 +628,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 							width: 0,
 							height: 0,
 							aspectRatio: '2/1',
-							scale: 'cover',
+							scale: siteScaleDefault,
 						} )
 					}
 					panelId={ clientId }
@@ -701,31 +718,22 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 						<ToolsPanelItem
 							label={ __( 'Scale', 'gatherpress' ) }
 							hasValue={ () =>
-								'cover' !== ( scale ?? 'cover' )
+								siteScaleDefault !==
+								( scale ?? siteScaleDefault )
 							}
 							onDeselect={ () =>
-								setAttributes( { scale: 'cover' } )
+								setAttributes( { scale: siteScaleDefault } )
 							}
 							isShownByDefault
 							panelId={ clientId }
 						>
 							<SelectControl
 								label={ __( 'Scale', 'gatherpress' ) }
-								value={ scale || 'cover' }
-								options={ [
-									{
-										label: __( 'Cover', 'gatherpress' ),
-										value: 'cover',
-									},
-									{
-										label: __( 'Contain', 'gatherpress' ),
-										value: 'contain',
-									},
-									{
-										label: __( 'Fill', 'gatherpress' ),
-										value: 'fill',
-									},
-								] }
+								value={ scale ?? siteScaleDefault }
+								options={ SCALE_OPTIONS.map( ( value ) => ( {
+									label: SCALE_LABELS[ value ],
+									value,
+								} ) ) }
 								onChange={ ( value ) =>
 									setAttributes( { scale: value } )
 								}

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -20,6 +20,8 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -109,6 +111,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 		width,
 		height,
 		aspectRatio,
+		scale,
 		renderMode,
 		align,
 		href,
@@ -445,6 +448,15 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 								? `${ __( 'Map of', 'gatherpress' ) } ${ fullAddress }`
 								: __( 'Venue map', 'gatherpress' )
 						}
+						style={ {
+							objectFit: [
+								'cover',
+								'contain',
+								'fill',
+							].includes( scale )
+								? scale
+								: 'cover',
+						} }
 					/>
 				</div>
 			) }
@@ -591,88 +603,136 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 					) }
 				</PanelBody>
 			</InspectorControls>
-			<InspectorControls group="dimensions">
-				<ToolsPanelItem
-					label={ __( 'Width & height', 'gatherpress' ) }
-					hasValue={ () => 0 < width || 0 < height }
-					onDeselect={ () =>
-						setAttributes( { width: 0, height: 0 } )
+			<InspectorControls>
+				<ToolsPanel
+					label={ __( 'Dimensions', 'gatherpress' ) }
+					resetAll={ () =>
+						setAttributes( {
+							width: 0,
+							height: 0,
+							aspectRatio: '2/1',
+							scale: 'cover',
+						} )
 					}
-					isShownByDefault
 					panelId={ clientId }
 				>
-					<Flex gap={ 2 } align="flex-end">
-						<FlexItem isBlock>
-							<TextControl
-								label={ __( 'Width', 'gatherpress' ) }
-								type="number"
-								placeholder={ __( 'Auto', 'gatherpress' ) }
-								value={ 0 < width ? String( width ) : '' }
-								onChange={ handleWidthInput }
-							/>
-						</FlexItem>
-						<FlexItem isBlock>
-							<TextControl
-								label={ __( 'Height', 'gatherpress' ) }
-								type="number"
-								placeholder={ __( 'Auto', 'gatherpress' ) }
-								value={ 0 < height ? String( height ) : '' }
-								onChange={ handleHeightInput }
-							/>
-						</FlexItem>
-					</Flex>
-				</ToolsPanelItem>
-				<ToolsPanelItem
-					label={ __( 'Aspect ratio', 'gatherpress' ) }
-					hasValue={ () =>
-						'' !== ( aspectRatio ?? '' ) &&
-						'2/1' !== aspectRatio
-					}
-					onDeselect={ () =>
-						setAttributes( { aspectRatio: '2/1' } )
-					}
-					isShownByDefault
-					panelId={ clientId }
-				>
-					<SelectControl
+					<ToolsPanelItem
+						label={ __( 'Width & height', 'gatherpress' ) }
+						hasValue={ () => 0 < width || 0 < height }
+						onDeselect={ () =>
+							setAttributes( { width: 0, height: 0 } )
+						}
+						isShownByDefault
+						panelId={ clientId }
+					>
+						<Flex gap={ 2 } align="flex-end">
+							<FlexItem isBlock>
+								<TextControl
+									label={ __( 'Width', 'gatherpress' ) }
+									type="number"
+									placeholder={ __( 'Auto', 'gatherpress' ) }
+									value={ 0 < width ? String( width ) : '' }
+									onChange={ handleWidthInput }
+								/>
+							</FlexItem>
+							<FlexItem isBlock>
+								<TextControl
+									label={ __( 'Height', 'gatherpress' ) }
+									type="number"
+									placeholder={ __( 'Auto', 'gatherpress' ) }
+									value={ 0 < height ? String( height ) : '' }
+									onChange={ handleHeightInput }
+								/>
+							</FlexItem>
+						</Flex>
+					</ToolsPanelItem>
+					<ToolsPanelItem
 						label={ __( 'Aspect ratio', 'gatherpress' ) }
-						value={ isCustomAspectRatio ? 'custom' : aspectRatio }
-						options={ ASPECT_RATIO_PRESETS }
-						onChange={ ( value ) => {
-							if ( 'custom' === value ) {
+						hasValue={ () =>
+							'' !== ( aspectRatio ?? '' ) &&
+						'2/1' !== aspectRatio
+						}
+						onDeselect={ () =>
+							setAttributes( { aspectRatio: '2/1' } )
+						}
+						isShownByDefault
+						panelId={ clientId }
+					>
+						<SelectControl
+							label={ __( 'Aspect ratio', 'gatherpress' ) }
+							value={ isCustomAspectRatio ? 'custom' : aspectRatio }
+							options={ ASPECT_RATIO_PRESETS }
+							onChange={ ( value ) => {
+								if ( 'custom' === value ) {
 								// Clear so the Custom text field below owns
 								// the value. If the user typed nothing, the
 								// server falls back to DEFAULT_ASPECT_RATIO
 								// for dimension derivation.
-								setAttributes( { aspectRatio: '' } );
-								return;
-							}
-							// Picking a preset resets height to auto so the
-							// new ratio drives the rendered shape — the
-							// user's stored width (if any) is preserved.
-							setAttributes( {
-								aspectRatio: value,
-								height: 0,
-							} );
-						} }
-					/>
-					{ isCustomAspectRatio && (
-						<TextControl
-							label={ __(
-								'Custom aspect ratio',
-								'gatherpress'
-							) }
-							help={ __(
-								'Format: "16/9" or "4:3".',
-								'gatherpress'
-							) }
-							value={ aspectRatio || '' }
-							onChange={ ( value ) =>
-								setAttributes( { aspectRatio: value } )
-							}
+									setAttributes( { aspectRatio: '' } );
+									return;
+								}
+								// Picking a preset resets height to auto so the
+								// new ratio drives the rendered shape — the
+								// user's stored width (if any) is preserved.
+								setAttributes( {
+									aspectRatio: value,
+									height: 0,
+								} );
+							} }
 						/>
+						{ isCustomAspectRatio && (
+							<TextControl
+								label={ __(
+									'Custom aspect ratio',
+									'gatherpress'
+								) }
+								help={ __(
+									'Format: "16/9" or "4:3".',
+									'gatherpress'
+								) }
+								value={ aspectRatio || '' }
+								onChange={ ( value ) =>
+									setAttributes( { aspectRatio: value } )
+								}
+							/>
+						) }
+					</ToolsPanelItem>
+					{ isStaticMode && (
+						<ToolsPanelItem
+							label={ __( 'Scale', 'gatherpress' ) }
+							hasValue={ () =>
+								'cover' !== ( scale ?? 'cover' )
+							}
+							onDeselect={ () =>
+								setAttributes( { scale: 'cover' } )
+							}
+							isShownByDefault
+							panelId={ clientId }
+						>
+							<SelectControl
+								label={ __( 'Scale', 'gatherpress' ) }
+								value={ scale || 'cover' }
+								options={ [
+									{
+										label: __( 'Cover', 'gatherpress' ),
+										value: 'cover',
+									},
+									{
+										label: __( 'Contain', 'gatherpress' ),
+										value: 'contain',
+									},
+									{
+										label: __( 'Fill', 'gatherpress' ),
+										value: 'fill',
+									},
+								] }
+								onChange={ ( value ) =>
+									setAttributes( { scale: value } )
+								}
+							/>
+						</ToolsPanelItem>
 					) }
-				</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 			{ isStaticMode && (
 				<BlockControls>

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -56,6 +56,15 @@ $gatherpress_raw_width   = (int) ( $attributes['width'] ?? 0 );
 $gatherpress_raw_height  = (int) ( $attributes['height'] ?? Venue_Map::DEFAULT_HEIGHT );
 $gatherpress_ratio       = (string) ( $attributes['aspectRatio'] ?? Venue_Map::DEFAULT_ASPECT_RATIO );
 
+// Allow-list for the `scale` block attribute. Anything outside this set
+// (a hand-edited block attr, a filter that mutates the value, a migration
+// miss) falls back to `cover` so the inline style stays safe and
+// predictable.
+$gatherpress_scale_candidate = (string) ( $attributes['scale'] ?? Venue_Map::DEFAULT_SCALE );
+$gatherpress_scale           = in_array( $gatherpress_scale_candidate, Venue_Map::SCALE_OPTIONS, true )
+	? $gatherpress_scale_candidate
+	: Venue_Map::DEFAULT_SCALE;
+
 $gatherpress_static_map_url = Venue_Map::get_instance()->get_url_for_post(
 	$gatherpress_post_id,
 	$gatherpress_post_type,
@@ -172,9 +181,10 @@ if ( '' !== $gatherpress_static_map_url ) {
 	}
 
 	printf(
-		'<img class="gatherpress-venue-map__image" src="%s" alt="%s" loading="lazy" />',
+		'<img class="gatherpress-venue-map__image" src="%s" alt="%s" loading="lazy" style="object-fit:%s;" />',
 		esc_url( $gatherpress_static_map_url ),
-		esc_attr( $gatherpress_alt )
+		esc_attr( $gatherpress_alt ),
+		esc_attr( $gatherpress_scale )
 	);
 
 	if ( '' !== $gatherpress_href ) {

--- a/src/blocks/venue-map/style.scss
+++ b/src/blocks/venue-map/style.scss
@@ -30,11 +30,14 @@
 		border-radius: inherit;
 	}
 
+	// The `object-fit` value is stamped inline from the block's `scale`
+	// attribute (render.php) so it can be `cover` / `contain` / `fill`
+	// per-block. No fallback here on purpose — the server always emits a
+	// valid value from the SCALE_OPTIONS allow-list.
 	&__image {
 		display: block;
 		width: 100%;
 		height: 100%;
-		object-fit: cover;
 	}
 
 	&__placeholder {

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -168,6 +168,7 @@ class Test_Venue_Map extends Base {
 		$settings->set( 'venue_map_default_render_mode', 'static' );
 		$settings->set( 'venue_map_default_zoom', 12 );
 		$settings->set( 'venue_map_default_height', 450 );
+		$settings->set( 'venue_map_default_scale', 'contain' );
 		$settings->set( 'venue_map_default_type', 'satellite' );
 
 		$metadata = array(
@@ -185,6 +186,10 @@ class Test_Venue_Map extends Base {
 					'type'    => 'number',
 					'default' => 300,
 				),
+				'scale'      => array(
+					'type'    => 'string',
+					'default' => 'cover',
+				),
 				'type'       => array(
 					'type'    => 'string',
 					'default' => 'roadmap',
@@ -197,7 +202,42 @@ class Test_Venue_Map extends Base {
 		$this->assertSame( 'static', $result['attributes']['renderMode']['default'] );
 		$this->assertSame( 12, $result['attributes']['zoom']['default'] );
 		$this->assertSame( 450, $result['attributes']['height']['default'] );
+		$this->assertSame( 'contain', $result['attributes']['scale']['default'] );
 		$this->assertSame( 'satellite', $result['attributes']['type']['default'] );
+	}
+
+	/**
+	 * A scale value outside the allow-list falls through — the block.json
+	 * default stays in place. Guards against a stale or hand-edited Settings
+	 * row smuggling an unexpected CSS keyword into `object-fit`.
+	 *
+	 * @covers ::apply_block_attribute_defaults
+	 *
+	 * @return void
+	 */
+	public function test_apply_block_attribute_defaults_rejects_invalid_scale(): void {
+		$instance = Venue_Map::get_instance();
+		$settings = \GatherPress\Core\Settings::get_instance();
+
+		$settings->set( 'venue_map_default_scale', 'none' );
+
+		$metadata = array(
+			'name'       => 'gatherpress/venue-map',
+			'attributes' => array(
+				'scale' => array(
+					'type'    => 'string',
+					'default' => 'cover',
+				),
+			),
+		);
+
+		$result = $instance->apply_block_attribute_defaults( $metadata );
+
+		$this->assertSame(
+			'cover',
+			$result['attributes']['scale']['default'],
+			'Block.json default sticks when Settings carries an invalid scale value.'
+		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
@@ -93,6 +93,7 @@ class Test_Venues extends Base {
 			'venue_map_default_render_mode' => 'interactive',
 			'venue_map_default_zoom'        => 18,
 			'venue_map_default_height'      => '',
+			'venue_map_default_scale'       => 'cover',
 			'venue_map_default_type'        => 'roadmap',
 		) as $key => $expected ) {
 			$this->assertArrayHasKey(


### PR DESCRIPTION
### Description of the Change

Adds the `scale` block attribute to `gatherpress/venue-map` (CSS `object-fit`) with three allow-listed values — `cover`, `contain`, `fill` — and reorganizes the dimension controls to match core/image's Inspector layout.

**Attribute + server**
- New `scale` attribute in `block.json` with default `"cover"`.
- `render.php` reads the attribute, allow-lists it against `Venue_Map::SCALE_OPTIONS` (`cover` / `contain` / `fill`), and stamps `object-fit:{scale}` as an inline style on the static `<img>`. Anything outside the allow-list falls back to `DEFAULT_SCALE` so a hand-edited block attr can't smuggle arbitrary CSS into the inline style.
- Interactive (Leaflet) maps fill their container natively; `object-fit` doesn't apply, so the scale attribute is ignored in interactive mode and the control is hidden in the Inspector.

**SCSS**
- Dropped the hardcoded `object-fit: cover` from `style.scss` — render.php owns the value per-block.

**Inspector reorg**
- Dimensions controls (Width, Height, Aspect ratio, Scale) moved from `<InspectorControls group="dimensions">` (Styles tab) to their own `<ToolsPanel label="Dimensions">` under the Settings tab. Mirrors core/image's layout — Dimensions lives under Settings, not Styles.
- `resetAll` on the panel restores all four attributes to their block defaults in one click.
- Each control remains a `<ToolsPanelItem>` with its own `hasValue` / `onDeselect`, so per-item reset menus still work.
- Scale control is gated on `isStaticMode`, since `object-fit` has no effect on the interactive Leaflet map.

**Settings → Venues → Maps**
- New `venue_map_default_scale` select (Cover / Contain / Fill) feeds the block's default via `Venue_Map::apply_block_attribute_defaults()`. Validator rejects any value outside the allow-list so a stale/hand-edited Settings row can't land on the block.

**Editor preview**
- The editor's `<img>` preview now stamps `objectFit` inline from the selected scale so the Inspector change reflects immediately.

**Constants added to `Venue_Map`**
- `DEFAULT_SCALE = 'cover'`
- `SCALE_OPTIONS = ['cover', 'contain', 'fill']`

<!-- This PR doesn't fully close any open issue. #1481 tracks multiple follow-ups from #1480, and the scale attribute / Dimensions reorg weren't on that list. -->

### How to test the Change

1. `npm run build`, reload the block editor on a venue post.
2. Insert a venue-map block, switch render mode to **Static**. Open the **Settings** tab — a new **Dimensions** panel holds Width/Height, Aspect ratio, Scale. Core/image's layout for comparison.
3. Switch Scale to **Contain** — editor preview updates immediately (image fits within wrapper, no crop). Save and check the frontend — the rendered `<img>` carries `style="object-fit:contain;"`.
4. Switch to **Fill** — image stretches to wrapper dimensions.
5. Switch render mode back to **Interactive** — Scale control disappears (object-fit irrelevant for Leaflet).
6. In Settings → Venues → Maps, change **Default Scale** to **Contain**. Insert a new venue-map block — it defaults to `contain`.
7. Hit the Dimensions panel's `⋮` → **Reset all** — width/height/aspect ratio/scale all return to their defaults.
8. Run `npm run test:unit:php` + `npm run test:unit:js`. Run `npm run lint:php` + `npm run lint:phpstan`.

### Changelog Entry

> Added - Scale (object-fit) attribute on the venue-map block and reorganized Dimensions controls under the Settings tab to match core/image.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.