### PR TITLE
Render retina (2×) static venue maps with srcset.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,15 @@ When working with this codebase:
 4. Test both PHP and JavaScript components
 5. Consider block editor compatibility when making changes
 
+### Auto-generated developer hook docs
+
+`docs/developer/hooks/` is regenerated automatically by CI — the `extract-wp-hooks-as-docs.yml` workflow runs on every push to `develop` that touches a `.php` file, runs `vendor/bin/extract-wp-hooks.php`, and opens a dedicated `fix/extract-wp-hooks-{sha}` PR titled "Hook docs updated!" with the regen.
+
+- **Do not commit changes under `docs/developer/hooks/` in feature PRs.** Add the new filter/action with a correct `@since` / `@param` / description docblock, and let CI regenerate the markdown on merge. Committing regen in a feature PR just creates duplicate diffs and churn when the auto-PR lands.
+- If you regenerated locally to sanity-check a docblock, revert before committing: `git checkout -- docs/developer/hooks/` and `rm` any newly-created hook markdown files.
+- The exception is a `fix/extract-wp-hooks-{sha}` branch itself — regen is the point of that branch. Merge-conflict resolution there is also fair game (take develop's version for any conflict, then re-run `vendor/bin/extract-wp-hooks.php` against the merged state).
+- This applies only to `docs/developer/hooks/`. `docs/user/` and the rest of `docs/developer/` are hand-maintained.
+
 ### JavaScript/TypeScript Guidelines
 
 - **No console.log statements**: JavaScript linting will fail if `console.log()` statements are present in the code. For debugging purposes, use proper debugging tools or remove all console statements before committing.
@@ -244,7 +253,16 @@ Based on WordPress Coding Standards (WPCS), always ensure:
     - Use `is_wp_error()`, `is_numeric()`, and similar WordPress/PHP functions
     - Cast types explicitly when needed: `(int) $comment->comment_post_ID`
 
-### PHP Testing Guidelines
+### Test Coverage
+
+**Full coverage is the bar — partial branch coverage does not count.** When you add or touch code, cover every branch: each side of a ternary, each arm of `||` / `??` fallbacks, each `if` / `else`, each optional-chain short-circuit, each falsy-default spread. If a line like `error?.message || __( 'fallback' )` has a test for the truthy side but not the falsy side, the PR is incomplete — add the missing case.
+
+- ✅ Good: a test for `error?.message` present *and* a test where `.message` is absent so the `__( 'fallback' )` branch executes.
+- ✅ Good: a test for `current.meta` being populated *and* a test where it's undefined so `( current.meta || {} )` spreads the empty default.
+- ✅ Good: a test where `response.descriptors` arrives *and* a test where it's missing so `response?.descriptors || {}` falls through.
+- ❌ Bad: shipping with the coverage tool reporting "1/2" on a branch and calling it done.
+
+Coverage gaps flagged by SonarCloud or the `test:unit:js` / `test:unit:php` coverage reports must be closed before merging — add the tests, don't suppress. `@codeCoverageIgnore` is reserved for genuinely unreachable/untestable code (the existing uses on missing-GD branches, unwritable filesystem branches) and is not a shortcut for "I didn't write the test yet."
 
 **Multisite test group**: GatherPress runs two separate PHPUnit test suites in CI — a standard single-site run and a multisite run. Tests that require a multisite WordPress environment are annotated with `@group multisite`. The standard `phpunit.xml.dist` excludes this group so it does not run locally via `npm run test:unit:php`, but CI runs it separately and merges the coverage data before the PR coverage check.
 

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -232,9 +232,14 @@ class Venue_Map {
 	const DEFAULT_TILE_URL = 'https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png';
 
 	/**
-	 * Post meta key under which the static-map descriptor is stored.
+	 * Post meta key under which the static-map descriptors are stored.
 	 *
-	 * Value shape: `array{ url: string, hash: string }`.
+	 * Stored value is an associative array keyed by `{zoom}x{width}x{height}`
+	 * with entries of shape
+	 * `array{ url: string, url_2x: string, hash: string, zoom: int, width: int, height: int }`.
+	 * `url_2x` is empty string when the retina variant is disabled or failed
+	 * to generate; pre-retina descriptors written by older versions omit the
+	 * key entirely and are normalized by {@see self::get_all_descriptors()}.
 	 *
 	 * @since 1.0.0
 	 * @var string
@@ -597,7 +602,7 @@ class Venue_Map {
 	 * @param int|null $extra_width        Optional extra width (0 = auto).
 	 * @param int|null $extra_height       Optional extra height (0 = auto).
 	 * @param string   $extra_aspect_ratio Optional aspect ratio hint for the extra combo.
-	 * @return array<string, array{url: string, hash: string, zoom: int, width: int, height: int}>
+	 * @return array<string, array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}>
 	 */
 	public function regenerate(
 		int $post_id,
@@ -761,17 +766,80 @@ class Venue_Map {
 	}
 
 	/**
-	 * Resolve the static map URL for any GatherPress post context.
+	 * Resolve the static-map descriptor for any GatherPress post context.
 	 *
 	 * Accepts either a venue post ID (supports `gatherpress-venue-information`)
-	 * or an event post ID (supports `gatherpress-venue`) and returns the URL
-	 * of the stored static map for the corresponding venue at the requested
-	 * zoom and height. When the cache doesn't yet have an image for that
-	 * combo, the method generates one synchronously — first render pays the
-	 * cost, subsequent renders hit the cache.
+	 * or an event post ID (supports `gatherpress-venue`) and returns the full
+	 * descriptor — both 1× and 2× URLs plus the bookkeeping fields — for the
+	 * corresponding venue at the requested zoom and height. When the cache
+	 * doesn't yet have an image for that combo, the method generates one
+	 * synchronously; first render pays the cost, subsequent renders hit the
+	 * cache. Returns null when the post isn't venue-related, the venue has
+	 * no coordinates, or generation failed.
 	 *
-	 * Returns '' when the post isn't venue-related, the venue has no
-	 * coordinates, or the on-demand generation failed.
+	 * @since 1.0.0
+	 *
+	 * @param int      $post_id      Event or venue post ID.
+	 * @param string   $post_type    The post type of `$post_id`.
+	 * @param int|null $zoom         Desired zoom level. Null falls back to the default.
+	 * @param int|null $width        Desired pixel width (0/null = auto).
+	 * @param int|null $height       Desired pixel height (0/null = auto).
+	 * @param string   $aspect_ratio Aspect-ratio hint used to derive any auto dimension.
+	 * @return array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}|null
+	 */
+	public function get_descriptor_for_post(
+		int $post_id,
+		string $post_type,
+		?int $zoom = null,
+		?int $width = null,
+		?int $height = null,
+		string $aspect_ratio = ''
+	): ?array {
+		$venue_post_id = 0;
+
+		if ( post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
+			$venue_post_id = $post_id;
+		} elseif ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
+			$venue_post = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
+
+			if ( $venue_post instanceof WP_Post ) {
+				$venue_post_id = $venue_post->ID;
+			}
+		}
+
+		if ( 0 === $venue_post_id ) {
+			return null;
+		}
+
+		$info = ( new Venue( $venue_post_id ) )->get_information();
+
+		if ( null === $this->parse_coord( $info['latitude'] ) ||
+			null === $this->parse_coord( $info['longitude'] ) ) {
+			return null;
+		}
+
+		$resolved = $this->resolve_dimensions(
+			(int) ( $width ?? 0 ),
+			(int) ( $height ?? $this->get_height() ),
+			'' !== $aspect_ratio ? $aspect_ratio : self::DEFAULT_ASPECT_RATIO
+		);
+
+		return $this->ensure_descriptor_for_combo(
+			$venue_post_id,
+			$info,
+			$zoom ?? $this->get_zoom(),
+			$resolved['width'],
+			$resolved['height']
+		);
+	}
+
+	/**
+	 * Resolve the static-map URL for any GatherPress post context.
+	 *
+	 * Thin wrapper around {@see self::get_descriptor_for_post()} that returns
+	 * just the 1× URL, preserved for callers that only need the baseline
+	 * image. For render paths that want the retina variant too, call
+	 * `get_descriptor_for_post()` directly.
 	 *
 	 * @since 1.0.0
 	 *
@@ -791,42 +859,7 @@ class Venue_Map {
 		?int $height = null,
 		string $aspect_ratio = ''
 	): string {
-		$venue_post_id = 0;
-
-		if ( post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
-			$venue_post_id = $post_id;
-		} elseif ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
-			$venue_post = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
-
-			if ( $venue_post instanceof WP_Post ) {
-				$venue_post_id = $venue_post->ID;
-			}
-		}
-
-		if ( 0 === $venue_post_id ) {
-			return '';
-		}
-
-		$info = ( new Venue( $venue_post_id ) )->get_information();
-
-		if ( null === $this->parse_coord( $info['latitude'] ) ||
-			null === $this->parse_coord( $info['longitude'] ) ) {
-			return '';
-		}
-
-		$resolved = $this->resolve_dimensions(
-			(int) ( $width ?? 0 ),
-			(int) ( $height ?? $this->get_height() ),
-			'' !== $aspect_ratio ? $aspect_ratio : self::DEFAULT_ASPECT_RATIO
-		);
-
-		$descriptor = $this->ensure_descriptor_for_combo(
-			$venue_post_id,
-			$info,
-			$zoom ?? $this->get_zoom(),
-			$resolved['width'],
-			$resolved['height']
-		);
+		$descriptor = $this->get_descriptor_for_post( $post_id, $post_type, $zoom, $width, $height, $aspect_ratio );
 
 		return null === $descriptor ? '' : $descriptor['url'];
 	}
@@ -851,7 +884,7 @@ class Venue_Map {
 	 * @param int    $width        Pixel width (0 = auto).
 	 * @param int    $height       Pixel height (0 = auto).
 	 * @param string $aspect_ratio Aspect-ratio string (e.g. "16/9").
-	 * @return array{url: string, hash: string, zoom: int, width: int, height: int}|null
+	 * @return array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
 	public function warm( int $post_id, int $zoom, int $width, int $height, string $aspect_ratio = '' ): ?array {
 		if ( 0 >= $post_id ) {
@@ -892,7 +925,7 @@ class Venue_Map {
 	 * @since 1.0.0
 	 *
 	 * @param int $post_id The venue post ID.
-	 * @return array{url: string, hash: string, zoom: int, width: int, height: int}|null
+	 * @return array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
 	public function get_stored_descriptor( int $post_id ): ?array {
 		$all      = $this->get_all_descriptors( $post_id );
@@ -923,7 +956,7 @@ class Venue_Map {
 	 * @since 1.0.0
 	 *
 	 * @param int $post_id The venue post ID.
-	 * @return array<string, array{url: string, hash: string, zoom: int, width: int, height: int}>
+	 * @return array<string, array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}>
 	 */
 	public function get_all_descriptors( int $post_id ): array {
 		$raw = get_post_meta( $post_id, self::META_KEY, true );
@@ -950,8 +983,13 @@ class Venue_Map {
 				continue;
 			}
 
+			// `url_2x` is nullable for back-compat: pre-retina descriptors
+			// written before this plugin version don't carry the key at all.
+			// Normalize to an empty string so downstream callers can check
+			// with a single `'' !== $url_2x` branch.
 			$descriptors[ (string) $key ] = array(
 				'url'    => (string) $entry['url'],
+				'url_2x' => isset( $entry['url_2x'] ) ? (string) $entry['url_2x'] : '',
 				'hash'   => (string) $entry['hash'],
 				'zoom'   => $zoom,
 				'width'  => $width,
@@ -1034,7 +1072,7 @@ class Venue_Map {
 	 * @param int   $zoom    Zoom level to render at.
 	 * @param int   $width   Pixel width of the PNG.
 	 * @param int   $height  Pixel height of the PNG.
-	 * @return array{url: string, hash: string, zoom: int, width: int, height: int}|null
+	 * @return array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
 	protected function ensure_descriptor_for_combo(
 		int $post_id,
@@ -1066,9 +1104,14 @@ class Venue_Map {
 
 		if ( null !== $existing && $existing['hash'] === $hash ) {
 			// The URL itself is deterministic from (address, zoom, dims) so
-			// existence on disk is the real validity signal.
+			// existence on disk is the real validity signal. If the retina
+			// variant is enabled but missing from this descriptor it's a
+			// pre-retina entry (`get_all_descriptors()` normalizes missing
+			// `url_2x` to an empty string) — fall through to regenerate so
+			// the 2× actually gets produced.
 			$expected_url = $this->build_image_url( $address, $zoom, $width, $height );
-			if ( $existing['url'] === $expected_url ) {
+			$needs_retina = $this->should_generate_retina() && '' === $existing['url_2x'];
+			if ( $existing['url'] === $expected_url && ! $needs_retina ) {
 				return $existing;
 			}
 		}
@@ -1090,8 +1133,28 @@ class Venue_Map {
 			return null;
 		}
 
+		// Retina variant: separate composite at 2× density (zoom+1 tiles,
+		// double-sized canvas) with its own wall-clock budget. Failure here
+		// is non-fatal — we keep the 1× URL and just leave `url_2x` empty so
+		// the front-end falls back to a plain `src`. Reuses the same hash:
+		// the 2× is fully derived from the same inputs.
+		$url_2x = '';
+		if ( $this->should_generate_retina() ) {
+			$image_2x = $this->composite_image( $latitude, $longitude, $zoom, $width, $height, $tiles, 2 );
+			if ( null !== $image_2x ) {
+				$this->stamp_marker( $image_2x, $width, $height, 2.0 );
+
+				$saved_2x = $this->save_image( $image_2x, $address, $zoom, $width, $height, 2 );
+				imagedestroy( $image_2x );
+				if ( null !== $saved_2x ) {
+					$url_2x = $saved_2x;
+				}
+			}
+		}
+
 		$all[ $key ] = array(
 			'url'    => $url,
+			'url_2x' => $url_2x,
 			'hash'   => $hash,
 			'zoom'   => $zoom,
 			'width'  => $width,
@@ -1115,6 +1178,33 @@ class Venue_Map {
 		}
 
 		return $all[ $key ];
+	}
+
+	/**
+	 * Whether the compositor should emit a retina (2×) variant alongside the 1× image.
+	 *
+	 * Default on — site owners who want to save disk can return false from
+	 * the filter. Called per-combo so a filter can even target specific
+	 * contexts (`is_admin()`, per-post, per-current-user).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool True when the retina variant should be generated.
+	 */
+	protected function should_generate_retina(): bool {
+		/**
+		 * Filter whether to generate the retina (2×) static-map variant.
+		 *
+		 * Disabling this halves the on-disk footprint at the cost of
+		 * losing true retina sharpness on HiDPI displays — the browser
+		 * will still upscale the 1× PNG, but labels and road lines will
+		 * look softer than a native 2× render. Default true.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param bool $enabled Whether to generate the 2× variant.
+		 */
+		return (bool) apply_filters( 'gatherpress_venue_map_generate_2x', true );
 	}
 
 	/**
@@ -1157,21 +1247,29 @@ class Venue_Map {
 	 * Mirrors {@see self::save_image()}'s filename composition so callers can
 	 * compare an existing descriptor's URL against the expected URL without
 	 * touching the filesystem. Two venues at the same address share the same
-	 * URL at matching dimensions — intentional dedupe.
+	 * URL at matching dimensions — intentional dedupe. `$density > 1` appends
+	 * the `@{density}x` suffix used by the retina variants.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param string $address Venue address string.
 	 * @param int    $zoom    Map zoom level.
-	 * @param int    $width   Output width.
-	 * @param int    $height  Output height.
+	 * @param int    $width   Output width (at density 1).
+	 * @param int    $height  Output height (at density 1).
+	 * @param int    $density Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @return string Full public URL for the PNG.
 	 */
-	protected function build_image_url( string $address, int $zoom, int $width, int $height ): string {
+	protected function build_image_url(
+		string $address,
+		int $zoom,
+		int $width,
+		int $height,
+		int $density = 1
+	): string {
 		$dirs     = wp_get_upload_dir();
 		$base_url = trailingslashit( $dirs['baseurl'] ) . self::UPLOADS_SUBDIR;
 
-		return trailingslashit( $base_url ) . $this->filename_for( $address, $zoom, $width, $height );
+		return trailingslashit( $base_url ) . $this->filename_for( $address, $zoom, $width, $height, $density );
 	}
 
 	/**
@@ -1181,17 +1279,19 @@ class Venue_Map {
 	 * so the full filename stays comfortably under the 255-byte cap common
 	 * to most filesystems. An empty or all-special-character address falls
 	 * back to `venue` so there's always something before the dimension
-	 * suffix.
+	 * suffix. `$density > 1` appends the `@{density}x` suffix used by the
+	 * retina variants, e.g. `venue-12-800-300@2x.png`.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param string $address Venue address.
 	 * @param int    $zoom    Map zoom level.
-	 * @param int    $width   Output width.
-	 * @param int    $height  Output height.
+	 * @param int    $width   Output width (at density 1).
+	 * @param int    $height  Output height (at density 1).
+	 * @param int    $density Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @return string Filename including the `.png` extension.
 	 */
-	protected function filename_for( string $address, int $zoom, int $width, int $height ): string {
+	protected function filename_for( string $address, int $zoom, int $width, int $height, int $density = 1 ): string {
 		// `sanitize_title()` URL-slugifies; pass the result through
 		// `sanitize_file_name()` as defense-in-depth so any path-sensitive
 		// characters that slip past (or future changes to sanitize_title's
@@ -1206,7 +1306,9 @@ class Venue_Map {
 			$slug = substr( $slug, 0, 150 );
 		}
 
-		return sprintf( '%s-%d-%d-%d.png', $slug, $zoom, $width, $height );
+		$suffix = $density > 1 ? sprintf( '@%dx', $density ) : '';
+
+		return sprintf( '%s-%d-%d-%d%s.png', $slug, $zoom, $width, $height, $suffix );
 	}
 
 	/**
@@ -1256,14 +1358,22 @@ class Venue_Map {
 	 * bounds intersect the canvas window, and copies each into its correct
 	 * pixel offset. Caller is responsible for `imagedestroy()` on the result.
 	 *
+	 * At `$density > 1` the method produces a retina variant: tiles are
+	 * fetched at `zoom + log2($density)` (so a 2× pass uses `zoom + 1` tiles)
+	 * and the canvas is sized at `$width * $density` × `$height * $density`.
+	 * That's true retina detail — the denser zoom level renders labels and
+	 * road lines at native 2× resolution rather than just upscaling the 1×
+	 * tile set. `$density` must be a power of two.
+	 *
 	 * @since 1.0.0
 	 *
-	 * @param float  $lat    Latitude in degrees.
-	 * @param float  $lng    Longitude in degrees.
-	 * @param int    $zoom   Zoom level (same zoom Leaflet would use for the same CSS viewport).
-	 * @param int    $width  Output pixel width.
-	 * @param int    $height Output pixel height.
-	 * @param string $tiles  Tile URL template.
+	 * @param float  $lat     Latitude in degrees.
+	 * @param float  $lng     Longitude in degrees.
+	 * @param int    $zoom    Zoom level (same zoom Leaflet would use for the same CSS viewport).
+	 * @param int    $width   Output pixel width at density 1.
+	 * @param int    $height  Output pixel height at density 1.
+	 * @param string $tiles   Tile URL template.
+	 * @param int    $density Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @return \GdImage|resource|null Composited image, or null when GD is unavailable.
 	 *                                GdImage on PHP 8+, resource on PHP 7.4.
 	 */
@@ -1273,29 +1383,41 @@ class Venue_Map {
 		int $zoom,
 		int $width,
 		int $height,
-		string $tiles
+		string $tiles,
+		int $density = 1
 	) {
 		// PHP built without the GD extension. Can't simulate in a unit test without making the runtime itself broken.
 		if ( ! function_exists( 'imagecreatetruecolor' ) ) { // @codeCoverageIgnore
 			return null; // @codeCoverageIgnore
 		}
 
-		$venue_world_x = $this->lng_to_world_pixel( $lng, $zoom );
-		$venue_world_y = $this->lat_to_world_pixel( $lat, $zoom );
+		$density = max( 1, $density );
 
-		$left_pixel = (int) round( $venue_world_x - $width / 2 );
-		$top_pixel  = (int) round( $venue_world_y - $height / 2 );
+		// Tile zoom climbs with density so the retina variant renders true
+		// zoom+1 detail (sharp labels and lines) rather than upscaled 1×
+		// pixels. For the only values we currently support (1, 2) this
+		// resolves to zoom or zoom+1.
+		$tile_zoom = $zoom + (int) log( $density, 2 );
+
+		$canvas_width  = $width * $density;
+		$canvas_height = $height * $density;
+
+		$venue_world_x = $this->lng_to_world_pixel( $lng, $tile_zoom );
+		$venue_world_y = $this->lat_to_world_pixel( $lat, $tile_zoom );
+
+		$left_pixel = (int) round( $venue_world_x - $canvas_width / 2 );
+		$top_pixel  = (int) round( $venue_world_y - $canvas_height / 2 );
 
 		$left_tile   = (int) floor( $left_pixel / self::TILE_SIZE );
 		$top_tile    = (int) floor( $top_pixel / self::TILE_SIZE );
-		$right_tile  = (int) floor( ( $left_pixel + $width - 1 ) / self::TILE_SIZE );
-		$bottom_tile = (int) floor( ( $top_pixel + $height - 1 ) / self::TILE_SIZE );
+		$right_tile  = (int) floor( ( $left_pixel + $canvas_width - 1 ) / self::TILE_SIZE );
+		$bottom_tile = (int) floor( ( $top_pixel + $canvas_height - 1 ) / self::TILE_SIZE );
 
-		$canvas = imagecreatetruecolor( $width, $height );
+		$canvas = imagecreatetruecolor( $canvas_width, $canvas_height );
 
 		// Background: neutral gray so missing tiles blend rather than glaring black.
 		$bg = imagecolorallocate( $canvas, 238, 238, 238 );
-		imagefilledrectangle( $canvas, 0, 0, $width - 1, $height - 1, $bg );
+		imagefilledrectangle( $canvas, 0, 0, $canvas_width - 1, $canvas_height - 1, $bg );
 
 		/**
 		 * Filter the wall-clock budget (in seconds) for a single
@@ -1324,7 +1446,7 @@ class Venue_Map {
 					break 2;
 				}
 
-				$tile_png = $this->fetch_tile( $zoom, $tx, $ty, $tiles );
+				$tile_png = $this->fetch_tile( $tile_zoom, $tx, $ty, $tiles );
 
 				if ( null === $tile_png ) {
 					continue;
@@ -1350,22 +1472,31 @@ class Venue_Map {
 	/**
 	 * Draw a simple pin marker at the given pixel coordinates.
 	 *
+	 * Passing `$scale > 1` proportionally scales the marker's three concentric
+	 * ellipses so a retina (2×) composite keeps the marker visually the same
+	 * size as the 1× render rather than shrinking to a pinprick.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param \GdImage|resource $canvas Destination canvas (GdImage on PHP 8+, resource on PHP 7.4).
 	 * @param int               $x      Pixel X position (marker center).
 	 * @param int               $y      Pixel Y position (marker center).
+	 * @param float             $scale  Multiplier applied to the marker radii. 1.0 keeps the original size.
 	 * @return void
 	 */
-	public function stamp_marker( $canvas, int $x, int $y ): void {
+	public function stamp_marker( $canvas, int $x, int $y, float $scale = 1.0 ): void {
 		$white = imagecolorallocate( $canvas, 255, 255, 255 );
 		$red   = imagecolorallocate( $canvas, 220, 53, 69 );
 		$dark  = imagecolorallocate( $canvas, 30, 30, 30 );
 
-		imagefilledellipse( $canvas, $x, $y, 20, 20, $white );
-		imagefilledellipse( $canvas, $x, $y, 16, 16, $red );
-		imageellipse( $canvas, $x, $y, 16, 16, $dark );
-		imagefilledellipse( $canvas, $x, $y, 6, 6, $white );
+		$outer = max( 1, (int) round( 20 * $scale ) );
+		$inner = max( 1, (int) round( 16 * $scale ) );
+		$dot   = max( 1, (int) round( 6 * $scale ) );
+
+		imagefilledellipse( $canvas, $x, $y, $outer, $outer, $white );
+		imagefilledellipse( $canvas, $x, $y, $inner, $inner, $red );
+		imageellipse( $canvas, $x, $y, $inner, $inner, $dark );
+		imagefilledellipse( $canvas, $x, $y, $dot, $dot, $white );
 	}
 
 	/**
@@ -1382,11 +1513,19 @@ class Venue_Map {
 	 * @param \GdImage|resource $image   The finished composite (GdImage on PHP 8+, resource on PHP 7.4).
 	 * @param string            $address Venue address (slugified for the filename).
 	 * @param int               $zoom    Map zoom level.
-	 * @param int               $width   Output width.
-	 * @param int               $height  Output height.
+	 * @param int               $width   Output width (at density 1).
+	 * @param int               $height  Output height (at density 1).
+	 * @param int               $density Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @return string|null Public URL of the saved file, or null on failure.
 	 */
-	public function save_image( $image, string $address, int $zoom, int $width, int $height ): ?string {
+	public function save_image(
+		$image,
+		string $address,
+		int $zoom,
+		int $width,
+		int $height,
+		int $density = 1
+	): ?string {
 		$dirs = wp_get_upload_dir();
 
 		if ( ! empty( $dirs['error'] ) ) {
@@ -1401,7 +1540,7 @@ class Venue_Map {
 			return null; // @codeCoverageIgnore
 		}
 
-		$filename = $this->filename_for( $address, $zoom, $width, $height );
+		$filename = $this->filename_for( $address, $zoom, $width, $height, $density );
 		$path     = trailingslashit( $base_dir ) . $filename;
 		$url      = trailingslashit( $base_url ) . $filename;
 

--- a/includes/core/classes/class-venue-map.php
+++ b/includes/core/classes/class-venue-map.php
@@ -210,6 +210,36 @@ class Venue_Map {
 	const TILE_SIZE = 256;
 
 	/**
+	 * Pixel-density multiplier for the retina (2×) static-map variant.
+	 *
+	 * Drives the `@{density}x` filename suffix, the canvas-size multiplier
+	 * in `composite_image()`, the marker-scale argument in `stamp_marker()`,
+	 * and the zoom offset when fetching tiles (tiles are pulled from
+	 * `base_zoom + log2(RETINA_DENSITY)` for true 2× detail rather than
+	 * upscaled pixels). Kept as a constant so the generator and the
+	 * filename composer can never drift out of lock-step — any future bump
+	 * (3×, 4×) lands in one place.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const RETINA_DENSITY = 2;
+
+	/**
+	 * Densities `composite_image()` knows how to produce.
+	 *
+	 * The tile-zoom offset is `log2($density)`, so only power-of-two values
+	 * give a whole-number zoom delta. Anything outside this allow-list is
+	 * coerced back to 1 so a caller can't accidentally generate a
+	 * canvas-doubled-but-tile-zoom-unchanged image (which would be a cheap
+	 * upscale and waste disk).
+	 *
+	 * @since 1.0.0
+	 * @var int[]
+	 */
+	const SUPPORTED_DENSITIES = array( 1, self::RETINA_DENSITY );
+
+	/**
 	 * PNG aspect ratio (width ÷ height).
 	 *
 	 * The block exposes height but not width (blocks render 100% of their
@@ -1102,35 +1132,48 @@ class Venue_Map {
 		$all      = $this->get_all_descriptors( $post_id );
 		$existing = $all[ $key ] ?? null;
 
-		if ( null !== $existing && $existing['hash'] === $hash ) {
-			// The URL itself is deterministic from (address, zoom, dims) so
-			// existence on disk is the real validity signal. If the retina
-			// variant is enabled but missing from this descriptor it's a
-			// pre-retina entry (`get_all_descriptors()` normalizes missing
-			// `url_2x` to an empty string) — fall through to regenerate so
-			// the 2× actually gets produced.
-			$expected_url = $this->build_image_url( $address, $zoom, $width, $height );
-			$needs_retina = $this->should_generate_retina() && '' === $existing['url_2x'];
-			if ( $existing['url'] === $expected_url && ! $needs_retina ) {
-				return $existing;
+		// Retina generation requires a zoom level with tiles available at
+		// `zoom + log2(RETINA_DENSITY)`. At the zoom ceiling the derived
+		// tile zoom would exceed what the provider serves, every fetch
+		// 404s, and we'd persist a solid-gray PNG — skip instead.
+		// Cached locally so we never invoke the filter twice per call.
+		$retina_enabled = $this->should_generate_retina()
+			&& ( $zoom + (int) log( self::RETINA_DENSITY, 2 ) ) <= self::ZOOM_MAX;
+
+		$expected_url = $this->build_image_url( $address, $zoom, $width, $height );
+		$has_valid_1x = null !== $existing
+			&& $existing['hash'] === $hash
+			&& $existing['url'] === $expected_url;
+		$needs_retina = $retina_enabled && ( null === $existing || '' === $existing['url_2x'] );
+
+		if ( $has_valid_1x && ! $needs_retina ) {
+			return $existing;
+		}
+
+		// Only recomposite the 1× when it's genuinely missing or stale.
+		// Legacy descriptors (pre-retina) land on the `has_valid_1x &&
+		// needs_retina` path — their 1× PNG is still valid so we skip the
+		// redundant fetch/save and only fill in the retina sibling.
+		$url = null;
+		if ( $has_valid_1x ) {
+			$url = $existing['url'];
+		} else {
+			$image = $this->composite_image( $latitude, $longitude, $zoom, $width, $height, $tiles );
+
+			// Downstream of the GD-missing branch in composite_image(); only
+			// reached on PHP builds without the GD extension.
+			if ( null === $image ) { // @codeCoverageIgnore
+				return null; // @codeCoverageIgnore
 			}
-		}
 
-		$image = $this->composite_image( $latitude, $longitude, $zoom, $width, $height, $tiles );
+			$this->stamp_marker( $image, (int) round( $width / 2 ), (int) round( $height / 2 ) );
 
-		// Downstream of the GD-missing branch in composite_image(); only
-		// reached on PHP builds without the GD extension.
-		if ( null === $image ) { // @codeCoverageIgnore
-			return null; // @codeCoverageIgnore
-		}
+			$url = $this->save_image( $image, $address, $zoom, $width, $height );
+			imagedestroy( $image );
 
-		$this->stamp_marker( $image, (int) round( $width / 2 ), (int) round( $height / 2 ) );
-
-		$url = $this->save_image( $image, $address, $zoom, $width, $height );
-		imagedestroy( $image );
-
-		if ( null === $url ) {
-			return null;
+			if ( null === $url ) {
+				return null;
+			}
 		}
 
 		// Retina variant: separate composite at 2× density (zoom+1 tiles,
@@ -1139,12 +1182,38 @@ class Venue_Map {
 		// the front-end falls back to a plain `src`. Reuses the same hash:
 		// the 2× is fully derived from the same inputs.
 		$url_2x = '';
-		if ( $this->should_generate_retina() ) {
-			$image_2x = $this->composite_image( $latitude, $longitude, $zoom, $width, $height, $tiles, 2 );
+		if ( $retina_enabled ) {
+			$canvas_width  = $width * self::RETINA_DENSITY;
+			$canvas_height = $height * self::RETINA_DENSITY;
+			$image_2x      = $this->composite_image(
+				$latitude,
+				$longitude,
+				$zoom,
+				$width,
+				$height,
+				$tiles,
+				self::RETINA_DENSITY
+			);
 			if ( null !== $image_2x ) {
-				$this->stamp_marker( $image_2x, $width, $height, 2.0 );
+				// Use the same `round( canvas / 2 )` pattern as the 1× call
+				// so both paths share a single marker-center convention;
+				// even canvas sizes make the results identical, the
+				// symmetry is for maintenance.
+				$this->stamp_marker(
+					$image_2x,
+					(int) round( $canvas_width / 2 ),
+					(int) round( $canvas_height / 2 ),
+					(float) self::RETINA_DENSITY
+				);
 
-				$saved_2x = $this->save_image( $image_2x, $address, $zoom, $width, $height, 2 );
+				$saved_2x = $this->save_image(
+					$image_2x,
+					$address,
+					$zoom,
+					$width,
+					$height,
+					self::RETINA_DENSITY
+				);
 				imagedestroy( $image_2x );
 				if ( null !== $saved_2x ) {
 					$url_2x = $saved_2x;
@@ -1391,13 +1460,22 @@ class Venue_Map {
 			return null; // @codeCoverageIgnore
 		}
 
-		$density = max( 1, $density );
+		// Coerce unsupported densities back to 1. Allowing, say, density=3
+		// with `(int) log(3, 2) === 1` would paint a 3×-sized canvas using
+		// only 2× tiles — a cheap upscale that wastes disk for no gain.
+		// Allow-listing keeps the tile-zoom offset a whole number.
+		if ( ! in_array( $density, self::SUPPORTED_DENSITIES, true ) ) {
+			$density = 1;
+		}
 
 		// Tile zoom climbs with density so the retina variant renders true
 		// zoom+1 detail (sharp labels and lines) rather than upscaled 1×
-		// pixels. For the only values we currently support (1, 2) this
-		// resolves to zoom or zoom+1.
-		$tile_zoom = $zoom + (int) log( $density, 2 );
+		// pixels. Clamp to ZOOM_MAX as defense-in-depth: at the zoom
+		// ceiling the caller should have skipped retina generation
+		// upstream, but if we're ever invoked directly at high zoom we'd
+		// rather render a degraded upscale than hit the tile server with
+		// zoom-beyond-max requests (every fetch 404s → gray canvas).
+		$tile_zoom = min( self::ZOOM_MAX, $zoom + (int) log( $density, 2 ) );
 
 		$canvas_width  = $width * $density;
 		$canvas_height = $height * $density;

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -65,7 +65,7 @@ $gatherpress_scale           = in_array( $gatherpress_scale_candidate, Venue_Map
 	? $gatherpress_scale_candidate
 	: Venue_Map::DEFAULT_SCALE;
 
-$gatherpress_static_map_url = Venue_Map::get_instance()->get_url_for_post(
+$gatherpress_static_map_descriptor = Venue_Map::get_instance()->get_descriptor_for_post(
 	$gatherpress_post_id,
 	$gatherpress_post_type,
 	$gatherpress_zoom,
@@ -73,6 +73,13 @@ $gatherpress_static_map_url = Venue_Map::get_instance()->get_url_for_post(
 	$gatherpress_raw_height,
 	$gatherpress_ratio
 );
+
+$gatherpress_static_map_url    = null !== $gatherpress_static_map_descriptor
+	? $gatherpress_static_map_descriptor['url']
+	: '';
+$gatherpress_static_map_url_2x = null !== $gatherpress_static_map_descriptor
+	? $gatherpress_static_map_descriptor['url_2x']
+	: '';
 
 // Hydration data sits on the outer wrapper so view.js can replace the
 // wrapper's children with a live Leaflet map (the `<img>` inside is a void
@@ -180,12 +187,27 @@ if ( '' !== $gatherpress_static_map_url ) {
 		);
 	}
 
-	printf(
-		'<img class="gatherpress-venue-map__image" src="%s" alt="%s" loading="lazy" style="object-fit:%s;" />',
-		esc_url( $gatherpress_static_map_url ),
-		esc_attr( $gatherpress_alt ),
-		esc_attr( $gatherpress_scale )
-	);
+	// Emit `srcset` only when the retina variant is actually present —
+	// pre-retina descriptors and sites that filtered the 2× off keep the
+	// existing plain `src` output so the browser doesn't try to resolve
+	// an empty 2× URL.
+	if ( '' !== $gatherpress_static_map_url_2x ) {
+		printf(
+			'<img class="gatherpress-venue-map__image" src="%s" srcset="%s 1x, %s 2x" alt="%s" loading="lazy" style="object-fit:%s;" />',
+			esc_url( $gatherpress_static_map_url ),
+			esc_url( $gatherpress_static_map_url ),
+			esc_url( $gatherpress_static_map_url_2x ),
+			esc_attr( $gatherpress_alt ),
+			esc_attr( $gatherpress_scale )
+		);
+	} else {
+		printf(
+			'<img class="gatherpress-venue-map__image" src="%s" alt="%s" loading="lazy" style="object-fit:%s;" />',
+			esc_url( $gatherpress_static_map_url ),
+			esc_attr( $gatherpress_alt ),
+			esc_attr( $gatherpress_scale )
+		);
+	}
 
 	if ( '' !== $gatherpress_href ) {
 		echo '</a>';

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -193,8 +193,7 @@ if ( '' !== $gatherpress_static_map_url ) {
 	// an empty 2× URL.
 	if ( '' !== $gatherpress_static_map_url_2x ) {
 		printf(
-			'<img class="gatherpress-venue-map__image" src="%s" srcset="%s 1x, %s 2x" alt="%s" loading="lazy" style="object-fit:%s;" />',
-			esc_url( $gatherpress_static_map_url ),
+			'<img class="gatherpress-venue-map__image" src="%1$s" srcset="%1$s 1x, %2$s 2x" alt="%3$s" loading="lazy" style="object-fit:%4$s;" />',
 			esc_url( $gatherpress_static_map_url ),
 			esc_url( $gatherpress_static_map_url_2x ),
 			esc_attr( $gatherpress_alt ),

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -255,6 +255,73 @@ describe( 'RegenerateMapButton', () => {
 		expect( button ).not.toBeDisabled();
 	} );
 
+	it( 'falls back to a translated message when the rejected error has no .message', async () => {
+		// `{}` has no `message` so `error?.message || __( 'Could not …' )`
+		// must pick the translated fallback — the branch we missed last PR.
+		mockApiFetch.mockRejectedValueOnce( {} );
+
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				expect.stringContaining( 'Could not regenerate' ),
+				{ type: 'snackbar' }
+			);
+		} );
+	} );
+
+	it( 'patches fresh descriptors into an empty meta object when current.meta is missing', async () => {
+		// A cached entity record that never got a `meta` key yet forces the
+		// `...( current.meta || {} )` spread to fall through to `{}`.
+		mockCurrentEntityRecord = { id: 42 };
+		mockApiFetch.mockResolvedValueOnce( {
+			descriptors: {
+				'18x300': {
+					url: 'https://example.test/42-abc.png',
+					hash: 'abc',
+					zoom: 18,
+					height: 300,
+				},
+			},
+			reason: '',
+		} );
+
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockReceiveEntityRecords ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		const [ , , records ] = mockReceiveEntityRecords.mock.calls[ 0 ];
+		expect( records[ 0 ].meta.gatherpress_venue_static_map ).toEqual( {
+			'18x300': {
+				url: 'https://example.test/42-abc.png',
+				hash: 'abc',
+				zoom: 18,
+				height: 300,
+			},
+		} );
+	} );
+
+	it( 'stores an empty descriptor map when the response omits descriptors', async () => {
+		// A success response that forgets the `descriptors` key exercises the
+		// `response?.descriptors || {}` fallback so we never serialize
+		// `undefined` into the entity-record meta.
+		mockApiFetch.mockResolvedValueOnce( { reason: '' } );
+
+		render( <RegenerateMapButton { ...defaultProps } /> );
+		fireEvent.click( screen.getByRole( 'button' ) );
+
+		await waitFor( () => {
+			expect( mockReceiveEntityRecords ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		const [ , , records ] = mockReceiveEntityRecords.mock.calls[ 0 ];
+		expect( records[ 0 ].meta.gatherpress_venue_static_map ).toEqual( {} );
+	} );
+
 	it( 'surfaces an error notice when the server reports generation_failed', async () => {
 		mockApiFetch.mockResolvedValueOnce( {
 			descriptors: {},

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -3119,4 +3119,85 @@ class Test_Venue_Map extends Base {
 
 		$this->assertNull( $instance->get_descriptor_for_post( $post_id, 'post' ) );
 	}
+
+	/**
+	 * Walks event → linked venue when called with an event post ID, mirroring
+	 * the same resolution path `get_url_for_post()` used before the
+	 * descriptor refactor. Locks the event-side branch in so a regression
+	 * can't silently reduce `get_descriptor_for_post()` to venue-only input.
+	 *
+	 * @covers ::get_descriptor_for_post
+	 *
+	 * @return void
+	 */
+	public function test_get_descriptor_for_post_resolves_event_via_linked_venue(): void {
+		$instance    = Venue_Map::get_instance();
+		$venue_setup = \GatherPress\Core\Venue_Setup::get_instance();
+
+		$venue = $this->mock->post(
+			array(
+				'post_type'  => Venue::POST_TYPE,
+				'post_name'  => 'venue-for-descriptor-helper',
+				'post_title' => 'Venue For Descriptor Helper',
+			)
+		)->get();
+
+		$event = $this->mock->post(
+			array(
+				'post_type' => \GatherPress\Core\Event::POST_TYPE,
+				'post_name' => 'event-for-descriptor-helper',
+			)
+		)->get();
+
+		$term_slug = $venue_setup->term_slug_from_post_name( $venue->post_name );
+		wp_set_post_terms( $event->ID, $term_slug, Venue::TAXONOMY );
+
+		update_post_meta(
+			$venue->ID,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+		$instance->maybe_generate( $venue->ID );
+
+		$expected = $instance->get_stored_descriptor( $venue->ID );
+		$actual   = $instance->get_descriptor_for_post( $event->ID, \GatherPress\Core\Event::POST_TYPE );
+
+		$this->assertIsArray( $actual );
+		$this->assertSame( $expected['url'], $actual['url'] );
+		$this->assertSame( $expected['url_2x'], $actual['url_2x'] );
+	}
+
+	/**
+	 * Returns null when the resolved venue has no parsable coordinates —
+	 * the renderer's cue to fall through to the "coming soon" placeholder
+	 * instead of emitting an `<img>` at all.
+	 *
+	 * @covers ::get_descriptor_for_post
+	 *
+	 * @return void
+	 */
+	public function test_get_descriptor_for_post_returns_null_when_venue_has_no_coordinates(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => 'Somewhere',
+					'latitude'    => '',
+					'longitude'   => '',
+				)
+			)
+		);
+
+		$this->assertNull( $instance->get_descriptor_for_post( $post_id, Venue::POST_TYPE ) );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -3395,6 +3395,15 @@ class Test_Venue_Map extends Base {
 		);
 	}
 
+	/**
+	 * Returns null when the resolved venue has no parsable coordinates —
+	 * the renderer's cue to fall through to the "coming soon" placeholder
+	 * instead of emitting an `<img>` at all.
+	 *
+	 * @covers ::get_descriptor_for_post
+	 *
+	 * @return void
+	 */
 	public function test_get_descriptor_for_post_returns_null_when_venue_has_no_coordinates(): void {
 		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -2815,6 +2815,10 @@ class Test_Venue_Map extends Base {
 	public function test_composite_image_density_two_doubles_canvas(): void {
 		$instance = Venue_Map::get_instance();
 
+		// `short_circuit_tile_requests` (installed in setUp) stubs every
+		// outbound tile request with the shared 1×1 PNG, so this call
+		// never touches CartoDB — we only care that the *canvas* GD hands
+		// back is sized correctly, not what it was composited from.
 		$image = $instance->composite_image(
 			37.3318,
 			-122.0312,
@@ -3182,6 +3186,215 @@ class Test_Venue_Map extends Base {
 	 *
 	 * @return void
 	 */
+	/**
+	 * At `zoom = ZOOM_MAX` the derived retina tile zoom would exceed what
+	 * the provider serves, so the retina variant must be skipped entirely
+	 * (empty `url_2x`, no `@2x.png` on disk). Generating it anyway would
+	 * 404 every tile request and persist a solid-gray PNG — the blocker
+	 * this test locks down.
+	 *
+	 * @covers ::ensure_descriptor_for_combo
+	 *
+	 * @return void
+	 */
+	public function test_ensure_descriptor_for_combo_skips_retina_at_zoom_ceiling(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$descriptor = $instance->get_descriptor_for_post(
+			$post_id,
+			Venue::POST_TYPE,
+			Venue_Map::ZOOM_MAX,
+			800,
+			400,
+			'2/1'
+		);
+
+		$this->assertIsArray( $descriptor );
+		$this->assertNotEmpty( $descriptor['url'], '1× must still render at the zoom ceiling.' );
+		$this->assertSame( '', $descriptor['url_2x'], 'Retina must be skipped at the zoom ceiling.' );
+
+		// Scope the on-disk check to this venue's slug — other tests in
+		// the run may have left their own @2x files behind that tearDown
+		// hasn't swept yet (tests share the uploads filesystem within a
+		// test class).
+		$expected_1x_path = $this->path_for_url( $descriptor['url'] );
+		$expected_2x_path = preg_replace( '/\.png$/', '@2x.png', $expected_1x_path );
+
+		$this->assertFileExists( $expected_1x_path, '1× file must be on disk at the ceiling.' );
+		$this->assertFileDoesNotExist(
+			$expected_2x_path,
+			'No @2x file must be written when the tile zoom would exceed the provider ceiling.'
+		);
+	}
+
+	/**
+	 * `composite_image()` clamps `tile_zoom` to `ZOOM_MAX` as
+	 * defense-in-depth. When a caller invokes it directly at the ceiling
+	 * the retina pass still returns a canvas — degraded (same zoom as 1×,
+	 * just larger) but not the broken all-gray PNG you'd get if we let
+	 * zoom+1 requests sail past the provider's max.
+	 *
+	 * @covers ::composite_image
+	 *
+	 * @return void
+	 */
+	public function test_composite_image_clamps_tile_zoom_to_ceiling(): void {
+		$instance = Venue_Map::get_instance();
+
+		$zooms_seen = array();
+		$spy        = function ( $preempt, $args, $url ) use ( &$zooms_seen ) {
+			unset( $args );
+			$path = (string) wp_parse_url( $url, PHP_URL_PATH );
+			if ( preg_match( '#/light_all/(\d+)/\d+/\d+\.png$#', $path, $m ) ) {
+				$zooms_seen[] = (int) $m[1];
+			}
+
+			return array(
+				'headers'  => array(),
+				'body'     => $this->tile_png,
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		add_filter( 'pre_http_request', $spy, 10, 3 );
+
+		$image = $instance->composite_image(
+			37.3318,
+			-122.0312,
+			Venue_Map::ZOOM_MAX,
+			400,
+			200,
+			Venue_Map::DEFAULT_TILE_URL,
+			Venue_Map::RETINA_DENSITY
+		);
+
+		remove_filter( 'pre_http_request', $spy, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+
+		imagedestroy( $image );
+
+		$this->assertNotEmpty( $zooms_seen, 'Retina composite at the ceiling must still attempt tile fetches.' );
+		$this->assertSame(
+			array( Venue_Map::ZOOM_MAX ),
+			array_values( array_unique( $zooms_seen ) ),
+			'Tile fetches must clamp to ZOOM_MAX instead of overshooting to zoom+1 above the provider ceiling.'
+		);
+	}
+
+	/**
+	 * Densities outside the supported allow-list (1, 2) are coerced back
+	 * to 1. Without this `(int) log(3, 2) === 1` would produce a
+	 * canvas-tripled-but-only-zoom+1-tiles image — a cheap upscale that
+	 * wastes disk for no retina win.
+	 *
+	 * @covers ::composite_image
+	 *
+	 * @return void
+	 */
+	public function test_composite_image_coerces_unsupported_density_back_to_one(): void {
+		$instance = Venue_Map::get_instance();
+
+		$image = $instance->composite_image(
+			37.3318,
+			-122.0312,
+			15,
+			400,
+			200,
+			Venue_Map::DEFAULT_TILE_URL,
+			3
+		);
+
+		$this->assertSame(
+			400,
+			imagesx( $image ),
+			'Unsupported density must fall back to 1× canvas width.'
+		);
+		$this->assertSame(
+			200,
+			imagesy( $image ),
+			'Unsupported density must fall back to 1× canvas height.'
+		);
+
+		imagedestroy( $image );
+	}
+
+	/**
+	 * When a legacy (pre-retina) descriptor's 1× PNG is already on disk
+	 * and the hash is still valid, `ensure_descriptor_for_combo()` must
+	 * only regenerate the retina sibling — not burn a round-trip
+	 * recompositing the 1× from scratch. Confirms the
+	 * `$has_valid_1x && $needs_retina` short-circuit by checking that the
+	 * 1× filesystem mtime stays put while the 2× sibling appears.
+	 *
+	 * @covers ::ensure_descriptor_for_combo
+	 *
+	 * @return void
+	 */
+	public function test_ensure_descriptor_for_combo_reuses_valid_1x_when_filling_in_retina(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		// Seed a legacy-shape descriptor: valid 1× on disk, no url_2x.
+		// Suppressing retina for this first pass gets us exactly the
+		// pre-retina-upgrade state the short-circuit is designed for.
+		$suppress_retina = static fn() => false;
+		add_filter( 'gatherpress_venue_map_generate_2x', $suppress_retina );
+		$instance->maybe_generate( $post_id );
+		remove_filter( 'gatherpress_venue_map_generate_2x', $suppress_retina );
+
+		$legacy = $instance->get_stored_descriptor( $post_id );
+		$this->assertSame( '', $legacy['url_2x'], 'Setup: legacy descriptor has no retina URL.' );
+
+		$one_x_path  = $this->path_for_url( $legacy['url'] );
+		$mtime_first = filemtime( $one_x_path );
+
+		// Force fs mtime to change if imagepng runs again.
+		sleep( 1 );
+
+		// Second call with retina back on — the 1× is still valid, only
+		// the retina sibling should be written.
+		$instance->maybe_generate( $post_id );
+
+		$upgraded = $instance->get_stored_descriptor( $post_id );
+		$this->assertNotEmpty( $upgraded['url_2x'], 'Retina fill-in must populate url_2x.' );
+		$this->assertSame(
+			$mtime_first,
+			filemtime( $one_x_path ),
+			'The valid 1× PNG must not be recomposited when only the retina sibling is missing.'
+		);
+	}
+
 	public function test_get_descriptor_for_post_returns_null_when_venue_has_no_coordinates(): void {
 		$instance = Venue_Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map.php
@@ -2775,4 +2775,348 @@ class Test_Venue_Map extends Base {
 		$data = $response->get_data();
 		$this->assertSame( 'awaiting_geocode', $data['reason'] );
 	}
+
+	/**
+	 * Appends the `@{density}x` suffix when density > 1 so the retina
+	 * variant lands at a sibling filename, and leaves the 1× filename
+	 * exactly as before.
+	 *
+	 * @covers ::filename_for
+	 *
+	 * @return void
+	 */
+	public function test_filename_for_appends_density_suffix_for_retina(): void {
+		$instance = Venue_Map::get_instance();
+
+		$one_x = Utility::invoke_hidden_method(
+			$instance,
+			'filename_for',
+			array( '1 Infinite Loop', 15, 800, 400, 1 )
+		);
+		$two_x = Utility::invoke_hidden_method(
+			$instance,
+			'filename_for',
+			array( '1 Infinite Loop', 15, 800, 400, 2 )
+		);
+
+		$this->assertSame( '1-infinite-loop-15-800-400.png', $one_x );
+		$this->assertSame( '1-infinite-loop-15-800-400@2x.png', $two_x );
+	}
+
+	/**
+	 * Passing `density=2` doubles the canvas dimensions and pulls tiles
+	 * from `zoom+1` so the retina variant contains true 2× detail rather
+	 * than upscaled 1× pixels. The 1× default is unchanged.
+	 *
+	 * @covers ::composite_image
+	 *
+	 * @return void
+	 */
+	public function test_composite_image_density_two_doubles_canvas(): void {
+		$instance = Venue_Map::get_instance();
+
+		$image = $instance->composite_image(
+			37.3318,
+			-122.0312,
+			15,
+			400,
+			200,
+			Venue_Map::DEFAULT_TILE_URL,
+			2
+		);
+
+		$this->assertInstanceOf( \GdImage::class, $image );
+		$this->assertSame( 800, imagesx( $image ), 'Retina canvas width is 2× the 1× value.' );
+		$this->assertSame( 400, imagesy( $image ), 'Retina canvas height is 2× the 1× value.' );
+
+		imagedestroy( $image );
+	}
+
+	/**
+	 * Density=2 must fetch tiles at `zoom + 1`. If the compositor uses
+	 * zoom+1 coords against zoom-N tile URLs the server 404s every request
+	 * and the canvas renders as gray — the bug this test locks down.
+	 *
+	 * @covers ::composite_image
+	 *
+	 * @return void
+	 */
+	public function test_composite_image_density_two_fetches_zoom_plus_one_tiles(): void {
+		$instance = Venue_Map::get_instance();
+
+		$zooms_seen = array();
+		$spy        = function ( $preempt, $args, $url ) use ( &$zooms_seen ) {
+			unset( $args );
+			$path = (string) wp_parse_url( $url, PHP_URL_PATH );
+			// CartoDB template: /light_all/{z}/{x}/{y}.png — the `{z}`
+			// segment is what composite_image() is supposed to bump by 1
+			// when density > 1.
+			if ( preg_match( '#/light_all/(\d+)/\d+/\d+\.png$#', $path, $m ) ) {
+				$zooms_seen[] = (int) $m[1];
+			}
+
+			return array(
+				'headers'  => array(),
+				'body'     => $this->tile_png,
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		add_filter( 'pre_http_request', $spy, 10, 3 );
+
+		$image = $instance->composite_image(
+			37.3318,
+			-122.0312,
+			15,
+			400,
+			200,
+			Venue_Map::DEFAULT_TILE_URL,
+			2
+		);
+
+		remove_filter( 'pre_http_request', $spy, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+
+		imagedestroy( $image );
+
+		$this->assertNotEmpty( $zooms_seen, 'Retina composite must attempt at least one tile fetch.' );
+		$this->assertSame(
+			array( 16 ),
+			array_values( array_unique( $zooms_seen ) ),
+			'All retina tile requests must go to zoom + 1.'
+		);
+	}
+
+	/**
+	 * `$scale > 1` proportionally grows the marker so a retina composite
+	 * doesn't shrink the pin to a pinprick. Checks the "outer white halo"
+	 * radius by sampling a pixel that is outside the 1× marker but inside
+	 * the 2× marker.
+	 *
+	 * @covers ::stamp_marker
+	 *
+	 * @return void
+	 */
+	public function test_stamp_marker_scales_radii(): void {
+		$instance = Venue_Map::get_instance();
+		$canvas   = imagecreatetruecolor( 80, 80 );
+
+		// Seed the canvas with a distinctive background so we can tell a
+		// stamped pixel from an untouched one.
+		$bg = imagecolorallocate( $canvas, 0, 0, 0 );
+		imagefilledrectangle( $canvas, 0, 0, 79, 79, $bg );
+
+		$instance->stamp_marker( $canvas, 40, 40, 2.0 );
+
+		// 15px from center: outside the 1× halo (radius ~10), inside the 2×
+		// halo (radius ~20). Any non-background pixel here proves the scale
+		// factor actually grew the marker.
+		$index = imagecolorat( $canvas, 40, 25 );
+		$rgb   = imagecolorsforindex( $canvas, $index );
+
+		$this->assertNotSame(
+			array( 0, 0, 0 ),
+			array( $rgb['red'], $rgb['green'], $rgb['blue'] ),
+			'A pixel 15px above the marker center is only painted when the marker is scaled.'
+		);
+
+		imagedestroy( $canvas );
+	}
+
+	/**
+	 * With the default (filter unchanged) the retina variant is generated
+	 * alongside the 1× image: the descriptor carries a non-empty `url_2x`
+	 * whose filename ends in the `@2x.png` sibling convention.
+	 *
+	 * @covers ::ensure_descriptor_for_combo
+	 * @covers ::should_generate_retina
+	 *
+	 * @return void
+	 */
+	public function test_ensure_descriptor_for_combo_emits_retina_variant(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$instance->maybe_generate( $post_id );
+		$descriptor = $instance->get_stored_descriptor( $post_id );
+
+		$this->assertIsArray( $descriptor );
+		$this->assertNotEmpty( $descriptor['url'], '1× URL must be populated.' );
+		$this->assertNotEmpty( $descriptor['url_2x'], '2× URL must be populated by default.' );
+		$this->assertStringEndsWith(
+			'@2x.png',
+			$descriptor['url_2x'],
+			'Retina filename uses the @2x sibling convention.'
+		);
+		$this->assertFileExists(
+			$this->path_for_url( $descriptor['url_2x'] ),
+			'The retina PNG must exist on disk.'
+		);
+	}
+
+	/**
+	 * Filtering `gatherpress_venue_map_generate_2x` to false halves the
+	 * on-disk footprint: the descriptor keeps its 1× URL but `url_2x`
+	 * stays empty, and no `@2x.png` file is written.
+	 *
+	 * @covers ::ensure_descriptor_for_combo
+	 * @covers ::should_generate_retina
+	 *
+	 * @return void
+	 */
+	public function test_ensure_descriptor_for_combo_skips_retina_when_filter_disables(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$disable = static fn() => false;
+		add_filter( 'gatherpress_venue_map_generate_2x', $disable );
+
+		$instance->maybe_generate( $post_id );
+		$descriptor = $instance->get_stored_descriptor( $post_id );
+
+		remove_filter( 'gatherpress_venue_map_generate_2x', $disable );
+
+		$this->assertIsArray( $descriptor );
+		$this->assertNotEmpty( $descriptor['url'], '1× URL must still be populated when the filter disables 2×.' );
+		$this->assertSame( '', $descriptor['url_2x'], '2× URL must be empty when the filter disables generation.' );
+
+		// No sibling @2x.png was ever written.
+		$dirs     = wp_get_upload_dir();
+		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Map::UPLOADS_SUBDIR;
+		$retina   = glob( $base_dir . '/*@2x.png' );
+
+		$this->assertEmpty( $retina, 'Disabling the filter must not leave any @2x files on disk.' );
+	}
+
+	/**
+	 * Pre-retina descriptors written before this plugin version omit the
+	 * `url_2x` key entirely. The read path normalizes the missing key to an
+	 * empty string so front-end callers can branch with a single
+	 * `'' !== $url_2x` check regardless of storage vintage.
+	 *
+	 * @covers ::get_all_descriptors
+	 *
+	 * @return void
+	 */
+	public function test_get_all_descriptors_normalizes_missing_url_2x(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		update_post_meta(
+			$post_id,
+			Venue_Map::META_KEY,
+			array(
+				'15x600x300' => array(
+					'url'    => 'https://example.test/legacy.png',
+					'hash'   => 'abc',
+					'zoom'   => 15,
+					'width'  => 600,
+					'height' => 300,
+				),
+			)
+		);
+
+		$descriptors = $instance->get_all_descriptors( $post_id );
+
+		$this->assertArrayHasKey(
+			'url_2x',
+			$descriptors['15x600x300'],
+			'Legacy descriptors still expose url_2x to callers.'
+		);
+		$this->assertSame(
+			'',
+			$descriptors['15x600x300']['url_2x'],
+			'Missing url_2x normalizes to empty string.'
+		);
+	}
+
+	/**
+	 * `get_descriptor_for_post()` is the render-path accessor — it returns
+	 * the full descriptor (1× + 2× URLs) rather than just the 1× URL string
+	 * that `get_url_for_post()` exposes, so the block renderer can emit a
+	 * `srcset` without a second round-trip.
+	 *
+	 * @covers ::get_descriptor_for_post
+	 *
+	 * @return void
+	 */
+	public function test_get_descriptor_for_post_returns_full_descriptor(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta(
+			$post_id,
+			'gatherpress_venue_information',
+			wp_json_encode(
+				array(
+					'fullAddress' => '1 Infinite Loop',
+					'latitude'    => '37.3318',
+					'longitude'   => '-122.0312',
+				)
+			)
+		);
+
+		$descriptor = $instance->get_descriptor_for_post(
+			$post_id,
+			Venue::POST_TYPE,
+			15,
+			800,
+			400,
+			'2/1'
+		);
+
+		$this->assertIsArray( $descriptor );
+		$this->assertSame( 15, $descriptor['zoom'] );
+		$this->assertSame( 800, $descriptor['width'] );
+		$this->assertSame( 400, $descriptor['height'] );
+		$this->assertNotEmpty( $descriptor['url'] );
+		$this->assertNotEmpty( $descriptor['url_2x'] );
+	}
+
+	/**
+	 * Returning `null` from `get_descriptor_for_post()` on a post that
+	 * isn't venue-related mirrors `get_url_for_post()`'s empty-string
+	 * contract — the renderer falls through to the "coming soon"
+	 * placeholder without attempting srcset emission.
+	 *
+	 * @covers ::get_descriptor_for_post
+	 *
+	 * @return void
+	 */
+	public function test_get_descriptor_for_post_returns_null_for_unrelated_post(): void {
+		$instance = Venue_Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => 'post' ) );
+
+		$this->assertNull( $instance->get_descriptor_for_post( $post_id, 'post' ) );
+	}
 }


### PR DESCRIPTION
### Description of the Change

On HiDPI displays the static venue-map PNG was visibly fuzzy: the browser was upscaling a single 1× raster and losing sharpness on tile labels, road lines, and the marker pin. This PR adds a native 2× variant and emits `srcset` so retina devices pick the sharper image while 1× devices keep the lighter payload.

Implementation:
- `Venue_Map::composite_image()` gains a `$density` parameter. At `density=2` it fetches tiles at `zoom + 1` (true retina detail, not upscaled pixels) and builds a `($width * 2) × ($height * 2)` canvas. The 1× path is unchanged at `density=1`.
- `stamp_marker()` gains a `$scale` parameter so the pin keeps its visual size on the 2× canvas instead of shrinking to a pinprick.
- `filename_for()` / `save_image()` / `build_image_url()` take `$density` and append the `@2x.png` sibling convention, e.g. `{slug}-{zoom}-{w}-{h}@2x.png` alongside `{slug}-{zoom}-{w}-{h}.png`.
- `ensure_descriptor_for_combo()` writes a separate 2× composite with its own wall-clock budget after the 1× finishes. Failure is non-fatal — the 1× still lands and `url_2x` stays empty so the front-end falls back to plain `src`. Descriptors gain a nullable `url_2x`; `get_all_descriptors()` normalizes missing keys to `''` for pre-retina entries written by older versions (back-compat, no migration needed).
- New `Venue_Map::get_descriptor_for_post()` returns the full descriptor (both URLs) for renderers; `get_url_for_post()` is preserved as a thin wrapper around it for callers that only need the 1× URL.
- `render.php` emits `<img src="{1x}" srcset="{1x} 1x, {2x} 2x">` when `url_2x` is populated, and the plain `<img src="{1x}">` otherwise — graceful fallback for pre-retina descriptors and sites that filter the 2× off.
- Opt-out via `gatherpress_venue_map_generate_2x` filter (bool, default `true`). Kept as a filter rather than a Settings toggle to avoid cluttering the admin UI. Site owners who want to halve the on-disk footprint return `false` and the 2× simply isn't generated.

Two adjacent housekeeping items in the same PR:

1. **Coverage gaps from #1497.** Three partial branches in `src/blocks/venue-map/helpers.js` (`error?.message ||` fallback, `( current.meta || {} )` spread, `response?.descriptors || {}` default) now have dedicated tests. `helpers.js` is back to 100% across all four coverage metrics.
2. **CLAUDE.md policies.** Two new sections:
   - **Test Coverage**: explicitly states partial branch coverage does not count, with examples. SonarCloud will still need to nudge, but the expectation is documented.
   - **Auto-generated developer hook docs**: `docs/developer/hooks/` is regenerated by the `extract-wp-hooks-as-docs.yml` workflow on push to `develop` and opens its own `fix/extract-wp-hooks-{sha}` PR — so feature PRs shouldn't include regen.

Tile cost for the 2× pass is ~3–4× the 1× call (doubled canvas at one zoom level deeper), comfortably under the existing 5s per-call budget for typical sizes. Disk cost is ~4× the bytes for the 2× sibling (e.g. the fixture venue this PR was tested against: 150KB 1× → 597KB 2×) — acceptable for retina sharpness, and will integrate with the static-map GC tool in #1486 so orphans get cleaned.

Closes #1495

### How to test the Change

1. Check out this branch and save a venue with a real address (or use an existing geocoded venue). Confirm the `gatherpress_venue_static_map` post meta now carries a `url_2x` field next to `url` for each cached combo, and that both `{slug}-{zoom}-{w}-{h}.png` and `{slug}-{zoom}-{w}-{h}@2x.png` exist under `wp-content/uploads/gatherpress/static-maps/`.
2. Visit the venue's public page on a HiDPI display (or set `devicePixelRatio` to 2 in DevTools' sensors panel). Inspect the `<img class="gatherpress-venue-map__image">` and confirm:
   - `src` points at the 1× file
   - `srcset="{1x} 1x, {2x} 2x"` is present
   - `img.currentSrc` resolves to the `@2x.png` file
3. Drop to a standard-density display (or force `devicePixelRatio: 1`). `img.currentSrc` should resolve back to the 1× file — sites without HiDPI viewers aren't forced to download the bigger asset.
4. `file` the two PNGs on disk to confirm the 2× variant is actually `(width * 2) × (height * 2)` pixels with a zoom+1-level of visible detail (labels should be crisper, not just scaled).
5. **Opt-out path:** add `add_filter( 'gatherpress_venue_map_generate_2x', '__return_false' );` in a mu-plugin, delete the venue's meta (or click "Regenerate Map" in the block editor), and verify no `@2x.png` is written and the rendered `<img>` emits only `src` — no `srcset`.
6. **Back-compat path:** seed a venue's `gatherpress_venue_static_map` meta with a legacy entry that has no `url_2x` key. Confirm `get_all_descriptors()` exposes an empty-string `url_2x` to callers and the front end falls through to plain `src`.
7. Run the full test suites:
   - `npm run test:unit:php` (1152 tests)
   - Multisite suite via `phpunit-multisite.xml.dist` (258 tests)
   - `npm run test:unit:js` (700 tests)
   - `npm run lint:php`, `npm run lint:phpstan`, `npm run lint:js` — all clean.

### Changelog Entry

> Added - Retina (2×) variant for static venue-map images, emitted via `srcset` so HiDPI displays render true zoom+1 detail while standard-density displays keep the lighter 1× payload. Generation is on by default and can be disabled via the new `gatherpress_venue_map_generate_2x` filter.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.