### PR TITLE
Expose gatherpress_venue_map_prewarm_pre_enqueue_job filter; slim Settings instantiation

### DIFF
--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -14,7 +14,6 @@ namespace GatherPress\Core;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-use GatherPress\Core\Settings\Network;
 use GatherPress\Core\Traits\Singleton;
 
 /**
@@ -97,7 +96,32 @@ class Settings {
 	 */
 	protected function __construct() {
 		$this->set_current_page();
+		$this->instantiate_classes();
 		$this->setup_hooks();
+	}
+
+	/**
+	 * Instantiate each settings-page subclass.
+	 *
+	 * Method name mirrors `Setup::instantiate_classes()` so the pattern
+	 * is consistent top-to-bottom: every class that owns a set of
+	 * singletons calls them `instantiate_classes()`. Keeps
+	 * `Setup::instantiate_classes()` slim — a new settings page lands as
+	 * a single added line here rather than edits to Setup. Each subclass
+	 * is a singleton, so repeat calls are safe.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function instantiate_classes(): void {
+		Settings\Credits::get_instance();
+		Settings\Events::get_instance();
+		Settings\Network::get_instance();
+		Settings\Roles::get_instance();
+		Settings\Rsvp_Settings::get_instance();
+		Settings\Tools::get_instance();
+		Settings\Venues::get_instance();
 	}
 
 	/**
@@ -651,7 +675,7 @@ class Settings {
 							'<a href="%s">%s</a>',
 							esc_url(
 								network_admin_url(
-									sprintf( 'settings.php?page=%s', Network::PAGE_SLUG )
+									sprintf( 'settings.php?page=%s', Settings\Network::PAGE_SLUG )
 								)
 							),
 							esc_html__( 'network', 'gatherpress' )
@@ -754,7 +778,7 @@ class Settings {
 		// is the network admin settings page itself, where super admins edit
 		// the network values — fields there must remain fully editable.
 		if ( is_multisite() && ! is_network_admin() ) {
-			$config = Network::get_config();
+			$config = Settings\Network::get_config();
 
 			if ( ! empty( $config['enabled'] ) ) {
 				$inherited = in_array( $option, (array) ( $config['inherited'] ?? array() ), true );
@@ -1199,7 +1223,7 @@ class Settings {
 		$this->write_stored_options( $scope, $sanitized );
 
 		if ( 'network' === $scope ) {
-			Network::flush_config_cache();
+			Settings\Network::flush_config_cache();
 		}
 
 		$result['success']  = true;

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -72,13 +72,6 @@ class Setup {
 		Rsvp_Query::get_instance();
 		Rsvp_Setup::get_instance();
 		Settings::get_instance();
-		Settings\Credits::get_instance();
-		Settings\Events::get_instance();
-		Settings\Network::get_instance();
-		Settings\Roles::get_instance();
-		Settings\Rsvp_Settings::get_instance();
-		Settings\Tools::get_instance();
-		Settings\Venues::get_instance();
 		Topic::get_instance();
 		User::get_instance();
 		Venue_Map::get_instance();

--- a/includes/core/classes/class-venue-map-prewarm.php
+++ b/includes/core/classes/class-venue-map-prewarm.php
@@ -323,7 +323,7 @@ class Venue_Map_Prewarm {
 	 * Schedule a single warm job, deduped via wp_next_scheduled().
 	 *
 	 * The actual scheduling is wrapped in the
-	 * {@see 'gatherpress_pre_prewarm_enqueue_job'} short-circuit filter so
+	 * {@see 'gatherpress_venue_map_prewarm_pre_enqueue_job'} short-circuit filter so
 	 * a companion plugin (e.g. "GatherPress at Scale") can intercept and
 	 * route the fanout through Action Scheduler — or any other queue —
 	 * without touching core. Returning a non-null value from the filter
@@ -365,7 +365,7 @@ class Venue_Map_Prewarm {
 		 *                              `array( $venue_post_id, $zoom, $width, $height, $aspect_ratio )`.
 		 */
 		$short_circuit = apply_filters(
-			'gatherpress_pre_prewarm_enqueue_job',
+			'gatherpress_venue_map_prewarm_pre_enqueue_job',
 			null,
 			self::CRON_ACTION,
 			$args

--- a/includes/core/classes/class-venue-map-prewarm.php
+++ b/includes/core/classes/class-venue-map-prewarm.php
@@ -322,6 +322,13 @@ class Venue_Map_Prewarm {
 	/**
 	 * Schedule a single warm job, deduped via wp_next_scheduled().
 	 *
+	 * The actual scheduling is wrapped in the
+	 * {@see 'gatherpress_pre_prewarm_enqueue_job'} short-circuit filter so
+	 * a companion plugin (e.g. "GatherPress at Scale") can intercept and
+	 * route the fanout through Action Scheduler — or any other queue —
+	 * without touching core. Returning a non-null value from the filter
+	 * suppresses the default WP-Cron path.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param int                                                      $venue_post_id Venue post ID.
@@ -336,6 +343,37 @@ class Venue_Map_Prewarm {
 			(int) $combo['height'],
 			(string) $combo['aspect_ratio'],
 		);
+
+		/**
+		 * Filter the prewarm enqueue call to take over scheduling.
+		 *
+		 * Return any non-null value from this filter to suppress the
+		 * default WP-Cron path so a companion plugin can enqueue the
+		 * same work through Action Scheduler or another persistent
+		 * queue. The returned value is not used by core — it's only
+		 * inspected for `null` vs. non-null — so a callback can return
+		 * anything meaningful to itself (e.g. an AS action ID).
+		 *
+		 * Mirrors the core `pre_*` filter convention (`pre_update_option`,
+		 * `pre_set_site_transient`, etc.).
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param mixed  $short_circuit Non-null to suppress the default enqueue.
+		 * @param string $hook          Action hook name fired when the job runs.
+		 * @param array  $args          Args passed to the action hook when the job runs:
+		 *                              `array( $venue_post_id, $zoom, $width, $height, $aspect_ratio )`.
+		 */
+		$short_circuit = apply_filters(
+			'gatherpress_pre_prewarm_enqueue_job',
+			null,
+			self::CRON_ACTION,
+			$args
+		);
+
+		if ( null !== $short_circuit ) {
+			return;
+		}
 
 		if ( false !== wp_next_scheduled( self::CRON_ACTION, $args ) ) {
 			return;

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -35,7 +35,11 @@ class Test_Settings extends Base {
 	 * @return void
 	 */
 	public function test_instantiate_classes_registers_subclasses(): void {
-		Settings::get_instance();
+		// Force the method to run inside the test's coverage window —
+		// Settings is a singleton cached during plugin bootstrap, so
+		// `get_instance()` here just returns the cached instance and
+		// doesn't re-fire the constructor.
+		Utility::invoke_hidden_method( Settings::get_instance(), 'instantiate_classes' );
 
 		$this->assertSame(
 			10,

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -20,6 +20,33 @@ use PMC\Unit_Test\Utility;
  */
 class Test_Settings extends Base {
 	/**
+	 * Settings now owns the instantiation of every settings-page subclass
+	 * (Credits, Events, Network, Roles, Rsvp_Settings, Tools, Venues) so
+	 * `Setup::instantiate_classes()` can hand off with a single
+	 * `Settings::get_instance()` call. Checks the subclass registrations
+	 * landed — `Credits` is the proxy: its constructor wires an
+	 * `admin_init` action, and that action is only present if
+	 * `Settings::instantiate_classes()` instantiated it.
+	 *
+	 * @covers ::__construct
+	 * @covers ::instantiate_classes
+	 *
+	 * @return void
+	 */
+	public function test_instantiate_classes_registers_subclasses(): void {
+		Settings::get_instance();
+
+		$this->assertSame(
+			10,
+			has_action(
+				'admin_init',
+				array( \GatherPress\Core\Settings\Credits::get_instance(), 'init' )
+			),
+			'Settings::instantiate_classes() must instantiate each subclass so its hooks register.'
+		);
+	}
+
+	/**
 	 * Coverage for setup_hooks.
 	 *
 	 * @covers ::__construct

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -9,6 +9,7 @@
 namespace GatherPress\Tests\Core;
 
 use GatherPress\Core\Settings;
+use GatherPress\Core\Settings\Credits;
 use GatherPress\Core\Utility as GatherPress_Utility;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
@@ -40,7 +41,7 @@ class Test_Settings extends Base {
 			10,
 			has_action(
 				'admin_init',
-				array( \GatherPress\Core\Settings\Credits::get_instance(), 'init' )
+				array( Credits::get_instance(), 'init' )
 			),
 			'Settings::instantiate_classes() must instantiate each subclass so its hooks register.'
 		);

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -277,7 +277,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	}
 
 	/**
-	 * A non-null return from the `gatherpress_pre_prewarm_enqueue_job`
+	 * A non-null return from the `gatherpress_venue_map_prewarm_pre_enqueue_job`
 	 * filter must suppress the default WP-Cron enqueue so a companion
 	 * plugin can route the fanout through its own queue (e.g. Action
 	 * Scheduler). The filter receives the hook name and args for routing
@@ -307,11 +307,11 @@ class Test_Venue_Map_Prewarm extends Base {
 			// action ID or similar; core only cares that it's not null.
 			return 'handled-by-companion';
 		};
-		add_filter( 'gatherpress_pre_prewarm_enqueue_job', $spy, 10, 3 );
+		add_filter( 'gatherpress_venue_map_prewarm_pre_enqueue_job', $spy, 10, 3 );
 
 		Utility::invoke_hidden_method( $instance, 'enqueue_warm_job', array( $venue_post_id, $combo ) );
 
-		remove_filter( 'gatherpress_pre_prewarm_enqueue_job', $spy, 10 );
+		remove_filter( 'gatherpress_venue_map_prewarm_pre_enqueue_job', $spy, 10 );
 
 		$this->assertFalse(
 			wp_next_scheduled(
@@ -351,11 +351,11 @@ class Test_Venue_Map_Prewarm extends Base {
 		$passthrough = static function ( $short_circuit ) {
 			return $short_circuit;
 		};
-		add_filter( 'gatherpress_pre_prewarm_enqueue_job', $passthrough );
+		add_filter( 'gatherpress_venue_map_prewarm_pre_enqueue_job', $passthrough );
 
 		Utility::invoke_hidden_method( $instance, 'enqueue_warm_job', array( $venue_post_id, $combo ) );
 
-		remove_filter( 'gatherpress_pre_prewarm_enqueue_job', $passthrough );
+		remove_filter( 'gatherpress_venue_map_prewarm_pre_enqueue_job', $passthrough );
 
 		$this->assertNotFalse(
 			wp_next_scheduled(

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-map-prewarm.php
@@ -277,6 +277,96 @@ class Test_Venue_Map_Prewarm extends Base {
 	}
 
 	/**
+	 * A non-null return from the `gatherpress_pre_prewarm_enqueue_job`
+	 * filter must suppress the default WP-Cron enqueue so a companion
+	 * plugin can route the fanout through its own queue (e.g. Action
+	 * Scheduler). The filter receives the hook name and args for routing
+	 * decisions.
+	 *
+	 * @covers ::enqueue_warm_job
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_warm_job_filter_short_circuits_wp_cron_path(): void {
+		$instance      = Venue_Map_Prewarm::get_instance();
+		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+		$combo         = array(
+			'zoom'         => 15,
+			'width'        => 800,
+			'height'       => 400,
+			'aspect_ratio' => '2/1',
+		);
+
+		$seen = array();
+		$spy  = static function ( $short_circuit, $hook, $args ) use ( &$seen ) {
+			$seen[] = array(
+				'hook' => $hook,
+				'args' => $args,
+			);
+			// Non-null return value. Companion plugins would return an AS
+			// action ID or similar; core only cares that it's not null.
+			return 'handled-by-companion';
+		};
+		add_filter( 'gatherpress_pre_prewarm_enqueue_job', $spy, 10, 3 );
+
+		Utility::invoke_hidden_method( $instance, 'enqueue_warm_job', array( $venue_post_id, $combo ) );
+
+		remove_filter( 'gatherpress_pre_prewarm_enqueue_job', $spy, 10 );
+
+		$this->assertFalse(
+			wp_next_scheduled(
+				Venue_Map_Prewarm::CRON_ACTION,
+				array( $venue_post_id, 15, 800, 400, '2/1' )
+			),
+			'Default WP-Cron path must be suppressed when the filter returns non-null.'
+		);
+		$this->assertCount( 1, $seen, 'Filter is invoked exactly once per enqueue call.' );
+		$this->assertSame( Venue_Map_Prewarm::CRON_ACTION, $seen[0]['hook'] );
+		$this->assertSame(
+			array( $venue_post_id, 15, 800, 400, '2/1' ),
+			$seen[0]['args'],
+			'Filter receives the same args that the hook would have fired with.'
+		);
+	}
+
+	/**
+	 * Returning `null` (the default) from the filter must leave the
+	 * default WP-Cron behavior untouched — the whole point of the filter
+	 * is to be a no-op when nothing hooks it.
+	 *
+	 * @covers ::enqueue_warm_job
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_warm_job_filter_returning_null_preserves_default_path(): void {
+		$instance      = Venue_Map_Prewarm::get_instance();
+		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+		$combo         = array(
+			'zoom'         => 15,
+			'width'        => 800,
+			'height'       => 400,
+			'aspect_ratio' => '2/1',
+		);
+
+		$passthrough = static function ( $short_circuit ) {
+			return $short_circuit;
+		};
+		add_filter( 'gatherpress_pre_prewarm_enqueue_job', $passthrough );
+
+		Utility::invoke_hidden_method( $instance, 'enqueue_warm_job', array( $venue_post_id, $combo ) );
+
+		remove_filter( 'gatherpress_pre_prewarm_enqueue_job', $passthrough );
+
+		$this->assertNotFalse(
+			wp_next_scheduled(
+				Venue_Map_Prewarm::CRON_ACTION,
+				array( $venue_post_id, 15, 800, 400, '2/1' )
+			),
+			'Null return from the filter must fall through to wp_schedule_single_event().'
+		);
+	}
+
+	/**
 	 * Saving a venue post enqueues a warm job for that venue when any
 	 * template in the site references a venue-map combo. We simulate the
 	 * template existence by saving a wp_template first.


### PR DESCRIPTION
### Description of the Change

Two separable pieces land in this PR; both are small and both land together because they touch the same `Setup::instantiate_classes()` neighborhood.

**1. Expose `gatherpress_venue_map_prewarm_pre_enqueue_job` filter.**

`Venue_Map_Prewarm::enqueue_warm_job()` currently schedules each warm job via `wp_schedule_single_event( time() + 1, self::CRON_ACTION, $args )`. On a site with hundreds of venues and multiple template combos, a single `switch_theme` enqueues thousands of events at the same tick — WP-Cron then tries to drain them on the next pageview, which can time out. Action Scheduler solves this cleanly, but as discussed in closed PR #1503, we've decided **not** to bundle AS in core because it adds meaningful overhead (~500KB–1MB PHP memory per request, 4 DB tables, a Tools → Scheduled Actions admin page) that small sites never benefit from.

The replacement shape: keep WP-Cron as the core default, but **make the enqueue call hookable** so a future companion plugin ("GatherPress at Scale" or similar) can intercept and route through Action Scheduler without any core changes.

The implementation wraps the existing `wp_schedule_single_event()` call with a short-circuit filter:

```php
$short_circuit = apply_filters(
    'gatherpress_venue_map_prewarm_pre_enqueue_job',
    null,
    self::CRON_ACTION,
    $args
);

if ( null !== $short_circuit ) {
    return;
}

if ( false !== wp_next_scheduled( self::CRON_ACTION, $args ) ) {
    return;
}

wp_schedule_single_event( time() + 1, self::CRON_ACTION, $args );
```

The filter name follows the existing `gatherpress_venue_map_prewarm_*` convention in the class (batch_size, content_batch_size), then the core-style `pre_*` marker, then the action. A companion plugin registers:

```php
add_filter( 'gatherpress_venue_map_prewarm_pre_enqueue_job', function ( $short_circuit, $hook, $args ) {
    if ( null !== $short_circuit ) {
        return $short_circuit;
    }
    return as_enqueue_async_action( $hook, $args, 'gatherpress_prewarm' );
}, 10, 3 );
```

Returning anything non-null suppresses the default WP-Cron path. Core never inspects the return value beyond null-vs-not-null, so callbacks can return whatever makes sense (an AS action ID, true, anything).

**2. Move Settings subclass instantiation into `Settings::instantiate_classes()`.**

`Setup::instantiate_classes()` used to call every Settings subclass individually:

```php
Settings::get_instance();
Settings\Credits::get_instance();
Settings\Events::get_instance();
Settings\Network::get_instance();
Settings\Roles::get_instance();
Settings\Rsvp_Settings::get_instance();
Settings\Tools::get_instance();
Settings\Venues::get_instance();
```

Settings now owns that list via a new `instantiate_classes()` method on `class-settings.php` (matching the naming convention of `Setup::instantiate_classes()`). Setup drops to a single `Settings::get_instance()` line. Adding a new settings page lands as a single line in `Settings::instantiate_classes()` instead of two edits (one in Setup, one new class file). The existing `use GatherPress\Core\Settings\Network;` import also goes away — all subclass references now use relative namespace (`Settings\Credits::get_instance()`) from inside `namespace GatherPress\Core`.

Closes #1487

### How to test the Change

1. Check out the branch and run the full PHP test suite: `npm run test:unit:php` (default) and `npm run test:unit:php:multisite` — both should pass with no regressions. Two new prewarm tests and one new Settings test ride along.
2. Activate the plugin on a site with at least one venue that has a rendered venue-map block. Save the venue and confirm a WP-Cron event is scheduled as before (nothing regresses without a companion filter hooked):

   ```php
   var_dump( wp_next_scheduled( 'gatherpress_warm_venue_map', array( $venue_post_id, 18, 800, 300, '2/1' ) ) );
   ```
3. Drop this mu-plugin snippet in to exercise the filter short-circuit:

   ```php
   <?php
   add_filter( 'gatherpress_venue_map_prewarm_pre_enqueue_job', function ( $short_circuit, $hook, $args ) {
       error_log( sprintf( 'Prewarm intercepted: %s %s', $hook, wp_json_encode( $args ) ) );
       return 'handled';
   }, 10, 3 );
   ```

   Save a venue, confirm the `error_log` line appears, and verify no WP-Cron event was scheduled (`wp_next_scheduled` returns `false` for that signature).
4. Remove the mu-plugin; save the venue again; confirm the WP-Cron path resumes and the event is scheduled.
5. Confirm the Settings refactor didn't regress the admin pages: navigate to **Events > Settings** and click through General / Roles / Tools / Credits / Venues — each should render without errors, and network-admin settings (if running multisite) should still load at **Network Admin > Settings > GatherPress**.

### Changelog Entry

> Added - `gatherpress_venue_map_prewarm_pre_enqueue_job` short-circuit filter lets a companion plugin replace the venue-map prewarm's WP-Cron enqueue with Action Scheduler (or any other queue) without touching core.
> Changed - Internal: `Settings` now instantiates its own subclasses via `Settings::instantiate_classes()`, which slims `Setup::instantiate_classes()` and matches the established `Setup` naming convention.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
