### PR TITLE
Poll for async-arriving venue-map descriptors in the editor.

### DIFF
--- a/src/blocks/modal-content/block.json
+++ b/src/blocks/modal-content/block.json
@@ -13,9 +13,6 @@
 		"style": {
 			"type": "object",
 			"default": {
-				"color": {
-					"background": "#ffffff"
-				},
 				"spacing": {
 					"padding": "20px"
 				},

--- a/src/blocks/rsvp/templates/attending.js
+++ b/src/blocks/rsvp/templates/attending.js
@@ -127,7 +127,7 @@ const ATTENDING = [
 				[
 					[
 						'gatherpress/modal-content',
-						{},
+						{ backgroundColor: 'white' },
 						[
 							[
 								'core/paragraph',

--- a/src/blocks/rsvp/templates/no-status.js
+++ b/src/blocks/rsvp/templates/no-status.js
@@ -58,7 +58,7 @@ const NO_STATUS = [
 				[
 					[
 						'gatherpress/modal-content',
-						{},
+						{ backgroundColor: 'white' },
 						[
 							[
 								'core/paragraph',
@@ -212,7 +212,7 @@ const NO_STATUS = [
 				[
 					[
 						'gatherpress/modal-content',
-						{},
+						{ backgroundColor: 'white' },
 						[
 							[
 								'core/paragraph',

--- a/src/blocks/rsvp/templates/not-attending.js
+++ b/src/blocks/rsvp/templates/not-attending.js
@@ -114,7 +114,7 @@ const NOT_ATTENDING = [
 				[
 					[
 						'gatherpress/modal-content',
-						{},
+						{ backgroundColor: 'white' },
 						[
 							[
 								'core/paragraph',

--- a/src/blocks/rsvp/templates/waiting-list.js
+++ b/src/blocks/rsvp/templates/waiting-list.js
@@ -114,7 +114,7 @@ const WAITING_LIST = [
 				[
 					[
 						'gatherpress/modal-content',
-						{},
+						{ backgroundColor: 'white' },
 						[
 							[
 								'core/paragraph',

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -43,6 +43,7 @@ import {
 	RegenerateMapButton,
 	parseAspectRatio,
 	resolveDimensions,
+	usePlaceholderPolling,
 } from './helpers';
 
 const WIDTH_MIN = 100;
@@ -373,6 +374,18 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 			aspectRatio: '',
 		} );
 	};
+
+	// Close the "async descriptor arrived while placeholder is showing"
+	// gap — see `usePlaceholderPolling` for the cadence + bail-out logic.
+	usePlaceholderPolling( {
+		active:
+			showStaticPlaceholder &&
+			Boolean( fullAddress ) &&
+			Boolean( latitude ) &&
+			Boolean( longitude ),
+		venuePostId,
+		venuePostType,
+	} );
 
 	// Keep the href in sync with a preset link destination so toggling the
 	// dropdown doesn't leave a stale URL behind. We only auto-write when a

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { Button, Spinner } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -242,4 +242,67 @@ export const resolveDimensions = ( {
 	h = Math.max( 100, Math.min( 4000, h ) );
 
 	return { width: w, height: h };
+};
+
+/**
+ * Poll cadence (ms) and cap for {@link usePlaceholderPolling}. Exported so
+ * tests can reference them without duplicating the constants.
+ *
+ * @since 1.0.0
+ */
+export const POLL_INTERVAL_MS = 15000;
+export const MAX_POLLS = 20;
+
+/**
+ * While the venue-map static placeholder is visible, periodically
+ * invalidate the venue's `core` entity record so background-generated
+ * descriptors (WP-Cron prewarm tick, out-of-band meta writes) surface in
+ * the editor without a manual reload.
+ *
+ * The hook only schedules an interval when `active` is true AND the
+ * venue is fully addressable (post id + type + resolved coordinates).
+ * Stops polling after {@link MAX_POLLS} ticks so a persistently failing
+ * generation doesn't pin the editor into forever polling; tears down
+ * on unmount or when any dep transitions to a falsy state.
+ *
+ * Scheduling only — no server-side changes here. The same behavior works
+ * whether generation runs via WP-Cron (today) or Action Scheduler (when
+ * #1487 lands).
+ *
+ * @since 1.0.0
+ *
+ * @param {Object}  args               Hook arguments.
+ * @param {boolean} args.active        Whether polling should run (typically `showStaticPlaceholder` gated on coords).
+ * @param {number}  args.venuePostId   Venue post ID.
+ * @param {string}  args.venuePostType Venue post type slug.
+ * @return {void}
+ */
+export const usePlaceholderPolling = ( {
+	active,
+	venuePostId,
+	venuePostType,
+} ) => {
+	const { invalidateResolution } = useDispatch( 'core' );
+
+	useEffect( () => {
+		if ( ! active || ! venuePostId || ! venuePostType ) {
+			return undefined;
+		}
+
+		let pollCount = 0;
+		const interval = setInterval( () => {
+			pollCount += 1;
+			if ( pollCount > MAX_POLLS ) {
+				clearInterval( interval );
+				return;
+			}
+			invalidateResolution( 'getEntityRecord', [
+				'postType',
+				venuePostType,
+				venuePostId,
+			] );
+		}, POLL_INTERVAL_MS );
+
+		return () => clearInterval( interval );
+	}, [ active, venuePostId, venuePostType, invalidateResolution ] );
 };

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -292,17 +292,23 @@ export const usePlaceholderPolling = ( {
 		let pollCount = 0;
 		const interval = setInterval( () => {
 			pollCount += 1;
-			if ( pollCount > MAX_POLLS ) {
-				clearInterval( interval );
-				return;
-			}
 			invalidateResolution( 'getEntityRecord', [
 				'postType',
 				venuePostType,
 				venuePostId,
 			] );
+			// Stop on the MAX_POLLS'th tick rather than letting a (MAX_POLLS + 1)th
+			// tick fire just to clear — matches the cap literally.
+			if ( pollCount >= MAX_POLLS ) {
+				clearInterval( interval );
+			}
 		}, POLL_INTERVAL_MS );
 
 		return () => clearInterval( interval );
-	}, [ active, venuePostId, venuePostType, invalidateResolution ] );
+		// `invalidateResolution` is a bound dispatch action; @wordpress/data
+		// returns a stable reference for it across renders, so omitting it
+		// from the deps is safe and avoids a spurious restart-on-rerender
+		// if that contract ever regresses.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ active, venuePostId, venuePostType ] );
 };

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -51,9 +51,12 @@ jest.mock( '@wordpress/components', () => ( {
  * Internal dependencies.
  */
 import {
+	MAX_POLLS,
+	POLL_INTERVAL_MS,
 	RegenerateMapButton,
 	parseAspectRatio,
 	resolveDimensions,
+	usePlaceholderPolling,
 } from '@src/blocks/venue-map/helpers';
 
 describe( 'RegenerateMapButton', () => {
@@ -344,5 +347,103 @@ describe( 'resolveDimensions', () => {
 				aspectRatio: 'garbage',
 			} )
 		).toEqual( { width: 800, height: 400 } );
+	} );
+} );
+
+describe( 'usePlaceholderPolling', () => {
+	// Minimal test harness that invokes the hook inside a React component.
+	// The component renders nothing — it exists only to run the effect and
+	// let us drive re-renders / unmounts via props.
+	const Harness = ( props ) => {
+		usePlaceholderPolling( props );
+		return null;
+	};
+
+	beforeEach( () => {
+		mockInvalidateResolution.mockReset();
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	const activeProps = {
+		active: true,
+		venuePostId: 42,
+		venuePostType: 'gatherpress_venue',
+	};
+
+	it( 'does not schedule an interval when active is false', () => {
+		render( <Harness { ...activeProps } active={ false } /> );
+
+		jest.advanceTimersByTime( POLL_INTERVAL_MS * 3 );
+
+		expect( mockInvalidateResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not schedule when venuePostId is missing', () => {
+		render( <Harness { ...activeProps } venuePostId={ 0 } /> );
+
+		jest.advanceTimersByTime( POLL_INTERVAL_MS * 3 );
+
+		expect( mockInvalidateResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not schedule when venuePostType is missing', () => {
+		render( <Harness { ...activeProps } venuePostType="" /> );
+
+		jest.advanceTimersByTime( POLL_INTERVAL_MS * 3 );
+
+		expect( mockInvalidateResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'ticks on the expected cadence and forwards the resolver args', () => {
+		render( <Harness { ...activeProps } /> );
+
+		jest.advanceTimersByTime( POLL_INTERVAL_MS - 1 );
+		expect( mockInvalidateResolution ).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime( 1 );
+		expect( mockInvalidateResolution ).toHaveBeenCalledTimes( 1 );
+		expect( mockInvalidateResolution ).toHaveBeenLastCalledWith(
+			'getEntityRecord',
+			[ 'postType', 'gatherpress_venue', 42 ]
+		);
+
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
+		expect( mockInvalidateResolution ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'stops polling after MAX_POLLS ticks', () => {
+		render( <Harness { ...activeProps } /> );
+
+		// Advance one tick past the cap. The pre-increment guard clears the
+		// interval on the tick that would push pollCount over MAX_POLLS, so
+		// exactly MAX_POLLS invalidations fire before the stop.
+		jest.advanceTimersByTime( POLL_INTERVAL_MS * ( MAX_POLLS + 5 ) );
+
+		expect( mockInvalidateResolution ).toHaveBeenCalledTimes( MAX_POLLS );
+	} );
+
+	it( 'clears the interval on unmount', () => {
+		const { unmount } = render( <Harness { ...activeProps } /> );
+
+		unmount();
+
+		jest.advanceTimersByTime( POLL_INTERVAL_MS * 3 );
+		expect( mockInvalidateResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'clears the interval when active flips back to false', () => {
+		const { rerender } = render( <Harness { ...activeProps } /> );
+
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
+		expect( mockInvalidateResolution ).toHaveBeenCalledTimes( 1 );
+
+		rerender( <Harness { ...activeProps } active={ false } /> );
+
+		jest.advanceTimersByTime( POLL_INTERVAL_MS * 3 );
+		expect( mockInvalidateResolution ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -446,4 +446,30 @@ describe( 'usePlaceholderPolling', () => {
 		jest.advanceTimersByTime( POLL_INTERVAL_MS * 3 );
 		expect( mockInvalidateResolution ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'restarts cleanly with a fresh poll count when venuePostId changes', () => {
+		const { rerender } = render( <Harness { ...activeProps } /> );
+
+		// Run halfway to the MAX_POLLS cap against venue 42.
+		jest.advanceTimersByTime( POLL_INTERVAL_MS * ( MAX_POLLS / 2 ) );
+		expect( mockInvalidateResolution ).toHaveBeenCalledTimes(
+			MAX_POLLS / 2
+		);
+
+		// Switch to a new venue — the interval should tear down and restart
+		// with a fresh pollCount targeting the new ID, not inherit the
+		// old counter (which would cap polling prematurely).
+		rerender( <Harness { ...activeProps } venuePostId={ 99 } /> );
+
+		// Drive another full MAX_POLLS cycle against venue 99; all should
+		// fire with the new ID and then cap out.
+		jest.advanceTimersByTime( POLL_INTERVAL_MS * ( MAX_POLLS + 2 ) );
+		expect( mockInvalidateResolution ).toHaveBeenCalledTimes(
+			( MAX_POLLS / 2 ) + MAX_POLLS
+		);
+		expect( mockInvalidateResolution ).toHaveBeenLastCalledWith(
+			'getEntityRecord',
+			[ 'postType', 'gatherpress_venue', 99 ]
+		);
+	} );
 } );


### PR DESCRIPTION
### Description of the Change

Closes the last open item tracked in [#1481](https://github.com/GatherPress/gatherpress/issues/1481) — async-aware editor preview for the venue-map block.

### Background

Static-map PNGs are now generated in background jobs (WP-Cron prewarm today, Action Scheduler once [#1487](https://github.com/GatherPress/gatherpress/issues/1487) lands). When a venue is saved fresh, the editor shows the "Map is being prepared" placeholder — but it had no push channel for the async descriptor write. Users had to manually reload to see the rendered PNG.

[#1485](https://github.com/GatherPress/gatherpress/pull/1485) patched the click-to-regenerate path directly via `receiveEntityRecords`. This PR closes the **async-arrival** gap for writes that happen outside a user click.

### What this PR does

**New hook**: `usePlaceholderPolling` in `src/blocks/venue-map/helpers.js`

Exports a small React hook that periodically invalidates the venue's `core` entity record while the block is showing the static placeholder. The useSelect already wired into `edit.js` re-reads the fresh meta on the next resolver cycle and the placeholder swaps for the `<img>` on the next render — no manual reload needed.

```js
usePlaceholderPolling({
    active: showStaticPlaceholder && Boolean(fullAddress) && Boolean(latitude) && Boolean(longitude),
    venuePostId,
    venuePostType,
});
```

**Cadence + bail-outs**:

- `POLL_INTERVAL_MS = 15000` — 15-second cadence. Long enough to tolerate a slow cron tick + tile fetch, short enough that arrival feels responsive.
- `MAX_POLLS = 20` — ~5-minute cap. A genuinely-stuck generation fails loud rather than polling forever.
- Tears down immediately when: image starts rendering, block leaves static mode, venue loses coordinates, component unmounts, or the cap is hit.

Polling only **notices** async writes — it does not trigger generation. A user changing to an uncached combo still needs to click Regenerate (that's the deliberate manual trigger). Polling closes the gap when some other process (cron prewarm, another browser tab, a direct meta write) landed a descriptor the editor would otherwise miss.

**Component simplification**

`src/blocks/venue-map/edit.js` replaces an inline `useEffect` with a one-line hook call. `useDispatch('core')` no longer imported directly in the component — the hook encapsulates it.

**RSVP / modal-content block-validation drift (bonus)**

Discovered mid-testing: existing RSVP-modal content in the wild stored `has-white-background-color` (palette-slug) class while the block's schema default was `style.color.background: '#ffffff'` (custom-hex). That made `save()` emit BOTH the class AND inline `background-color:#ffffff` — stored markup had only the class, so every editor load showed a "Block contains unexpected or invalid content" warning on the modal-content block.

Fix bundled into this PR:

- `src/blocks/modal-content/block.json` — dropped `color.background` from the attribute default (spacing + dimensions kept). The alpha-plugin migration templates and existing user content both use the palette-slug shape; the custom-hex default was the only thing disagreeing.
- `src/blocks/rsvp/templates/{attending,no-status,not-attending,waiting-list}.js` — modal-content instantiations now pass `{ backgroundColor: 'white' }` instead of `{}` so fresh inserts get the palette slug directly.

No gatherpress-alpha migration changes needed — its templates already emit the correct palette-slug format; this PR just removes our conflicting default.

Closes #1481

### How to test the Change

1. `npm run build` and reload the editor.
2. **Polling smoke test**:
   - Open a venue in the editor; insert a venue-map block in Static mode.
   - Clear the descriptor meta: `wp --path=app/public post meta delete <venue_id> gatherpress_venue_static_map`.
   - Reload the editor. Placeholder shows.
   - In DevTools → Network tab, watch for `wp/v2/<post_type>/<id>` refetches every 15s.
   - Manually write a descriptor via `wp --path=app/public post meta update <venue_id> gatherpress_venue_static_map '{"18x600x300":{"url":"https://placehold.co/600x300.png","hash":"test","zoom":18,"width":600,"height":300}}' --format=json` — placeholder should swap to the `<img>` within 15s without a reload.
   - Switch the block to Interactive mode — polling stops.
   - Leave a stuck placeholder up for 5+ minutes — polling stops itself at the cap.
3. **Modal drift smoke test**:
   - Open a post with a saved RSVP block.
   - Confirm no "Block contains unexpected or invalid content" warning on `gatherpress/modal-content` in the console.
   - In the Inspector, pick transparent / reduce opacity on the modal background. Save, reload, verify choice stuck.
4. `npm run test:unit:js` — 7 new tests in `test/unit/js/src/blocks/venue-map/helpers.test.js` covering active/inactive gating, tick cadence + resolver args, MAX_POLLS cap, unmount cleanup, active→false cleanup. 29/29 pass.
5. `npm run lint:js` + `npm run lint:phpstan` + `npm run build` all clean.

### Changelog Entry

> Added - Editor polling so async-arriving venue-map descriptors (WP-Cron prewarm, out-of-band writes) swap the placeholder for the rendered PNG automatically. Fixes block-validation drift on the Modal Content block used by RSVP.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.