### PR TITLE
Enforce per-post edit capability on venue/event meta and post-specific REST routes

### DIFF
--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -104,6 +104,38 @@ class Utility {
 	}
 
 	/**
+	 * Authorization callback for post meta that mirrors the post-level edit cap.
+	 *
+	 * Routes through `user_can( $user_id, 'edit_post', $object_id )` so the
+	 * per-post permission model (`map_meta_cap` → `edit_others_posts`,
+	 * `edit_published_posts`, etc.) gates meta the same way it gates the post
+	 * itself. Without this, the meta layer would be more permissive than the
+	 * post layer that owns it: a custom REST route or third-party
+	 * `update_post_meta()` call could bypass the per-post check that the WP
+	 * posts controller already enforces on the post.
+	 *
+	 * Wired in via `'auth_callback' => array( Utility::class, 'can_edit_post_meta' )`
+	 * on every editor-writable meta key registered through `register_post_meta()`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param bool   $allowed   Whether the user can edit the post meta. Unused;
+	 *                          we authoritatively return based on `edit_post`.
+	 * @param string $meta_key  The meta key being accessed. Unused.
+	 * @param int    $object_id The post ID the meta belongs to.
+	 * @param int    $user_id   The user ID attempting the edit.
+	 * @return bool True if the user can edit the post, false otherwise.
+	 */
+	public static function can_edit_post_meta(
+		bool $allowed,
+		string $meta_key,
+		int $object_id,
+		int $user_id
+	): bool {
+		return user_can( $user_id, 'edit_post', $object_id );
+	}
+
+	/**
 	 * Retrieve an array of time zone choices.
 	 *
 	 * This method converts the Time Zone markup returned by WordPress into an associative array

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -119,6 +119,9 @@ class Utility {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) -- $allowed and $meta_key
+	 * are required by WP's register_post_meta auth_callback signature.
+	 *
 	 * @param bool   $allowed   Whether the user can edit the post meta. Unused;
 	 *                          we authoritatively return based on `edit_post`.
 	 * @param string $meta_key  The meta key being accessed. Unused.

--- a/includes/core/classes/class-venue-setup.php
+++ b/includes/core/classes/class-venue-setup.php
@@ -221,14 +221,32 @@ class Venue_Setup {
 	}
 
 	/**
-	 * Authorization callback for post meta that requires edit_posts capability.
+	 * Authorization callback for post meta that mirrors the post-level edit cap.
+	 *
+	 * Routes through `user_can( $user_id, 'edit_post', $object_id )` so the
+	 * per-post permission model (`map_meta_cap` → `edit_others_posts`,
+	 * `edit_published_posts`, etc.) gates meta the same way it gates the post
+	 * itself. Without this, the meta layer would be more permissive than the
+	 * post layer that owns it: a custom REST route or third-party
+	 * `update_post_meta()` call could bypass the per-post check that the WP
+	 * posts controller already enforces on the post.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return bool True if user can edit posts, false otherwise.
+	 * @param bool   $allowed   Whether the user can edit the post meta. Unused;
+	 *                          we authoritatively return based on `edit_post`.
+	 * @param string $meta_key  The meta key being accessed. Unused.
+	 * @param int    $object_id The post ID the meta belongs to.
+	 * @param int    $user_id   The user ID attempting the edit.
+	 * @return bool True if the user can edit the post, false otherwise.
 	 */
-	public function can_edit_posts_meta(): bool {
-		return current_user_can( 'edit_posts' );
+	public function can_edit_post_meta(
+		bool $allowed,
+		string $meta_key,
+		int $object_id,
+		int $user_id
+	): bool {
+		return user_can( $user_id, 'edit_post', $object_id );
 	}
 
 	/**
@@ -265,7 +283,7 @@ class Venue_Setup {
 	public function maybe_register_post_meta( string $post_type ): void {
 		$venue_information_meta = array(
 			'gatherpress_address'   => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -274,7 +292,7 @@ class Venue_Setup {
 				'revisions_enabled' => true,
 			),
 			'gatherpress_latitude'  => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => array( $this, 'sanitize_coordinate' ),
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -283,7 +301,7 @@ class Venue_Setup {
 				'revisions_enabled' => true,
 			),
 			'gatherpress_longitude' => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => array( $this, 'sanitize_coordinate' ),
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -292,7 +310,7 @@ class Venue_Setup {
 				'revisions_enabled' => true,
 			),
 			'gatherpress_phone'     => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -301,7 +319,7 @@ class Venue_Setup {
 				'revisions_enabled' => true,
 			),
 			'gatherpress_website'   => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'sanitize_url',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -336,7 +354,7 @@ class Venue_Setup {
 		$venue_map_meta = array(
 			// Map display settings.
 			'gatherpress_venue_map_show'   => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -344,7 +362,7 @@ class Venue_Setup {
 				'default'           => true,
 			),
 			'gatherpress_venue_map_zoom'   => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -352,7 +370,7 @@ class Venue_Setup {
 				'default'           => 10,
 			),
 			'gatherpress_venue_map_height' => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,

--- a/includes/core/classes/class-venue-setup.php
+++ b/includes/core/classes/class-venue-setup.php
@@ -17,6 +17,7 @@ namespace GatherPress\Core;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Utility;
 use GatherPress\Core\Validate;
 use stdClass;
 use WP_Block_Patterns_Registry;
@@ -221,35 +222,6 @@ class Venue_Setup {
 	}
 
 	/**
-	 * Authorization callback for post meta that mirrors the post-level edit cap.
-	 *
-	 * Routes through `user_can( $user_id, 'edit_post', $object_id )` so the
-	 * per-post permission model (`map_meta_cap` → `edit_others_posts`,
-	 * `edit_published_posts`, etc.) gates meta the same way it gates the post
-	 * itself. Without this, the meta layer would be more permissive than the
-	 * post layer that owns it: a custom REST route or third-party
-	 * `update_post_meta()` call could bypass the per-post check that the WP
-	 * posts controller already enforces on the post.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param bool   $allowed   Whether the user can edit the post meta. Unused;
-	 *                          we authoritatively return based on `edit_post`.
-	 * @param string $meta_key  The meta key being accessed. Unused.
-	 * @param int    $object_id The post ID the meta belongs to.
-	 * @param int    $user_id   The user ID attempting the edit.
-	 * @return bool True if the user can edit the post, false otherwise.
-	 */
-	public function can_edit_post_meta(
-		bool $allowed,
-		string $meta_key,
-		int $object_id,
-		int $user_id
-	): bool {
-		return user_can( $user_id, 'edit_post', $object_id );
-	}
-
-	/**
 	 * Sanitize callback for venue coordinate meta (latitude / longitude).
 	 *
 	 * Numeric values within the ±180 range are normalized to a string form via
@@ -283,7 +255,7 @@ class Venue_Setup {
 	public function maybe_register_post_meta( string $post_type ): void {
 		$venue_information_meta = array(
 			'gatherpress_address'   => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -292,7 +264,7 @@ class Venue_Setup {
 				'revisions_enabled' => true,
 			),
 			'gatherpress_latitude'  => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => array( $this, 'sanitize_coordinate' ),
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -301,7 +273,7 @@ class Venue_Setup {
 				'revisions_enabled' => true,
 			),
 			'gatherpress_longitude' => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => array( $this, 'sanitize_coordinate' ),
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -310,7 +282,7 @@ class Venue_Setup {
 				'revisions_enabled' => true,
 			),
 			'gatherpress_phone'     => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -319,7 +291,7 @@ class Venue_Setup {
 				'revisions_enabled' => true,
 			),
 			'gatherpress_website'   => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'sanitize_url',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -354,7 +326,7 @@ class Venue_Setup {
 		$venue_map_meta = array(
 			// Map display settings.
 			'gatherpress_venue_map_show'   => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -362,7 +334,7 @@ class Venue_Setup {
 				'default'           => true,
 			),
 			'gatherpress_venue_map_zoom'   => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -370,7 +342,7 @@ class Venue_Setup {
 				'default'           => 10,
 			),
 			'gatherpress_venue_map_height' => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -132,8 +132,12 @@ class Rest_Api {
 			'args'  => array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'email' ),
-				'permission_callback' => static function (): bool {
-					return current_user_can( 'edit_posts' );
+				'permission_callback' => static function ( WP_REST_Request $request ): bool {
+					// Per-post check: only users who can edit *this* event may
+					// send emails about it. Mirrors the meta auth_callback
+					// model so a non-owner Author can't blast emails about
+					// someone else's event via this route.
+					return current_user_can( 'edit_post', (int) $request['post_id'] );
 				},
 				'args'                => array(
 					'post_id' => array(
@@ -752,7 +756,11 @@ class Rest_Api {
 			$user_id &&
 			$current_user_id !== $user_id
 		) {
-			if ( ! current_user_can( 'edit_posts' ) ) {
+			// Per-event check: only users who can edit *this* event may
+			// RSVP someone else into it. The previous flat `edit_posts`
+			// check would have let any Author manage attendees on any
+			// event, including ones they don't own.
+			if ( ! current_user_can( 'edit_post', $post_id ) ) {
 				$user_id = 0;
 			}
 		} else {

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -247,35 +247,6 @@ class Setup {
 	}
 
 	/**
-	 * Authorization callback for post meta that mirrors the post-level edit cap.
-	 *
-	 * Routes through `user_can( $user_id, 'edit_post', $object_id )` so the
-	 * per-post permission model (`map_meta_cap` → `edit_others_posts`,
-	 * `edit_published_posts`, etc.) gates meta the same way it gates the post
-	 * itself. Without this, the meta layer would be more permissive than the
-	 * post layer that owns it: a custom REST route or third-party
-	 * `update_post_meta()` call could bypass the per-post check that the WP
-	 * posts controller already enforces on the post.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param bool   $allowed   Whether the user can edit the post meta. Unused;
-	 *                          we authoritatively return based on `edit_post`.
-	 * @param string $meta_key  The meta key being accessed. Unused.
-	 * @param int    $object_id The post ID the meta belongs to.
-	 * @param int    $user_id   The user ID attempting the edit.
-	 * @return bool True if the user can edit the post, false otherwise.
-	 */
-	public function can_edit_post_meta(
-		bool $allowed,
-		string $meta_key,
-		int $object_id,
-		int $user_id
-	): bool {
-		return user_can( $user_id, 'edit_post', $object_id );
-	}
-
-	/**
 	 * Registers datetime meta + the read-only REST filter when a post type
 	 * declares gatherpress-event-date support.
 	 *
@@ -291,7 +262,7 @@ class Setup {
 
 		$event_date_meta = array(
 			'gatherpress_datetime'           => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -359,7 +330,7 @@ class Setup {
 		// Missing meta is treated as "on"; only an explicit 0 disables RSVP per event.
 		$event_only_meta = array(
 			'gatherpress_enable_rsvp'           => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -367,7 +338,7 @@ class Setup {
 				'default'           => 1,
 			),
 			'gatherpress_max_guest_limit'       => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -375,7 +346,7 @@ class Setup {
 				'default'           => (int) Settings::get_instance()->get( 'max_guest_limit' ),
 			),
 			'gatherpress_enable_anonymous_rsvp' => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -385,7 +356,7 @@ class Setup {
 			// Always register so it can be written regardless of open RSVP mode.
 			// Stored as integer (1 = enabled, 0 = disabled); an unset meta (empty string) is treated as enabled.
 			'gatherpress_enable_open_rsvp'      => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -393,7 +364,7 @@ class Setup {
 				'default'           => 1,
 			),
 			'gatherpress_online_event_link'     => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'sanitize_url',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -401,7 +372,7 @@ class Setup {
 				'default'           => '',
 			),
 			'gatherpress_max_attendance_limit'  => array(
-				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
+				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -247,14 +247,32 @@ class Setup {
 	}
 
 	/**
-	 * Authorization callback for post meta that requires edit_posts capability.
+	 * Authorization callback for post meta that mirrors the post-level edit cap.
+	 *
+	 * Routes through `user_can( $user_id, 'edit_post', $object_id )` so the
+	 * per-post permission model (`map_meta_cap` → `edit_others_posts`,
+	 * `edit_published_posts`, etc.) gates meta the same way it gates the post
+	 * itself. Without this, the meta layer would be more permissive than the
+	 * post layer that owns it: a custom REST route or third-party
+	 * `update_post_meta()` call could bypass the per-post check that the WP
+	 * posts controller already enforces on the post.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return bool True if user can edit posts, false otherwise.
+	 * @param bool   $allowed   Whether the user can edit the post meta. Unused;
+	 *                          we authoritatively return based on `edit_post`.
+	 * @param string $meta_key  The meta key being accessed. Unused.
+	 * @param int    $object_id The post ID the meta belongs to.
+	 * @param int    $user_id   The user ID attempting the edit.
+	 * @return bool True if the user can edit the post, false otherwise.
 	 */
-	public function can_edit_posts_meta(): bool {
-		return current_user_can( 'edit_posts' );
+	public function can_edit_post_meta(
+		bool $allowed,
+		string $meta_key,
+		int $object_id,
+		int $user_id
+	): bool {
+		return user_can( $user_id, 'edit_post', $object_id );
 	}
 
 	/**
@@ -273,7 +291,7 @@ class Setup {
 
 		$event_date_meta = array(
 			'gatherpress_datetime'           => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -341,7 +359,7 @@ class Setup {
 		// Missing meta is treated as "on"; only an explicit 0 disables RSVP per event.
 		$event_only_meta = array(
 			'gatherpress_enable_rsvp'           => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -349,7 +367,7 @@ class Setup {
 				'default'           => 1,
 			),
 			'gatherpress_max_guest_limit'       => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -357,7 +375,7 @@ class Setup {
 				'default'           => (int) Settings::get_instance()->get( 'max_guest_limit' ),
 			),
 			'gatherpress_enable_anonymous_rsvp' => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -367,7 +385,7 @@ class Setup {
 			// Always register so it can be written regardless of open RSVP mode.
 			// Stored as integer (1 = enabled, 0 = disabled); an unset meta (empty string) is treated as enabled.
 			'gatherpress_enable_open_rsvp'      => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -375,7 +393,7 @@ class Setup {
 				'default'           => 1,
 			),
 			'gatherpress_online_event_link'     => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'sanitize_url',
 				'show_in_rest'      => true,
 				'single'            => true,
@@ -383,7 +401,7 @@ class Setup {
 				'default'           => '',
 			),
 			'gatherpress_max_attendance_limit'  => array(
-				'auth_callback'     => array( $this, 'can_edit_posts_meta' ),
+				'auth_callback'     => array( $this, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
 				'single'            => true,

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -102,6 +102,55 @@ class Test_Utility extends Base {
 	}
 
 	/**
+	 * Coverage for can_edit_post_meta — per-post auth callback shared by every
+	 * editor-writable post meta GatherPress registers.
+	 *
+	 * Routes through `user_can( $user_id, 'edit_post', $object_id )` so the
+	 * permission model matches what WP applies to the post itself: Editors
+	 * (via `edit_others_posts`) can edit anyone's meta, Authors only their
+	 * own posts, Subscribers and logged-out users are denied.
+	 *
+	 * @covers ::can_edit_post_meta
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_post_meta(): void {
+		$author_one_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$author_two_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$editor_id     = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_author' => $author_one_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertTrue(
+			Utility::can_edit_post_meta( false, 'any_meta_key', $post_id, $author_one_id ),
+			'The post author should be able to edit their own post meta.'
+		);
+		$this->assertFalse(
+			Utility::can_edit_post_meta( false, 'any_meta_key', $post_id, $author_two_id ),
+			'A different author should not be able to edit a post they do not own.'
+		);
+		$this->assertTrue(
+			Utility::can_edit_post_meta( false, 'any_meta_key', $post_id, $editor_id ),
+			'An editor should be able to edit any post meta via edit_others_posts.'
+		);
+		$this->assertFalse(
+			Utility::can_edit_post_meta( false, 'any_meta_key', $post_id, $subscriber_id ),
+			'A subscriber should not be able to edit any post meta.'
+		);
+		$this->assertFalse(
+			Utility::can_edit_post_meta( false, 'any_meta_key', $post_id, 0 ),
+			'A logged-out user (user_id 0) should not be able to edit any post meta.'
+		);
+	}
+
+	/**
 	 * Coverage for timezone_choices method.
 	 *
 	 * @covers ::timezone_choices

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-setup.php
@@ -339,56 +339,6 @@ class Test_Venue_Setup extends Base {
 	}
 
 	/**
-	 * Tests can_edit_post_meta authorization callback — per-post check.
-	 *
-	 * Routes through `user_can( $user_id, 'edit_post', $object_id )` so the
-	 * permission model matches what WP uses for the post itself: Editors
-	 * (with `edit_others_posts`) can edit anyone's venue meta, Authors can
-	 * edit only their own, Subscribers and logged-out users are denied.
-	 *
-	 * @covers ::can_edit_post_meta
-	 *
-	 * @return void
-	 */
-	public function test_can_edit_post_meta(): void {
-		$instance = Venue_Setup::get_instance();
-
-		$author_one_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$author_two_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$editor_id     = $this->factory->user->create( array( 'role' => 'editor' ) );
-		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
-
-		$venue_id = $this->factory->post->create(
-			array(
-				'post_type'   => Venue::POST_TYPE,
-				'post_author' => $author_one_id,
-				'post_status' => 'publish',
-			)
-		);
-
-		$this->assertTrue(
-			$instance->can_edit_post_meta( false, 'gatherpress_address', $venue_id, $author_one_id ),
-			'The venue author should be able to edit their own venue meta.'
-		);
-		$this->assertFalse(
-			$instance->can_edit_post_meta( false, 'gatherpress_address', $venue_id, $author_two_id ),
-			'A different author should not be able to edit a venue they do not own.'
-		);
-		$this->assertTrue(
-			$instance->can_edit_post_meta( false, 'gatherpress_address', $venue_id, $editor_id ),
-			'An editor should be able to edit any venue meta via edit_others_posts.'
-		);
-		$this->assertFalse(
-			$instance->can_edit_post_meta( false, 'gatherpress_address', $venue_id, $subscriber_id ),
-			'A subscriber should not be able to edit any venue meta.'
-		);
-		$this->assertFalse(
-			$instance->can_edit_post_meta( false, 'gatherpress_address', $venue_id, 0 ),
-			'A logged-out user (user_id 0) should not be able to edit any venue meta.'
-		);
-	}
-
-	/**
 	 * Coverage for sanitize_coordinate.
 	 *
 	 * Numeric values within the ±180 range pass through; everything else

--- a/test/unit/php/includes/tests/core/classes/class-test-venue-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-venue-setup.php
@@ -339,31 +339,53 @@ class Test_Venue_Setup extends Base {
 	}
 
 	/**
-	 * Tests can_edit_posts_meta authorization callback.
+	 * Tests can_edit_post_meta authorization callback — per-post check.
 	 *
-	 * @covers ::can_edit_posts_meta
+	 * Routes through `user_can( $user_id, 'edit_post', $object_id )` so the
+	 * permission model matches what WP uses for the post itself: Editors
+	 * (with `edit_others_posts`) can edit anyone's venue meta, Authors can
+	 * edit only their own, Subscribers and logged-out users are denied.
+	 *
+	 * @covers ::can_edit_post_meta
 	 *
 	 * @return void
 	 */
-	public function test_can_edit_posts_meta(): void {
+	public function test_can_edit_post_meta(): void {
 		$instance = Venue_Setup::get_instance();
 
-		// Test with user who can edit posts.
-		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
-		wp_set_current_user( $editor_id );
-
-		$this->assertTrue( $instance->can_edit_posts_meta(), 'Editor should be able to edit post meta.' );
-
-		// Test with user who cannot edit posts.
+		$author_one_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$author_two_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$editor_id     = $this->factory->user->create( array( 'role' => 'editor' ) );
 		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
-		wp_set_current_user( $subscriber_id );
 
-		$this->assertFalse( $instance->can_edit_posts_meta(), 'Subscriber should not be able to edit post meta.' );
+		$venue_id = $this->factory->post->create(
+			array(
+				'post_type'   => Venue::POST_TYPE,
+				'post_author' => $author_one_id,
+				'post_status' => 'publish',
+			)
+		);
 
-		// Test with logged-out user.
-		wp_set_current_user( 0 );
-
-		$this->assertFalse( $instance->can_edit_posts_meta(), 'Logged-out user should not be able to edit post meta.' );
+		$this->assertTrue(
+			$instance->can_edit_post_meta( false, 'gatherpress_address', $venue_id, $author_one_id ),
+			'The venue author should be able to edit their own venue meta.'
+		);
+		$this->assertFalse(
+			$instance->can_edit_post_meta( false, 'gatherpress_address', $venue_id, $author_two_id ),
+			'A different author should not be able to edit a venue they do not own.'
+		);
+		$this->assertTrue(
+			$instance->can_edit_post_meta( false, 'gatherpress_address', $venue_id, $editor_id ),
+			'An editor should be able to edit any venue meta via edit_others_posts.'
+		);
+		$this->assertFalse(
+			$instance->can_edit_post_meta( false, 'gatherpress_address', $venue_id, $subscriber_id ),
+			'A subscriber should not be able to edit any venue meta.'
+		);
+		$this->assertFalse(
+			$instance->can_edit_post_meta( false, 'gatherpress_address', $venue_id, 0 ),
+			'A logged-out user (user_id 0) should not be able to edit any venue meta.'
+		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -1600,47 +1600,65 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
-	 * Tests email_route permission callback with user who can edit posts.
+	 * Tests email_route permission callback enforces a per-post edit check.
 	 *
-	 * Covers: permission callback returning true for users with edit_posts capability.
-	 *
-	 * @covers ::email_route
-	 */
-	public function test_email_route_permission_callback_can_edit(): void {
-		$instance = Rest_Api::get_instance();
-		$route    = Utility::invoke_hidden_method( $instance, 'email_route' );
-
-		// Create an editor who can edit posts.
-		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
-		wp_set_current_user( $editor_id );
-
-		// Call the permission callback.
-		$permission_callback = $route['args']['permission_callback'];
-		$result              = call_user_func( $permission_callback );
-
-		$this->assertTrue( $result, 'Permission callback should return true for user with edit_posts capability' );
-	}
-
-	/**
-	 * Tests email_route permission callback with user who cannot edit posts.
-	 *
-	 * Covers: permission callback returning false for users without edit_posts capability.
+	 * Routes through `current_user_can( 'edit_post', $post_id )` so the
+	 * permission model matches what WP applies to the event itself: Editors
+	 * can email about anyone's event, Authors can email only about their own,
+	 * and Subscribers / non-owner Authors are denied.
 	 *
 	 * @covers ::email_route
 	 */
-	public function test_email_route_permission_callback_cannot_edit(): void {
+	public function test_email_route_permission_callback_per_post(): void {
 		$instance = Rest_Api::get_instance();
 		$route    = Utility::invoke_hidden_method( $instance, 'email_route' );
+		$callback = $route['args']['permission_callback'];
 
-		// Create a subscriber who cannot edit posts.
+		$author_one_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$author_two_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$editor_id     = $this->factory->user->create( array( 'role' => 'editor' ) );
 		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		$event_id = $this->factory->post->create(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_author' => $author_one_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		$request = new \WP_REST_Request();
+		$request->set_param( 'post_id', $event_id );
+
+		wp_set_current_user( $author_one_id );
+		$this->assertTrue(
+			call_user_func( $callback, $request ),
+			'The event author should be allowed to email about their own event.'
+		);
+
+		wp_set_current_user( $author_two_id );
+		$this->assertFalse(
+			call_user_func( $callback, $request ),
+			'A different author should not be allowed to email about an event they do not own.'
+		);
+
+		wp_set_current_user( $editor_id );
+		$this->assertTrue(
+			call_user_func( $callback, $request ),
+			'An editor should be allowed to email about any event via edit_others_posts.'
+		);
+
 		wp_set_current_user( $subscriber_id );
+		$this->assertFalse(
+			call_user_func( $callback, $request ),
+			'A subscriber should not be allowed to email about any event.'
+		);
 
-		// Call the permission callback.
-		$permission_callback = $route['args']['permission_callback'];
-		$result              = call_user_func( $permission_callback );
-
-		$this->assertFalse( $result, 'Permission callback should return false for user without edit_posts capability' );
+		wp_set_current_user( 0 );
+		$this->assertFalse(
+			call_user_func( $callback, $request ),
+			'A logged-out user should not be allowed to email about any event.'
+		);
 	}
 
 	/**
@@ -1971,16 +1989,16 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
-	 * Tests update_rsvp when non-admin user tries to add someone else.
+	 * Tests update_rsvp when a subscriber tries to add someone else.
 	 *
-	 * Covers: user without edit_posts permission gets user_id set to 0.
+	 * Covers: user without edit_post on the target event gets user_id set to 0.
 	 *
 	 * @covers ::update_rsvp
 	 */
 	public function test_update_rsvp_non_admin_cannot_add_others(): void {
 		$instance = Rest_Api::get_instance();
 
-		// Create a subscriber (no edit_posts capability).
+		// Create a subscriber (no edit_post on any event).
 		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $subscriber_id );
 
@@ -2001,8 +2019,49 @@ class Test_Rest_Api extends Base {
 		$response = $instance->update_rsvp( $request );
 
 		$this->assertInstanceOf( 'WP_REST_Response', $response );
-		// The user_id should be reset to 0 since subscriber doesn't have edit_posts.
+		// The user_id should be reset to 0 since subscriber lacks edit_post on this event.
 		$this->assertFalse( $response->data['success'], 'RSVP should fail when non-admin tries to add someone else' );
+	}
+
+	/**
+	 * Tests update_rsvp when an Author tries to add someone else to a foreign event.
+	 *
+	 * The previous flat `edit_posts` gate would have let any Author manage
+	 * attendees on any event. The per-post `edit_post` check denies an Author
+	 * acting on an event they don't own.
+	 *
+	 * @covers ::update_rsvp
+	 */
+	public function test_update_rsvp_author_cannot_add_others_to_foreign_event(): void {
+		$instance = Rest_Api::get_instance();
+
+		$event_owner_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$author_id      = $this->factory->user->create( array( 'role' => 'author' ) );
+		$other_user_id  = $this->factory->user->create();
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_author' => $event_owner_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		// Switch to a *different* author who doesn't own the event.
+		wp_set_current_user( $author_id );
+
+		$request = new WP_REST_Request( 'POST', '/gatherpress/v1/event/rsvp' );
+		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'user_id', $other_user_id );
+		$request->set_param( 'status', 'attending' );
+
+		$response = $instance->update_rsvp( $request );
+
+		$this->assertInstanceOf( 'WP_REST_Response', $response );
+		$this->assertFalse(
+			$response->data['success'],
+			'A non-owner Author should not be able to RSVP someone else into another author\'s event.'
+		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -1112,7 +1112,6 @@ class Test_Setup extends Base {
 	 *
 	 * @covers ::register_event_only_meta
 	 * @covers ::maybe_register_event_date_meta
-	 * @covers ::can_edit_post_meta
 	 * @return void
 	 */
 	public function test_register_post_meta_auth_callbacks(): void {
@@ -1149,56 +1148,6 @@ class Test_Setup extends Base {
 
 		$result = update_post_meta( $post_id, 'gatherpress_max_attendance_limit', 100 );
 		$this->assertNotFalse( $result, 'Should allow meta update for max_attendance_limit' );
-	}
-
-	/**
-	 * Tests can_edit_post_meta authorization callback — per-post check.
-	 *
-	 * Routes through `user_can( $user_id, 'edit_post', $object_id )` so the
-	 * permission model matches what WP uses for the post itself: Editors
-	 * (with `edit_others_posts`) can edit anyone's event meta, Authors can
-	 * edit only their own, Subscribers and logged-out users are denied.
-	 *
-	 * @covers ::can_edit_post_meta
-	 *
-	 * @return void
-	 */
-	public function test_can_edit_post_meta(): void {
-		$instance = Setup::get_instance();
-
-		$author_one_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$author_two_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$editor_id     = $this->factory->user->create( array( 'role' => 'editor' ) );
-		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
-
-		$event_id = $this->factory->post->create(
-			array(
-				'post_type'   => Event::POST_TYPE,
-				'post_author' => $author_one_id,
-				'post_status' => 'publish',
-			)
-		);
-
-		$this->assertTrue(
-			$instance->can_edit_post_meta( false, 'gatherpress_datetime', $event_id, $author_one_id ),
-			'The event author should be able to edit their own event meta.'
-		);
-		$this->assertFalse(
-			$instance->can_edit_post_meta( false, 'gatherpress_datetime', $event_id, $author_two_id ),
-			'A different author should not be able to edit an event they do not own.'
-		);
-		$this->assertTrue(
-			$instance->can_edit_post_meta( false, 'gatherpress_datetime', $event_id, $editor_id ),
-			'An editor should be able to edit any event meta via edit_others_posts.'
-		);
-		$this->assertFalse(
-			$instance->can_edit_post_meta( false, 'gatherpress_datetime', $event_id, $subscriber_id ),
-			'A subscriber should not be able to edit any event meta.'
-		);
-		$this->assertFalse(
-			$instance->can_edit_post_meta( false, 'gatherpress_datetime', $event_id, 0 ),
-			'A logged-out user (user_id 0) should not be able to edit any event meta.'
-		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -1112,7 +1112,7 @@ class Test_Setup extends Base {
 	 *
 	 * @covers ::register_event_only_meta
 	 * @covers ::maybe_register_event_date_meta
-	 * @covers ::can_edit_posts_meta
+	 * @covers ::can_edit_post_meta
 	 * @return void
 	 */
 	public function test_register_post_meta_auth_callbacks(): void {
@@ -1152,31 +1152,53 @@ class Test_Setup extends Base {
 	}
 
 	/**
-	 * Tests can_edit_posts_meta authorization callback.
+	 * Tests can_edit_post_meta authorization callback — per-post check.
 	 *
-	 * @covers ::can_edit_posts_meta
+	 * Routes through `user_can( $user_id, 'edit_post', $object_id )` so the
+	 * permission model matches what WP uses for the post itself: Editors
+	 * (with `edit_others_posts`) can edit anyone's event meta, Authors can
+	 * edit only their own, Subscribers and logged-out users are denied.
+	 *
+	 * @covers ::can_edit_post_meta
 	 *
 	 * @return void
 	 */
-	public function test_can_edit_posts_meta(): void {
+	public function test_can_edit_post_meta(): void {
 		$instance = Setup::get_instance();
 
-		// Test with user who can edit posts.
-		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
-		wp_set_current_user( $editor_id );
-
-		$this->assertTrue( $instance->can_edit_posts_meta(), 'Editor should be able to edit post meta' );
-
-		// Test with user who cannot edit posts.
+		$author_one_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$author_two_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$editor_id     = $this->factory->user->create( array( 'role' => 'editor' ) );
 		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
-		wp_set_current_user( $subscriber_id );
 
-		$this->assertFalse( $instance->can_edit_posts_meta(), 'Subscriber should not be able to edit post meta' );
+		$event_id = $this->factory->post->create(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_author' => $author_one_id,
+				'post_status' => 'publish',
+			)
+		);
 
-		// Test with logged-out user.
-		wp_set_current_user( 0 );
-
-		$this->assertFalse( $instance->can_edit_posts_meta(), 'Logged-out user should not be able to edit post meta' );
+		$this->assertTrue(
+			$instance->can_edit_post_meta( false, 'gatherpress_datetime', $event_id, $author_one_id ),
+			'The event author should be able to edit their own event meta.'
+		);
+		$this->assertFalse(
+			$instance->can_edit_post_meta( false, 'gatherpress_datetime', $event_id, $author_two_id ),
+			'A different author should not be able to edit an event they do not own.'
+		);
+		$this->assertTrue(
+			$instance->can_edit_post_meta( false, 'gatherpress_datetime', $event_id, $editor_id ),
+			'An editor should be able to edit any event meta via edit_others_posts.'
+		);
+		$this->assertFalse(
+			$instance->can_edit_post_meta( false, 'gatherpress_datetime', $event_id, $subscriber_id ),
+			'A subscriber should not be able to edit any event meta.'
+		);
+		$this->assertFalse(
+			$instance->can_edit_post_meta( false, 'gatherpress_datetime', $event_id, 0 ),
+			'A logged-out user (user_id 0) should not be able to edit any event meta.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change

Tightens three permission checks that were using the role-level `current_user_can( 'edit_posts' )` capability to gate post-specific actions, and aligns them with the per-post `edit_post` model that WP applies to the post itself. Without this, the meta layer and a couple of REST routes were more permissive than the post they live on — a non-owner Author could rewrite venue/event meta or trigger event-scoped actions through paths that bypass the WP posts controller's per-post permission check.

**Meta auth_callback rename: `can_edit_posts_meta()` → `can_edit_post_meta()`.**

`Venue_Setup::can_edit_posts_meta()` and `Event\Setup::can_edit_posts_meta()` are renamed and reworked to consume the `$object_id` and `$user_id` arguments WP's meta-auth path passes in:

```php
public function can_edit_post_meta(
    bool $allowed,
    string $meta_key,
    int $object_id,
    int $user_id
): bool {
    return user_can( $user_id, 'edit_post', $object_id );
}
```

`user_can(..., 'edit_post', $object_id)` is a meta capability — it routes through `map_meta_cap` and resolves to the post-type-specific primitive caps (`edit_others_posts`, `edit_published_posts`, etc.) for the post in question. Editors still pass for any post via `edit_others_posts`; Authors pass for their own posts only; Subscribers and logged-out users fail closed. All 8 venue meta keys and all 7 event meta keys that previously used the loose helper are updated to point at the new method.

**REST route hardening (same shape):**

Two routes had the same loose pattern. Both are post-scoped actions, so the same `edit_post`-against-the-target-post fix applies.

- `Rest_Api::email_route()` — sends emails about a specific event. The `permission_callback` now reads the route's required `post_id` arg and checks `current_user_can( 'edit_post', (int) $request['post_id'] )`. Previously, any user with `edit_posts` could trigger emails about events they don't own.
- `Rest_Api::update_rsvp()` "manage another user" branch — gates whether the current user can RSVP someone *else* into the event. The inner check is now `current_user_can( 'edit_post', $post_id )` against the event being acted on. Previously, any `edit_posts` user could manage attendees on any event.

**What's intentionally left alone (audited and confirmed correct):**

- `Geocoding::register_endpoints()` `/geocode` and `/geocode/search` — utility endpoints that don't modify any specific post; `edit_posts` is the right rate-limit defense.
- `Rsvp_Template` anonymity check — display/privacy concern, not a write-authorization gate.
- `Rsvp::save_rsvp()` anonymous-RSVP gate — gates a user-facing behavior, not write auth.
- `Rsvp::CAPABILITY = 'moderate_comments'` — RSVPs are stored as comments; the comment-moderation cap is the correct model.

**Why this matters even though the WP posts controller already enforces per-post permissions:**

In default WP, `update_item_permissions_check` on `WP_REST_Posts_Controller` runs `current_user_can( 'edit_post', $id )` *before* the meta auth_callback fires, so the standard `PATCH /wp-json/wp/v2/{post_type}/{id}` flow is already protected. The auth_callback matters as a defense-in-depth layer for paths that don't go through the posts controller: third-party REST routes that touch meta directly, internal `update_post_meta()` calls from non-controller code, custom `user_has_cap` filters, and our own future routes that we'd otherwise have to remember to gate at the route level. Holding the API correctly here means forgetting to layer in per-post checks at the route level fails closed instead of open.

Renaming the public helper is a 0.34.0-track breaking change, consistent with the rest of the release. Companion plugins that registered their own venue/event post types and reused these helpers will inherit the tightened check, which is the desired outcome.

Closes #1518

### How to test the Change

1. Create three test users on a fresh install:
   - User A: Editor.
   - User B: Author.
   - User C: Author (different account than B).
   - User D: Subscriber.
2. Sign in as User B and create an event (gives B authorship of an event).
3. Sign in as User C, then test each path against User B's event:
   - **Meta via REST.** `PATCH /wp-json/wp/v2/gatherpress_event/{B-event-id}` with a `meta` payload that touches `gatherpress_max_guest_limit`. Should 403 (the WP posts controller blocks the outer request before meta is reached, but the auth_callback layer is now the right shape too).
   - **`/gatherpress/v1/event/email` route.** POST to the route with `post_id = B-event-id`. Should 401/403. Same call as User B (the event owner) → should succeed. Same call as User A (Editor) → should succeed.
   - **`update_rsvp` manage-others branch.** POST to `/gatherpress/v1/event/rsvp` as User C with `post_id = B-event-id` and a `user_id` belonging to a fourth user. The response should report `success: false` (User C has no `edit_post` on B's event, so `$user_id` is reset to `0` before the RSVP attempt).
4. Repeat the three calls as User B against B's own event — all three should succeed.
5. Repeat as User A (Editor) against B's event — all three should succeed via `edit_others_posts`.
6. Repeat as User D (Subscriber) — all three should be denied.
7. Companion-plugin smoke check: register a custom venue post type (`my_custom_venue`) with `gatherpress-venue-information` support. Confirm meta on a custom-venue post inherits the same per-post check as the built-in venue post type.
8. Run `npm run lint:php` (clean) and `npm run test:unit:php` (covers `test_can_edit_post_meta` per-author matrix on both `Venue_Setup` and `Event\Setup`, the `test_email_route_permission_callback_per_post` matrix, and the new `test_update_rsvp_author_cannot_add_others_to_foreign_event` case).

### Changelog Entry

> **Security.** Venue and event meta `auth_callback` and two post-specific REST routes (`/gatherpress/v1/event/email`, `/gatherpress/v1/event/rsvp` "manage another user" branch) now enforce the per-post `edit_post` capability instead of the role-level `edit_posts` cap. This aligns the meta layer and these post-scoped routes with the same author/editor boundary WP enforces on the post itself, closing a defense-in-depth gap where a non-owner Author could otherwise rewrite meta or trigger event-scoped actions through paths that don't go through the WP posts controller.
>
> **Changed.** `Venue_Setup::can_edit_posts_meta()` and `Event\Setup::can_edit_posts_meta()` are renamed to `can_edit_post_meta()` and now take the standard `$allowed`, `$meta_key`, `$object_id`, `$user_id` arguments WP passes to a meta `auth_callback`. Companion plugins that referenced the old helper by name will need to update.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.