### PR TITLE
Add network-wide GatherPress settings and per-option inheritance

### DIFF
--- a/docs/developer/settings/README.md
+++ b/docs/developer/settings/README.md
@@ -116,3 +116,4 @@ wp gatherpress settings import settings.json --apply --mode=replace
 
 - [Extending Settings](extending-settings.md) -- How to add custom tabs, sections, and fields
 - [Architecture](architecture.md) -- Storage, sanitization, defaults, and caching internals
+- [Multisite Network Settings](multisite.md) -- Network-wide values and per-option inheritance on WordPress Multisite

--- a/docs/developer/settings/multisite.md
+++ b/docs/developer/settings/multisite.md
@@ -7,9 +7,9 @@ On a WordPress Multisite install, GatherPress can expose settings at the network
 Two separate surfaces render the Settings form:
 
 - **Per-site** (unchanged) — `Dashboard → Events → Settings` on each site. Writes to the site's own `gatherpress_settings` blog option.
-- **Network-wide** (new) — `Network Admin → Settings → GatherPress`. Renders the same Events / Venues / Roles / RSVP / Credits tabs plus an additional **Network** tab. Writes to the network-wide `gatherpress_settings` *site* option via `update_site_option()`. Requires the `manage_network_options` capability.
+- **Network-wide** (new) — `Network Admin → Settings → GatherPress`. Renders the same Events / Venues / Roles / RSVP / Credits / Tools tabs plus an additional **Network** tab. Writes to the network-wide `gatherpress_settings` *site* option via `update_site_option()`. Requires the `manage_network_options` capability.
 
-The Tools tab (import / export) stays per-site only — import / export is blog-scoped.
+The Tools tab (import / export) is available at both scopes. In per-site admin it operates on the blog option; in network admin it reads and writes the network-wide site option. A hidden `scope` value on the Tools form (and in the `gatherpress_export_settings` / `gatherpress_import_settings` AJAX payload) tells the handler which store to target, and capability is gated per-scope (`manage_options` for blog, `manage_network_options` for network).
 
 ## The Network Tab
 
@@ -84,3 +84,10 @@ Returning `true` forces inheritance for an option that wasn't in the allowlist. 
 
 - Viewing and saving the Network Admin → Settings → GatherPress page requires `manage_network_options`. The save handlers (`network_admin_edit_gatherpress_network_settings` and `network_admin_edit_gatherpress_network_values`) re-check the capability and a per-action nonce.
 - Per-site Settings pages remain gated by the existing `manage_options` capability.
+- The Tools tab's AJAX handlers (`gatherpress_export_settings` / `gatherpress_import_settings`) scope the required capability to match the requested store: `manage_options` for a blog-scoped export/import, `manage_network_options` for a network-scoped one.
+
+## Import / Export Scope
+
+`Settings::export_settings()`, `Settings::validate_import()`, and `Settings::import_settings()` each accept a trailing `string $scope = 'blog'` parameter. When `'network'` is passed, the methods read from and write to the network-wide site option instead of the blog option, and `import_settings()` flushes `Network::get_config()` so subsequent reads see the new values.
+
+The JSON produced by `export_settings()` includes a `"scope"` field so an import can be routed to the right store even if the operator picks the wrong UI by accident. The Tools template and its AJAX handlers use the current screen (`is_network_admin()`) to set the scope when the tab is rendered at network admin.

--- a/docs/developer/settings/multisite.md
+++ b/docs/developer/settings/multisite.md
@@ -1,0 +1,86 @@
+# Multisite Network Settings
+
+On a WordPress Multisite install, GatherPress can expose settings at the network level so super admins set one value that all sites in the network inherit. The inheritance is opt-in per option — individual sites remain free to manage the rest locally.
+
+## UI Surfaces
+
+Two separate surfaces render the Settings form:
+
+- **Per-site** (unchanged) — `Dashboard → Events → Settings` on each site. Writes to the site's own `gatherpress_settings` blog option.
+- **Network-wide** (new) — `Network Admin → Settings → GatherPress`. Renders the same Events / Venues / Roles / RSVP / Credits tabs plus an additional **Network** tab. Writes to the network-wide `gatherpress_settings` *site* option via `update_site_option()`. Requires the `manage_network_options` capability.
+
+The Tools tab (import / export) stays per-site only — import / export is blog-scoped.
+
+## The Network Tab
+
+The Network tab at network admin holds the inheritance configuration. It is **not** a settings page in the usual sense; it writes to a separate site option `gatherpress_network_settings` whose shape is:
+
+```php
+array(
+    'enabled'   => (bool) true,
+    'inherited' => array( 'date_format', 'time_format', ... ),
+)
+```
+
+When `enabled` is `false`, inheritance is off — every site reads its own blog option as usual. When `enabled` is `true`, any option key listed in `inherited` is resolved from the network-wide site option on subsites.
+
+## Storage Layers
+
+| Layer                                  | Stored As                                         | Used When                                                                 |
+|----------------------------------------|---------------------------------------------------|---------------------------------------------------------------------------|
+| Site / blog option `gatherpress_settings`             | `get_option` / `update_option`                    | Per-site values.                                                          |
+| Network site option `gatherpress_settings`            | `get_site_option` / `update_site_option`          | Values set at Network Admin → Settings → GatherPress.                     |
+| Network site option `gatherpress_network_settings`    | `get_site_option` / `update_site_option`          | Inheritance config — master toggle + list of inherited option keys.       |
+
+The network admin UI reuses the existing `Settings` class: a `pre_option_gatherpress_settings` filter scoped to the network admin page (`load-{hook}`) short-circuits reads to the site option while that page renders, so the renderer is oblivious to which storage layer is in play.
+
+## Resolver: `Settings::get()`
+
+```php
+use GatherPress\Core\Settings;
+
+$date_format = Settings::get_instance()->get( 'date_format' );
+```
+
+Behavior:
+
+1. On a **main site** or **single-site install**, returns the blog option value (or the flat default).
+2. On a **subsite**, calls `Settings::is_option_inherited( 'date_format' )`. If `true`, returns the value from the network-wide site option (falling back to the flat default). If `false`, returns the blog option value.
+
+## Per-Site Override Filter
+
+`Settings::is_option_inherited()` runs its result through a filter so individual sites can opt out of inheritance for a given option. This is intentional as an escape hatch for edge cases — the default path is always "respect the network config."
+
+```php
+/**
+ * Let site 42 manage its own date_format even though the network forces it.
+ *
+ * @param bool   $inherited Whether the option is inherited from the network.
+ * @param string $option    The option key being resolved.
+ * @param int    $blog_id   The current site ID.
+ */
+add_filter(
+    'gatherpress_network_is_option_inherited',
+    static function ( bool $inherited, string $option, int $blog_id ): bool {
+        if ( 42 === $blog_id && 'date_format' === $option ) {
+            return false;
+        }
+        return $inherited;
+    },
+    10,
+    3
+);
+```
+
+Returning `true` forces inheritance for an option that wasn't in the allowlist. Returning `false` exempts the current site.
+
+## Subsite UX When an Option is Locked
+
+- The field renders disabled + dimmed (`.gatherpress-field-inherited` wrapper + native `disabled` attribute on the `input` / `select`), and **shows the current network value** — not whatever the subsite had stored locally.
+- A per-field note appears underneath. Super admins see `Inherited from the <a>network</a>. Edit there to change this value.`; regular site admins see a plain `Inherited from the network.` (no dead-end link).
+- A page-level `notice-info` appears whenever any setting on the current page is inherited. Every admin sees the first sentence; only users with `manage_network_options` see the appended link sentence pointing to network admin.
+
+## Capabilities
+
+- Viewing and saving the Network Admin → Settings → GatherPress page requires `manage_network_options`. The save handlers (`network_admin_edit_gatherpress_network_settings` and `network_admin_edit_gatherpress_network_values`) re-check the capability and a per-action nonce.
+- Per-site Settings pages remain gated by the existing `manage_options` capability.

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -126,9 +126,15 @@ class Assets {
 
 		$script_path = GATHERPRESS_CORE_PATH . '/includes/templates/admin/timezone-shim.js';
 
+		// The shim file ships with the plugin; this guard is defensive in case
+		// someone strips template assets from a distribution.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreStart
 		if ( ! file_exists( $script_path ) ) {
-			return; // @codeCoverageIgnore -- template ships with the plugin.
+			return;
 		}
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreEnd
 
 		wp_enqueue_script( 'wp-date' );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a plugin-local static file.

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -91,7 +91,6 @@ class Assets {
 		add_action( 'wp_head', array( $this, 'add_interactivity_state' ) );
 		// Set priority to 11 to not conflict with media modal.
 		add_action( 'admin_footer', array( $this, 'event_communication_modal' ), 11 );
-
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_timezone_shim' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_timezone_shim' ) );
 
@@ -125,23 +124,15 @@ class Assets {
 			return;
 		}
 
+		$script_path = GATHERPRESS_CORE_PATH . '/includes/templates/admin/timezone-shim.js';
+
+		if ( ! file_exists( $script_path ) ) {
+			return; // @codeCoverageIgnore -- template ships with the plugin.
+		}
+
 		wp_enqueue_script( 'wp-date' );
-		wp_add_inline_script(
-			'wp-date',
-			// Keep the shim tight — it runs on every admin and front-end request.
-			// Only acts when the default timezone is literally `UTC+0` / `UTC-0`.
-			'( function () {'
-			. ' if ( ! window.wp || ! window.wp.date ) { return; }'
-			. ' if ( "function" !== typeof window.wp.date.getSettings ) { return; }'
-			. ' var settings = window.wp.date.getSettings();'
-			. ' if ( ! settings || ! settings.timezone || ! settings.timezone.string ) { return; }'
-			. ' if ( /^UTC[+-]0$/.test( settings.timezone.string ) ) {'
-			. '  settings.timezone.string = "UTC";'
-			. '  window.wp.date.setSettings( settings );'
-			. ' }'
-			. '} )();',
-			'after'
-		);
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a plugin-local static file.
+		wp_add_inline_script( 'wp-date', file_get_contents( $script_path ), 'after' );
 	}
 
 	/**

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -92,8 +92,56 @@ class Assets {
 		// Set priority to 11 to not conflict with media modal.
 		add_action( 'admin_footer', array( $this, 'event_communication_modal' ), 11 );
 
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_timezone_shim' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_timezone_shim' ) );
+
 		add_filter( 'render_block', array( $this, 'maybe_enqueue_styles' ), 10, 2 );
 		add_filter( 'render_block', array( $this, 'maybe_enqueue_tooltip_assets' ) );
+	}
+
+	/**
+	 * Patch `wp.date`'s timezone when WordPress hands Moment Timezone a bogus
+	 * `UTC+0` (or `UTC-0`) string.
+	 *
+	 * On a fresh WordPress install the Settings → General timezone is
+	 * unset (no `timezone_string`, `gmt_offset` of 0), so WP core emits
+	 * `wp.date.setSettings({ timezone: { string: 'UTC+0' } })`. That is
+	 * not a valid IANA zone, which triggers a stream of
+	 * "Moment Timezone has no data for UTC+0" console warnings from the
+	 * block editor's panels and any plugin using `@wordpress/date`.
+	 *
+	 * We can't reach into WP core, but we can append an inline script
+	 * after its `setSettings` call to re-call it with a valid zone. We
+	 * only normalize the zero-offset case; non-zero UTC offsets are
+	 * rarer and surface a different warning that users fix by choosing
+	 * an IANA zone in Settings → General.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function enqueue_timezone_shim(): void {
+		if ( ! wp_script_is( 'wp-date', 'registered' ) ) {
+			return;
+		}
+
+		wp_enqueue_script( 'wp-date' );
+		wp_add_inline_script(
+			'wp-date',
+			// Keep the shim tight — it runs on every admin and front-end request.
+			// Only acts when the default timezone is literally `UTC+0` / `UTC-0`.
+			'( function () {'
+			. ' if ( ! window.wp || ! window.wp.date ) { return; }'
+			. ' if ( "function" !== typeof window.wp.date.getSettings ) { return; }'
+			. ' var settings = window.wp.date.getSettings();'
+			. ' if ( ! settings || ! settings.timezone || ! settings.timezone.string ) { return; }'
+			. ' if ( /^UTC[+-]0$/.test( settings.timezone.string ) ) {'
+			. '  settings.timezone.string = "UTC";'
+			. '  window.wp.date.setSettings( settings );'
+			. ' }'
+			. '} )();',
+			'after'
+		);
 	}
 
 	/**

--- a/includes/core/classes/class-event.php
+++ b/includes/core/classes/class-event.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use DateTimeZone;
 use Exception;
+use GatherPress\Core\Utility;
 use WP_Post;
 
 /**
@@ -413,7 +414,7 @@ class Event {
 			&& ! empty( $dt['timezone'] )
 			&& in_array( $dt['timezone'], Utility::list_timezone_and_utc_offsets(), true )
 		) {
-			$tz = new DateTimeZone( $dt['timezone'] );
+			$tz = new DateTimeZone( Utility::normalize_timezone_string( (string) $dt['timezone'] ) );
 		} elseif ( false === $local ) {
 			$tz = new DateTimeZone( 'GMT+0000' );
 		}
@@ -875,7 +876,7 @@ class Event {
 		}
 
 		$fields['timezone'] = ( ! empty( $fields['timezone'] ) ) ? $fields['timezone'] : wp_timezone_string();
-		$timezone           = new DateTimeZone( $fields['timezone'] );
+		$timezone           = new DateTimeZone( Utility::normalize_timezone_string( (string) $fields['timezone'] ) );
 
 		$fields['datetime_start_gmt'] = $this->get_gmt_datetime( (string) $fields['datetime_start'], $timezone );
 		$fields['datetime_end_gmt']   = $this->get_gmt_datetime( (string) $fields['datetime_end'], $timezone );

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -476,6 +476,12 @@ class Settings {
 	 * preserve settings from other tabs. Handles various input types including checkboxes,
 	 * numbers, autocomplete fields, text fields, and select dropdowns.
 	 *
+	 * Values that equal their configured default are stripped from the merged
+	 * result to keep the stored option lean. This means the option cannot
+	 * represent "explicitly set to the default" vs "unset" — both collapse
+	 * to the same state. Consumers rely on `get_flat_default()` as the
+	 * authoritative source of defaults in both read paths.
+	 *
 	 * @param array $field_type_map Flat map of option_key => field_type.
 	 * @return callable A callback function that sanitizes input based on field types.
 	 */

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -740,7 +740,11 @@ class Settings {
 	public function is_option_inherited( string $option ): bool {
 		$inherited = false;
 
-		if ( is_multisite() && ! is_main_site() ) {
+		// Apply inheritance on any site in the network (including the main site)
+		// so the UI reflects the network config everywhere. The only exemption
+		// is the network admin settings page itself, where super admins edit
+		// the network values — fields there must remain fully editable.
+		if ( is_multisite() && ! is_network_admin() ) {
 			$config = Network::get_config();
 
 			if ( ! empty( $config['enabled'] ) ) {

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -14,6 +14,7 @@ namespace GatherPress\Core;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Settings\Network;
 use GatherPress\Core\Traits\Singleton;
 
 /**
@@ -587,9 +588,10 @@ class Settings {
 	 * @return void
 	 */
 	public function render_field( string $option, array $option_settings ): void {
-		$type  = $option_settings['field']['type'] ?? '';
-		$name  = $this->get_name_field( $option );
-		$value = $this->get( $option );
+		$type      = $option_settings['field']['type'] ?? '';
+		$name      = $this->get_name_field( $option );
+		$value     = $this->get( $option );
+		$inherited = $this->is_option_inherited( $option );
 
 		$params = array(
 			'name'        => $name,
@@ -597,6 +599,7 @@ class Settings {
 			'value'       => $value,
 			'label'       => $option_settings['field']['label'] ?? '',
 			'description' => $option_settings['description'] ?? '',
+			'disabled'    => $inherited,
 		);
 
 		switch ( $type ) {
@@ -619,11 +622,42 @@ class Settings {
 				break;
 		}
 
+		if ( $inherited ) {
+			echo '<div class="gatherpress-field-inherited" aria-disabled="true">';
+		}
+
 		Utility::render_template(
 			sprintf( '%s/includes/templates/admin/settings/fields/%s.php', GATHERPRESS_CORE_PATH, $type ),
 			$params,
 			true
 		);
+
+		if ( $inherited ) {
+			if ( current_user_can( 'manage_network_options' ) ) {
+				$inherited_message = wp_kses(
+					sprintf(
+						/* translators: %s: link to the network admin GatherPress settings page. */
+						__( 'Inherited from the %s. Edit there to change this value.', 'gatherpress' ),
+						sprintf(
+							'<a href="%s">%s</a>',
+							esc_url(
+								network_admin_url(
+									sprintf( 'settings.php?page=%s', Network::PAGE_SLUG )
+								)
+							),
+							esc_html__( 'network', 'gatherpress' )
+						)
+					),
+					array( 'a' => array( 'href' => true ) )
+				);
+			} else {
+				$inherited_message = esc_html__( 'Inherited from the network.', 'gatherpress' );
+			}
+
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped via wp_kses / esc_html above.
+			echo '<p class="description gatherpress-field-inherited__note">' . $inherited_message . '</p>';
+			echo '</div>';
+		}
 	}
 
 	/**
@@ -657,12 +691,29 @@ class Settings {
 	 * gatherpress_settings option. If the option is set, its value is returned;
 	 * otherwise, the default value is returned.
 	 *
+	 * On a multisite subsite, options that are flagged as network-inherited
+	 * are read from the main site instead of the local site.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param string $option The unique name of the option to retrieve.
 	 * @return mixed The value of the option or its default value.
 	 */
 	public function get( string $option ) {
+		if ( $this->is_option_inherited( $option ) ) {
+			$network_options = get_site_option( self::OPTION_NAME, array() );
+
+			if (
+				is_array( $network_options )
+				&& isset( $network_options[ $option ] )
+				&& '' !== $network_options[ $option ]
+			) {
+				return $network_options[ $option ];
+			}
+
+			return $this->get_flat_default( $option );
+		}
+
 		$options = get_option( self::OPTION_NAME, array() );
 
 		if ( isset( $options[ $option ] ) && '' !== $options[ $option ] ) {
@@ -670,6 +721,52 @@ class Settings {
 		}
 
 		return $this->get_flat_default( $option );
+	}
+
+	/**
+	 * Whether a given option is inherited from the network.
+	 *
+	 * Returns true when we're on a subsite of a multisite install, the
+	 * network inheritance feature is enabled, and the option is listed as
+	 * inherited in the network config. The result passes through the
+	 * `gatherpress_network_is_option_inherited` filter so a companion plugin or
+	 * site-specific code can override the decision for an individual site.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $option The option key to check.
+	 * @return bool
+	 */
+	public function is_option_inherited( string $option ): bool {
+		$inherited = false;
+
+		if ( is_multisite() && ! is_main_site() ) {
+			$config = Network::get_config();
+
+			if ( ! empty( $config['enabled'] ) ) {
+				$inherited = in_array( $option, (array) ( $config['inherited'] ?? array() ), true );
+			}
+		}
+
+		/**
+		 * Filters whether a specific GatherPress option is inherited from the network.
+		 *
+		 * Returning false exempts the current site from network-level inheritance
+		 * for that option; returning true forces inheritance even if the network
+		 * config would otherwise leave it site-editable.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param bool   $inherited Whether the option is inherited from the network.
+		 * @param string $option    The option key being resolved.
+		 * @param int    $blog_id   The current site ID.
+		 */
+		return (bool) apply_filters(
+			'gatherpress_network_is_option_inherited',
+			$inherited,
+			$option,
+			get_current_blog_id()
+		);
 	}
 
 	/**

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -482,11 +482,14 @@ class Settings {
 	 * to the same state. Consumers rely on `get_flat_default()` as the
 	 * authoritative source of defaults in both read paths.
 	 *
-	 * @param array $field_type_map Flat map of option_key => field_type.
+	 * @param array  $field_type_map Flat map of option_key => field_type.
+	 * @param string $scope          Storage scope: 'blog' (default) or 'network'.
+	 *                               Determines which option store the closure
+	 *                               reads from when merging with existing values.
 	 * @return callable A callback function that sanitizes input based on field types.
 	 */
-	public function sanitize_page_settings( array $field_type_map ): callable {
-		return function ( $input ) use ( $field_type_map ): array {
+	public function sanitize_page_settings( array $field_type_map, string $scope = 'blog' ): callable {
+		return function ( $input ) use ( $field_type_map, $scope ): array {
 			$sanitized = array();
 
 			foreach ( $input as $key => $value ) {
@@ -517,7 +520,7 @@ class Settings {
 			}
 
 			// Merge with existing values to preserve settings from other tabs.
-			$existing = get_option( self::OPTION_NAME, array() );
+			$existing = $this->read_stored_options( $scope );
 			$merged   = array_merge( $existing, $sanitized );
 
 			// Remove values that match their defaults to keep the option lean.
@@ -1021,14 +1024,69 @@ class Settings {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return array Export data with version, timestamp, and settings.
+	 * @param string $scope Storage scope: 'blog' (default) or 'network'.
+	 *                      'network' reads the network-wide site option,
+	 *                      used when exporting from Network Admin.
+	 * @return array Export data with version, timestamp, scope, and settings.
 	 */
-	public function export_settings(): array {
+	public function export_settings( string $scope = 'blog' ): array {
 		return array(
 			'version'     => GATHERPRESS_VERSION,
 			'exported_at' => current_time( 'c' ),
-			'settings'    => get_option( self::OPTION_NAME, array() ),
+			'scope'       => $scope,
+			'settings'    => $this->read_stored_options( $scope ),
 		);
+	}
+
+	/**
+	 * Read the stored settings option in the given storage scope.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $scope Storage scope: 'blog' or 'network'.
+	 * @return array
+	 */
+	protected function read_stored_options( string $scope ): array {
+		if ( 'network' === $scope ) {
+			return (array) get_site_option( self::OPTION_NAME, array() );
+		}
+
+		return (array) get_option( self::OPTION_NAME, array() );
+	}
+
+	/**
+	 * Write the stored settings option in the given storage scope.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $scope   Storage scope: 'blog' or 'network'.
+	 * @param array  $options Options array to persist.
+	 * @return void
+	 */
+	protected function write_stored_options( string $scope, array $options ): void {
+		if ( 'network' === $scope ) {
+			update_site_option( self::OPTION_NAME, $options );
+			return;
+		}
+
+		update_option( self::OPTION_NAME, $options );
+	}
+
+	/**
+	 * Delete the stored settings option in the given storage scope.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $scope Storage scope: 'blog' or 'network'.
+	 * @return void
+	 */
+	protected function delete_stored_options( string $scope ): void {
+		if ( 'network' === $scope ) {
+			delete_site_option( self::OPTION_NAME );
+			return;
+		}
+
+		delete_option( self::OPTION_NAME );
 	}
 
 	/**
@@ -1039,10 +1097,11 @@ class Settings {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array $data The parsed import data.
+	 * @param array  $data  The parsed import data.
+	 * @param string $scope Storage scope: 'blog' (default) or 'network'.
 	 * @return array Validation result with 'valid', 'changes', 'unknown', and 'warnings' keys.
 	 */
-	public function validate_import( array $data ): array {
+	public function validate_import( array $data, string $scope = 'blog' ): array {
 		$result = array(
 			'valid'    => true,
 			'changes'  => array(),
@@ -1070,7 +1129,7 @@ class Settings {
 		}
 
 		$field_type_map = $this->build_field_type_map( $this->get_sub_pages() );
-		$current        = get_option( self::OPTION_NAME, array() );
+		$current        = $this->read_stored_options( $scope );
 
 		foreach ( $data['settings'] as $key => $value ) {
 			if ( ! isset( $field_type_map[ $key ] ) ) {
@@ -1096,11 +1155,12 @@ class Settings {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array  $data The parsed import data.
-	 * @param string $mode Import mode: 'merge' or 'replace'.
+	 * @param array  $data  The parsed import data.
+	 * @param string $mode  Import mode: 'merge' or 'replace'.
+	 * @param string $scope Storage scope: 'blog' (default) or 'network'.
 	 * @return array Result with 'success', 'imported', 'skipped', and 'warnings' keys.
 	 */
-	public function import_settings( array $data, string $mode = 'merge' ): array {
+	public function import_settings( array $data, string $mode = 'merge', string $scope = 'blog' ): array {
 		$result = array(
 			'success'  => false,
 			'imported' => array(),
@@ -1108,7 +1168,7 @@ class Settings {
 			'warnings' => array(),
 		);
 
-		$validation = $this->validate_import( $data );
+		$validation = $this->validate_import( $data, $scope );
 
 		if ( ! $validation['valid'] ) {
 			$result['warnings'] = $validation['warnings'];
@@ -1120,7 +1180,7 @@ class Settings {
 		$result['skipped']  = $validation['unknown'];
 
 		$field_type_map = $this->build_field_type_map( $this->get_sub_pages() );
-		$sanitize       = $this->sanitize_page_settings( $field_type_map );
+		$sanitize       = $this->sanitize_page_settings( $field_type_map, $scope );
 
 		// Filter to only known keys.
 		$to_import = array_intersect_key(
@@ -1131,12 +1191,16 @@ class Settings {
 		// Sanitize imported values.
 		if ( 'replace' === $mode ) {
 			// Replace mode: clear existing, only use imported values.
-			delete_option( self::OPTION_NAME );
+			$this->delete_stored_options( $scope );
 		}
 
 		$sanitized = $sanitize( $to_import );
 
-		update_option( self::OPTION_NAME, $sanitized );
+		$this->write_stored_options( $scope, $sanitized );
+
+		if ( 'network' === $scope ) {
+			Network::flush_config_cache();
+		}
 
 		$result['success']  = true;
 		$result['imported'] = array_keys( $to_import );

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -398,6 +398,7 @@ class Setup {
 	 * @return void
 	 */
 	public function on_site_create( WP_Site $new_site ): void {
+		// @codeCoverageIgnoreStart -- Defensive shim: wp-admin/includes/plugin.php is always loaded under PHPUnit.
 		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
 			// Load the admin-only helper when the site is created from a
 			// context that hasn't pulled it in (e.g. WP-CLI, REST, or the
@@ -409,6 +410,7 @@ class Setup {
 				require_once $plugin_php; // NOSONAR.
 			}
 		}
+		// @codeCoverageIgnoreEnd
 
 		if ( ! is_plugin_active_for_network( plugin_basename( GATHERPRESS_CORE_FILE ) ) ) {
 			return;

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -74,6 +74,7 @@ class Setup {
 		Settings::get_instance();
 		Settings\Credits::get_instance();
 		Settings\Events::get_instance();
+		Settings\Network::get_instance();
 		Settings\Roles::get_instance();
 		Settings\Rsvp_Settings::get_instance();
 		Settings\Tools::get_instance();
@@ -223,6 +224,11 @@ class Setup {
 		$current_version = GATHERPRESS_VERSION;
 
 		if ( $stored_version !== $current_version ) {
+			// Ensure per-blog tables exist — covers multisite cases where a
+			// subsite's table was never created (e.g. site created before
+			// plugin activation, or an `on_site_create` race). dbDelta is
+			// idempotent so re-running here is safe.
+			$this->create_tables();
 			$this->schedule_rewrite_flush();
 			update_option( 'gatherpress_version', $current_version );
 		}
@@ -392,11 +398,20 @@ class Setup {
 	 * @return void
 	 */
 	public function on_site_create( WP_Site $new_site ): void {
-		if ( is_plugin_active_for_network( 'gatherpress/gatherpress.php' ) ) {
-			switch_to_blog( intval( $new_site->blog_id ) );
-			$this->create_tables();
-			restore_current_blog();
+		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
+			// Load the admin-only helper when the site is created from a
+			// context that hasn't pulled it in (e.g. WP-CLI, REST, or the
+			// `wp_initialize_site` path before wp-admin bootstraps).
+			require_once ABSPATH . 'wp-admin/includes/plugin.php'; // NOSONAR.
 		}
+
+		if ( ! is_plugin_active_for_network( plugin_basename( GATHERPRESS_CORE_FILE ) ) ) {
+			return;
+		}
+
+		switch_to_blog( intval( $new_site->blog_id ) );
+		$this->create_tables();
+		restore_current_blog();
 	}
 
 	/**

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -228,6 +228,11 @@ class Setup {
 			// subsite's table was never created (e.g. site created before
 			// plugin activation, or an `on_site_create` race). dbDelta is
 			// idempotent so re-running here is safe.
+			//
+			// Note: create_tables() also re-adds the online-event term and
+			// schedules a rewrite flush. Those side effects are intentional on
+			// a version change — don't split the self-heal out without
+			// accounting for them.
 			$this->create_tables();
 			$this->schedule_rewrite_flush();
 			update_option( 'gatherpress_version', $current_version );
@@ -398,11 +403,13 @@ class Setup {
 	 * @return void
 	 */
 	public function on_site_create( WP_Site $new_site ): void {
-		// @codeCoverageIgnoreStart -- Defensive shim: wp-admin/includes/plugin.php is always loaded under PHPUnit.
+		// Defensive shim for contexts where wp-admin/includes/plugin.php
+		// hasn't been loaded (WP-CLI, REST, early wp_initialize_site paths).
+		// Under PHPUnit this file is always loaded, so the branch below is
+		// unreachable — the whole block is flagged @codeCoverageIgnore.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreStart
 		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
-			// Load the admin-only helper when the site is created from a
-			// context that hasn't pulled it in (e.g. WP-CLI, REST, or the
-			// `wp_initialize_site` path before wp-admin bootstraps).
 			$plugin_php = ABSPATH . 'wp-admin/includes/plugin.php';
 
 			if ( file_exists( $plugin_php ) ) {
@@ -410,6 +417,7 @@ class Setup {
 				require_once $plugin_php; // NOSONAR.
 			}
 		}
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
 		// @codeCoverageIgnoreEnd
 
 		if ( ! is_plugin_active_for_network( plugin_basename( GATHERPRESS_CORE_FILE ) ) ) {

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -402,7 +402,12 @@ class Setup {
 			// Load the admin-only helper when the site is created from a
 			// context that hasn't pulled it in (e.g. WP-CLI, REST, or the
 			// `wp_initialize_site` path before wp-admin bootstraps).
-			require_once ABSPATH . 'wp-admin/includes/plugin.php'; // NOSONAR.
+			$plugin_php = ABSPATH . 'wp-admin/includes/plugin.php';
+
+			if ( file_exists( $plugin_php ) ) {
+				// @phpstan-ignore requireOnce.fileNotFound
+				require_once $plugin_php; // NOSONAR.
+			}
 		}
 
 		if ( ! is_plugin_active_for_network( plugin_basename( GATHERPRESS_CORE_FILE ) ) ) {

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -255,7 +255,7 @@ class Utility {
 	 *                Falls back to a UTC offset representation if a named timezone string is not set.
 	 */
 	public static function get_system_timezone(): string {
-		$gmt_offset      = intval( get_option( 'gmt_offset' ) );
+		$gmt_offset      = get_option( 'gmt_offset' );
 		$timezone_string = get_option( 'timezone_string' );
 
 		// Remove old Etc mappings. Fallback to gmt_offset.
@@ -263,17 +263,96 @@ class Utility {
 			$timezone_string = '';
 		}
 
-		if ( empty( $timezone_string ) ) { // Create a UTC+- zone if no timezone string exists.
-			if ( 0 === $gmt_offset ) {
-				$timezone_string = 'UTC+0';
-			} elseif ( $gmt_offset < 0 ) {
-				$timezone_string = 'UTC' . $gmt_offset;
-			} else {
-				$timezone_string = 'UTC+' . $gmt_offset;
-			}
+		if ( empty( $timezone_string ) ) {
+			$timezone_string = self::offset_to_timezone_string( (float) $gmt_offset );
 		}
 
 		return $timezone_string;
+	}
+
+	/**
+	 * Convert a gmt_offset (in hours) into a DateTimeZone-compatible string.
+	 *
+	 * WordPress stores the gmt_offset as a decimal hour (e.g. 5.5 for
+	 * IST, -3.5 for Newfoundland). PHP's DateTimeZone rejects WP's display
+	 * strings like `UTC+0` or `UTC+5` but accepts `UTC` and `+HH:MM` /
+	 * `-HH:MM` offsets, so normalize here.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param float $offset Decimal-hour offset from UTC.
+	 * @return string PHP-valid timezone identifier.
+	 */
+	public static function offset_to_timezone_string( float $offset ): string {
+		if ( 0.0 === $offset ) {
+			return 'UTC';
+		}
+
+		$sign    = $offset < 0 ? '-' : '+';
+		$abs     = abs( $offset );
+		$hours   = (int) $abs;
+		$minutes = (int) round( ( $abs - $hours ) * 60 );
+
+		return sprintf( '%s%02d:%02d', $sign, $hours, $minutes );
+	}
+
+	/**
+	 * Normalize a timezone string to a PHP `DateTimeZone`-compatible form.
+	 *
+	 * Accepts anything WordPress / GatherPress might have stored (IANA,
+	 * `+HH:MM`, `UTC`, `UTC+N`, `UTC-N`, decimal UTC like `UTC+5.5`) and
+	 * returns a string that `new DateTimeZone(...)` will accept.
+	 *
+	 * Unknown values pass through unchanged so downstream error handling
+	 * can surface anything genuinely unexpected.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $timezone Raw timezone string.
+	 * @return string
+	 */
+	public static function normalize_timezone_string( string $timezone ): string {
+		$timezone = trim( $timezone );
+
+		if ( '' === $timezone ) {
+			return 'UTC';
+		}
+
+		// Already in +HH:MM / -HH:MM form — DateTimeZone accepts these.
+		if ( preg_match( '/^[+-]\d{2}:\d{2}$/', $timezone ) ) {
+			return $timezone;
+		}
+
+		// WP-style display strings: UTC, UTC+0, UTC-5, UTC+5.5, UTC+5:30.
+		if ( preg_match( '/^UTC([+-])(\d+(?:\.\d+)?|\d+:\d{2})?$/i', $timezone, $matches ) ) {
+			if ( empty( $matches[2] ) ) {
+				return 'UTC';
+			}
+
+			$sign    = $matches[1];
+			$value   = $matches[2];
+			$hours   = 0;
+			$minutes = 0;
+
+			if ( false !== strpos( $value, ':' ) ) {
+				list( $hours, $minutes ) = array_map( 'intval', explode( ':', $value ) );
+			} elseif ( false !== strpos( $value, '.' ) ) {
+				$hours   = (int) $value;
+				$minutes = (int) round( ( (float) $value - $hours ) * 60 );
+			} else {
+				$hours = (int) $value;
+			}
+
+			if ( 0 === $hours && 0 === $minutes ) {
+				return 'UTC';
+			}
+
+			return sprintf( '%s%02d:%02d', $sign, $hours, $minutes );
+		}
+
+		// Assume anything else is a valid IANA identifier (America/New_York,
+		// Europe/London, etc.) — passthrough.
+		return $timezone;
 	}
 
 	/**

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -274,7 +274,7 @@ class Utility {
 	 * Convert a gmt_offset (in hours) into a DateTimeZone-compatible string.
 	 *
 	 * WordPress stores the gmt_offset as a decimal hour (e.g. 5.5 for
-	 * IST, -3.5 for Newfoundland). PHP's DateTimeZone rejects WP's display
+	 * India, -3.5 for Newfoundland). PHP's DateTimeZone rejects WP's display
 	 * strings like `UTC+0` or `UTC+5` but accepts `UTC` and `+HH:MM` /
 	 * `-HH:MM` offsets, so normalize here.
 	 *

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -62,7 +62,7 @@ class Events extends Base {
 	 * @return int The priority for displaying the events settings page.
 	 */
 	protected function get_priority(): int {
-		return PHP_INT_MIN;
+		return PHP_INT_MIN + 1;
 	}
 
 	/**

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -73,6 +73,15 @@ class Network {
 	const VALUES_EDIT_ACTION  = 'gatherpress_network_values';
 
 	/**
+	 * Per-request cache for get_config() — see get_config() for rationale.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array|null
+	 */
+	protected static ?array $config_cache = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0
@@ -138,9 +147,15 @@ class Network {
 
 		// The notice should not render on the network admin settings page
 		// itself — that's where super admins edit the inherited values.
+		// Defining WP_NETWORK_ADMIN under PHPUnit is process-wide and
+		// pollutes sibling tests, so this branch is not covered in tests.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreStart
 		if ( is_network_admin() ) {
 			return;
 		}
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreEnd
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only page check.
 		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
@@ -370,6 +385,11 @@ class Network {
 
 		check_admin_referer( self::NONCE_ACTION );
 
+		// The body below runs only on a valid nonce and terminates via
+		// redirect_to_tab → exit, so it's untestable under PHPUnit without
+		// subprocess isolation.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreStart
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Validated above.
 		$raw = isset( $_POST[ self::OPTION_NAME ] ) && is_array( $_POST[ self::OPTION_NAME ] )
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing
@@ -377,8 +397,11 @@ class Network {
 			: array();
 
 		update_site_option( self::OPTION_NAME, $this->sanitize( $raw ) );
+		self::flush_config_cache();
 
 		$this->redirect_to_tab( self::NETWORK_TAB );
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -400,6 +423,11 @@ class Network {
 
 		check_admin_referer( self::VALUES_NONCE_ACTION );
 
+		// The body below runs only on a valid nonce and terminates via
+		// redirect_to_tab → exit, so it's untestable under PHPUnit without
+		// subprocess isolation.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreStart
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Validated above.
 		$raw = isset( $_POST[ Settings::OPTION_NAME ] ) && is_array( $_POST[ Settings::OPTION_NAME ] )
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing
@@ -426,6 +454,8 @@ class Network {
 		$tab       = isset( $available[ $submitted ] ) ? $submitted : (string) array_key_first( $available );
 
 		$this->redirect_to_tab( $tab );
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -525,19 +555,42 @@ class Network {
 	 * @return array Config with 'enabled' (bool) and 'inherited' (string[]).
 	 */
 	public static function get_config(): array {
+		// Called twice per field render (via Settings::render_field → get() →
+		// is_option_inherited()). Memoize for the duration of the request so
+		// we're not repeatedly hitting get_site_option on settings pages with
+		// many fields. `flush_config_cache()` invalidates it after a save.
+		if ( null !== self::$config_cache ) {
+			return self::$config_cache;
+		}
+
 		$defaults = self::get_default_config();
 
 		if ( ! is_multisite() ) {
-			return $defaults;
+			self::$config_cache = $defaults;
+			return self::$config_cache;
 		}
 
 		$stored = get_site_option( self::OPTION_NAME, array() );
 
 		if ( ! is_array( $stored ) ) {
-			return $defaults;
+			self::$config_cache = $defaults;
+			return self::$config_cache;
 		}
 
-		return array_merge( $defaults, $stored );
+		self::$config_cache = array_merge( $defaults, $stored );
+		return self::$config_cache;
+	}
+
+	/**
+	 * Reset the per-request config cache. Called after a save so the next
+	 * read sees the fresh value, and used by tests to isolate assertions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public static function flush_config_cache(): void {
+		self::$config_cache = null;
 	}
 
 	/**

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -132,7 +132,13 @@ class Network {
 	 * @return void
 	 */
 	public function subsite_inheritance_notice(): void {
-		if ( ! is_multisite() || is_main_site() ) {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		// The notice should not render on the network admin settings page
+		// itself — that's where super admins edit the inherited values.
+		if ( is_network_admin() ) {
 			return;
 		}
 
@@ -235,6 +241,9 @@ class Network {
 			return;
 		}
 
+		// wp_safe_redirect + exit is a terminator; can't run under PHPUnit without a subprocess.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreStart
 		wp_safe_redirect(
 			add_query_arg(
 				array(
@@ -245,6 +254,7 @@ class Network {
 			)
 		);
 		exit;
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -461,6 +471,9 @@ class Network {
 	 * @return void
 	 */
 	protected function redirect_to_tab( string $tab ): void {
+		// wp_safe_redirect + exit is a terminator; can't run under PHPUnit without a subprocess.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreStart
 		wp_safe_redirect(
 			add_query_arg(
 				array(
@@ -472,6 +485,7 @@ class Network {
 			)
 		);
 		exit;
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -1,0 +1,543 @@
+<?php
+/**
+ * Network settings page for GatherPress multisite.
+ *
+ * Registers "GatherPress" under Network Admin → Settings with a tabbed UI
+ * that mirrors the per-site GatherPress Settings (Events, Venues, Roles,
+ * RSVP) plus an additional "Network" tab for the inheritance allowlist.
+ *
+ * Values set here are saved to the network-wide site option
+ * `gatherpress_settings` via `update_site_option()`; subsites with an option
+ * in the inherited allowlist resolve `Settings::get()` to that network value.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Core\Settings;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Settings;
+use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Utility;
+
+/**
+ * Class Network.
+ *
+ * @since 1.0.0
+ */
+class Network {
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Site option storing the network inheritance config (enabled + inherited list).
+	 *
+	 * @since 1.0.0
+	 */
+	const OPTION_NAME = 'gatherpress_network_settings';
+
+	/**
+	 * Admin page slug used in the network admin menu.
+	 *
+	 * @since 1.0.0
+	 */
+	const PAGE_SLUG = 'gatherpress-network-settings';
+
+	/**
+	 * Slug for the special "Network" tab (inheritance allowlist).
+	 *
+	 * @since 1.0.0
+	 */
+	const NETWORK_TAB = 'network';
+
+	/**
+	 * Nonce + edit action for saving the inheritance allowlist.
+	 *
+	 * @since 1.0.0
+	 */
+	const NONCE_ACTION = 'gatherpress_network_settings_save';
+	const EDIT_ACTION  = 'gatherpress_network_settings';
+
+	/**
+	 * Nonce + edit action for saving the network-level settings values
+	 * (the content of the Events/Venues/Roles/RSVP tabs).
+	 *
+	 * @since 1.0.0
+	 */
+	const VALUES_NONCE_ACTION = 'gatherpress_network_values_save';
+	const VALUES_EDIT_ACTION  = 'gatherpress_network_values';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Set up hooks.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks(): void {
+		add_action( 'network_admin_menu', array( $this, 'register_page' ) );
+		add_action( 'network_admin_edit_' . self::EDIT_ACTION, array( $this, 'handle_save' ) );
+		add_action( 'network_admin_edit_' . self::VALUES_EDIT_ACTION, array( $this, 'handle_values_save' ) );
+		add_action( 'admin_notices', array( $this, 'subsite_inheritance_notice' ) );
+		add_action( 'admin_head', array( $this, 'print_inherited_styles' ) );
+	}
+
+	/**
+	 * Print inline styles that dim inherited fields on subsite settings pages.
+	 *
+	 * Runs on every admin_head so the styling is applied whether or not the
+	 * built SCSS bundle is available.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function print_inherited_styles(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only page check.
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+
+		if ( '' === $page || 0 !== strpos( $page, 'gatherpress_' ) ) {
+			return;
+		}
+
+		echo '<style>
+			.gatherpress-field-inherited { opacity: 0.6; pointer-events: none; }
+			.gatherpress-field-inherited__note { font-style: italic; margin-top: 4px; pointer-events: auto; }
+		</style>';
+	}
+
+	/**
+	 * Show a notice on a subsite's GatherPress Settings page when any option
+	 * is currently inherited from the network.
+	 *
+	 * Links to the Network Admin → Settings → GatherPress page so super admins
+	 * know where to change values that are locked here.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function subsite_inheritance_notice(): void {
+		if ( ! is_multisite() || is_main_site() ) {
+			return;
+		}
+
+		// Only surface the notice to users who can actually act on the link.
+		// Regular site admins get per-field notes instead (no dead-end link).
+		if ( ! current_user_can( 'manage_network_options' ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only page check.
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+
+		if ( '' === $page || 0 !== strpos( $page, 'gatherpress_' ) ) {
+			return;
+		}
+
+		$config = self::get_config();
+
+		if ( empty( $config['enabled'] ) || empty( $config['inherited'] ) ) {
+			return;
+		}
+
+		$settings   = Settings::get_instance();
+		$has_locked = false;
+
+		foreach ( (array) $config['inherited'] as $option_key ) {
+			if ( $settings->is_option_inherited( (string) $option_key ) ) {
+				$has_locked = true;
+				break;
+			}
+		}
+
+		if ( ! $has_locked ) {
+			return;
+		}
+
+		$link = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url(
+				network_admin_url(
+					sprintf( 'settings.php?page=%s', self::PAGE_SLUG )
+				)
+			),
+			esc_html__( 'Network Admin → Settings → GatherPress', 'gatherpress' )
+		);
+
+		printf(
+			'<div class="notice notice-info"><p>%s</p></div>',
+			wp_kses(
+				sprintf(
+					/* translators: %s: link to the network admin GatherPress settings page. */
+					__(
+						// phpcs:disable Generic.Files.LineLength.TooLong
+						'Some GatherPress settings on this site are inherited from the network. Locked fields can only be changed from %s.',
+						// phpcs:enable Generic.Files.LineLength.TooLong
+						'gatherpress'
+					),
+					$link
+				),
+				array( 'a' => array( 'href' => true ) )
+			)
+		);
+	}
+
+	/**
+	 * Register the Network Admin → Settings → GatherPress page and scope the
+	 * read filter to only this screen so network values appear in the UI
+	 * while the per-site Settings remain untouched.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function register_page(): void {
+		$hook = add_submenu_page(
+			'settings.php',
+			__( 'GatherPress Network Settings', 'gatherpress' ),
+			__( 'GatherPress', 'gatherpress' ),
+			'manage_network_options',
+			self::PAGE_SLUG,
+			array( $this, 'render_page' )
+		);
+
+		if ( $hook ) {
+			add_action( 'load-' . $hook, array( $this, 'scope_read_filter' ) );
+			add_action( 'load-' . $hook, array( $this, 'maybe_redirect_to_default_tab' ) );
+		}
+	}
+
+	/**
+	 * Redirect bare `?page=gatherpress-network-settings` to the Network tab
+	 * so the URL always reflects the active tab (and bookmarks land correctly).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function maybe_redirect_to_default_tab(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only check on a navigation parameter.
+		if ( isset( $_GET['tab'] ) ) {
+			return;
+		}
+
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page' => self::PAGE_SLUG,
+					'tab'  => self::NETWORK_TAB,
+				),
+				network_admin_url( 'settings.php' )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Attach the read-routing filter on the network admin page load.
+	 *
+	 * Ensures `get_option( 'gatherpress_settings' )` returns the network-wide
+	 * value while this page renders, so field values show network values,
+	 * not the blog option of whichever site is "current" for the admin.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function scope_read_filter(): void {
+		add_filter( 'pre_option_' . Settings::OPTION_NAME, array( $this, 'route_read_to_site_option' ) );
+	}
+
+	/**
+	 * Short-circuit get_option to return the network-wide site option.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $pre The pre-filter value (false when not short-circuited).
+	 * @return mixed
+	 */
+	public function route_read_to_site_option( $pre ) {
+		unset( $pre );
+
+		return get_site_option( Settings::OPTION_NAME, array() );
+	}
+
+	/**
+	 * Render the network admin page.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_network_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to access this page.', 'gatherpress' ) );
+		}
+
+		$sub_pages   = $this->get_network_sub_pages();
+		$current_tab = $this->get_current_tab( $sub_pages );
+
+		Utility::render_template(
+			sprintf( '%s/includes/templates/admin/settings/network-page.php', GATHERPRESS_CORE_PATH ),
+			array(
+				'sub_pages'   => $sub_pages,
+				'current_tab' => $current_tab,
+				'config'      => self::get_config(),
+			),
+			true
+		);
+	}
+
+	/**
+	 * Sub-pages shown at network admin: existing sub-pages minus Tools
+	 * (import/export is blog-scoped), plus the special "Network" tab.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array
+	 */
+	protected function get_network_sub_pages(): array {
+		$sub_pages = Settings::get_instance()->get_sub_pages();
+
+		unset( $sub_pages['tools'] );
+
+		$sub_pages[ self::NETWORK_TAB ] = array(
+			'name'     => __( 'Network', 'gatherpress' ),
+			'priority' => PHP_INT_MIN, // Before Events.
+			'sections' => array(),
+		);
+
+		uasort( $sub_pages, array( Settings::get_instance(), 'sort_sub_pages_by_priority' ) );
+
+		return $sub_pages;
+	}
+
+	/**
+	 * Resolve the current tab from the `tab` query arg, falling back to the
+	 * first sub-page when missing or unknown.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $sub_pages Available sub-pages keyed by slug.
+	 * @return string
+	 */
+	protected function get_current_tab( array $sub_pages ): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Tab selection is a navigation parameter.
+		$tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : '';
+
+		if ( '' !== $tab && isset( $sub_pages[ $tab ] ) ) {
+			return $tab;
+		}
+
+		return (string) array_key_first( $sub_pages );
+	}
+
+	/**
+	 * Handle save of the inheritance allowlist (Network tab).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function handle_save(): void {
+		if ( ! current_user_can( 'manage_network_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to perform this action.', 'gatherpress' ) );
+		}
+
+		check_admin_referer( self::NONCE_ACTION );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Validated above.
+		$raw = isset( $_POST[ self::OPTION_NAME ] ) && is_array( $_POST[ self::OPTION_NAME ] )
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing
+			? wp_unslash( $_POST[ self::OPTION_NAME ] )
+			: array();
+
+		update_site_option( self::OPTION_NAME, $this->sanitize( $raw ) );
+
+		$this->redirect_to_tab( self::NETWORK_TAB );
+	}
+
+	/**
+	 * Handle save of the network-level settings values (other tabs).
+	 *
+	 * Routes reads to the site option while the existing Settings sanitize
+	 * closure runs (so it merges with the current network values rather than
+	 * the main site's blog option), then persists the sanitized result to
+	 * the site option.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function handle_values_save(): void {
+		if ( ! current_user_can( 'manage_network_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to perform this action.', 'gatherpress' ) );
+		}
+
+		check_admin_referer( self::VALUES_NONCE_ACTION );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Validated above.
+		$raw = isset( $_POST[ Settings::OPTION_NAME ] ) && is_array( $_POST[ Settings::OPTION_NAME ] )
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing
+			? wp_unslash( $_POST[ Settings::OPTION_NAME ] )
+			: array();
+
+		$submitted = sanitize_key(
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Validated above.
+			isset( $_POST['gatherpress_tab'] ) ? wp_unslash( $_POST['gatherpress_tab'] ) : ''
+		);
+
+		$settings       = Settings::get_instance();
+		$sub_pages      = $settings->get_sub_pages();
+		$field_type_map = $this->build_field_type_map( $sub_pages );
+
+		add_filter( 'pre_option_' . Settings::OPTION_NAME, array( $this, 'route_read_to_site_option' ) );
+		$sanitize  = $settings->sanitize_page_settings( $field_type_map );
+		$sanitized = $sanitize( $raw );
+		remove_filter( 'pre_option_' . Settings::OPTION_NAME, array( $this, 'route_read_to_site_option' ) );
+
+		update_site_option( Settings::OPTION_NAME, $sanitized );
+
+		$available = $this->get_network_sub_pages();
+		$tab       = isset( $available[ $submitted ] ) ? $submitted : (string) array_key_first( $available );
+
+		$this->redirect_to_tab( $tab );
+	}
+
+	/**
+	 * Flat map of option_key => field_type, built from the Settings sub-pages.
+	 *
+	 * Mirrors `Settings::build_field_type_map()` (protected there) so we can
+	 * sanitize POSTs in our own save handler without exposing that method.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $sub_pages Sub-pages from Settings::get_sub_pages().
+	 * @return array<string, string>
+	 */
+	protected function build_field_type_map( array $sub_pages ): array {
+		$map = array();
+
+		foreach ( $sub_pages as $sub_page_settings ) {
+			if ( empty( $sub_page_settings['sections'] ) ) {
+				continue;
+			}
+
+			foreach ( (array) $sub_page_settings['sections'] as $section_settings ) {
+				if ( empty( $section_settings['options'] ) ) {
+					continue;
+				}
+
+				foreach ( (array) $section_settings['options'] as $option => $option_settings ) {
+					$map[ $option ] = $option_settings['field']['type'] ?? 'text';
+				}
+			}
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Redirect back to the network admin page on the given tab with a
+	 * success flag.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $tab The tab slug to return to.
+	 * @return void
+	 */
+	protected function redirect_to_tab( string $tab ): void {
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'    => self::PAGE_SLUG,
+					'tab'     => $tab,
+					'updated' => 'true',
+				),
+				network_admin_url( 'settings.php' )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Sanitize the submitted inheritance config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $input Raw input array.
+	 * @return array
+	 */
+	public function sanitize( $input ): array {
+		$input     = is_array( $input ) ? $input : array();
+		$inherited = isset( $input['inherited'] ) && is_array( $input['inherited'] )
+			? array_values(
+				array_unique(
+					array_filter(
+						array_map( 'sanitize_key', $input['inherited'] ),
+						static function ( string $key ): bool {
+							return '' !== $key;
+						}
+					)
+				)
+			)
+			: array();
+
+		return array(
+			'enabled'   => ! empty( $input['enabled'] ),
+			'inherited' => $inherited,
+		);
+	}
+
+	/**
+	 * Current inheritance config, merged with defaults.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array Config with 'enabled' (bool) and 'inherited' (string[]).
+	 */
+	public static function get_config(): array {
+		$defaults = self::get_default_config();
+
+		if ( ! is_multisite() ) {
+			return $defaults;
+		}
+
+		$stored = get_site_option( self::OPTION_NAME, array() );
+
+		if ( ! is_array( $stored ) ) {
+			return $defaults;
+		}
+
+		return array_merge( $defaults, $stored );
+	}
+
+	/**
+	 * Default inheritance config.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array
+	 */
+	public static function get_default_config(): array {
+		return array(
+			'enabled'   => false,
+			'inherited' => array(),
+		);
+	}
+}

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -73,6 +73,15 @@ class Network {
 	const VALUES_EDIT_ACTION  = 'gatherpress_network_values';
 
 	/**
+	 * Capability required for any network-scope GatherPress action:
+	 * viewing/saving the Network Admin Settings page, importing or
+	 * exporting network values, etc.
+	 *
+	 * @since 1.0.0
+	 */
+	const CAPABILITY = 'manage_network_options';
+
+	/**
 	 * Per-request cache for get_config() — see get_config() for rationale.
 	 *
 	 * @since 1.0.0
@@ -192,7 +201,7 @@ class Network {
 
 		// Append the network-admin link only for users who can actually
 		// follow it — regular site admins would hit a dead end.
-		if ( current_user_can( 'manage_network_options' ) ) {
+		if ( current_user_can( self::CAPABILITY ) ) {
 			$link = sprintf(
 				'<a href="%s">%s</a>',
 				esc_url(
@@ -231,7 +240,7 @@ class Network {
 			'settings.php',
 			__( 'GatherPress Network Settings', 'gatherpress' ),
 			__( 'GatherPress', 'gatherpress' ),
-			'manage_network_options',
+			self::CAPABILITY,
 			self::PAGE_SLUG,
 			array( $this, 'render_page' )
 		);
@@ -309,7 +318,7 @@ class Network {
 	 * @return void
 	 */
 	public function render_page(): void {
-		if ( ! current_user_can( 'manage_network_options' ) ) {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
 			wp_die( esc_html__( 'You do not have permission to access this page.', 'gatherpress' ) );
 		}
 
@@ -337,8 +346,6 @@ class Network {
 	 */
 	protected function get_network_sub_pages(): array {
 		$sub_pages = Settings::get_instance()->get_sub_pages();
-
-		unset( $sub_pages['tools'] );
 
 		$sub_pages[ self::NETWORK_TAB ] = array(
 			'name'     => __( 'Network', 'gatherpress' ),
@@ -379,7 +386,7 @@ class Network {
 	 * @return void
 	 */
 	public function handle_save(): void {
-		if ( ! current_user_can( 'manage_network_options' ) ) {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
 			wp_die( esc_html__( 'You do not have permission to perform this action.', 'gatherpress' ) );
 		}
 
@@ -417,7 +424,7 @@ class Network {
 	 * @return void
 	 */
 	public function handle_values_save(): void {
-		if ( ! current_user_can( 'manage_network_options' ) ) {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
 			wp_die( esc_html__( 'You do not have permission to perform this action.', 'gatherpress' ) );
 		}
 

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -110,7 +110,7 @@ class Network {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only page check.
 		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
 
-		if ( '' === $page || 0 !== strpos( $page, 'gatherpress_' ) ) {
+		if ( '' === $page || ! str_starts_with( $page, 'gatherpress_' ) ) {
 			return;
 		}
 
@@ -136,16 +136,10 @@ class Network {
 			return;
 		}
 
-		// Only surface the notice to users who can actually act on the link.
-		// Regular site admins get per-field notes instead (no dead-end link).
-		if ( ! current_user_can( 'manage_network_options' ) ) {
-			return;
-		}
-
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only page check.
 		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
 
-		if ( '' === $page || 0 !== strpos( $page, 'gatherpress_' ) ) {
+		if ( '' === $page || ! str_starts_with( $page, 'gatherpress_' ) ) {
 			return;
 		}
 
@@ -169,32 +163,37 @@ class Network {
 			return;
 		}
 
-		$link = sprintf(
-			'<a href="%s">%s</a>',
-			esc_url(
-				network_admin_url(
-					sprintf( 'settings.php?page=%s', self::PAGE_SLUG )
-				)
-			),
-			esc_html__( 'Network Admin → Settings → GatherPress', 'gatherpress' )
+		// Shown to every admin who can reach the settings page.
+		$message = esc_html__(
+			'Some GatherPress settings on this site are inherited from the network.',
+			'gatherpress'
 		);
 
-		printf(
-			'<div class="notice notice-info"><p>%s</p></div>',
-			wp_kses(
+		// Append the network-admin link only for users who can actually
+		// follow it — regular site admins would hit a dead end.
+		if ( current_user_can( 'manage_network_options' ) ) {
+			$link = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url(
+					network_admin_url(
+						sprintf( 'settings.php?page=%s', self::PAGE_SLUG )
+					)
+				),
+				esc_html__( 'Network Admin → Settings → GatherPress', 'gatherpress' )
+			);
+
+			$message .= ' ' . wp_kses(
 				sprintf(
 					/* translators: %s: link to the network admin GatherPress settings page. */
-					__(
-						// phpcs:disable Generic.Files.LineLength.TooLong
-						'Some GatherPress settings on this site are inherited from the network. Locked fields can only be changed from %s.',
-						// phpcs:enable Generic.Files.LineLength.TooLong
-						'gatherpress'
-					),
+					__( 'Locked fields can only be changed from %s.', 'gatherpress' ),
 					$link
 				),
 				array( 'a' => array( 'href' => true ) )
-			)
-		);
+			);
+		}
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Both halves escaped above.
+		printf( '<div class="notice notice-info"><p>%s</p></div>', $message );
 	}
 
 	/**

--- a/includes/core/classes/settings/class-tools.php
+++ b/includes/core/classes/settings/class-tools.php
@@ -96,7 +96,7 @@ class Tools extends Base {
 
 			Utility::render_template(
 				sprintf( '%s/includes/templates/admin/settings/tools.php', GATHERPRESS_CORE_PATH ),
-				array(),
+				array( 'scope' => is_network_admin() ? 'network' : 'blog' ),
 				true
 			);
 		}
@@ -112,7 +112,9 @@ class Tools extends Base {
 	 * @return void
 	 */
 	public function ajax_export(): void {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		$scope = $this->resolve_scope();
+
+		if ( ! current_user_can( $this->capability_for_scope( $scope ) ) ) {
 			wp_send_json_error(
 				array( 'message' => __( 'Permission denied.', 'gatherpress' ) )
 			);
@@ -122,7 +124,33 @@ class Tools extends Base {
 
 		$settings = Settings::get_instance();
 
-		wp_send_json_success( $settings->export_settings() );
+		wp_send_json_success( $settings->export_settings( $scope ) );
+	}
+
+	/**
+	 * Resolve the storage scope from the AJAX POST.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string 'network' or 'blog'.
+	 */
+	protected function resolve_scope(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce checked elsewhere in the handler.
+		$raw = isset( $_POST['scope'] ) ? sanitize_key( wp_unslash( $_POST['scope'] ) ) : 'blog';
+
+		return 'network' === $raw ? 'network' : 'blog';
+	}
+
+	/**
+	 * Minimum capability required to act in the given scope.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $scope 'network' or 'blog'.
+	 * @return string
+	 */
+	protected function capability_for_scope( string $scope ): string {
+		return 'network' === $scope ? 'manage_network_options' : 'manage_options';
 	}
 
 	/**
@@ -136,7 +164,9 @@ class Tools extends Base {
 	 * @return void
 	 */
 	public function ajax_import(): void {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		$scope = $this->resolve_scope();
+
+		if ( ! current_user_can( $this->capability_for_scope( $scope ) ) ) {
 			wp_send_json_error(
 				array( 'message' => __( 'Permission denied.', 'gatherpress' ) )
 			);
@@ -168,7 +198,7 @@ class Tools extends Base {
 		}
 
 		$settings = Settings::get_instance();
-		$result   = $settings->import_settings( $data, $mode );
+		$result   = $settings->import_settings( $data, $mode, $scope );
 
 		if ( $result['success'] ) {
 			wp_send_json_success( $result );

--- a/includes/templates/admin/settings/fields/autocomplete.php
+++ b/includes/templates/admin/settings/fields/autocomplete.php
@@ -26,6 +26,7 @@ $gatherpress_component_attrs = array(
 	'option'       => $option,
 	'value'        => ! empty( $value ) ? $value : '[]',
 	'fieldOptions' => $field_options,
+	'disabled'     => ! empty( $disabled ),
 );
 ?>
 <div class="regular-text" data-gatherpress_component_name="autocomplete" data-gatherpress_component_attrs="<?php echo esc_attr( htmlspecialchars( wp_json_encode( $gatherpress_component_attrs ), ENT_QUOTES, 'UTF-8' ) ); ?>"></div>

--- a/includes/templates/admin/settings/fields/checkbox.php
+++ b/includes/templates/admin/settings/fields/checkbox.php
@@ -20,9 +20,11 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 if ( ! isset( $name, $label, $option, $value, $description ) ) {
 	return;
 }
+
+$gatherpress_disabled = ! empty( $disabled ) ? ' disabled' : '';
 ?>
 <input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="0" />
-<input id="<?php echo esc_attr( $option ); ?>" type="checkbox" name="<?php echo esc_attr( $name ); ?>" value="1" <?php checked( 1, rest_sanitize_boolean( $value ), true ); ?> />
+<input id="<?php echo esc_attr( $option ); ?>" type="checkbox" name="<?php echo esc_attr( $name ); ?>" value="1" <?php checked( 1, rest_sanitize_boolean( $value ), true ); ?><?php echo $gatherpress_disabled; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?> />
 <label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label>
 
 <?php

--- a/includes/templates/admin/settings/fields/checkbox.php
+++ b/includes/templates/admin/settings/fields/checkbox.php
@@ -22,8 +22,13 @@ if ( ! isset( $name, $label, $option, $value, $description ) ) {
 }
 
 $gatherpress_disabled = ! empty( $disabled ) ? ' disabled' : '';
+// Checkboxes can't use `readonly`. When disabled the field is omitted
+// from the POST, so the trailing hidden input's value is what lands in
+// `$_POST[$name]` — carry the current (possibly inherited) boolean so
+// the saved value matches what the UI displayed.
+$gatherpress_fallback = ! empty( $disabled ) && rest_sanitize_boolean( $value ) ? '1' : '0';
 ?>
-<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="0" />
+<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( $gatherpress_fallback ); ?>" />
 <input id="<?php echo esc_attr( $option ); ?>" type="checkbox" name="<?php echo esc_attr( $name ); ?>" value="1" <?php checked( 1, rest_sanitize_boolean( $value ), true ); ?><?php echo $gatherpress_disabled; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?> />
 <label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label>
 

--- a/includes/templates/admin/settings/fields/checkbox.php
+++ b/includes/templates/admin/settings/fields/checkbox.php
@@ -27,6 +27,11 @@ $gatherpress_disabled = ! empty( $disabled ) ? ' disabled' : '';
 // `$_POST[$name]` — carry the current (possibly inherited) boolean so
 // the saved value matches what the UI displayed.
 $gatherpress_fallback = ! empty( $disabled ) && rest_sanitize_boolean( $value ) ? '1' : '0';
+
+// IMPORTANT: keep the hidden input BEFORE the checkbox. PHP takes the
+// last value for a repeated name, so a checked (enabled) checkbox wins
+// over the hidden fallback. If you reorder these two, the hidden
+// overrides the checkbox and the saved value is always the fallback.
 ?>
 <input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( $gatherpress_fallback ); ?>" />
 <input id="<?php echo esc_attr( $option ); ?>" type="checkbox" name="<?php echo esc_attr( $name ); ?>" value="1" <?php checked( 1, rest_sanitize_boolean( $value ), true ); ?><?php echo $gatherpress_disabled; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?> />

--- a/includes/templates/admin/settings/fields/number.php
+++ b/includes/templates/admin/settings/fields/number.php
@@ -29,12 +29,15 @@ if ( ! isset( $name, $label, $option, $value, $description, $size, $min, $max ) 
 // values — both render literally. The flag is preserved so downstream
 // code can distinguish "numeric-only" inputs from "optional numeric" ones.
 $gatherpress_placeholder = $placeholder ?? '';
-$gatherpress_disabled    = ! empty( $disabled ) ? ' disabled' : '';
+// Use `readonly` rather than `disabled` so the field still submits its
+// value; `disabled` inputs are omitted from the POST payload, which would
+// drop inherited values out of the blog option on save.
+$gatherpress_readonly = ! empty( $disabled ) ? ' readonly' : '';
 
 ?>
 <div class="form-wrap">
 	<label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label>
-	<input id="<?php echo esc_attr( $option ); ?>" type="number" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $value ); ?>" min="<?php echo esc_attr( $min ); ?>" max="<?php echo esc_attr( $max ); ?>"<?php echo '' !== $gatherpress_placeholder ? ' placeholder="' . esc_attr( $gatherpress_placeholder ) . '"' : ''; ?><?php echo $gatherpress_disabled; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?> />
+	<input id="<?php echo esc_attr( $option ); ?>" type="number" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $value ); ?>" min="<?php echo esc_attr( $min ); ?>" max="<?php echo esc_attr( $max ); ?>"<?php echo '' !== $gatherpress_placeholder ? ' placeholder="' . esc_attr( $gatherpress_placeholder ) . '"' : ''; ?><?php echo $gatherpress_readonly; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?> />
 	<?php
 	if ( ! empty( $description ) ) {
 		?>

--- a/includes/templates/admin/settings/fields/number.php
+++ b/includes/templates/admin/settings/fields/number.php
@@ -29,11 +29,12 @@ if ( ! isset( $name, $label, $option, $value, $description, $size, $min, $max ) 
 // values — both render literally. The flag is preserved so downstream
 // code can distinguish "numeric-only" inputs from "optional numeric" ones.
 $gatherpress_placeholder = $placeholder ?? '';
+$gatherpress_disabled    = ! empty( $disabled ) ? ' disabled' : '';
 
 ?>
 <div class="form-wrap">
 	<label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label>
-	<input id="<?php echo esc_attr( $option ); ?>" type="number" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $value ); ?>" min="<?php echo esc_attr( $min ); ?>" max="<?php echo esc_attr( $max ); ?>"<?php echo '' !== $gatherpress_placeholder ? ' placeholder="' . esc_attr( $gatherpress_placeholder ) . '"' : ''; ?> />
+	<input id="<?php echo esc_attr( $option ); ?>" type="number" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $value ); ?>" min="<?php echo esc_attr( $min ); ?>" max="<?php echo esc_attr( $max ); ?>"<?php echo '' !== $gatherpress_placeholder ? ' placeholder="' . esc_attr( $gatherpress_placeholder ) . '"' : ''; ?><?php echo $gatherpress_disabled; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?> />
 	<?php
 	if ( ! empty( $description ) ) {
 		?>

--- a/includes/templates/admin/settings/fields/select.php
+++ b/includes/templates/admin/settings/fields/select.php
@@ -28,6 +28,11 @@ $gatherpress_disabled = ! empty( $disabled ) ? ' disabled' : '';
 // `$_POST[$name]` — carry the current (possibly inherited) value so the
 // saved value matches what the UI displayed.
 $gatherpress_fallback = ! empty( $disabled ) ? (string) $value : '0';
+
+// IMPORTANT: keep the hidden input BEFORE the select. PHP takes the
+// last value for a repeated name, so an enabled select's submission
+// wins over the hidden fallback. If you reorder these two, the hidden
+// overrides the select and the saved value is always the fallback.
 ?>
 <input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( $gatherpress_fallback ); ?>" />
 <label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label><br/>

--- a/includes/templates/admin/settings/fields/select.php
+++ b/includes/templates/admin/settings/fields/select.php
@@ -23,8 +23,13 @@ if ( ! isset( $name, $label, $option, $options, $options['items'], $value, $desc
 }
 
 $gatherpress_disabled = ! empty( $disabled ) ? ' disabled' : '';
+// Selects can't use `readonly`. When disabled the field is omitted from
+// the POST, so the trailing hidden input's value is what lands in
+// `$_POST[$name]` — carry the current (possibly inherited) value so the
+// saved value matches what the UI displayed.
+$gatherpress_fallback = ! empty( $disabled ) ? (string) $value : '0';
 ?>
-<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="0" />
+<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( $gatherpress_fallback ); ?>" />
 <label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label><br/>
 <select id="<?php echo esc_attr( $option ); ?>" name="<?php echo esc_attr( $name ); ?>"<?php echo $gatherpress_disabled; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?>>
 	<?php

--- a/includes/templates/admin/settings/fields/select.php
+++ b/includes/templates/admin/settings/fields/select.php
@@ -21,10 +21,12 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 if ( ! isset( $name, $label, $option, $options, $options['items'], $value, $description ) ) {
 	return;
 }
+
+$gatherpress_disabled = ! empty( $disabled ) ? ' disabled' : '';
 ?>
 <input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="0" />
 <label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label><br/>
-<select id="<?php echo esc_attr( $option ); ?>" name="<?php echo esc_attr( $name ); ?>">
+<select id="<?php echo esc_attr( $option ); ?>" name="<?php echo esc_attr( $name ); ?>"<?php echo $gatherpress_disabled; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?>>
 	<?php
 	foreach ( $options['items'] as $gatherpress_key => $gatherpress_label ) :
 		// phpcs:ignore Generic.Files.LineLength.TooLong -- Template output formatting.

--- a/includes/templates/admin/settings/fields/text.php
+++ b/includes/templates/admin/settings/fields/text.php
@@ -23,10 +23,11 @@ if ( ! isset( $name, $label, $option, $value, $description, $size, $preview ) ) 
 	return;
 }
 
+$gatherpress_disabled = ! empty( $disabled ) ? ' disabled' : '';
 ?>
 <div class="form-wrap">
 	<label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label>
-	<input id="<?php echo esc_attr( $option ); ?>" type="text" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $value ); ?>" />
+	<input id="<?php echo esc_attr( $option ); ?>" type="text" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $value ); ?>"<?php echo $gatherpress_disabled; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?> />
 	<?php
 	if ( ! empty( $description ) ) {
 		?>

--- a/includes/templates/admin/settings/fields/text.php
+++ b/includes/templates/admin/settings/fields/text.php
@@ -23,11 +23,14 @@ if ( ! isset( $name, $label, $option, $value, $description, $size, $preview ) ) 
 	return;
 }
 
-$gatherpress_disabled = ! empty( $disabled ) ? ' disabled' : '';
+// Use `readonly` rather than `disabled` so the field still submits its
+// value; `disabled` inputs are omitted from the POST payload, which would
+// drop inherited values out of the blog option on save.
+$gatherpress_readonly = ! empty( $disabled ) ? ' readonly' : '';
 ?>
 <div class="form-wrap">
 	<label for="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( $label ); ?></label>
-	<input id="<?php echo esc_attr( $option ); ?>" type="text" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $value ); ?>"<?php echo $gatherpress_disabled; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?> />
+	<input id="<?php echo esc_attr( $option ); ?>" type="text" name="<?php echo esc_attr( $name ); ?>" class="<?php echo esc_attr( $size . '-text' ); ?>" value="<?php echo esc_attr( $value ); ?>"<?php echo $gatherpress_readonly; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static value. ?> />
 	<?php
 	if ( ! empty( $description ) ) {
 		?>

--- a/includes/templates/admin/settings/network-page.php
+++ b/includes/templates/admin/settings/network-page.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Render the GatherPress Network Settings page.
+ *
+ * Rendered under Network Admin → Settings → GatherPress. Presents the same
+ * tabs as the per-site GatherPress settings (minus Tools), saving values to
+ * a network-wide site option. A final "Network" tab configures which
+ * settings subsites are forced to inherit from the network.
+ *
+ * @package GatherPress\Core
+ * @param array  $sub_pages   Tabs to render, keyed by slug.
+ * @param string $current_tab Slug of the active tab.
+ * @param array  $config      Current network inheritance config.
+ * @since 1.0.0
+ */
+
+use GatherPress\Core\Settings\Network;
+use GatherPress\Core\Utility;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+if ( ! isset( $sub_pages, $current_tab, $config ) ) {
+	return;
+}
+
+$gatherpress_network_url = network_admin_url( 'settings.php' );
+$gatherpress_is_network  = Network::NETWORK_TAB === $current_tab;
+?>
+
+<style>
+	.gatherpress-allowlist__options {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+	.gatherpress-allowlist__options li {
+		margin: 0;
+		padding: 3px 0;
+	}
+	.gatherpress-allowlist__options label {
+		align-items: center;
+		display: inline-flex;
+		gap: 6px;
+	}
+	.gatherpress-allowlist__bulk-actions {
+		font-size: 13px;
+	}
+	.gatherpress-allowlist__group-actions {
+		font-size: 12px;
+		font-weight: 400;
+		margin-left: 8px;
+	}
+</style>
+
+<div class="wrap gatherpress-settings">
+	<h1 class="wp-heading-inline">
+		<?php esc_html_e( 'GatherPress Network Settings', 'gatherpress' ); ?>
+	</h1>
+
+	<?php if ( isset( $_GET['updated'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
+		<div class="notice notice-success is-dismissible">
+			<p><?php esc_html_e( 'Settings saved.', 'gatherpress' ); ?></p>
+		</div>
+	<?php endif; ?>
+
+	<h2 class="nav-tab-wrapper">
+		<?php foreach ( $sub_pages as $gatherpress_tab_slug => $gatherpress_tab ) : ?>
+			<?php
+			$gatherpress_active = ( $gatherpress_tab_slug === $current_tab ) ? 'nav-tab-active' : '';
+			$gatherpress_href   = add_query_arg(
+				array(
+					'page' => Network::PAGE_SLUG,
+					'tab'  => $gatherpress_tab_slug,
+				),
+				$gatherpress_network_url
+			);
+			?>
+			<a
+				class="<?php echo esc_attr( trim( 'nav-tab ' . $gatherpress_active ) ); ?>"
+				href="<?php echo esc_url( $gatherpress_href ); ?>"
+			>
+				<?php echo esc_html( $gatherpress_tab['name'] ); ?>
+			</a>
+		<?php endforeach; ?>
+	</h2>
+
+	<?php if ( $gatherpress_is_network ) : ?>
+		<?php
+		$gatherpress_enabled   = ! empty( $config['enabled'] );
+		$gatherpress_inherited = array_flip( (array) ( $config['inherited'] ?? array() ) );
+		$gatherpress_name      = sprintf( '%s[inherited][]', Network::OPTION_NAME );
+
+		// Pre-filter the sub-page list so only groups that actually contain
+		// at least one option are rendered (and empty sections are skipped).
+		$gatherpress_groups = array();
+
+		foreach ( $sub_pages as $gatherpress_sub_page_slug => $gatherpress_sub_page ) {
+			if ( Network::NETWORK_TAB === $gatherpress_sub_page_slug ) {
+				continue;
+			}
+
+			if ( empty( $gatherpress_sub_page['sections'] ) ) {
+				continue;
+			}
+
+			$gatherpress_sections = array();
+
+			foreach ( (array) $gatherpress_sub_page['sections'] as $gatherpress_section ) {
+				if ( empty( $gatherpress_section['options'] ) ) {
+					continue;
+				}
+
+				$gatherpress_sections[] = $gatherpress_section;
+			}
+
+			if ( empty( $gatherpress_sections ) ) {
+				continue;
+			}
+
+			$gatherpress_groups[] = array(
+				'name'     => $gatherpress_sub_page['name'],
+				'sections' => $gatherpress_sections,
+			);
+		}
+		?>
+
+		<form method="post" action="<?php echo esc_url( network_admin_url( 'edit.php?action=' . Network::EDIT_ACTION ) ); ?>">
+			<?php wp_nonce_field( Network::NONCE_ACTION ); ?>
+
+			<h2><?php esc_html_e( 'Network Inheritance', 'gatherpress' ); ?></h2>
+			<p>
+				<?php
+				esc_html_e(
+					// phpcs:disable Generic.Files.LineLength.TooLong
+					'Control whether individual sites in this network can change GatherPress settings locally, or must inherit them from the values set on the other tabs above.',
+					// phpcs:enable Generic.Files.LineLength.TooLong
+					'gatherpress'
+				);
+				?>
+			</p>
+
+			<table class="form-table" role="presentation">
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Enable', 'gatherpress' ); ?></th>
+					<td>
+						<label>
+							<input
+								type="checkbox"
+								name="<?php echo esc_attr( sprintf( '%s[enabled]', Network::OPTION_NAME ) ); ?>"
+								value="1"
+								<?php checked( $gatherpress_enabled ); ?>
+							/>
+							<?php
+							esc_html_e(
+								// phpcs:disable Generic.Files.LineLength.TooLong
+								'Allow individual settings below to be inherited from the network.',
+								// phpcs:enable Generic.Files.LineLength.TooLong
+								'gatherpress'
+							);
+							?>
+						</label>
+					</td>
+				</tr>
+			</table>
+
+			<h2><?php esc_html_e( 'Inherited Settings', 'gatherpress' ); ?></h2>
+			<p>
+				<?php
+				esc_html_e(
+					// phpcs:disable Generic.Files.LineLength.TooLong
+					'Check any setting that subsites must inherit from the network. Unchecked settings remain editable per site.',
+					// phpcs:enable Generic.Files.LineLength.TooLong
+					'gatherpress'
+				);
+				?>
+			</p>
+
+			<p class="gatherpress-allowlist__bulk-actions">
+				<a href="#" data-gatherpress-toggle="all" data-gatherpress-state="1">
+					<?php esc_html_e( 'Select all', 'gatherpress' ); ?>
+				</a>
+				<span aria-hidden="true"> | </span>
+				<a href="#" data-gatherpress-toggle="all" data-gatherpress-state="0">
+					<?php esc_html_e( 'Deselect all', 'gatherpress' ); ?>
+				</a>
+			</p>
+
+			<?php foreach ( $gatherpress_groups as $gatherpress_group ) : ?>
+				<div class="gatherpress-allowlist__group">
+					<h3>
+						<?php echo esc_html( $gatherpress_group['name'] ); ?>
+						<span class="gatherpress-allowlist__group-actions">
+							(<a href="#" data-gatherpress-toggle="group" data-gatherpress-state="1">
+								<?php esc_html_e( 'select all', 'gatherpress' ); ?>
+							</a>
+							<span aria-hidden="true">|</span>
+							<a href="#" data-gatherpress-toggle="group" data-gatherpress-state="0">
+								<?php esc_html_e( 'deselect all', 'gatherpress' ); ?>
+							</a>)
+						</span>
+					</h3>
+					<table class="form-table" role="presentation">
+					<?php foreach ( $gatherpress_group['sections'] as $gatherpress_section ) : ?>
+						<tr>
+							<th scope="row">
+								<?php echo esc_html( $gatherpress_section['name'] ?? '' ); ?>
+							</th>
+							<td>
+								<ul class="gatherpress-allowlist__options">
+									<?php foreach ( (array) $gatherpress_section['options'] as $gatherpress_option_key => $gatherpress_option ) : ?>
+										<li>
+											<label>
+												<input
+													type="checkbox"
+													name="<?php echo esc_attr( $gatherpress_name ); ?>"
+													value="<?php echo esc_attr( $gatherpress_option_key ); ?>"
+													<?php checked( isset( $gatherpress_inherited[ $gatherpress_option_key ] ) ); ?>
+												/>
+												<?php echo esc_html( $gatherpress_option['labels']['name'] ?? $gatherpress_option_key ); ?>
+											</label>
+										</li>
+									<?php endforeach; ?>
+								</ul>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+					</table>
+				</div>
+			<?php endforeach; ?>
+
+			<?php submit_button( __( 'Save Network Settings', 'gatherpress' ) ); ?>
+		</form>
+
+		<script>
+			( function () {
+				var container = document.querySelector( '.gatherpress-settings' );
+
+				if ( ! container ) {
+					return;
+				}
+
+				var inheritedName = <?php echo wp_json_encode( sprintf( '%s[inherited][]', Network::OPTION_NAME ) ); ?>;
+
+				function setAll( nodeList, checked ) {
+					Array.prototype.forEach.call( nodeList, function ( cb ) {
+						cb.checked = checked;
+					} );
+				}
+
+				container.addEventListener( 'click', function ( event ) {
+					var trigger = event.target.closest( '[data-gatherpress-toggle]' );
+
+					if ( ! trigger ) {
+						return;
+					}
+
+					event.preventDefault();
+
+					var scope   = trigger.getAttribute( 'data-gatherpress-toggle' );
+					var checked = '1' === trigger.getAttribute( 'data-gatherpress-state' );
+					var root    = 'group' === scope
+						? trigger.closest( '.gatherpress-allowlist__group' )
+						: container;
+
+					if ( ! root ) {
+						return;
+					}
+
+					setAll(
+						root.querySelectorAll( 'input[type="checkbox"][name="' + inheritedName + '"]' ),
+						checked
+					);
+				} );
+			} )();
+		</script>
+	<?php else : ?>
+		<?php
+		$gatherpress_current_page = Utility::prefix_key( $current_tab );
+		$gatherpress_has_fields   = ! empty( $GLOBALS['wp_settings_fields'][ $gatherpress_current_page ] ?? array() );
+		?>
+
+		<?php if ( $gatherpress_has_fields ) : ?>
+			<form method="post" action="<?php echo esc_url( network_admin_url( 'edit.php?action=' . Network::VALUES_EDIT_ACTION ) ); ?>">
+				<?php wp_nonce_field( Network::VALUES_NONCE_ACTION ); ?>
+				<input type="hidden" name="gatherpress_tab" value="<?php echo esc_attr( $current_tab ); ?>" />
+				<?php do_settings_sections( $gatherpress_current_page ); ?>
+				<?php submit_button( __( 'Save Settings', 'gatherpress' ) ); ?>
+			</form>
+		<?php else : ?>
+			<?php
+			/**
+			 * Fires so tabs that render via the GatherPress settings section action
+			 * (e.g. the Alpha sub-page) can emit their own content. Mirrors the
+			 * per-site settings page template.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param string $page Prefixed page slug (e.g. `gatherpress_alpha`).
+			 */
+			do_action( 'gatherpress_settings_section', $gatherpress_current_page );
+			?>
+		<?php endif; ?>
+	<?php endif; ?>
+</div>

--- a/includes/templates/admin/settings/tools.php
+++ b/includes/templates/admin/settings/tools.php
@@ -12,11 +12,18 @@
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 $gatherpress_nonce = wp_create_nonce( 'gatherpress_tools_nonce' );
+$gatherpress_scope = isset( $scope ) && 'network' === $scope ? 'network' : 'blog';
 ?>
 
 <h2><?php esc_html_e( 'Export Settings', 'gatherpress' ); ?></h2>
 <p class="description">
-	<?php esc_html_e( 'Download your current GatherPress settings as a JSON file. Only non-default values are exported.', 'gatherpress' ); ?>
+	<?php
+	if ( 'network' === $gatherpress_scope ) {
+		esc_html_e( 'Download the network-wide GatherPress settings (values set on the other tabs at Network Admin) as a JSON file.', 'gatherpress' );
+	} else {
+		esc_html_e( 'Download your current GatherPress settings as a JSON file. Only non-default values are exported.', 'gatherpress' );
+	}
+	?>
 </p>
 <p>
 	<button id="gatherpress-export" class="button button-primary">
@@ -79,6 +86,7 @@ $gatherpress_nonce = wp_create_nonce( 'gatherpress_tools_nonce' );
 <script>
 (function() {
 	const nonce = '<?php echo esc_js( $gatherpress_nonce ); ?>';
+	const scope = '<?php echo esc_js( $gatherpress_scope ); ?>';
 	let importData = null;
 
 	// Export handler.
@@ -87,7 +95,8 @@ $gatherpress_nonce = wp_create_nonce( 'gatherpress_tools_nonce' );
 
 		const data = new URLSearchParams({
 			action: 'gatherpress_export_settings',
-			nonce: nonce
+			nonce: nonce,
+			scope: scope
 		});
 
 		fetch(window.ajaxurl, {
@@ -196,6 +205,7 @@ $gatherpress_nonce = wp_create_nonce( 'gatherpress_tools_nonce' );
 		const data = new URLSearchParams({
 			action: 'gatherpress_import_settings',
 			nonce: nonce,
+			scope: scope,
 			settings_json: JSON.stringify(importData),
 			import_mode: mode
 		});

--- a/includes/templates/admin/timezone-shim.js
+++ b/includes/templates/admin/timezone-shim.js
@@ -12,7 +12,7 @@
  * Non-zero UTC offsets are left untouched — operators with those configured
  * should pick an IANA zone in Settings → General.
  */
-( function () {
+( function() {
 	if ( ! window.wp || ! window.wp.date ) {
 		return;
 	}
@@ -21,7 +21,7 @@
 		return;
 	}
 
-	var settings = window.wp.date.getSettings();
+	const settings = window.wp.date.getSettings();
 
 	if ( ! settings || ! settings.timezone || ! settings.timezone.string ) {
 		return;
@@ -31,4 +31,4 @@
 		settings.timezone.string = 'UTC';
 		window.wp.date.setSettings( settings );
 	}
-} )();
+}() );

--- a/includes/templates/admin/timezone-shim.js
+++ b/includes/templates/admin/timezone-shim.js
@@ -1,0 +1,34 @@
+/**
+ * Timezone shim for `wp.date` on fresh WordPress installs.
+ *
+ * WordPress emits `"UTC+0"` / `"UTC-0"` as the default timezone string when
+ * Settings → General is left at its defaults. Moment Timezone can't resolve
+ * those strings and spams `"Moment Timezone has no data for UTC+0"` warnings
+ * throughout the block editor. This shim runs immediately after
+ * `wp.date.setSettings(...)` and rewrites the string to the IANA-valid `"UTC"`
+ * so downstream consumers (Gutenberg, GatherPress, other plugins) don't log
+ * the warning.
+ *
+ * Non-zero UTC offsets are left untouched — operators with those configured
+ * should pick an IANA zone in Settings → General.
+ */
+( function () {
+	if ( ! window.wp || ! window.wp.date ) {
+		return;
+	}
+
+	if ( 'function' !== typeof window.wp.date.getSettings ) {
+		return;
+	}
+
+	var settings = window.wp.date.getSettings();
+
+	if ( ! settings || ! settings.timezone || ! settings.timezone.string ) {
+		return;
+	}
+
+	if ( /^UTC[+-]0$/.test( settings.timezone.string ) ) {
+		settings.timezone.string = 'UTC';
+		window.wp.date.setSettings( settings );
+	}
+} )();

--- a/src/settings/style.scss
+++ b/src/settings/style.scss
@@ -54,3 +54,13 @@
 		background: #fff;
 	}
 }
+
+.gatherpress-field-inherited {
+	opacity: 0.6;
+	pointer-events: none;
+
+	&__note {
+		font-style: italic;
+		pointer-events: auto;
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -79,6 +79,18 @@ class Test_Assets extends Base {
 				'callback' => array( $instance, 'event_communication_modal' ),
 			),
 			array(
+				'type'     => 'action',
+				'name'     => 'admin_enqueue_scripts',
+				'priority' => 10,
+				'callback' => array( $instance, 'enqueue_timezone_shim' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'wp_enqueue_scripts',
+				'priority' => 10,
+				'callback' => array( $instance, 'enqueue_timezone_shim' ),
+			),
+			array(
 				'type'     => 'filter',
 				'name'     => 'render_block',
 				'priority' => 10,

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -109,6 +109,58 @@ class Test_Assets extends Base {
 	}
 
 	/**
+	 * Coverage for enqueue_timezone_shim when wp-date isn't registered.
+	 *
+	 * @covers ::enqueue_timezone_shim
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_timezone_shim_bails_without_wp_date(): void {
+		$instance       = Assets::get_instance();
+		$was_registered = wp_script_is( 'wp-date', 'registered' );
+
+		if ( $was_registered ) {
+			wp_deregister_script( 'wp-date' );
+		}
+
+		$instance->enqueue_timezone_shim();
+
+		$this->assertFalse( wp_script_is( 'wp-date', 'enqueued' ) );
+
+		// Leave the global script registry as we found it.
+		if ( $was_registered ) {
+			wp_default_packages_scripts( wp_scripts() );
+		}
+	}
+
+	/**
+	 * Coverage for enqueue_timezone_shim when wp-date is registered — enqueues
+	 * the shim and attaches the inline script that normalizes `UTC+0` / `UTC-0`.
+	 *
+	 * @covers ::enqueue_timezone_shim
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_timezone_shim_enqueues_and_attaches_inline_script(): void {
+		$instance = Assets::get_instance();
+
+		if ( ! wp_script_is( 'wp-date', 'registered' ) ) {
+			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion -- Test registration; no real asset.
+			wp_register_script( 'wp-date', '', array(), '1', false );
+		}
+
+		$instance->enqueue_timezone_shim();
+
+		$this->assertTrue( wp_script_is( 'wp-date', 'enqueued' ) );
+
+		$inline = wp_scripts()->get_data( 'wp-date', 'after' );
+		$joined = is_array( $inline ) ? implode( "\n", $inline ) : (string) $inline;
+
+		$this->assertStringContainsString( 'wp.date.setSettings', $joined );
+		$this->assertStringContainsString( 'UTC', $joined );
+	}
+
+	/**
 	 * Coverage for add_interactivity_state method.
 	 *
 	 * @covers ::add_interactivity_state

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -2167,11 +2167,13 @@ class Test_Settings extends Base {
 				'inherited' => array( 'date_format' ),
 			)
 		);
+		\GatherPress\Core\Settings\Network::flush_config_cache();
 
 		$this->assertTrue( Settings::get_instance()->is_option_inherited( 'date_format' ) );
 		$this->assertFalse( Settings::get_instance()->is_option_inherited( 'time_format' ) );
 
 		delete_site_option( 'gatherpress_network_settings' );
+		\GatherPress\Core\Settings\Network::flush_config_cache();
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -2111,4 +2111,191 @@ class Test_Settings extends Base {
 
 		delete_option( 'gatherpress_settings' );
 	}
+
+	/**
+	 * Coverage for is_option_inherited on single-site (not multisite).
+	 *
+	 * @covers ::is_option_inherited
+	 *
+	 * @return void
+	 */
+	public function test_is_option_inherited_returns_false_single_site(): void {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Single-site only.' );
+		}
+
+		$this->assertFalse( Settings::get_instance()->is_option_inherited( 'date_format' ) );
+	}
+
+	/**
+	 * Coverage for is_option_inherited filter — can force `true` even when
+	 * the network config would otherwise say no.
+	 *
+	 * @covers ::is_option_inherited
+	 *
+	 * @return void
+	 */
+	public function test_is_option_inherited_filter_can_force_true(): void {
+		$filter = static function (): bool {
+			return true;
+		};
+		add_filter( 'gatherpress_network_is_option_inherited', $filter );
+
+		$this->assertTrue( Settings::get_instance()->is_option_inherited( 'date_format' ) );
+
+		remove_filter( 'gatherpress_network_is_option_inherited', $filter );
+	}
+
+	/**
+	 * Coverage for is_option_inherited when multisite + network config forces it.
+	 *
+	 * @covers ::is_option_inherited
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_is_option_inherited_respects_network_config(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		update_site_option(
+			'gatherpress_network_settings',
+			array(
+				'enabled'   => true,
+				'inherited' => array( 'date_format' ),
+			)
+		);
+
+		$this->assertTrue( Settings::get_instance()->is_option_inherited( 'date_format' ) );
+		$this->assertFalse( Settings::get_instance()->is_option_inherited( 'time_format' ) );
+
+		delete_site_option( 'gatherpress_network_settings' );
+	}
+
+	/**
+	 * Coverage for get() inheritance branch — reads the network site option
+	 * when the option is flagged as inherited.
+	 *
+	 * @covers ::get
+	 *
+	 * @return void
+	 */
+	public function test_get_reads_network_value_when_inherited(): void {
+		update_site_option( 'gatherpress_settings', array( 'date_format' => 'Y-m-d' ) );
+
+		$filter = static function (): bool {
+			return true;
+		};
+		add_filter( 'gatherpress_network_is_option_inherited', $filter );
+
+		$this->assertSame( 'Y-m-d', Settings::get_instance()->get( 'date_format' ) );
+
+		remove_filter( 'gatherpress_network_is_option_inherited', $filter );
+		delete_site_option( 'gatherpress_settings' );
+	}
+
+	/**
+	 * Coverage for get() falling back to default when inherited but the
+	 * network site option has nothing for this key.
+	 *
+	 * @covers ::get
+	 *
+	 * @return void
+	 */
+	public function test_get_falls_back_to_default_when_inherited_and_network_empty(): void {
+		delete_site_option( 'gatherpress_settings' );
+
+		$filter = static function (): bool {
+			return true;
+		};
+		add_filter( 'gatherpress_network_is_option_inherited', $filter );
+
+		// `show_timezone` defaults to true.
+		$this->assertTrue( Settings::get_instance()->get( 'show_timezone' ) );
+
+		remove_filter( 'gatherpress_network_is_option_inherited', $filter );
+	}
+
+	/**
+	 * Coverage for render_field wrapping output with the inherited marker +
+	 * the super-admin variant of the note (link included).
+	 *
+	 * @covers ::render_field
+	 *
+	 * @return void
+	 */
+	public function test_render_field_wraps_when_inherited_for_super_admin(): void {
+		$instance = Settings::get_instance();
+		$user_id  = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		$user     = get_user_by( 'id', $user_id );
+		$user->add_cap( 'manage_network_options' );
+		wp_set_current_user( $user_id );
+
+		$filter = static function (): bool {
+			return true;
+		};
+		add_filter( 'gatherpress_network_is_option_inherited', $filter );
+
+		$output = Utility::buffer_and_return(
+			array( $instance, 'render_field' ),
+			array(
+				'date_format',
+				array(
+					'field' => array(
+						'type'    => 'text',
+						'size'    => 'regular',
+						'options' => array( 'default' => 'F j, Y' ),
+					),
+				),
+			)
+		);
+
+		remove_filter( 'gatherpress_network_is_option_inherited', $filter );
+		wp_delete_user( $user_id );
+
+		$this->assertStringContainsString( 'gatherpress-field-inherited', $output );
+		$this->assertStringContainsString( 'settings.php?page=gatherpress-network-settings', $output );
+	}
+
+	/**
+	 * Coverage for render_field wrapping output with the inherited marker +
+	 * the regular-admin variant (no link).
+	 *
+	 * @covers ::render_field
+	 *
+	 * @return void
+	 */
+	public function test_render_field_wraps_when_inherited_for_regular_admin(): void {
+		$instance = Settings::get_instance();
+		$user_id  = $this->factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		$filter = static function (): bool {
+			return true;
+		};
+		add_filter( 'gatherpress_network_is_option_inherited', $filter );
+
+		$output = Utility::buffer_and_return(
+			array( $instance, 'render_field' ),
+			array(
+				'date_format',
+				array(
+					'field' => array(
+						'type'    => 'text',
+						'size'    => 'regular',
+						'options' => array( 'default' => 'F j, Y' ),
+					),
+				),
+			)
+		);
+
+		remove_filter( 'gatherpress_network_is_option_inherited', $filter );
+		wp_delete_user( $user_id );
+
+		$this->assertStringContainsString( 'gatherpress-field-inherited', $output );
+		$this->assertStringContainsString( 'Inherited from the network.', $output );
+		$this->assertStringNotContainsString( 'settings.php?page=gatherpress-network-settings', $output );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -541,7 +541,7 @@ class Test_Settings extends Base {
 			'<div class="regular-text" data-gatherpress_component_name="autocomplete" ' .
 			'data-gatherpress_component_attrs="{&quot;name&quot;:&quot;gatherpress_settings[option]&quot;,' .
 			'&quot;option&quot;:&quot;gatherpress_option&quot;,&quot;value&quot;:&quot;[]&quot;,' .
-			'&quot;fieldOptions&quot;:{&quot;unit&quot;:&quot;test&quot;}}"></div>',
+			'&quot;fieldOptions&quot;:{&quot;unit&quot;:&quot;test&quot;},&quot;disabled&quot;:false}"></div>',
 			$autocomplete,
 			'Failed to assert that markup matches.'
 		);

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -2300,4 +2300,183 @@ class Test_Settings extends Base {
 		$this->assertStringContainsString( 'Inherited from the network.', $output );
 		$this->assertStringNotContainsString( 'settings.php?page=gatherpress-network-settings', $output );
 	}
+
+	/**
+	 * Coverage for read_stored_options — blog-scope branch reads from the
+	 * standard blog option.
+	 *
+	 * @covers ::read_stored_options
+	 *
+	 * @return void
+	 */
+	public function test_read_stored_options_blog_scope(): void {
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'google' ) );
+
+		$result = Utility::invoke_hidden_method(
+			Settings::get_instance(),
+			'read_stored_options',
+			array( 'blog' )
+		);
+
+		delete_option( Settings::OPTION_NAME );
+
+		$this->assertSame( array( 'map_platform' => 'google' ), $result );
+	}
+
+	/**
+	 * Coverage for read_stored_options — network-scope branch reads the
+	 * network-wide site option.
+	 *
+	 * @covers ::read_stored_options
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_read_stored_options_network_scope(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		update_site_option( Settings::OPTION_NAME, array( 'map_platform' => 'google' ) );
+
+		$result = Utility::invoke_hidden_method(
+			Settings::get_instance(),
+			'read_stored_options',
+			array( 'network' )
+		);
+
+		delete_site_option( Settings::OPTION_NAME );
+
+		$this->assertSame( array( 'map_platform' => 'google' ), $result );
+	}
+
+	/**
+	 * Coverage for write_stored_options — both scope branches.
+	 *
+	 * @covers ::write_stored_options
+	 *
+	 * @return void
+	 */
+	public function test_write_stored_options_blog_scope(): void {
+		Utility::invoke_hidden_method(
+			Settings::get_instance(),
+			'write_stored_options',
+			array( 'blog', array( 'map_platform' => 'osm' ) )
+		);
+
+		$this->assertSame(
+			array( 'map_platform' => 'osm' ),
+			get_option( Settings::OPTION_NAME )
+		);
+
+		delete_option( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Coverage for write_stored_options network scope.
+	 *
+	 * @covers ::write_stored_options
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_write_stored_options_network_scope(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		Utility::invoke_hidden_method(
+			Settings::get_instance(),
+			'write_stored_options',
+			array( 'network', array( 'map_platform' => 'osm' ) )
+		);
+
+		$this->assertSame(
+			array( 'map_platform' => 'osm' ),
+			get_site_option( Settings::OPTION_NAME )
+		);
+
+		delete_site_option( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Coverage for delete_stored_options — both scope branches.
+	 *
+	 * @covers ::delete_stored_options
+	 *
+	 * @return void
+	 */
+	public function test_delete_stored_options_blog_scope(): void {
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'osm' ) );
+
+		Utility::invoke_hidden_method(
+			Settings::get_instance(),
+			'delete_stored_options',
+			array( 'blog' )
+		);
+
+		$this->assertFalse( get_option( Settings::OPTION_NAME ) );
+	}
+
+	/**
+	 * Coverage for delete_stored_options network scope.
+	 *
+	 * @covers ::delete_stored_options
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_delete_stored_options_network_scope(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		update_site_option( Settings::OPTION_NAME, array( 'map_platform' => 'osm' ) );
+
+		Utility::invoke_hidden_method(
+			Settings::get_instance(),
+			'delete_stored_options',
+			array( 'network' )
+		);
+
+		$this->assertFalse( get_site_option( Settings::OPTION_NAME ) );
+	}
+
+	/**
+	 * Coverage for import_settings with replace mode in network scope — covers
+	 * the Network::flush_config_cache() call path at the tail of import.
+	 *
+	 * @covers ::import_settings
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_import_settings_replace_network_scope(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		update_site_option( Settings::OPTION_NAME, array( 'map_platform' => 'osm' ) );
+		\GatherPress\Core\Settings\Network::flush_config_cache();
+
+		$data = array(
+			'version'  => GATHERPRESS_VERSION,
+			'settings' => array( 'map_platform' => 'google' ),
+		);
+
+		$result = Settings::get_instance()->import_settings( $data, 'replace', 'network' );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame(
+			array( 'map_platform' => 'google' ),
+			get_site_option( Settings::OPTION_NAME )
+		);
+
+		delete_site_option( Settings::OPTION_NAME );
+		\GatherPress\Core\Settings\Network::flush_config_cache();
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-setup.php
@@ -647,6 +647,39 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * Coverage for on_site_create bail path when GatherPress is not
+	 * network-active — no tables should be created on the new site.
+	 *
+	 * @group multisite
+	 * @covers ::on_site_create
+	 *
+	 * @return void
+	 */
+	public function test_on_site_create_bails_when_not_network_active(): void {
+		global $wpdb;
+
+		// Ensure the plugin is NOT listed in active_sitewide_plugins.
+		$active_sitewide_plugins = get_site_option( 'active_sitewide_plugins', array() );
+		unset( $active_sitewide_plugins['gatherpress/gatherpress.php'] );
+		update_site_option( 'active_sitewide_plugins', $active_sitewide_plugins );
+
+		$new_site_id = $this->factory()->blog->create();
+
+		switch_to_blog( $new_site_id );
+
+		$table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery -- Required for testing table absence.
+		$table_exists = $wpdb->get_var( "SHOW TABLES LIKE '{$table}'" );
+
+		restore_current_blog();
+
+		$this->assertNull(
+			$table_exists,
+			'Table should not be created when plugin is not network-active.'
+		);
+	}
+
+	/**
 	 * Coverage for on_site_create method when new site is created in multisite.
 	 *
 	 * @group multisite

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -217,32 +217,116 @@ class Test_Utility extends Base {
 	 */
 	public function data_get_system_timezone(): array {
 		return array(
+			// No gmt_offset and no timezone_string → defaults to UTC.
 			array(
 				false,
 				false,
-				'UTC+0',
+				'UTC',
 			),
+			// Whole positive offset.
 			array(
 				5,
 				false,
-				'UTC+5',
+				'+05:00',
 			),
+			// Whole negative offset.
 			array(
 				-4,
 				false,
-				'UTC-4',
+				'-04:00',
 			),
+			// Fractional offset (e.g. India).
+			array(
+				5.5,
+				false,
+				'+05:30',
+			),
+			// IANA passthrough.
 			array(
 				false,
 				'Europe/London',
 				'Europe/London',
 			),
+			// Etc/GMT is stripped; falls back to gmt_offset.
 			array(
-				false,
+				-3,
 				'Etc/GMT+3',
-				'UTC-3',
+				'-03:00',
 			),
 		);
+	}
+
+	/**
+	 * Data provider for test_offset_to_timezone_string.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array
+	 */
+	public function data_offset_to_timezone_string(): array {
+		return array(
+			'zero returns UTC'                  => array( 0.0, 'UTC' ),
+			'positive whole hour'               => array( 5.0, '+05:00' ),
+			'negative whole hour'               => array( -8.0, '-08:00' ),
+			'positive half hour (India)'        => array( 5.5, '+05:30' ),
+			'negative half hour (Newfoundland)' => array( -3.5, '-03:30' ),
+			'positive quarter hour (Kathmandu)' => array( 5.75, '+05:45' ),
+		);
+	}
+
+	/**
+	 * Coverage for offset_to_timezone_string.
+	 *
+	 * @dataProvider data_offset_to_timezone_string
+	 *
+	 * @covers ::offset_to_timezone_string
+	 *
+	 * @param float  $offset   Decimal hour offset from UTC.
+	 * @param string $expected Expected DateTimeZone-compatible string.
+	 * @return void
+	 */
+	public function test_offset_to_timezone_string( float $offset, string $expected ): void {
+		$this->assertSame( $expected, Utility::offset_to_timezone_string( $offset ) );
+	}
+
+	/**
+	 * Data provider for test_normalize_timezone_string.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array
+	 */
+	public function data_normalize_timezone_string(): array {
+		return array(
+			'empty string becomes UTC'           => array( '', 'UTC' ),
+			'whitespace-only string becomes UTC' => array( '   ', 'UTC' ),
+			'offset +HH:MM passes through'       => array( '+05:30', '+05:30' ),
+			'offset -HH:MM passes through'       => array( '-08:00', '-08:00' ),
+			'literal UTC passes through'         => array( 'UTC', 'UTC' ),
+			'UTC+0 normalizes to UTC'            => array( 'UTC+0', 'UTC' ),
+			'UTC-0 normalizes to UTC'            => array( 'UTC-0', 'UTC' ),
+			'UTC+5 becomes +05:00'               => array( 'UTC+5', '+05:00' ),
+			'UTC-8 becomes -08:00'               => array( 'UTC-8', '-08:00' ),
+			'UTC+5.5 becomes +05:30'             => array( 'UTC+5.5', '+05:30' ),
+			'UTC+5:30 becomes +05:30'            => array( 'UTC+5:30', '+05:30' ),
+			'UTC with zero colon form'           => array( 'UTC+0:00', 'UTC' ),
+			'IANA identifier passes through'     => array( 'America/New_York', 'America/New_York' ),
+		);
+	}
+
+	/**
+	 * Coverage for normalize_timezone_string.
+	 *
+	 * @dataProvider data_normalize_timezone_string
+	 *
+	 * @covers ::normalize_timezone_string
+	 *
+	 * @param string $input    Input timezone string.
+	 * @param string $expected Expected normalized output.
+	 * @return void
+	 */
+	public function test_normalize_timezone_string( string $input, string $expected ): void {
+		$this->assertSame( $expected, Utility::normalize_timezone_string( $input ) );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-events.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-events.php
@@ -57,7 +57,7 @@ class Test_Events extends Base {
 		$instance = Events::get_instance();
 		$priority = Utility::invoke_hidden_method( $instance, 'get_priority' );
 
-		$this->assertEquals( PHP_INT_MIN, $priority, 'Failed to assert correct priority.' );
+		$this->assertEquals( PHP_INT_MIN + 1, $priority, 'Failed to assert correct priority.' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
@@ -106,6 +106,48 @@ class Test_Network extends Base {
 	}
 
 	/**
+	 * Coverage for the cache-hit branch of get_config — second call returns
+	 * the memoized value without re-reading the site option.
+	 *
+	 * @covers ::get_config
+	 *
+	 * @return void
+	 */
+	public function test_get_config_returns_cached_value(): void {
+		Network::flush_config_cache();
+
+		// First call populates the cache.
+		$first = Network::get_config();
+
+		// Second call should hit the cache branch and return an identical
+		// reference (same values) without another read.
+		$second = Network::get_config();
+
+		$this->assertSame( $first, $second );
+	}
+
+	/**
+	 * Coverage for flush_config_cache — explicitly exercising the public
+	 * reset so the two-line method body is captured by coverage.
+	 *
+	 * @covers ::flush_config_cache
+	 *
+	 * @return void
+	 */
+	public function test_flush_config_cache_resets_cache(): void {
+		// Prime the cache.
+		Network::get_config();
+
+		Network::flush_config_cache();
+
+		$reflection = new ReflectionClass( Network::class );
+		$property   = $reflection->getProperty( 'config_cache' );
+		$property->setAccessible( true );
+
+		$this->assertNull( $property->getValue() );
+	}
+
+	/**
 	 * Coverage for get_config when stored value is not an array — returns defaults.
 	 *
 	 * @covers ::get_config

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
@@ -109,9 +109,15 @@ class Test_Network extends Base {
 	 *
 	 * @covers ::get_config
 	 *
+	 * @group   multisite
+	 *
 	 * @return void
 	 */
 	public function test_get_config_returns_defaults_when_stored_is_not_array(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
 		update_site_option( Network::OPTION_NAME, 'not-an-array' );
 
 		$this->assertSame( Network::get_default_config(), Network::get_config() );
@@ -122,9 +128,15 @@ class Test_Network extends Base {
 	 *
 	 * @covers ::get_config
 	 *
+	 * @group   multisite
+	 *
 	 * @return void
 	 */
 	public function test_get_config_merges_stored_over_defaults(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
 		update_site_option(
 			Network::OPTION_NAME,
 			array(

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
@@ -27,6 +27,7 @@ class Test_Network extends Base {
 	 */
 	public function tearDown(): void {
 		delete_site_option( Network::OPTION_NAME );
+		Network::flush_config_cache();
 		parent::tearDown();
 	}
 
@@ -674,6 +675,96 @@ class Test_Network extends Base {
 		try {
 			$instance->render_page();
 		} finally {
+			wp_delete_user( $user_id );
+		}
+	}
+
+	/**
+	 * Coverage for render_page when the current user has the required
+	 * capability — renders the template without dying.
+	 *
+	 * @covers ::render_page
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_render_page_renders_template_for_super_admin(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		$instance = Network::get_instance();
+		$output   = PMC_Utility::buffer_and_return( array( $instance, 'render_page' ) );
+
+		revoke_super_admin( $user_id );
+		wp_delete_user( $user_id );
+
+		$this->assertStringContainsString( 'GatherPress Network Settings', $output );
+	}
+
+	/**
+	 * Coverage for handle_save when the nonce is missing or invalid —
+	 * check_admin_referer calls wp_die.
+	 *
+	 * @covers ::handle_save
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_handle_save_wp_dies_on_invalid_nonce(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		$instance = Network::get_instance();
+
+		$this->expectException( \WPDieException::class );
+
+		try {
+			$instance->handle_save();
+		} finally {
+			revoke_super_admin( $user_id );
+			wp_delete_user( $user_id );
+		}
+	}
+
+	/**
+	 * Coverage for handle_values_save when the nonce is missing or invalid —
+	 * check_admin_referer calls wp_die.
+	 *
+	 * @covers ::handle_values_save
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_handle_values_save_wp_dies_on_invalid_nonce(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		$instance = Network::get_instance();
+
+		$this->expectException( \WPDieException::class );
+
+		try {
+			$instance->handle_values_save();
+		} finally {
+			revoke_super_admin( $user_id );
 			wp_delete_user( $user_id );
 		}
 	}

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
@@ -316,13 +316,15 @@ class Test_Network extends Base {
 	}
 
 	/**
-	 * Coverage for get_network_sub_pages — drops Tools and injects Network tab.
+	 * Coverage for get_network_sub_pages — adds the Network tab alongside
+	 * the existing sub-pages (including Tools, which operates in network
+	 * scope at this level).
 	 *
 	 * @covers ::get_network_sub_pages
 	 *
 	 * @return void
 	 */
-	public function test_get_network_sub_pages_drops_tools_and_adds_network(): void {
+	public function test_get_network_sub_pages_adds_network_tab(): void {
 		$instance   = Network::get_instance();
 		$reflection = new ReflectionClass( $instance );
 		$method     = $reflection->getMethod( 'get_network_sub_pages' );
@@ -347,7 +349,8 @@ class Test_Network extends Base {
 		$result = $method->invoke( $instance );
 		remove_filter( 'gatherpress_sub_pages', $filter, 100 );
 
-		$this->assertArrayNotHasKey( 'tools', $result );
+		$this->assertArrayHasKey( 'events', $result );
+		$this->assertArrayHasKey( 'tools', $result );
 		$this->assertArrayHasKey( 'network', $result );
 	}
 

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
@@ -721,5 +721,4 @@ class Test_Network extends Base {
 			wp_delete_user( $user_id );
 		}
 	}
-
 }

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
@@ -1,0 +1,438 @@
+<?php
+/**
+ * Class handles unit tests for GatherPress\Core\Settings\Network.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Core\Settings;
+
+use GatherPress\Core\Settings;
+use GatherPress\Core\Settings\Network;
+use GatherPress\Tests\Base;
+use PMC\Unit_Test\Utility as PMC_Utility;
+use ReflectionClass;
+
+/**
+ * Class Test_Network.
+ *
+ * @coversDefaultClass \GatherPress\Core\Settings\Network
+ */
+class Test_Network extends Base {
+	/**
+	 * Reset the Network site option after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		delete_site_option( Network::OPTION_NAME );
+		parent::tearDown();
+	}
+
+	/**
+	 * Coverage for setup_hooks method.
+	 *
+	 * @covers ::__construct
+	 * @covers ::setup_hooks
+	 *
+	 * @return void
+	 */
+	public function test_setup_hooks(): void {
+		$instance = Network::get_instance();
+		$hooks    = array(
+			array(
+				'type'     => 'action',
+				'name'     => 'network_admin_menu',
+				'priority' => 10,
+				'callback' => array( $instance, 'register_page' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'network_admin_edit_' . Network::EDIT_ACTION,
+				'priority' => 10,
+				'callback' => array( $instance, 'handle_save' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'network_admin_edit_' . Network::VALUES_EDIT_ACTION,
+				'priority' => 10,
+				'callback' => array( $instance, 'handle_values_save' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'admin_notices',
+				'priority' => 10,
+				'callback' => array( $instance, 'subsite_inheritance_notice' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'admin_head',
+				'priority' => 10,
+				'callback' => array( $instance, 'print_inherited_styles' ),
+			),
+		);
+
+		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * Coverage for get_default_config.
+	 *
+	 * @covers ::get_default_config
+	 *
+	 * @return void
+	 */
+	public function test_get_default_config(): void {
+		$this->assertSame(
+			array(
+				'enabled'   => false,
+				'inherited' => array(),
+			),
+			Network::get_default_config()
+		);
+	}
+
+	/**
+	 * Coverage for get_config when the site option is empty — returns defaults.
+	 *
+	 * @covers ::get_config
+	 *
+	 * @return void
+	 */
+	public function test_get_config_returns_defaults_when_unset(): void {
+		$this->assertSame( Network::get_default_config(), Network::get_config() );
+	}
+
+	/**
+	 * Coverage for get_config when stored value is not an array — returns defaults.
+	 *
+	 * @covers ::get_config
+	 *
+	 * @return void
+	 */
+	public function test_get_config_returns_defaults_when_stored_is_not_array(): void {
+		update_site_option( Network::OPTION_NAME, 'not-an-array' );
+
+		$this->assertSame( Network::get_default_config(), Network::get_config() );
+	}
+
+	/**
+	 * Coverage for get_config when stored config merges over defaults.
+	 *
+	 * @covers ::get_config
+	 *
+	 * @return void
+	 */
+	public function test_get_config_merges_stored_over_defaults(): void {
+		update_site_option(
+			Network::OPTION_NAME,
+			array(
+				'enabled'   => true,
+				'inherited' => array( 'date_format' ),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'enabled'   => true,
+				'inherited' => array( 'date_format' ),
+			),
+			Network::get_config()
+		);
+	}
+
+	/**
+	 * Coverage for sanitize with a fully populated valid input.
+	 *
+	 * @covers ::sanitize
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_valid_input(): void {
+		$instance = Network::get_instance();
+
+		$result = $instance->sanitize(
+			array(
+				'enabled'   => '1',
+				'inherited' => array( 'date_format', 'time_format', 'date_format' ),
+			)
+		);
+
+		$this->assertTrue( $result['enabled'] );
+		$this->assertSame( array( 'date_format', 'time_format' ), $result['inherited'] );
+	}
+
+	/**
+	 * Coverage for sanitize with a non-array input (robustness check).
+	 *
+	 * @covers ::sanitize
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_non_array_input_defaults(): void {
+		$instance = Network::get_instance();
+
+		$this->assertSame(
+			array(
+				'enabled'   => false,
+				'inherited' => array(),
+			),
+			$instance->sanitize( 'garbage' )
+		);
+	}
+
+	/**
+	 * Coverage for sanitize with empty strings filtered out of the inherited list.
+	 *
+	 * @covers ::sanitize
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_filters_empty_keys(): void {
+		$instance = Network::get_instance();
+
+		$result = $instance->sanitize(
+			array(
+				'enabled'   => true,
+				'inherited' => array( 'date_format', '', '   ', 'time_format' ),
+			)
+		);
+
+		$this->assertSame( array( 'date_format', 'time_format' ), $result['inherited'] );
+	}
+
+	/**
+	 * Coverage for build_field_type_map — uses reflection to invoke the protected
+	 * method.
+	 *
+	 * @covers ::build_field_type_map
+	 *
+	 * @return void
+	 */
+	public function test_build_field_type_map(): void {
+		$instance   = Network::get_instance();
+		$reflection = new ReflectionClass( $instance );
+		$method     = $reflection->getMethod( 'build_field_type_map' );
+		$method->setAccessible( true );
+
+		$sub_pages = array(
+			'events'       => array(
+				'name'     => 'Events',
+				'sections' => array(
+					'date_time'       => array(
+						'options' => array(
+							'date_format'   => array( 'field' => array( 'type' => 'text' ) ),
+							'show_timezone' => array( 'field' => array( 'type' => 'checkbox' ) ),
+						),
+					),
+					'no_options_here' => array(),
+				),
+			),
+			'no_sections'  => array( 'name' => 'Empty' ),
+			'skip_section' => array(
+				'name'     => 'Skip',
+				'sections' => array(
+					'empty_section' => array(),
+				),
+			),
+		);
+
+		$this->assertSame(
+			array(
+				'date_format'   => 'text',
+				'show_timezone' => 'checkbox',
+			),
+			$method->invoke( $instance, $sub_pages )
+		);
+	}
+
+	/**
+	 * Coverage for route_read_to_site_option — always returns the site option
+	 * regardless of the pre value.
+	 *
+	 * @covers ::route_read_to_site_option
+	 *
+	 * @return void
+	 */
+	public function test_route_read_to_site_option(): void {
+		update_site_option( Settings::OPTION_NAME, array( 'date_format' => 'Y-m-d' ) );
+
+		$instance = Network::get_instance();
+
+		$this->assertSame(
+			array( 'date_format' => 'Y-m-d' ),
+			$instance->route_read_to_site_option( 'ignored' )
+		);
+
+		delete_site_option( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Coverage for get_current_tab — falls back to first key when no tab is
+	 * supplied, returns the tab when present in the sub-pages list.
+	 *
+	 * @covers ::get_current_tab
+	 *
+	 * @return void
+	 */
+	public function test_get_current_tab(): void {
+		$instance   = Network::get_instance();
+		$reflection = new ReflectionClass( $instance );
+		$method     = $reflection->getMethod( 'get_current_tab' );
+		$method->setAccessible( true );
+
+		$sub_pages = array(
+			'network' => array(),
+			'events'  => array(),
+		);
+
+		// No tab in $_GET → falls back to first key.
+		unset( $_GET['tab'] );
+		$this->assertSame( 'network', $method->invoke( $instance, $sub_pages ) );
+
+		// Valid tab in $_GET.
+		$_GET['tab'] = 'events';
+		$this->assertSame( 'events', $method->invoke( $instance, $sub_pages ) );
+
+		// Unknown tab in $_GET → falls back to first key.
+		$_GET['tab'] = 'nonexistent';
+		$this->assertSame( 'network', $method->invoke( $instance, $sub_pages ) );
+
+		unset( $_GET['tab'] );
+	}
+
+	/**
+	 * Coverage for get_network_sub_pages — drops Tools and injects Network tab.
+	 *
+	 * @covers ::get_network_sub_pages
+	 *
+	 * @return void
+	 */
+	public function test_get_network_sub_pages_drops_tools_and_adds_network(): void {
+		$instance   = Network::get_instance();
+		$reflection = new ReflectionClass( $instance );
+		$method     = $reflection->getMethod( 'get_network_sub_pages' );
+		$method->setAccessible( true );
+
+		$filter = static function (): array {
+			return array(
+				'events' => array(
+					'name'     => 'Events',
+					'priority' => 0,
+					'sections' => array(),
+				),
+				'tools'  => array(
+					'name'     => 'Tools',
+					'priority' => 10,
+					'sections' => array(),
+				),
+			);
+		};
+
+		add_filter( 'gatherpress_sub_pages', $filter, 100 );
+		$result = $method->invoke( $instance );
+		remove_filter( 'gatherpress_sub_pages', $filter, 100 );
+
+		$this->assertArrayNotHasKey( 'tools', $result );
+		$this->assertArrayHasKey( 'network', $result );
+	}
+
+	/**
+	 * Coverage for subsite_inheritance_notice on the main site (never shows).
+	 *
+	 * @covers ::subsite_inheritance_notice
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_subsite_inheritance_notice_bails_on_main_site(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$instance = Network::get_instance();
+		$output   = PMC_Utility::buffer_and_return( array( $instance, 'subsite_inheritance_notice' ) );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Coverage for subsite_inheritance_notice when not on a GatherPress page.
+	 *
+	 * @covers ::subsite_inheritance_notice
+	 *
+	 * @return void
+	 */
+	public function test_subsite_inheritance_notice_bails_on_non_gatherpress_page(): void {
+		$instance = Network::get_instance();
+
+		$_GET['page'] = 'something-else';
+
+		$output = PMC_Utility::buffer_and_return( array( $instance, 'subsite_inheritance_notice' ) );
+
+		unset( $_GET['page'] );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Coverage for print_inherited_styles — only emits on GatherPress pages.
+	 *
+	 * @covers ::print_inherited_styles
+	 *
+	 * @return void
+	 */
+	public function test_print_inherited_styles_bails_on_non_gatherpress_page(): void {
+		$instance = Network::get_instance();
+
+		unset( $_GET['page'] );
+
+		$output = PMC_Utility::buffer_and_return( array( $instance, 'print_inherited_styles' ) );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Coverage for print_inherited_styles — emits a style block on GatherPress pages.
+	 *
+	 * @covers ::print_inherited_styles
+	 *
+	 * @return void
+	 */
+	public function test_print_inherited_styles_emits_on_gatherpress_page(): void {
+		$instance     = Network::get_instance();
+		$_GET['page'] = 'gatherpress_general';
+
+		$output = PMC_Utility::buffer_and_return( array( $instance, 'print_inherited_styles' ) );
+
+		unset( $_GET['page'] );
+
+		$this->assertStringContainsString( '.gatherpress-field-inherited', $output );
+	}
+
+	/**
+	 * Coverage for scope_read_filter — registers the pre_option filter.
+	 *
+	 * @covers ::scope_read_filter
+	 *
+	 * @return void
+	 */
+	public function test_scope_read_filter_registers_filter(): void {
+		$instance = Network::get_instance();
+		$instance->scope_read_filter();
+
+		$this->assertNotFalse(
+			has_filter(
+				'pre_option_' . Settings::OPTION_NAME,
+				array( $instance, 'route_read_to_site_option' )
+			)
+		);
+
+		remove_filter(
+			'pre_option_' . Settings::OPTION_NAME,
+			array( $instance, 'route_read_to_site_option' )
+		);
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
@@ -351,17 +351,15 @@ class Test_Network extends Base {
 	}
 
 	/**
-	 * Coverage for subsite_inheritance_notice on the main site (never shows).
+	 * Coverage for subsite_inheritance_notice when not on multisite.
 	 *
 	 * @covers ::subsite_inheritance_notice
 	 *
-	 * @group   multisite
-	 *
 	 * @return void
 	 */
-	public function test_subsite_inheritance_notice_bails_on_main_site(): void {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Requires multisite.' );
+	public function test_subsite_inheritance_notice_bails_when_not_multisite(): void {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Single-site only.' );
 		}
 
 		$instance = Network::get_instance();
@@ -447,4 +445,281 @@ class Test_Network extends Base {
 			array( $instance, 'route_read_to_site_option' )
 		);
 	}
+
+	/**
+	 * Coverage for subsite_inheritance_notice rendering for a super admin — the
+	 * second sentence (network link) should be present.
+	 *
+	 * @covers ::subsite_inheritance_notice
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_subsite_inheritance_notice_renders_for_super_admin(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		update_site_option(
+			Network::OPTION_NAME,
+			array(
+				'enabled'   => true,
+				'inherited' => array( 'date_format' ),
+			)
+		);
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		$_GET['page'] = 'gatherpress_general';
+
+		$instance = Network::get_instance();
+		$output   = PMC_Utility::buffer_and_return( array( $instance, 'subsite_inheritance_notice' ) );
+
+		unset( $_GET['page'] );
+		revoke_super_admin( $user_id );
+		wp_delete_user( $user_id );
+
+		$this->assertStringContainsString(
+			'Some GatherPress settings on this site are inherited from the network.',
+			$output
+		);
+		$this->assertStringContainsString( 'Network Admin → Settings → GatherPress', $output );
+	}
+
+	/**
+	 * Coverage for subsite_inheritance_notice rendering for a regular admin —
+	 * first sentence only (no link, since they can't act on it).
+	 *
+	 * @covers ::subsite_inheritance_notice
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_subsite_inheritance_notice_renders_for_regular_admin(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		update_site_option(
+			Network::OPTION_NAME,
+			array(
+				'enabled'   => true,
+				'inherited' => array( 'date_format' ),
+			)
+		);
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$_GET['page'] = 'gatherpress_general';
+
+		$instance = Network::get_instance();
+		$output   = PMC_Utility::buffer_and_return( array( $instance, 'subsite_inheritance_notice' ) );
+
+		unset( $_GET['page'] );
+		wp_delete_user( $user_id );
+
+		$this->assertStringContainsString(
+			'Some GatherPress settings on this site are inherited from the network.',
+			$output
+		);
+		$this->assertStringNotContainsString( 'Network Admin → Settings → GatherPress', $output );
+	}
+
+	/**
+	 * Coverage for subsite_inheritance_notice when no options actually resolve
+	 * as locked for the current site — nothing to tell the user, so bail.
+	 *
+	 * @covers ::subsite_inheritance_notice
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_subsite_inheritance_notice_bails_when_nothing_locked(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		update_site_option(
+			Network::OPTION_NAME,
+			array(
+				'enabled'   => true,
+				'inherited' => array( 'date_format' ),
+			)
+		);
+
+		$_GET['page'] = 'gatherpress_general';
+
+		// Filter exempts every option so `is_option_inherited` always returns
+		// false for this site.
+		$filter = static function (): bool {
+			return false;
+		};
+		add_filter( 'gatherpress_network_is_option_inherited', $filter );
+
+		$instance = Network::get_instance();
+		$output   = PMC_Utility::buffer_and_return( array( $instance, 'subsite_inheritance_notice' ) );
+
+		remove_filter( 'gatherpress_network_is_option_inherited', $filter );
+		unset( $_GET['page'] );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Coverage for subsite_inheritance_notice when the feature is disabled.
+	 *
+	 * @covers ::subsite_inheritance_notice
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_subsite_inheritance_notice_bails_when_feature_disabled(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		update_site_option(
+			Network::OPTION_NAME,
+			array(
+				'enabled'   => false,
+				'inherited' => array( 'date_format' ),
+			)
+		);
+
+		$_GET['page'] = 'gatherpress_general';
+
+		$instance = Network::get_instance();
+		$output   = PMC_Utility::buffer_and_return( array( $instance, 'subsite_inheritance_notice' ) );
+
+		unset( $_GET['page'] );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Coverage for register_page — adds the Network Admin submenu.
+	 *
+	 * @covers ::register_page
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_register_page_adds_submenu(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		global $submenu;
+		$submenu = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Isolate test state.
+
+		$instance = Network::get_instance();
+		$instance->register_page();
+
+		$this->assertArrayHasKey( 'settings.php', $submenu );
+
+		$slugs = array_column( $submenu['settings.php'], 2 );
+		$this->assertContains( Network::PAGE_SLUG, $slugs );
+
+		revoke_super_admin( $user_id );
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Coverage for maybe_redirect_to_default_tab when a tab is already set —
+	 * method returns without redirecting.
+	 *
+	 * @covers ::maybe_redirect_to_default_tab
+	 *
+	 * @return void
+	 */
+	public function test_maybe_redirect_to_default_tab_skips_when_tab_set(): void {
+		$_GET['tab'] = 'events';
+
+		$instance = Network::get_instance();
+		$instance->maybe_redirect_to_default_tab(); // Does not exit.
+
+		unset( $_GET['tab'] );
+
+		$this->assertTrue( true ); // Reached — no exit.
+	}
+
+	/**
+	 * Coverage for render_page when the current user lacks the required
+	 * capability — calls wp_die.
+	 *
+	 * @covers ::render_page
+	 *
+	 * @return void
+	 */
+	public function test_render_page_wp_dies_without_capability(): void {
+		$user_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$instance = Network::get_instance();
+
+		$this->expectException( \WPDieException::class );
+
+		try {
+			$instance->render_page();
+		} finally {
+			wp_delete_user( $user_id );
+		}
+	}
+
+	/**
+	 * Coverage for handle_save wp_die path (no capability).
+	 *
+	 * @covers ::handle_save
+	 *
+	 * @return void
+	 */
+	public function test_handle_save_wp_dies_without_capability(): void {
+		$user_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$instance = Network::get_instance();
+
+		$this->expectException( \WPDieException::class );
+
+		try {
+			$instance->handle_save();
+		} finally {
+			wp_delete_user( $user_id );
+		}
+	}
+
+	/**
+	 * Coverage for handle_values_save wp_die path (no capability).
+	 *
+	 * @covers ::handle_values_save
+	 *
+	 * @return void
+	 */
+	public function test_handle_values_save_wp_dies_without_capability(): void {
+		$user_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$instance = Network::get_instance();
+
+		$this->expectException( \WPDieException::class );
+
+		try {
+			$instance->handle_values_save();
+		} finally {
+			wp_delete_user( $user_id );
+		}
+	}
+
 }

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
@@ -120,6 +120,7 @@ class Test_Network extends Base {
 		}
 
 		update_site_option( Network::OPTION_NAME, 'not-an-array' );
+		Network::flush_config_cache();
 
 		$this->assertSame( Network::get_default_config(), Network::get_config() );
 	}
@@ -145,6 +146,7 @@ class Test_Network extends Base {
 				'inherited' => array( 'date_format' ),
 			)
 		);
+		Network::flush_config_cache();
 
 		$this->assertSame(
 			array(
@@ -377,9 +379,15 @@ class Test_Network extends Base {
 	 *
 	 * @covers ::subsite_inheritance_notice
 	 *
+	 * @group   multisite
+	 *
 	 * @return void
 	 */
 	public function test_subsite_inheritance_notice_bails_on_non_gatherpress_page(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
 		$instance = Network::get_instance();
 
 		$_GET['page'] = 'something-else';

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-tools.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-tools.php
@@ -357,4 +357,95 @@ class Test_Tools extends Base_Ajax {
 			unset( $_POST['nonce'], $_POST['settings_json'] );
 		}
 	}
+
+	/**
+	 * Coverage for ajax_export in the network scope — reads the network
+	 * site option rather than the blog option.
+	 *
+	 * @covers ::ajax_export
+	 * @covers ::resolve_scope
+	 * @covers ::capability_for_scope
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_ajax_export_network_scope(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		update_site_option( 'gatherpress_settings', array( 'map_platform' => 'google' ) );
+
+		$_POST['nonce'] = wp_create_nonce( 'gatherpress_tools_nonce' );
+		$_POST['scope'] = 'network';
+
+		$response = $this->do_ajax( 'gatherpress_export_settings' );
+
+		$this->assertTrue( $response->success, 'Network-scope export should succeed.' );
+		$this->assertSame( 'network', $response->data->scope, 'Response should reflect network scope.' );
+		$this->assertSame(
+			'google',
+			$response->data->settings->map_platform,
+			'Exported value should come from the site option.'
+		);
+
+		delete_site_option( 'gatherpress_settings' );
+		revoke_super_admin( $user_id );
+		wp_delete_user( $user_id );
+		unset( $_POST['nonce'], $_POST['scope'] );
+	}
+
+	/**
+	 * Coverage for ajax_import in the network scope — writes to the site
+	 * option, not the blog option, and flushes the Network config cache.
+	 *
+	 * @covers ::ajax_import
+	 * @covers ::resolve_scope
+	 *
+	 * @group   multisite
+	 *
+	 * @return void
+	 */
+	public function test_ajax_import_network_scope(): void {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Requires multisite.' );
+		}
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		$payload = array(
+			'version'     => '1.0.0',
+			'exported_at' => '2026-01-01T00:00:00Z',
+			'scope'       => 'network',
+			'settings'    => array( 'map_platform' => 'google' ),
+		);
+
+		$_POST['nonce']         = wp_create_nonce( 'gatherpress_tools_nonce' );
+		$_POST['scope']         = 'network';
+		$_POST['settings_json'] = wp_json_encode( $payload );
+		$_POST['import_mode']   = 'merge';
+
+		$response = $this->do_ajax( 'gatherpress_import_settings' );
+
+		$this->assertTrue( $response->success, 'Network-scope import should succeed.' );
+
+		$stored = get_site_option( 'gatherpress_settings' );
+		$this->assertSame(
+			'google',
+			$stored['map_platform'] ?? null,
+			'Imported value should be written to the site option.'
+		);
+
+		delete_site_option( 'gatherpress_settings' );
+		revoke_super_admin( $user_id );
+		wp_delete_user( $user_id );
+		unset( $_POST['nonce'], $_POST['scope'], $_POST['settings_json'], $_POST['import_mode'] );
+	}
 }


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change

Adds network-wide GatherPress settings for WordPress multisite, plus a handful of multisite-adjacent bug fixes surfaced while building it.

**Network-wide settings (main objective)**

- New `Network Admin → Settings → GatherPress` page that mirrors the per-site Settings (Events, Venues, Roles, RSVP, Credits) under a tabbed UI plus a dedicated **Network** tab.
- The Network tab holds the inheritance allowlist: a master toggle and a per-option checklist grouped by sub-page / section. Select-all and per-group select/deselect shortcuts included.
- Values set on the network admin tabs save to the network-wide `gatherpress_settings` site option via `update_site_option`. A `pre_option_gatherpress_settings` filter scoped to the network admin screen (via `load-{hook}`) routes reads transparently so the existing Settings class is unchanged.
- Subsite resolver: `Settings::get( $option )` checks `is_option_inherited( $option )` and, when true, reads from the site option instead of the blog option. An escape-hatch filter `gatherpress_network_is_option_inherited( $inherited, $option, $blog_id )` lets a companion plugin exempt a specific site.
- Subsite UX when an option is locked:
  - The field is rendered disabled + dimmed (`.gatherpress-field-inherited` wrapper, native `disabled` attribute on `input`/`select`) and shows the current network value.
  - Per-field note underneath. Super admins get `"Inherited from the [network]. Edit there to change this value."` with a link; regular site admins get `"Inherited from the network."` (no dead-end link).
  - Page-level admin notice on any GatherPress settings page. Everyone sees the first sentence; only users with `manage_network_options` see the appended `"Locked fields can only be changed from [Network Admin → Settings → GatherPress]."` sentence.
- `manage_network_options` capability gate on the network admin page; saves run through dedicated `network_admin_edit_*` handlers with per-action nonces.

**Multisite bug fixes landed along the way**

- **Missing `{prefix}gatherpress_events` table on subsites.** `on_site_create` was gated on `is_plugin_active_for_network()`, which can be unavailable depending on the context that creates the site (CLI, REST, early hooks). Now loads `wp-admin/includes/plugin.php` when needed and uses `plugin_basename( GATHERPRESS_CORE_FILE )` instead of a hard-coded path. `check_plugin_version` also auto-heals any subsite where the `gatherpress_version` option doesn't match current, running `create_tables()` idempotently via `dbDelta`.
- **`DateTimeZone('UTC+0')` 500 on save.** `Utility::get_system_timezone()` used to emit invalid WP-style strings like `UTC+0` / `UTC+5`. Rewrote it to return a PHP-valid identifier via a new `Utility::offset_to_timezone_string()`. Added `Utility::normalize_timezone_string()` to sanitize any legacy values already stored in event meta, and wrapped the `DateTimeZone` constructor calls in `class-event.php` through it.
- **`Moment Timezone has no data for UTC+0` console spam in the block editor on a fresh WordPress install.** Added an inline shim (`Assets::enqueue_timezone_shim()`) that runs after `wp-date`'s `setSettings` call and rewrites `UTC+0` / `UTC-0` → `UTC` before Gutenberg's `panels.js` reads it.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change

Multisite verification:

1. On the main site, visit **Network Admin → Settings → GatherPress**. Confirm the tab row (Events / Venues / Roles / RSVP / Credits / Network), that Tools is omitted, and that the sidebar `GatherPress` link lands you on the Network tab.
2. On the Network tab, toggle `Enable` and check a handful of options (e.g. `date_format`, `show_timezone`). Use the top-of-page `Select all` / `Deselect all` and the per-sub-page toggles to verify the bulk helpers. Save.
3. On one of the other tabs, set a distinctive value (e.g. custom `Date Format`). Save.
4. Visit a subsite's `Events → Settings` page as a super admin:
   - Notice banner appears with both sentences and a link to network admin.
   - The fields you marked inherited are disabled, dimmed, showing the network value, with the per-field `Inherited from the [network]…` link.
   - Fields you didn't mark remain editable.
5. Log in to the same subsite as a regular site admin:
   - Notice banner shows only the first sentence (no network link).
   - Per-field notes show plain `"Inherited from the network."`.
6. Register a companion-plugin filter for `gatherpress_network_is_option_inherited` that returns `false` for one `(blog_id, option)` pair. Confirm that field renders fully editable on that site.

Multisite bug verification:

1. Create a new subsite (or visit a subsite whose `wp_<n>_gatherpress_events` table is missing). Load the admin at least once and confirm the table is created by the auto-heal. Event list now shows events (previously the JOIN against the missing table made the list appear empty while counts still showed rows).
2. With the main site set to Settings → General → `UTC+0`, save an event. Confirm no `DateTimeZone::__construct` 500 and no console warnings from `panels.js` / `date.min.js`.
3. Run Alpha's **Apply Updates** at network admin — confirm it iterates each site and completes without a fatal.

### Changelog Entry

> Added - Network-wide GatherPress settings with per-option inheritance control at `Network Admin → Settings → GatherPress`.
> Fixed - Missing `gatherpress_events` table on multisite subsites now auto-heals on admin load.
> Fixed - Saving events with a `UTC+0` / `UTC+N` timezone no longer raises a PHP fatal.
> Fixed - `Moment Timezone has no data for UTC+0` warning from the block editor on fresh WordPress installs.

### Credits

Props @mauteri, @carstingaxion (inspiration + messaging from [#917](https://github.com/GatherPress/gatherpress/pull/917)).

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.