### PR TITLE
Flatten Event_* into GatherPress\Core\Event subnamespace

### DIFF
--- a/.github/coverage-config.json
+++ b/.github/coverage-config.json
@@ -13,6 +13,7 @@
     "*/class-singleton.php",
     "*/requirements-check.php",
     "*/duplicate-check.php",
+    "*/register-class-aliases.php",
     "*/templates/*",
     "*/render.php",
     "*/e2e/*",

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -42,6 +42,9 @@ if ( ! require_once GATHERPRESS_CORE_PATH . '/includes/core/requirements-check.p
 	return;
 }
 
+// Register class aliases so prior fully-qualified names continue to resolve to their current locations.
+require_once GATHERPRESS_CORE_PATH . '/includes/core/register-class-aliases.php';
+
 // Include and register the autoloader class for automatic loading of plugin classes.
 require_once GATHERPRESS_CORE_PATH . '/includes/core/classes/class-autoloader.php';
 GatherPress\Core\Autoloader::register();

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -369,7 +369,7 @@ class Event_Query {
 	 *
 	 * When AQL is used with the gatherpress_event post type, this ensures that
 	 * GatherPress-specific query parameters (event type, unfinished events, datetime ordering)
-	 * are passed through to WP_Query, where the Event_Query class picks them up
+	 * are passed through to WP_Query, where the core Event\Query class picks them up
 	 * via pre_get_posts for SQL modification.
 	 *
 	 * @since 1.0.0

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -71,7 +71,7 @@ class Feed {
 	/**
 	 * Handle events feed queries by setting the appropriate parameters.
 	 *
-	 * This method works in conjunction with Event_Query::prepare_event_query_before_execution()
+	 * This method works in conjunction with Event\Query::prepare_event_query_before_execution()
 	 * to ensure feeds show upcoming events with proper sorting. Supports ?type=past parameter
 	 * to show past events instead of upcoming events.
 	 *
@@ -96,7 +96,7 @@ class Feed {
 
 			// Check if this is the events feed URL.
 			if ( str_contains( $request_uri, '/' . $rewrite_slug . '/' . $GLOBALS['wp_rewrite']->feed_base ) ) {
-				// Set the post type and let Event_Query handle the rest.
+				// Set the post type and let Event\Query handle the rest.
 				$query->set( 'post_type', get_post_types_by_support( 'gatherpress-event-date' ) );
 
 				// Check for type parameter to determine if we want past or upcoming events.

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -59,10 +59,7 @@ class Setup {
 		Assets::get_instance();
 		Block::get_instance();
 		Cli::get_instance();
-		Event_Admin_List::get_instance();
-		Event_Query::get_instance();
-		Event_Rest_Api::get_instance();
-		Event_Setup::get_instance();
+		Event\Setup::get_instance();
 		Export::get_instance();
 		Feed::get_instance();
 		Geocoding::get_instance();

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -6,17 +6,21 @@
  * sorting by event date, RSVP count, and venue, view filters for upcoming and past events,
  * and admin menu link modifications.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
 
-namespace GatherPress\Core;
+namespace GatherPress\Core\Event;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use Exception;
+use GatherPress\Core\Event;
+use GatherPress\Core\Rsvp;
+use GatherPress\Core\Rsvp_Query;
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Venue_Setup;
 use WP_Query;
 
 /**
@@ -25,10 +29,10 @@ use WP_Query;
  * This class handles all admin list table concerns for events, including custom columns,
  * sortable columns, sorting logic, view filters, and admin menu modifications.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
-class Event_Admin_List {
+class Admin_List {
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -240,7 +244,7 @@ class Event_Admin_List {
 	/**
 	 * Get counts of upcoming and past events for a given post type.
 	 *
-	 * Uses the same datetime comparison logic as Event_Query::adjust_event_sql()
+	 * Uses the same datetime comparison logic as Query::adjust_event_sql()
 	 * with inclusive=true: upcoming uses datetime_end_gmt (includes running events),
 	 * past uses datetime_start_gmt (excludes running events).
 	 *

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -5,18 +5,23 @@
  * The Event class is responsible for creating and managing instances of events within the GatherPress plugin.
  * It provides methods for working with event data, such as retrieving event details and managing RSVPs.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
 
-namespace GatherPress\Core;
+namespace GatherPress\Core\Event;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use DateTimeZone;
 use Exception;
+use GatherPress\Core\Rsvp;
+use GatherPress\Core\Rsvp_Setup;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Utility;
+use GatherPress\Core\Validate;
+use GatherPress\Core\Venue_Setup;
 use WP_Post;
 
 /**

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -6,29 +6,32 @@
  * upcoming and past events, applying filters and ordering events. It also handles adjustments
  * for event pages and admin queries.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
 
-namespace GatherPress\Core;
+namespace GatherPress\Core\Event;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Event;
 use GatherPress\Core\Settings;
+use GatherPress\Core\Topic;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Venue;
+use GatherPress\Core\Venue_Setup;
 use WP_Post;
 use WP_Query;
 
 /**
- * Class Event_Query.
+ * Class Query.
  *
  * Responsible for managing event-related queries and customizations.
  *
  * @since 1.0.0
  */
-class Event_Query {
+class Query {
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -5,35 +5,43 @@
  * This file contains the Rest_Api class, which is responsible for registering and managing
  * various Event REST API endpoints within the GatherPress plugin.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
 
-namespace GatherPress\Core;
+namespace GatherPress\Core\Event;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use Exception;
 use GatherPress\Core\Blocks\Rsvp_Template;
+use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp_Form as Rsvp_Form_Core;
+use GatherPress\Core\Rsvp_Query;
+use GatherPress\Core\Rsvp_Setup;
+use GatherPress\Core\Rsvp_Token;
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\User;
+use GatherPress\Core\Utility;
+use GatherPress\Core\Validate;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 use WP_User;
 
 /**
- * Class Event_Rest_Api.
+ * Class Rest_Api.
  *
- * The Rest_Api class is responsible for registering and managing various REST API endpoints
- * used by the GatherPress plugin. It provides methods for defining routes, handling requests,
- * and delivering responses via the WordPress REST API infrastructure.
+ * Responsible for registering and managing various REST API endpoints used
+ * by the GatherPress plugin. It provides methods for defining routes,
+ * handling requests, and delivering responses via the WordPress REST API
+ * infrastructure.
  *
  * @since 1.0.0
  */
-class Event_Rest_Api {
+class Rest_Api {
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -652,7 +660,7 @@ class Event_Rest_Api {
 			);
 		}
 
-		$query = Event_Query::get_instance()->get_events_list( $event_list_type, $max_number, $topics, $venues );
+		$query = Query::get_instance()->get_events_list( $event_list_type, $max_number, $topics, $venues );
 
 		if ( $query->have_posts() ) {
 			foreach ( $query->posts as $post_id ) {

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -5,18 +5,22 @@
  * This class is responsible for integrating events into the WordPress environment, including the creation
  * of the custom post type for events, managing event metadata, and enhancing the admin dashboard for event management.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
 
-namespace GatherPress\Core;
+namespace GatherPress\Core\Event;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use Exception;
-use GatherPress\Core\Event_Query;
+use GatherPress\Core\Event;
+use GatherPress\Core\Feed;
+use GatherPress\Core\Rsvp;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Utility;
 use stdClass;
 use WP;
 use WP_Block;
@@ -24,13 +28,13 @@ use WP_Post;
 use WP_REST_Request;
 
 /**
- * Class Event_Setup.
+ * Class Setup.
  *
  * Manages event-related functionalities, including registration of event post types and metadata.
  *
  * @since 1.0.0
  */
-class Event_Setup {
+class Setup {
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -48,12 +52,33 @@ class Event_Setup {
 	/**
 	 * Class constructor.
 	 *
-	 * This method initializes the object and sets up necessary hooks.
+	 * Instantiates the sibling Event\* singletons before wiring hooks so
+	 * `Setup::instantiate_classes()` can hand off the whole event
+	 * subsystem with a single `Event\Setup::get_instance()` line — same
+	 * shape as `Settings::instantiate_classes()`.
 	 *
 	 * @since 1.0.0
 	 */
 	public function __construct() {
+		$this->instantiate_classes();
 		$this->setup_hooks();
+	}
+
+	/**
+	 * Instantiate each Event\* sibling singleton.
+	 *
+	 * Keeps the outer `Setup::instantiate_classes()` slim — adding a new
+	 * Event\* class lands as a single line here rather than edits to
+	 * Setup. Each subclass is a singleton, so repeat calls are safe.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function instantiate_classes(): void {
+		Admin_List::get_instance();
+		Query::get_instance();
+		Rest_Api::get_instance();
 	}
 
 	/**
@@ -531,7 +556,7 @@ class Event_Setup {
 		}
 
 		// Don't interfere if event-query already assigned this as an archive page.
-		if ( $wp_query->get( Event_Query::EVENT_QUERY_PARAM ) ) {
+		if ( $wp_query->get( Query::EVENT_QUERY_PARAM ) ) {
 			return;
 		}
 
@@ -564,9 +589,9 @@ class Event_Setup {
 
 				$wp_query->query(
 					array(
-						'post_type'                    => Event::POST_TYPE,
-						Event_Query::EVENT_QUERY_PARAM => $key,
-						'paged'                        => $paged,
+						'post_type'              => Event::POST_TYPE,
+						Query::EVENT_QUERY_PARAM => $key,
+						'paged'                  => $paged,
 					)
 				);
 

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -15,7 +15,7 @@ namespace GatherPress\Core\Settings;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Event_Setup;
+use GatherPress\Core\Event\Setup as Event_Setup;
 use GatherPress\Core\Venue_Setup;
 use GatherPress\Core\Topic;
 

--- a/includes/core/register-class-aliases.php
+++ b/includes/core/register-class-aliases.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Registers class aliases mapping prior fully-qualified class names to their current locations.
+ *
+ * When a class moves into a subnamespace as part of an internal reorganization, this shim
+ * keeps the prior fully-qualified name resolvable so downstream consumers (other plugins,
+ * theme code, and existing call sites within this plugin) do not need to update their
+ * `use` statements or fully-qualified references in lockstep with the move.
+ *
+ * Aliases resolve lazily via an autoloader: the underlying class file is only loaded when
+ * the prior name is actually referenced.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+spl_autoload_register(
+	static function ( string $class_string ): void {
+		// Map of prior fully-qualified class names to their current fully-qualified class names.
+		$aliases = array(
+			'GatherPress\\Core\\Event' => 'GatherPress\\Core\\Event\\Event',
+		);
+
+		if ( ! isset( $aliases[ $class_string ] ) ) {
+			return;
+		}
+
+		class_alias( $aliases[ $class_string ], $class_string );
+	}
+);

--- a/phpstan.stubs
+++ b/phpstan.stubs
@@ -35,4 +35,17 @@ namespace {
     if ( ! class_exists( '\GdImage', false ) ) {
         class GdImage {}
     }
+
+    /**
+     * Mirror the class aliases registered at runtime in
+     * `includes/core/register-class-aliases.php`. PHPStan does not execute the
+     * plugin bootstrap and cannot see runtime `class_alias` calls, so without
+     * this declaration every consumer of the prior fully-qualified class name
+     * reports `class.notFound`. Loading the source file first defines the
+     * current class so `class_alias` can resolve it.
+     */
+    if ( ! class_exists( 'GatherPress\\Core\\Event', false ) ) {
+        require_once __DIR__ . '/includes/core/classes/event/class-event.php';
+        class_alias( 'GatherPress\\Core\\Event\\Event', 'GatherPress\\Core\\Event' );
+    }
 }

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
@@ -10,7 +10,7 @@ namespace GatherPress\Tests\Core\Blocks;
 
 use GatherPress\Core\Blocks\Rsvp;
 use GatherPress\Core\Event;
-use GatherPress\Core\Event_Setup;
+use GatherPress\Core\Event\Setup as Event_Setup;
 use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Class handles unit tests for GatherPress\Core\Event_Admin_List.
+ * Class handles unit tests for GatherPress\Core\Event\Admin_List.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core;
+namespace GatherPress\Tests\Core\Event;
 
 use GatherPress\Core\Event;
-use GatherPress\Core\Event_Admin_List;
+use GatherPress\Core\Event\Admin_List;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Venue;
 use GatherPress\Core\Venue_Setup;
@@ -18,11 +18,11 @@ use PMC\Unit_Test\Utility;
 use WP_Query;
 
 /**
- * Class Test_Event_Admin_List.
+ * Class Test_Admin_List.
  *
- * @coversDefaultClass \GatherPress\Core\Event_Admin_List
+ * @coversDefaultClass \GatherPress\Core\Event\Admin_List
  */
-class Test_Event_Admin_List extends Base {
+class Test_Admin_List extends Base {
 	/**
 	 * Coverage for setup_hooks method.
 	 *
@@ -32,7 +32,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_setup_hooks(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$hooks    = array(
 			array(
 				'type'     => 'action',
@@ -77,7 +77,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_post_type_hooks(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$test_pt  = 'test_event_admin';
 
 		// Register a temporary post type with gatherpress-event-date support.
@@ -127,7 +127,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_post_type_hooks_skips_unsupported_post_type(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Standard 'post' does not declare gatherpress-event-date support.
 		$instance->maybe_register_post_type_hooks( 'post' );
@@ -149,7 +149,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_default_sort_no_screen(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Ensure no screen is set so get_current_screen() returns null.
 		unset( $GLOBALS['current_screen'] );
@@ -175,7 +175,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_default_sort_wrong_screen(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Set current screen to a non-event screen.
 		set_current_screen( 'edit-post' );
@@ -204,7 +204,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_default_sort_orderby_already_set(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Set current screen to event edit screen.
 		set_current_screen( 'edit-gatherpress_event' );
@@ -233,7 +233,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_default_sort_sets_defaults(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Set current screen to event edit screen.
 		set_current_screen( 'edit-gatherpress_event' );
@@ -264,7 +264,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_sortable_columns(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$default  = array( 'unit' => 'test' );
 		$expects  = array(
 			'unit'     => 'test',
@@ -291,7 +291,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_views_edit_no_screen(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Ensure no screen is set so get_current_screen() returns null.
 		unset( $GLOBALS['current_screen'] );
@@ -310,7 +310,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_views_edit_adds_links(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		set_current_screen( 'edit-' . Event::POST_TYPE );
 
@@ -382,7 +382,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_views_edit_placement(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		set_current_screen( 'edit-' . Event::POST_TYPE );
 
@@ -410,7 +410,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_views_edit_active_upcoming(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		set_current_screen( 'edit-' . Event::POST_TYPE );
 
@@ -463,7 +463,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_views_edit_active_past(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		set_current_screen( 'edit-' . Event::POST_TYPE );
 
@@ -503,7 +503,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_views_edit_no_active_filter(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		set_current_screen( 'edit-' . Event::POST_TYPE );
 
@@ -551,7 +551,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_views_edit_all_gets_current_when_missing(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		set_current_screen( 'edit-' . Event::POST_TYPE );
 
@@ -591,7 +591,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_views_edit_displays_counts(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Create a published upcoming event.
 		$post_id = $this->mock->post(
@@ -646,7 +646,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_get_event_counts_no_events(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Reset cached counts and invoke the protected method.
 		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
@@ -667,7 +667,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_get_event_counts_with_upcoming(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Create a published event in the future.
 		$post_id = $this->mock->post(
@@ -703,7 +703,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_get_event_counts_with_past(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Create a published event in the past.
 		$post_id = $this->mock->post(
@@ -739,7 +739,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_get_event_counts_with_mixed(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Create a published upcoming event.
 		$upcoming_id = $this->mock->post(
@@ -813,7 +813,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_get_event_counts_running_event(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Create a published event that is currently running.
 		$post_id = $this->mock->post(
@@ -853,7 +853,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_get_event_counts_with_no_date(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Reset cached counts.
 		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
@@ -882,7 +882,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_get_event_counts_caches_result(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Reset cached counts.
 		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
@@ -930,7 +930,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_query_vars(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		$result = $instance->query_vars( array( 'existing_var' ) );
 
@@ -955,7 +955,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_query_vars_empty_input(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		$result = $instance->query_vars( array() );
 
@@ -975,7 +975,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_handle_rsvp_sorting(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Create a mock query.
 		$query = $this->createMock( \WP_Query::class );
@@ -1042,7 +1042,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_handle_venue_sorting(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Create a mock query.
 		$query = $this->createMock( \WP_Query::class );
@@ -1110,7 +1110,7 @@ class Test_Event_Admin_List extends Base {
 	 */
 	public function test_rsvp_sorting_join_paged(): void {
 		global $wpdb;
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		$original_join = "LEFT JOIN {$wpdb->posts} AS posts ON posts.ID = {$wpdb->posts}.ID";
 		$result        = $instance->rsvp_sorting_join_paged( $original_join );
@@ -1133,7 +1133,7 @@ class Test_Event_Admin_List extends Base {
 	 */
 	public function test_sorting_groupby_post_id(): void {
 		global $wpdb;
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		$result = $instance->sorting_groupby_post_id( '' );
 		$this->assertEquals( "`{$wpdb->posts}`.`ID`", $result );
@@ -1155,7 +1155,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_rsvp_sorting_orderby(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		$result = $instance->rsvp_sorting_orderby( 'original_orderby' );
 
@@ -1185,7 +1185,7 @@ class Test_Event_Admin_List extends Base {
 	 */
 	public function test_venue_sorting_join_paged_with_screen(): void {
 		global $wpdb;
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		set_current_screen( 'edit-' . Event::POST_TYPE );
 
@@ -1206,7 +1206,7 @@ class Test_Event_Admin_List extends Base {
 	 */
 	public function test_venue_sorting_join_paged(): void {
 		global $wpdb;
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Ensure no screen is set so the method falls back to the default post type.
 		unset( $GLOBALS['current_screen'] );
@@ -1238,7 +1238,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_venue_sorting_join_paged_unregistered_taxonomy(): void {
-		$instance      = Event_Admin_List::get_instance();
+		$instance      = Admin_List::get_instance();
 		$original_join = 'ORIGINAL_JOIN';
 
 		// Temporarily unregister the venue taxonomy so taxonomy_exists() returns false.
@@ -1267,7 +1267,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_venue_sorting_orderby(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		$result = $instance->venue_sorting_orderby( 'original_orderby' );
 
@@ -1316,7 +1316,7 @@ class Test_Event_Admin_List extends Base {
 		// Simulate admin context.
 		set_current_screen( 'edit-gatherpress_event' );
 
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$instance->handle_rsvp_sorting( $query );
 
 		// Verify that sorting order was set.
@@ -1371,7 +1371,7 @@ class Test_Event_Admin_List extends Base {
 
 		set_current_screen( 'edit-gatherpress_event' );
 
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$instance->handle_rsvp_sorting( $query );
 
 		// Should default to ASC for invalid order.
@@ -1410,7 +1410,7 @@ class Test_Event_Admin_List extends Base {
 
 		set_current_screen( 'edit-gatherpress_event' );
 
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$instance->handle_rsvp_sorting( $query );
 
 		// Should return early — rsvp_sort_order must not be set.
@@ -1442,7 +1442,7 @@ class Test_Event_Admin_List extends Base {
 
 		set_current_screen( 'edit-gatherpress_event' );
 
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$instance->handle_rsvp_sorting( $query );
 
 		// Should not set rsvp_sort_order since orderby is not 'rsvps'.
@@ -1477,7 +1477,7 @@ class Test_Event_Admin_List extends Base {
 
 		set_current_screen( 'edit-gatherpress_event' );
 
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$instance->handle_venue_sorting( $query );
 
 		// Verify that sorting order was set.
@@ -1532,7 +1532,7 @@ class Test_Event_Admin_List extends Base {
 
 		set_current_screen( 'edit-gatherpress_event' );
 
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$instance->handle_venue_sorting( $query );
 
 		// Should default to ASC for invalid order.
@@ -1568,7 +1568,7 @@ class Test_Event_Admin_List extends Base {
 
 		set_current_screen( 'edit-gatherpress_event' );
 
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$instance->handle_venue_sorting( $query );
 
 		// Should not set venue_sort_order since orderby is not 'venue'.
@@ -1588,7 +1588,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_custom_columns_datetime(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -1618,7 +1618,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_custom_columns_venue_with_name(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -1643,7 +1643,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_custom_columns_venue_no_venue(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -1663,7 +1663,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_custom_columns_venue_online_event(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -1687,7 +1687,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_custom_columns_rsvps_no_rsvps(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -1707,7 +1707,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_custom_columns_rsvps_with_approved(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -1737,7 +1737,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_custom_columns_rsvps_with_unapproved(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -1778,7 +1778,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_set_custom_columns(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		$default_columns = array(
 			'cb'     => '<input type="checkbox" />',
@@ -1812,7 +1812,7 @@ class Test_Event_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_remove_comments_column(): void {
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		// Test with columns that include comments.
 		$columns_with_comments = array(
@@ -1889,7 +1889,7 @@ class Test_Event_Admin_List extends Base {
 		// Assign the term to the event.
 		wp_set_object_terms( $post_id, $term['term_id'], '_gatherpress_venue' );
 
-		$instance = Event_Admin_List::get_instance();
+		$instance = Admin_List::get_instance();
 
 		ob_start();
 		$instance->custom_columns( 'venue', $post_id );

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -1,26 +1,27 @@
 <?php
 /**
- * Class handles unit tests for GatherPress\Core\Event.
+ * Class handles unit tests for GatherPress\Core\Event\Event.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core;
+namespace GatherPress\Tests\Core\Event;
 
 use DateTime;
 use DateTimeZone;
-use GatherPress\Core\Event;
+use GatherPress\Core\Event\Event;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
+use ReflectionClass;
 use WP_Post;
 
 /**
  * Class Test_Event.
  *
- * @coversDefaultClass \GatherPress\Core\Event
+ * @coversDefaultClass \GatherPress\Core\Event\Event
  */
 class Test_Event extends Base {
 	/**
@@ -42,6 +43,34 @@ class Test_Event extends Base {
 
 		$this->assertInstanceOf( WP_Post::class, Utility::get_hidden_property( $event, 'event' ) );
 		$this->assertInstanceOf( Rsvp::class, Utility::get_hidden_property( $event, 'rsvp' ) );
+	}
+
+	/**
+	 * Asserts that the prior fully-qualified class name `GatherPress\Core\Event` continues
+	 * to resolve to the current class `GatherPress\Core\Event\Event` via the alias map in
+	 * `includes/core/register-class-aliases.php`. Removing the alias entry would silently
+	 * break external consumers (other plugins, theme code) that reference the prior FQN —
+	 * this test fails loudly first.
+	 *
+	 * @return void
+	 */
+	public function test_prior_fqn_resolves_to_current_class(): void {
+		$prior_fqn = 'GatherPress\\Core\\Event';
+
+		$this->assertTrue(
+			class_exists( $prior_fqn ),
+			'The prior fully-qualified class name should resolve via the alias map.'
+		);
+
+		$reflection = new ReflectionClass( $prior_fqn );
+		$this->assertSame(
+			Event::class,
+			$reflection->getName(),
+			'The prior FQN should resolve to the current Event class.'
+		);
+
+		// Read a class constant through the prior FQN to confirm runtime usability.
+		$this->assertSame( Event::POST_TYPE, constant( $prior_fqn . '::POST_TYPE' ) );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Class handles unit tests for GatherPress\Core\Event_Query.
+ * Class handles unit tests for GatherPress\Core\Event\Query.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core;
+namespace GatherPress\Tests\Core\Event;
 
 use DateTime;
 use GatherPress\Core\Event;
-use GatherPress\Core\Event_Query;
+use GatherPress\Core\Event\Query;
 use GatherPress\Core\Topic;
 use GatherPress\Core\Venue;
 use GatherPress\Core\Venue_Setup;
@@ -19,11 +19,11 @@ use PMC\Unit_Test\Utility;
 use WP_Query;
 
 /**
- * Class Test_Event_Query.
+ * Class Test_Query.
  *
- * @coversDefaultClass \GatherPress\Core\Event_Query
+ * @coversDefaultClass \GatherPress\Core\Event\Query
  */
-class Test_Event_Query extends Base {
+class Test_Query extends Base {
 	/**
 	 * Coverage for setup_hooks method.
 	 *
@@ -33,7 +33,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_setup_hooks(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 		$hooks    = array(
 			array(
 				'type'     => 'action',
@@ -62,7 +62,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_get_upcoming_events(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 		$response = $instance->get_upcoming_events();
 
 		$this->assertEmpty( $response->posts, 'Failed to assert that posts array is empty.' );
@@ -106,7 +106,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_get_past_events(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 		$response = $instance->get_past_events();
 
 		$this->assertEmpty( $response->posts, 'Failed to assert that posts array is empty.' );
@@ -148,7 +148,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_get_events_list(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 		$post_1   = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
 		$post_2   = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
 		$event_1  = new Event( $post_1->ID );
@@ -219,7 +219,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_for_upcoming_events(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 		$query    = new WP_Query();
 
 		$query->set( 'post_type', 'gatherpress_event' );
@@ -247,7 +247,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_for_past_events(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 		$query    = new WP_Query();
 
 		$query->set( 'post_type', 'gatherpress_event' );
@@ -275,7 +275,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_for_archive_page(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Mock WP_Query with necessary properties.
 		$query = $this->getMockBuilder( 'WP_Query' )
@@ -348,7 +348,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_resolves_page_by_pagename(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create a real page with a known slug.
 		$page_id = $this->factory->post->create(
@@ -434,7 +434,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_with_invalid_general_options(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Mock WP_Query with necessary properties.
 		$query = $this->getMockBuilder( 'WP_Query' )
@@ -471,7 +471,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_with_empty_pages(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Mock WP_Query with necessary properties.
 		$query = $this->getMockBuilder( 'WP_Query' )
@@ -521,7 +521,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_pre_option_filters(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create a page to use as the archive page.
 		$page_id = $this->factory->post->create(
@@ -591,7 +591,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_archive_title_filter(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create a page to use as the archive page.
 		$page_id = $this->factory->post->create(
@@ -655,7 +655,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_with_no_event_type(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 		$query    = new WP_Query();
 
 		$instance->prepare_event_query_before_execution( $query );
@@ -679,7 +679,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_adjust_admin_event_sorting(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 		$wp_query = new WP_Query();
 
 		$this->mock->user( false, 'admin' );
@@ -728,7 +728,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_adjust_admin_event_sorting_wrong_screen(): void {
-		$instance     = Event_Query::get_instance();
+		$instance     = Query::get_instance();
 		$wp_query     = new WP_Query();
 		$query_pieces = array( 'orderby' => 'post_date' );
 
@@ -760,7 +760,7 @@ class Test_Event_Query extends Base {
 	public function test_adjust_event_sql(): void {
 		global $wpdb;
 
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		$table  = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 		$retval = $instance->adjust_event_sql( array(), 'all', 'DESC' );
@@ -813,7 +813,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_build_venue_tax_query(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 		$venues   = array( '_unit-test-venue', '_another-venue' );
 
 		$tax_query = Utility::invoke_hidden_method( $instance, 'build_venue_tax_query', array( $venues ) );
@@ -864,7 +864,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_get_datetime_comparison_column(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		$this->assertSame(
 			'datetime_end_gmt',
@@ -898,7 +898,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_past_events_order(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create multiple past events with different dates.
 		$oldest_post  = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
@@ -968,7 +968,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_upcoming_events_order(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create multiple upcoming events with different dates.
 		$soon_post  = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
@@ -1037,7 +1037,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_include_unfinished_parameter_for_past_events(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create a currently running event.
 		$running_post  = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
@@ -1055,10 +1055,10 @@ class Test_Event_Query extends Base {
 		// Default behavior: currently running events should NOT appear in past events.
 		$query = new WP_Query(
 			array(
-				'post_type'                    => Event::POST_TYPE,
-				'posts_per_page'               => 10,
-				'fields'                       => 'ids',
-				Event_Query::EVENT_QUERY_PARAM => 'past',
+				'post_type'              => Event::POST_TYPE,
+				'posts_per_page'         => 10,
+				'fields'                 => 'ids',
+				Query::EVENT_QUERY_PARAM => 'past',
 			)
 		);
 		$instance->prepare_event_query_before_execution( $query );
@@ -1073,11 +1073,11 @@ class Test_Event_Query extends Base {
 		// With include_unfinished=true: currently running events SHOULD appear.
 		$query = new WP_Query(
 			array(
-				'post_type'                    => Event::POST_TYPE,
-				'posts_per_page'               => 10,
-				'fields'                       => 'ids',
-				Event_Query::EVENT_QUERY_PARAM => 'past',
-				'include_unfinished'           => true,
+				'post_type'              => Event::POST_TYPE,
+				'posts_per_page'         => 10,
+				'fields'                 => 'ids',
+				Query::EVENT_QUERY_PARAM => 'past',
+				'include_unfinished'     => true,
 			)
 		);
 		$instance->prepare_event_query_before_execution( $query );
@@ -1102,7 +1102,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_include_unfinished_integer_values(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create a currently running event (using exact same pattern as working test).
 		$running_post  = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
@@ -1120,11 +1120,11 @@ class Test_Event_Query extends Base {
 		// First verify that boolean true works (like the original test).
 		$query = new WP_Query(
 			array(
-				'post_type'                    => Event::POST_TYPE,
-				'posts_per_page'               => 10,
-				'fields'                       => 'ids',
-				Event_Query::EVENT_QUERY_PARAM => 'past',
-				'include_unfinished'           => true, // Boolean true.
+				'post_type'              => Event::POST_TYPE,
+				'posts_per_page'         => 10,
+				'fields'                 => 'ids',
+				Query::EVENT_QUERY_PARAM => 'past',
+				'include_unfinished'     => true, // Boolean true.
 			)
 		);
 		$instance->prepare_event_query_before_execution( $query );
@@ -1139,11 +1139,11 @@ class Test_Event_Query extends Base {
 		// Now test integer 1 (should work the same as boolean true).
 		$query = new WP_Query(
 			array(
-				'post_type'                    => Event::POST_TYPE,
-				'posts_per_page'               => 10,
-				'fields'                       => 'ids',
-				Event_Query::EVENT_QUERY_PARAM => 'past',
-				'include_unfinished'           => 1, // Integer 1.
+				'post_type'              => Event::POST_TYPE,
+				'posts_per_page'         => 10,
+				'fields'                 => 'ids',
+				Query::EVENT_QUERY_PARAM => 'past',
+				'include_unfinished'     => 1, // Integer 1.
 			)
 		);
 		$instance->prepare_event_query_before_execution( $query );
@@ -1162,11 +1162,11 @@ class Test_Event_Query extends Base {
 		// Test integer 0 value (exclude unfinished).
 		$query = new WP_Query(
 			array(
-				'post_type'                    => Event::POST_TYPE,
-				'posts_per_page'               => 10,
-				'fields'                       => 'ids',
-				Event_Query::EVENT_QUERY_PARAM => 'past',
-				'include_unfinished'           => 0, // Integer 0.
+				'post_type'              => Event::POST_TYPE,
+				'posts_per_page'         => 10,
+				'fields'                 => 'ids',
+				Query::EVENT_QUERY_PARAM => 'past',
+				'include_unfinished'     => 0, // Integer 0.
 			)
 		);
 		$instance->prepare_event_query_before_execution( $query );
@@ -1181,11 +1181,11 @@ class Test_Event_Query extends Base {
 		// Test for upcoming events with integer 0 (should exclude).
 		$query = new WP_Query(
 			array(
-				'post_type'                    => Event::POST_TYPE,
-				'posts_per_page'               => 10,
-				'fields'                       => 'ids',
-				Event_Query::EVENT_QUERY_PARAM => 'upcoming',
-				'include_unfinished'           => 0, // Integer 0.
+				'post_type'              => Event::POST_TYPE,
+				'posts_per_page'         => 10,
+				'fields'                 => 'ids',
+				Query::EVENT_QUERY_PARAM => 'upcoming',
+				'include_unfinished'     => 0, // Integer 0.
 			)
 		);
 		$instance->prepare_event_query_before_execution( $query );
@@ -1200,11 +1200,11 @@ class Test_Event_Query extends Base {
 		// Test for upcoming events with integer 1 (should include).
 		$query = new WP_Query(
 			array(
-				'post_type'                    => Event::POST_TYPE,
-				'posts_per_page'               => 10,
-				'fields'                       => 'ids',
-				Event_Query::EVENT_QUERY_PARAM => 'upcoming',
-				'include_unfinished'           => 1, // Integer 1.
+				'post_type'              => Event::POST_TYPE,
+				'posts_per_page'         => 10,
+				'fields'                 => 'ids',
+				Query::EVENT_QUERY_PARAM => 'upcoming',
+				'include_unfinished'     => 1, // Integer 1.
 			)
 		);
 		$instance->prepare_event_query_before_execution( $query );
@@ -1229,7 +1229,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_include_unfinished_defaults(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create a currently running event.
 		$running_post  = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
@@ -1246,10 +1246,10 @@ class Test_Event_Query extends Base {
 		// Test upcoming events default behavior (should include currently running).
 		$query = new WP_Query(
 			array(
-				'post_type'                    => Event::POST_TYPE,
-				'posts_per_page'               => 10,
-				'fields'                       => 'ids',
-				Event_Query::EVENT_QUERY_PARAM => 'upcoming',
+				'post_type'              => Event::POST_TYPE,
+				'posts_per_page'         => 10,
+				'fields'                 => 'ids',
+				Query::EVENT_QUERY_PARAM => 'upcoming',
 				// No include_unfinished parameter - test default.
 			)
 		);
@@ -1265,10 +1265,10 @@ class Test_Event_Query extends Base {
 		// Test past events default behavior (should exclude currently running).
 		$query = new WP_Query(
 			array(
-				'post_type'                    => Event::POST_TYPE,
-				'posts_per_page'               => 10,
-				'fields'                       => 'ids',
-				Event_Query::EVENT_QUERY_PARAM => 'past',
+				'post_type'              => Event::POST_TYPE,
+				'posts_per_page'         => 10,
+				'fields'                 => 'ids',
+				Query::EVENT_QUERY_PARAM => 'past',
 				// No include_unfinished parameter - test default.
 			)
 		);
@@ -1296,7 +1296,7 @@ class Test_Event_Query extends Base {
 	public function test_events_without_dates_in_admin_upcoming(): void {
 		global $wpdb;
 
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 		$table    = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 
 		// Create an event without setting any dates (no row in gatherpress_events).
@@ -1396,7 +1396,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_currently_running_events_in_upcoming_query(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create an event that started yesterday and ends tomorrow (currently running).
 		$running_post  = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
@@ -1487,7 +1487,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_venue_filter_sets_tax_query(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create a venue post to establish proper singular context.
 		$venue_post_id = $this->factory->post->create(
@@ -1564,7 +1564,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_venue_filter_merges_with_existing_tax_query(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create a venue post to establish proper singular context.
 		$venue_post_id = $this->factory->post->create(
@@ -1660,7 +1660,7 @@ class Test_Event_Query extends Base {
 	 * @return void
 	 */
 	public function test_prepare_query_venue_filter_skipped_when_empty(): void {
-		$instance = Event_Query::get_instance();
+		$instance = Query::get_instance();
 
 		// Create a venue post to establish proper singular context.
 		$venue_post_id = $this->factory->post->create(

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Class handles unit tests for GatherPress\Core\Event_Rest_Api.
+ * Class handles unit tests for GatherPress\Core\Event\Rest_Api.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core;
+namespace GatherPress\Tests\Core\Event;
 
 use GatherPress\Core\Event;
-use GatherPress\Core\Event_Rest_Api;
+use GatherPress\Core\Event\Rest_Api;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp_Token;
 use GatherPress\Core\Settings;
@@ -23,11 +23,11 @@ use WP_REST_Response;
 use WP_REST_Server;
 
 /**
- * Class Test_Event_Rest_Api.
+ * Class Test_Rest_Api.
  *
- * @coversDefaultClass \GatherPress\Core\Event_Rest_Api
+ * @coversDefaultClass \GatherPress\Core\Event\Rest_Api
  */
-class Test_Event_Rest_Api extends Base {
+class Test_Rest_Api extends Base {
 	/**
 	 * Enable open RSVP for all tests in this class so RSVP form submission paths are exercisable.
 	 *
@@ -57,7 +57,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_setup_hooks(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$hooks    = array(
 			array(
 				'type'     => 'action',
@@ -90,7 +90,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_register_endpoints(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		$instance->register_endpoints();
 
@@ -133,7 +133,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_get_event_routes(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$routes   = Utility::invoke_hidden_method( $instance, 'get_event_routes' );
 
 		$this->assertSame( 'email', $routes[0]['route'], 'Failed to assert route is email.' );
@@ -184,7 +184,7 @@ class Test_Event_Rest_Api extends Base {
 	public function test_email(): void {
 		add_filter( 'pre_wp_mail', '__return_false' );
 
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$request  = new WP_REST_Request( 'POST' );
 		$event_id = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
@@ -218,7 +218,7 @@ class Test_Event_Rest_Api extends Base {
 	public function test_send_email(): void {
 		add_filter( 'pre_wp_mail', '__return_false' );
 
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$event_id = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -255,7 +255,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_get_recipients_with_no_send_options(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$event_id = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -280,7 +280,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_get_recipients_with_all_users_only(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$event_id = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -319,7 +319,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_get_recipients_with_attending_filter(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$event_id = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -397,7 +397,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_get_recipients_with_mixed_recipients(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$event_id = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -530,7 +530,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_events_list(): void {
-		$instance          = Event_Rest_Api::get_instance();
+		$instance          = Rest_Api::get_instance();
 		$request           = new WP_REST_Request( 'POST' );
 		$upcoming_event_id = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
@@ -606,7 +606,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_max_number(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		$this->assertEquals(
 			5,
@@ -628,7 +628,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_update_rsvp(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$request  = new WP_REST_Request( 'POST' );
 		$user_id  = $this->factory->user->create( array( 'role' => 'administrator' ) );
 
@@ -683,7 +683,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_rsvp_form_route(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'rsvp_form_route' );
 
 		$this->assertEquals( 'rsvp-form', $route['route'] );
@@ -715,7 +715,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_handle_rsvp_form_submission_success(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -785,7 +785,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_handle_rsvp_form_submission_duplicate(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -836,7 +836,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_handle_rsvp_form_submission_logged_in_user(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -882,7 +882,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_handle_rsvp_form_submission_past_event(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -921,7 +921,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_handle_rsvp_form_submission_open_rsvp_disabled(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -953,7 +953,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_handle_rsvp_form_submission_open_rsvp_disabled_per_event(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -985,7 +985,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_handle_email_send_action(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -1010,7 +1010,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_rsvp_responses(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -1041,7 +1041,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_rsvp_responses_non_event_post(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create();
 
 		$request = new WP_REST_Request( 'GET' );
@@ -1062,7 +1062,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_rsvp_status_html(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -1104,7 +1104,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_rsvp_status_html_no_responses(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -1135,7 +1135,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_prepare_event_data(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -1165,7 +1165,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_events_list_with_topics(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -1204,7 +1204,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_events_list_with_venues(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -1243,7 +1243,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_events_list_custom_datetime_format(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -1281,7 +1281,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_update_rsvp_with_token(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -1326,7 +1326,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_update_rsvp_past_event(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create(
 			array(
 				'post_type' => Event::POST_TYPE,
@@ -1363,7 +1363,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_send_emails_non_event_post(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$post_id  = $this->factory()->post->create();
 
 		$result = $instance->send_emails( $post_id, array( 'all' => true ), '' );
@@ -1381,7 +1381,7 @@ class Test_Event_Rest_Api extends Base {
 	public function test_send_emails_with_opted_out_user(): void {
 		add_filter( 'pre_wp_mail', '__return_false' );
 
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$event_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 		$user_id  = $this->factory->user->create();
 
@@ -1412,7 +1412,7 @@ class Test_Event_Rest_Api extends Base {
 	public function test_send_emails_with_opted_out_non_user(): void {
 		add_filter( 'pre_wp_mail', '__return_false' );
 
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$event_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 
 		// Create anonymous RSVP.
@@ -1454,7 +1454,7 @@ class Test_Event_Rest_Api extends Base {
 	public function test_send_emails_with_no_email(): void {
 		add_filter( 'pre_wp_mail', '__return_false' );
 
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$event_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 
 		// Create RSVP with no email.
@@ -1490,7 +1490,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_get_recipients_skips_empty_email(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$event_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 
 		// Create RSVP with empty email.
@@ -1527,7 +1527,7 @@ class Test_Event_Rest_Api extends Base {
 	public function test_send_emails_with_locale_switching(): void {
 		add_filter( 'pre_wp_mail', '__return_false' );
 
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$event_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
 		$user_id  = $this->factory->user->create();
 
@@ -1556,7 +1556,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::nonce_route
 	 */
 	public function test_nonce_route(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		$route = Utility::invoke_hidden_method( $instance, 'nonce_route' );
 
@@ -1577,7 +1577,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::nonce_route
 	 */
 	public function test_nonce_route_callback(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'nonce_route' );
 
 		// Create a logged-in user.
@@ -1607,7 +1607,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::email_route
 	 */
 	public function test_email_route_permission_callback_can_edit(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'email_route' );
 
 		// Create an editor who can edit posts.
@@ -1629,7 +1629,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::email_route
 	 */
 	public function test_email_route_permission_callback_cannot_edit(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'email_route' );
 
 		// Create a subscriber who cannot edit posts.
@@ -1651,7 +1651,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::rsvp_route
 	 */
 	public function test_rsvp_route_permission_callback_with_token(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'rsvp_route' );
 
 		$post_id = $this->factory->post->create(
@@ -1690,7 +1690,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::rsvp_route
 	 */
 	public function test_rsvp_route_permission_callback_logged_out(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'rsvp_route' );
 
 		// Ensure user is logged out.
@@ -1717,7 +1717,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::rsvp_route
 	 */
 	public function test_rsvp_route_token_validate_callback_empty(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'rsvp_route' );
 
 		$validate_callback = $route['args']['args']['rsvp_token']['validate_callback'];
@@ -1734,7 +1734,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::rsvp_form_route
 	 */
 	public function test_rsvp_form_route_author_validate_callback_empty(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'rsvp_form_route' );
 
 		$validate_callback = $route['args']['args']['author']['validate_callback'];
@@ -1756,7 +1756,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::rsvp_form_route
 	 */
 	public function test_rsvp_form_route_email_validate_callback(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'rsvp_form_route' );
 
 		$validate_callback = $route['args']['args']['email']['validate_callback'];
@@ -1778,7 +1778,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::rsvp_form_route
 	 */
 	public function test_rsvp_form_route_form_schema_id_validate_callback(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'rsvp_form_route' );
 
 		$validate_callback = $route['args']['args']['gatherpress_form_schema_id']['validate_callback'];
@@ -1806,7 +1806,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::rsvp_status_html_route
 	 */
 	public function test_rsvp_status_html_route(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		$route = Utility::invoke_hidden_method( $instance, 'rsvp_status_html_route' );
 
@@ -1825,7 +1825,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::rsvp_responses_route
 	 */
 	public function test_rsvp_responses_route(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		$route = Utility::invoke_hidden_method( $instance, 'rsvp_responses_route' );
 
@@ -1846,7 +1846,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::send_emails
 	 */
 	public function test_send_emails_skip_non_user_opt_out(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		$post_id = $this->factory->post->create(
 			array(
@@ -1889,7 +1889,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::send_emails
 	 */
 	public function test_send_emails_restore_locale(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		$user_id = $this->factory->user->create(
 			array(
@@ -1941,7 +1941,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::get_recipients
 	 */
 	public function test_get_recipients_skip_empty_email(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		$post_id = $this->factory->post->create(
 			array(
@@ -1978,7 +1978,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::update_rsvp
 	 */
 	public function test_update_rsvp_non_admin_cannot_add_others(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		// Create a subscriber (no edit_posts capability).
 		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
@@ -2013,7 +2013,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::rsvp_status_html
 	 */
 	public function test_rsvp_status_html_nocache_when_logged_in(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		// Create and log in a user.
 		$user_id = $this->factory->user->create();
@@ -2045,7 +2045,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::handle_rsvp_form_submission
 	 */
 	public function test_handle_rsvp_form_submission_custom_fields(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		$user_id = $this->factory->user->create(
 			array(
@@ -2086,7 +2086,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @covers ::rsvp_responses
 	 */
 	public function test_rsvp_responses_nocache_when_logged_in(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		// Create and log in a user.
 		$user_id = $this->factory->user->create();
@@ -2120,7 +2120,7 @@ class Test_Event_Rest_Api extends Base {
 	 * @return void
 	 */
 	public function test_update_rsvp_adds_user_to_blog_multisite(): void {
-		$instance = Event_Rest_Api::get_instance();
+		$instance = Rest_Api::get_instance();
 
 		// Create a user on site 1.
 		$user_id = $this->factory->user->create(

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -48,9 +48,18 @@ class Test_Setup extends Base {
 		Utility::invoke_hidden_method( Setup::get_instance(), 'instantiate_classes' );
 
 		$expected_hooks = array(
-			Admin_List::class => array( 'load-edit.php', array( Admin_List::get_instance(), 'default_sort' ) ),
-			Query::class      => array( 'pre_get_posts', array( Query::get_instance(), 'prepare_event_query_before_execution' ) ),
-			Rest_Api::class   => array( 'rest_api_init', array( Rest_Api::get_instance(), 'register_endpoints' ) ),
+			Admin_List::class => array(
+				'load-edit.php',
+				array( Admin_List::get_instance(), 'default_sort' ),
+			),
+			Query::class      => array(
+				'pre_get_posts',
+				array( Query::get_instance(), 'prepare_event_query_before_execution' ),
+			),
+			Rest_Api::class   => array(
+				'rest_api_init',
+				array( Rest_Api::get_instance(), 'register_endpoints' ),
+			),
 		);
 
 		foreach ( $expected_hooks as $class_name => $expected ) {

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -1,16 +1,18 @@
 <?php
 /**
- * Class handles unit tests for GatherPress\Core\Event_Setup.
+ * Class handles unit tests for GatherPress\Core\Event\Setup.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Event
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core;
+namespace GatherPress\Tests\Core\Event;
 
 use GatherPress\Core\Event;
-use GatherPress\Core\Event_Query;
-use GatherPress\Core\Event_Setup;
+use GatherPress\Core\Event\Admin_List;
+use GatherPress\Core\Event\Query;
+use GatherPress\Core\Event\Rest_Api;
+use GatherPress\Core\Event\Setup;
 use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
@@ -20,11 +22,47 @@ use WP_Block;
 use WP_REST_Request;
 
 /**
- * Class Test_Event_Setup.
+ * Class Test_Setup.
  *
- * @coversDefaultClass \GatherPress\Core\Event_Setup
+ * @coversDefaultClass \GatherPress\Core\Event\Setup
  */
-class Test_Event_Setup extends Base {
+class Test_Setup extends Base {
+	/**
+	 * Event\Setup now owns the instantiation of the Event\* sibling
+	 * singletons (Admin_List, Query, Rest_Api) so the outer
+	 * `Setup::instantiate_classes()` can hand off with a single
+	 * `Event\Setup::get_instance()` call. Per-sibling proof-of-construction
+	 * via their `setup_hooks()`-registered hooks — catches the case where
+	 * a sibling silently drops out of `Event\Setup::instantiate_classes()`.
+	 *
+	 * @covers ::__construct
+	 * @covers ::instantiate_classes
+	 *
+	 * @return void
+	 */
+	public function test_instantiate_classes_registers_siblings(): void {
+		// Force the method to run inside the test's coverage window —
+		// Setup is a singleton cached during plugin bootstrap, so
+		// `get_instance()` here returns the cached instance and doesn't
+		// re-fire the constructor.
+		Utility::invoke_hidden_method( Setup::get_instance(), 'instantiate_classes' );
+
+		$expected_hooks = array(
+			Admin_List::class => array( 'load-edit.php', array( Admin_List::get_instance(), 'default_sort' ) ),
+			Query::class      => array( 'pre_get_posts', array( Query::get_instance(), 'prepare_event_query_before_execution' ) ),
+			Rest_Api::class   => array( 'rest_api_init', array( Rest_Api::get_instance(), 'register_endpoints' ) ),
+		);
+
+		foreach ( $expected_hooks as $class_name => $expected ) {
+			list( $hook, $callback ) = $expected;
+			$this->assertSame(
+				10,
+				has_action( $hook, $callback ),
+				sprintf( '%s must be instantiated so its %s hook registers.', $class_name, $hook )
+			);
+		}
+	}
+
 	/**
 	 * Coverage for setup_hooks.
 	 *
@@ -34,7 +72,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_setup_hooks(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$hooks    = array(
 			array(
 				'type'     => 'action',
@@ -133,7 +171,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_register_calendar_rewrite_rule(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$settings = Settings::get_instance();
 
 		// Get the dynamic slug from settings (default is 'events' plural).
@@ -191,7 +229,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_disable_ics_canonical_redirect(): void {
-		$instance     = Event_Setup::get_instance();
+		$instance     = Setup::get_instance();
 		$ics_url      = 'https://example.org/event/test-event.ics';
 		$redirect_url = 'https://example.org/event/test-event.ics/';
 		$result       = $instance->disable_ics_canonical_redirect( $redirect_url, $ics_url );
@@ -222,7 +260,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_register_post_type(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		unregister_post_type( Event::POST_TYPE );
 
@@ -244,7 +282,7 @@ class Test_Event_Setup extends Base {
 
 		$this->assertSame(
 			'event',
-			Event_Setup::get_localized_post_type_slug(),
+			Setup::get_localized_post_type_slug(),
 			'Failed to assert English post type slug is "event".'
 		);
 
@@ -258,7 +296,7 @@ class Test_Event_Setup extends Base {
 		// it will return the string in English.
 		$this->assertSame(
 			'event',
-			Event_Setup::get_localized_post_type_slug(),
+			Setup::get_localized_post_type_slug(),
 			'Failed to assert post type slug is "event", even the locale is not English anymore.'
 		);
 		// But at least the restoring of the user locale can be tested, without .po files.
@@ -295,7 +333,7 @@ class Test_Event_Setup extends Base {
 
 		$this->assertSame(
 			'unit-test',
-			Event_Setup::get_localized_post_type_slug(),
+			Setup::get_localized_post_type_slug(),
 			'Failed to assert the post type slug is "unit-test".'
 		);
 
@@ -310,7 +348,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_register_event_only_meta(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		unregister_post_meta( Event::POST_TYPE, 'gatherpress_online_event_link' );
 		unregister_post_meta( Event::POST_TYPE, 'gatherpress_enable_anonymous_rsvp' );
@@ -376,7 +414,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_event_date_meta(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$test_pt  = 'test_event_date_meta';
 
 		register_post_type(
@@ -418,7 +456,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_event_date_meta_skips_unsupported_post_type(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$instance->maybe_register_event_date_meta( 'post' );
 
@@ -436,7 +474,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_set_datetimes(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post()->get()->ID;
 
 		$instance->set_datetimes( $post_id );
@@ -501,7 +539,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_check_waiting_list(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -519,7 +557,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_check_waiting_list_skips_non_rsvp_post_type(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post()->get()->ID;
 
 		// A plain post does not support gatherpress-rsvp so the method returns early.
@@ -535,7 +573,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_delete_event_non_event_post(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post()->get()->ID;
 
 		// Should return early for non-event posts.
@@ -553,7 +591,7 @@ class Test_Event_Setup extends Base {
 	public function test_delete_event(): void {
 		global $wpdb;
 
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -591,7 +629,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_the_event_date_use_event_date(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -630,7 +668,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_the_event_date_iso_format(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -670,7 +708,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_the_event_date_use_post_date(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -700,7 +738,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_the_event_date_non_event(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post()->get()->ID;
 
 		$this->go_to( get_permalink( $post_id ) );
@@ -720,7 +758,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_render_event_post_date_block_with_event(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -773,7 +811,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_render_event_post_date_block_setting_disabled(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -812,7 +850,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_render_event_post_date_block_non_event(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post()->get()->ID;
 
 		$this->go_to( get_permalink( $post_id ) );
@@ -841,7 +879,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_render_event_post_date_block_empty_datetime(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
@@ -896,7 +934,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_set_event_archive_labels_no_pages(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		delete_option( 'gatherpress_settings' );
 
@@ -916,7 +954,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_set_event_archive_labels_empty_pages(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		update_option(
 			'gatherpress_settings',
@@ -941,7 +979,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_set_event_archive_labels_upcoming_events(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$page_id = $this->mock->post( array( 'post_type' => 'page' ) )->get()->ID;
 
@@ -980,7 +1018,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_set_event_archive_labels_past_events(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$page_id = $this->mock->post( array( 'post_type' => 'page' ) )->get()->ID;
 
@@ -1019,7 +1057,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_set_datetimes_non_event_post(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post_id  = $this->mock->post()->get()->ID;
 
 		// Should return early for non-event posts.
@@ -1050,7 +1088,7 @@ class Test_Event_Setup extends Base {
 		add_filter( 'locale', $locale_filter );
 
 		// Now get_locale() will return 'de_DE', triggering switch and restore.
-		$slug = Event_Setup::get_localized_post_type_slug();
+		$slug = Setup::get_localized_post_type_slug();
 
 		// If no error occurs, restore_previous_locale was called correctly.
 		$this->assertIsString( $slug, 'Should return a string slug' );
@@ -1112,7 +1150,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_can_edit_posts_meta(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Test with user who can edit posts.
 		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
@@ -1145,7 +1183,7 @@ class Test_Event_Setup extends Base {
 			'name'            => 'non-existent-event',
 		);
 
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$this->expectException( 'WPDieException' );
 		$this->expectExceptionMessage( 'Event not found.' );
@@ -1197,7 +1235,7 @@ class Test_Event_Setup extends Base {
 			'name'            => 'test-ics-download',
 		);
 
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Buffer output to capture ICS content without displaying it.
 		$output = Utility::buffer_and_return(
@@ -1221,7 +1259,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_filter_readonly_meta_removes_readonly_keys(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Create a mock REST request with all readonly keys plus a writable key.
 		$request = new WP_REST_Request( 'POST', '/wp/v2/gatherpress_event' );
@@ -1296,7 +1334,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_filter_readonly_meta_with_null_meta(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Create a REST request without meta parameter.
 		$request = new WP_REST_Request( 'POST', '/wp/v2/gatherpress_event' );
@@ -1324,7 +1362,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_filter_readonly_meta_with_empty_meta(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Create a REST request with empty meta array.
 		$request = new WP_REST_Request( 'POST', '/wp/v2/gatherpress_event' );
@@ -1351,7 +1389,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_filter_readonly_meta_with_only_writable_keys(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Create a REST request with only writable meta keys.
 		$request = new WP_REST_Request( 'POST', '/wp/v2/gatherpress_event' );
@@ -1392,7 +1430,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_filter_readonly_meta_with_only_readonly_keys(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Create a REST request with only readonly meta keys.
 		$request = new WP_REST_Request( 'POST', '/wp/v2/gatherpress_event' );
@@ -1429,7 +1467,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_handle_event_archive_redirect_not_archive(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Create an event and go to its single page.
 		$post_id = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
@@ -1450,7 +1488,7 @@ class Test_Event_Setup extends Base {
 	public function test_handle_event_archive_redirect_with_page(): void {
 		global $wp_query;
 
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Get the rewrite slug from settings.
 		$settings     = Settings::get_instance();
@@ -1494,7 +1532,7 @@ class Test_Event_Setup extends Base {
 	public function test_handle_event_archive_redirect_no_page_404(): void {
 		global $wp_query;
 
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Get the rewrite slug from settings.
 		$settings     = Settings::get_instance();
@@ -1526,7 +1564,7 @@ class Test_Event_Setup extends Base {
 	public function test_handle_event_archive_redirect_draft_page_404(): void {
 		global $wp_query;
 
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Get the rewrite slug from settings.
 		$settings     = Settings::get_instance();
@@ -1567,7 +1605,7 @@ class Test_Event_Setup extends Base {
 	public function test_handle_event_archive_redirect_feed_not_affected(): void {
 		global $wp_query;
 
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Mock being on the post type archive feed.
 		$wp_query->is_post_type_archive = true;
@@ -1592,12 +1630,12 @@ class Test_Event_Setup extends Base {
 	public function test_handle_event_archive_redirect_skips_event_query_param(): void {
 		global $wp_query;
 
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Mock being on post type archive with EVENT_QUERY_PARAM set.
 		$wp_query->is_post_type_archive = true;
 		$wp_query->set( 'post_type', Event::POST_TYPE );
-		$wp_query->set( Event_Query::EVENT_QUERY_PARAM, 'past' );
+		$wp_query->set( Query::EVENT_QUERY_PARAM, 'past' );
 
 		$instance->handle_event_archive_redirect();
 
@@ -1616,7 +1654,7 @@ class Test_Event_Setup extends Base {
 	public function test_handle_event_archive_redirect_designated_archive_page(): void {
 		global $wp_query;
 
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Get the rewrite slug from settings.
 		$settings     = Settings::get_instance();
@@ -1657,7 +1695,7 @@ class Test_Event_Setup extends Base {
 		$this->assertFalse( $wp_query->is_page, 'Should not be a page.' );
 		$this->assertSame(
 			'past',
-			$wp_query->get( Event_Query::EVENT_QUERY_PARAM ),
+			$wp_query->get( Query::EVENT_QUERY_PARAM ),
 			'Should have event query param set to past.'
 		);
 		$this->assertSame(
@@ -1695,7 +1733,7 @@ class Test_Event_Setup extends Base {
 	public function test_handle_event_archive_redirect_preserves_pagination(): void {
 		global $wp_query;
 
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$settings     = Settings::get_instance();
 		$rewrite_slug = $settings->get( 'events_url' );
@@ -1749,7 +1787,7 @@ class Test_Event_Setup extends Base {
 	 * @return void
 	 */
 	public function test_filter_archive_title(): void {
-		$instance = Event_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		Utility::set_and_get_hidden_property( $instance, 'archive_title', 'Test Title' );
 


### PR DESCRIPTION
### Description of the Change

First of three PRs implementing [#1502](https://github.com/GatherPress/gatherpress/issues/1502) — flattens the `Event_*` classes from `GatherPress\Core` into a subnamespace matching the existing `Settings` / `Settings\*` pattern. Rsvp and Venue subsystems land as separate follow-up PRs so each subsystem stays reviewable independently.

**Moved + renamed (`git mv` — rename history is preserved for `git log --follow`):**

| Old | New |
|---|---|
| `GatherPress\Core\Event_Admin_List` at `classes/class-event-admin-list.php` | `GatherPress\Core\Event\Admin_List` at `classes/event/class-admin-list.php` |
| `GatherPress\Core\Event_Query` at `classes/class-event-query.php` | `GatherPress\Core\Event\Query` at `classes/event/class-query.php` |
| `GatherPress\Core\Event_Rest_Api` at `classes/class-event-rest-api.php` | `GatherPress\Core\Event\Rest_Api` at `classes/event/class-rest-api.php` |
| `GatherPress\Core\Event_Setup` at `classes/class-event-setup.php` | `GatherPress\Core\Event\Setup` at `classes/event/class-setup.php` |

Test files moved in lockstep to `test/unit/php/includes/tests/core/classes/event/` with matching class renames (`Test_Event_Admin_List` → `Test_Admin_List`, etc.) and updated `@coversDefaultClass` annotations.

**Hub pattern mirrors Settings.** `Event\Setup` gained an `instantiate_classes()` method that creates its sibling singletons (`Admin_List`, `Query`, `Rest_Api`). The outer `Setup::instantiate_classes()` drops from four `Event\*::get_instance()` lines to a single `Event\Setup::get_instance()` line. Adding a new `Event\*` class in the future lands as one line in `Event\Setup::instantiate_classes()` rather than two edits (Setup list + new class file).

Before:

```php
// class-setup.php
Event_Admin_List::get_instance();
Event_Query::get_instance();
Event_Rest_Api::get_instance();
Event_Setup::get_instance();
```

After:

```php
// class-setup.php
Event\Setup::get_instance();

// event/class-setup.php
protected function instantiate_classes(): void {
    Admin_List::get_instance();
    Query::get_instance();
    Rest_Api::get_instance();
}
```

**Cross-namespace `use` statements.** Moved files now need explicit imports for classes that used to resolve via same-namespace lookup from `GatherPress\Core` — added `use` statements for `Rsvp`, `Topic`, `Venue`, `Venue_Setup`, `Settings`, `Utility`, `Validate`, `Feed`, `Rsvp_Query`, `Rsvp_Setup`, `Rsvp_Token`, `User`, and the parent `GatherPress\Core\Event` class itself where each file references them.

**Aliased imports at two consumer sites** to avoid touching unrelated call sites:

```php
// includes/core/classes/settings/class-events.php
use GatherPress\Core\Event\Setup as Event_Setup;  // was: use GatherPress\Core\Event_Setup;

// test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
use GatherPress\Core\Event\Setup as Event_Setup;  // was: use GatherPress\Core\Event_Setup;
```

The call sites inside those two files read `Event_Setup::whatever()` unchanged. The aliases also double as future insurance — when Venue renames `Venue_Setup` → `Venue\Setup`, a bare `use Setup` in those files would collide with one coming from Event or Venue; aliasing sidesteps that.

**Not in this PR** (deferred to follow-ups on #1502):

- `Rsvp_*` → `Rsvp\*` (Cleanup, Form, Query, Setup, Token — 5 subclasses + outer `Setup` collision to handle inside `Rsvp\Setup`)
- `Venue_*` → `Venue\*` (Map, Map_Prewarm, Setup — 3 subclasses)
- Auto-generated developer hook docs at `docs/developer/hooks/` — line numbers for every hook in the moved Event files will shift, but the `extract-wp-hooks-as-docs.yml` workflow regenerates these automatically on merge to `develop` per the repo convention. Not included in this PR.

Part of #1502 — keeping the ticket open for the Rsvp and Venue follow-ups.

### How to test the Change

1. Check out the branch and run the full PHP test suite (`npm run test:unit:php` + `npm run test:unit:php:multisite`) plus JS (`npm run test:unit:js`). One new test joins: `GatherPress\Tests\Core\Event\Test_Setup::test_instantiate_classes_registers_siblings` proves each Event\* sibling got instantiated by checking for its distinctive registered hook (`load-edit.php` for `Admin_List`, `pre_get_posts` for `Query`, `rest_api_init` for `Rest_Api`).
2. Activate the plugin on a site with existing events and click around the Events admin list — sorting by event date, filtering "Upcoming"/"Past", RSVP count column. Nothing should have changed visually or behaviorally — this PR is pure internal reorganization.
3. Create a new event via the block editor and save — confirms `Event\Setup` is still registering the custom post type correctly.
4. Hit the REST endpoints once (e.g. `GET /wp-json/gatherpress/v1/event/…`) to confirm `Event\Rest_Api` is still registering its routes.
5. Check Events → Settings and navigate between General / Roles / Tools / Credits / Venues — the `Event_Setup` alias in `settings/class-events.php` keeps the "default post type slug" logic working.
6. `git log --follow includes/core/classes/event/class-setup.php` should still trace back through the rename to the original `class-event-setup.php` history. Same for the other three.

### Changelog Entry

> Changed - Internal: flattened `Event_*` classes into the `GatherPress\Core\Event` subnamespace (`Event_Admin_List` → `Event\Admin_List`, etc.) matching the existing `Settings\*` pattern. `Event\Setup` now owns its sibling instantiation via `Event\Setup::instantiate_classes()`, collapsing four lines of `Setup::instantiate_classes()` into one. No user-facing behavior change.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.