### PR TITLE
Flatten Venue_* into GatherPress\Core\Venue subnamespace

### DIFF
--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -13,7 +13,7 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Setup;
 use WP_Block;
 
 /**
@@ -116,7 +116,7 @@ class Online_Event {
 		}
 
 		$event_post_type = (string) get_post_type( $post_id );
-		$taxonomy        = Venue_Setup::get_instance()->taxonomy_for_event_post_type( $event_post_type );
+		$taxonomy        = Setup::get_instance()->taxonomy_for_event_post_type( $event_post_type );
 		$venue_terms     = get_the_terms( $post_id, $taxonomy );
 
 		if ( ! is_array( $venue_terms ) ) {

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -13,7 +13,7 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue_Setup;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 use WP_Block;
 
 /**

--- a/includes/core/classes/blocks/class-venue.php
+++ b/includes/core/classes/blocks/class-venue.php
@@ -16,8 +16,8 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue as Venue_Core;
-use GatherPress\Core\Venue_Setup;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Venue as Venue_Core;
 use WP_Block;
 use WP_Post;
 

--- a/includes/core/classes/blocks/class-venue.php
+++ b/includes/core/classes/blocks/class-venue.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Block;
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue as Venue_Core;
 use WP_Block;
 use WP_Post;
@@ -128,7 +128,7 @@ class Venue {
 		}
 
 		if ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
-			$venue_post = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
+			$venue_post = Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
 
 			if ( $venue_post instanceof WP_Post && Venue_Core::POST_TYPE === $venue_post->post_type ) {
 				return $venue_post;

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -71,9 +71,7 @@ class Setup {
 		Settings::get_instance();
 		Topic::get_instance();
 		User::get_instance();
-		Venue_Map::get_instance();
-		Venue_Map_Prewarm::get_instance();
-		Venue_Setup::get_instance();
+		Venue\Setup::get_instance();
 	}
 
 	/**
@@ -348,14 +346,14 @@ class Setup {
 	 * @return void
 	 */
 	public function add_online_event_term(): void {
-		Venue_Setup::get_instance()->register_taxonomy();
+		Venue\Setup::get_instance()->register_taxonomy();
 
 		$term_name = __( 'Online event', 'gatherpress' );
 		$term_slug = 'online-event';
 
 		// Ensure the online-event term exists in each registered venue taxonomy.
 		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $venue_post_type ) {
-			$taxonomy = Venue_Setup::get_instance()->get_taxonomy( $venue_post_type );
+			$taxonomy = Venue\Setup::get_instance()->get_taxonomy( $venue_post_type );
 			$term     = term_exists( $term_slug, $taxonomy );
 
 			if ( ! $term ) {

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -20,7 +20,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp_Query;
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Setup;
 use WP_Query;
 
 /**
@@ -500,7 +500,7 @@ class Admin_List {
 
 		$screen         = get_current_screen();
 		$post_type      = $screen ? $screen->post_type : Event::POST_TYPE;
-		$venue_taxonomy = Venue_Setup::get_instance()->taxonomy_for_event_post_type( $post_type );
+		$venue_taxonomy = Setup::get_instance()->taxonomy_for_event_post_type( $post_type );
 
 		// Bail early if the derived taxonomy is not registered to avoid invalid SQL.
 		if ( ! taxonomy_exists( $venue_taxonomy ) ) {
@@ -572,7 +572,7 @@ class Admin_List {
 			$event             = new Event( $post_id );
 			$venue_information = $event->get_venue_information();
 			$venue_name        = $venue_information['name'];
-			$venue_taxonomy    = Venue_Setup::get_instance()->taxonomy_for_event_post_type(
+			$venue_taxonomy    = Setup::get_instance()->taxonomy_for_event_post_type(
 				(string) get_post_type( $post_id )
 			);
 

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -20,7 +20,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp_Query;
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue_Setup;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 use WP_Query;
 
 /**

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -21,7 +21,7 @@ use GatherPress\Core\Rsvp_Setup;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Validate;
-use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue;
 use WP_Post;
 
@@ -547,7 +547,7 @@ class Event {
 		);
 
 		$event_post_type = (string) get_post_type( $this->event );
-		$venue_setup     = Venue_Setup::get_instance();
+		$venue_setup     = Setup::get_instance();
 		$taxonomy        = $venue_setup->taxonomy_for_event_post_type( $event_post_type );
 		$venue_terms     = (array) get_the_terms( $this->event, $taxonomy );
 

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -21,8 +21,8 @@ use GatherPress\Core\Rsvp_Setup;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Validate;
-use GatherPress\Core\Venue;
-use GatherPress\Core\Venue_Setup;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Venue;
 use WP_Post;
 
 /**

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -19,7 +19,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Topic;
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue;
 use WP_Post;
 use WP_Query;
@@ -529,7 +529,7 @@ class Query {
 
 		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $venue_post_type ) {
 			$venue_tax_query[] = array(
-				'taxonomy' => Venue_Setup::get_instance()->get_taxonomy( $venue_post_type ),
+				'taxonomy' => Setup::get_instance()->get_taxonomy( $venue_post_type ),
 				'field'    => 'slug',
 				'terms'    => $venues,
 			);

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -19,8 +19,8 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Topic;
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue;
-use GatherPress\Core\Venue_Setup;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Venue;
 use WP_Post;
 use WP_Query;
 

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Event\Setup as Event_Setup;
-use GatherPress\Core\Venue_Setup;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 use GatherPress\Core\Topic;
 
 /**

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -16,7 +16,7 @@ namespace GatherPress\Core\Settings;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue\Map as Venue_Map;
+use GatherPress\Core\Venue\Map;
 
 /**
  * Class Venues.
@@ -116,7 +116,7 @@ class Venues extends Base {
 							'label'   => __( 'Render mode for new blocks:', 'gatherpress' ),
 							'type'    => 'select',
 							'options' => array(
-								'default' => Venue_Map::DEFAULT_RENDER_MODE,
+								'default' => Map::DEFAULT_RENDER_MODE,
 								'items'   => array(
 									'interactive' => __( 'Interactive', 'gatherpress' ),
 									'static'      => __( 'Static image', 'gatherpress' ),
@@ -137,7 +137,7 @@ class Venues extends Base {
 							'type'    => 'number',
 							'size'    => 'small',
 							'options' => array(
-								'default' => Venue_Map::DEFAULT_ZOOM,
+								'default' => Map::DEFAULT_ZOOM,
 								'min'     => '1',
 								'max'     => '20',
 							),
@@ -160,7 +160,7 @@ class Venues extends Base {
 							'options'     => array(
 								'default' => '',
 								'min'     => '0',
-								'max'     => (string) Venue_Map::HEIGHT_MAX,
+								'max'     => (string) Map::HEIGHT_MAX,
 							),
 						),
 					),
@@ -181,7 +181,7 @@ class Venues extends Base {
 							'options'     => array(
 								'default' => '',
 								'min'     => '0',
-								'max'     => (string) Venue_Map::WIDTH_MAX,
+								'max'     => (string) Map::WIDTH_MAX,
 							),
 						),
 					),
@@ -197,7 +197,7 @@ class Venues extends Base {
 							'label'   => __( 'Aspect ratio for new blocks:', 'gatherpress' ),
 							'type'    => 'select',
 							'options' => array(
-								'default' => Venue_Map::DEFAULT_ASPECT_RATIO,
+								'default' => Map::DEFAULT_ASPECT_RATIO,
 								'items'   => array(
 									'2/1'  => __( '2:1 (landscape)', 'gatherpress' ),
 									'16/9' => __( '16:9 (wide)', 'gatherpress' ),
@@ -220,7 +220,7 @@ class Venues extends Base {
 							'label'   => __( 'Scale for new blocks:', 'gatherpress' ),
 							'type'    => 'select',
 							'options' => array(
-								'default' => Venue_Map::DEFAULT_SCALE,
+								'default' => Map::DEFAULT_SCALE,
 								'items'   => array(
 									'cover'   => __( 'Cover', 'gatherpress' ),
 									'contain' => __( 'Contain', 'gatherpress' ),
@@ -242,7 +242,7 @@ class Venues extends Base {
 							'label'   => __( 'Map type for new blocks:', 'gatherpress' ),
 							'type'    => 'select',
 							'options' => array(
-								'default' => Venue_Map::DEFAULT_MAP_TYPE,
+								'default' => Map::DEFAULT_MAP_TYPE,
 								'items'   => array(
 									'roadmap'   => __( 'Roadmap', 'gatherpress' ),
 									'satellite' => __( 'Satellite', 'gatherpress' ),

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -16,7 +16,7 @@ namespace GatherPress\Core\Settings;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue_Map;
+use GatherPress\Core\Venue\Map as Venue_Map;
 
 /**
  * Class Venues.

--- a/includes/core/classes/venue/class-map-prewarm.php
+++ b/includes/core/classes/venue/class-map-prewarm.php
@@ -5,7 +5,7 @@
  * Scans FSE templates, template parts, and event post content for
  * `gatherpress/venue-map` blocks, collects every distinct (zoom, width,
  * height, aspectRatio) combo they request, and enqueues per-venue cron
- * jobs that drive {@see Venue_Map::warm()}. The goal is to keep the first
+ * jobs that drive {@see Map::warm()}. The goal is to keep the first
  * render of a venue page instant — once the venue has been saved, every
  * combo the site's templates reference has a PNG on disk before any
  * front-end request arrives.
@@ -19,11 +19,11 @@
  * Scheduling is WP-Cron for now. Action Scheduler integration will
  * replace this layer once it's pulled into the plugin.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Venue
  * @since 1.0.0
  */
 
-namespace GatherPress\Core;
+namespace GatherPress\Core\Venue;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
@@ -32,14 +32,14 @@ use GatherPress\Core\Traits\Singleton;
 use WP_Post;
 
 /**
- * Class Venue_Map_Prewarm.
+ * Class Map_Prewarm.
  *
  * Scans templates + events for venue-map combos, enqueues cron jobs to
- * warm each (venue, combo) via {@see Venue_Map::warm()}.
+ * warm each (venue, combo) via {@see Map::warm()}.
  *
  * @since 1.0.0
  */
-class Venue_Map_Prewarm {
+class Map_Prewarm {
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -156,7 +156,7 @@ class Venue_Map_Prewarm {
 	protected function setup_hooks(): void {
 		add_action( self::CRON_ACTION, array( $this, 'process_warm_job' ), 10, 5 );
 
-		// Priority 12 — after Venue_Map::maybe_generate() (priority 11) has
+		// Priority 12 — after Map::maybe_generate() (priority 11) has
 		// synchronously rendered whatever combos were already cached on the
 		// venue. This hook picks up template combos the venue has never
 		// been rendered at.
@@ -213,7 +213,7 @@ class Venue_Map_Prewarm {
 				return;
 			}
 
-			$venue = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
+			$venue = Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
 
 			if ( $venue instanceof WP_Post ) {
 				foreach ( $combos as $combo ) {
@@ -236,7 +236,7 @@ class Venue_Map_Prewarm {
 	}
 
 	/**
-	 * Cron handler. Delegates to {@see Venue_Map::warm()}.
+	 * Cron handler. Delegates to {@see Map::warm()}.
 	 *
 	 * @since 1.0.0
 	 *
@@ -248,7 +248,7 @@ class Venue_Map_Prewarm {
 	 * @return void
 	 */
 	public function process_warm_job( int $post_id, int $zoom, int $width, int $height, string $aspect_ratio ): void {
-		Venue_Map::get_instance()->warm( $post_id, $zoom, $width, $height, $aspect_ratio );
+		Map::get_instance()->warm( $post_id, $zoom, $width, $height, $aspect_ratio );
 	}
 
 	/**
@@ -519,14 +519,14 @@ class Venue_Map_Prewarm {
 	 */
 	protected function extract_block_combo( array $attrs ): array {
 		return array(
-			'zoom'         => isset( $attrs['zoom'] ) ? (int) $attrs['zoom'] : Venue_Map::DEFAULT_ZOOM,
+			'zoom'         => isset( $attrs['zoom'] ) ? (int) $attrs['zoom'] : Map::DEFAULT_ZOOM,
 			'width'        => isset( $attrs['width'] ) ? (int) $attrs['width'] : 0,
 			'height'       => isset( $attrs['height'] )
 				? (int) $attrs['height']
-				: Venue_Map::DEFAULT_HEIGHT,
+				: Map::DEFAULT_HEIGHT,
 			'aspect_ratio' => isset( $attrs['aspectRatio'] )
 				? (string) $attrs['aspectRatio']
-				: Venue_Map::DEFAULT_ASPECT_RATIO,
+				: Map::DEFAULT_ASPECT_RATIO,
 		);
 	}
 

--- a/includes/core/classes/venue/class-map.php
+++ b/includes/core/classes/venue/class-map.php
@@ -16,15 +16,16 @@
  * map-related additions (REST endpoint for the editor preview, interactive
  * map server-side bits, async regeneration, etc.) have a natural home.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Venue
  * @since 1.0.0
  */
 
-namespace GatherPress\Core;
+namespace GatherPress\Core\Venue;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use WP_Post;
 use WP_REST_Request;
@@ -32,7 +33,7 @@ use WP_REST_Response;
 use WP_REST_Server;
 
 /**
- * Class Venue_Map.
+ * Class Map.
  *
  * Singleton hosting the venue map server-side pipeline. Currently owns the
  * static PNG cache keyed by (zoom, height) combo; structured so that
@@ -41,7 +42,7 @@ use WP_REST_Server;
  *
  * @since 1.0.0
  */
-class Venue_Map {
+class Map {
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -830,7 +831,7 @@ class Venue_Map {
 		if ( post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
 			$venue_post_id = $post_id;
 		} elseif ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
-			$venue_post = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
+			$venue_post = Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
 
 			if ( $venue_post instanceof WP_Post ) {
 				$venue_post_id = $venue_post->ID;

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -7,15 +7,17 @@
  * slug maintenance). Per-venue data accessors live on the `Venue` instance
  * class instead.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Venue
  * @since 1.0.0
  */
 
-namespace GatherPress\Core;
+namespace GatherPress\Core\Venue;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Event\Event;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Validate;
@@ -26,14 +28,18 @@ use WP_REST_Request;
 use WP_Term;
 
 /**
- * Class Venue_Setup.
+ * Class Setup.
  *
  * Registers the Venue post type + taxonomy and wires the WordPress hooks that
- * keep venue data consistent (term lifecycle, template content).
+ * keep venue data consistent (term lifecycle, template content). Also owns
+ * instantiation of the Venue\* sibling singletons (Map, Map_Prewarm) so the
+ * outer `Setup::instantiate_classes()` can hand off the whole venue subsystem
+ * with a single `Venue\Setup::get_instance()` line — same shape as
+ * `Settings::instantiate_classes()`.
  *
  * @since 1.0.0
  */
-class Venue_Setup {
+class Setup {
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -42,10 +48,32 @@ class Venue_Setup {
 	/**
 	 * Class constructor.
 	 *
+	 * Instantiates the sibling Venue\* singletons before wiring hooks so
+	 * `Setup::instantiate_classes()` can hand off the whole venue
+	 * subsystem with a single `Venue\Setup::get_instance()` line — same
+	 * shape as `Settings::instantiate_classes()`.
+	 *
 	 * @since 1.0.0
 	 */
 	public function __construct() {
+		$this->instantiate_classes();
 		$this->setup_hooks();
+	}
+
+	/**
+	 * Instantiate each Venue\* sibling singleton.
+	 *
+	 * Keeps the outer `Setup::instantiate_classes()` slim — adding a new
+	 * Venue\* class lands as a single line here rather than edits to
+	 * Setup. Each subclass is a singleton, so repeat calls are safe.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function instantiate_classes(): void {
+		Map::get_instance();
+		Map_Prewarm::get_instance();
 	}
 
 	/**
@@ -227,7 +255,7 @@ class Venue_Setup {
 	 * Numeric values within the ±180 range are normalized to a string form via
 	 * a float cast (trims whitespace, normalizes scientific notation). Anything
 	 * else collapses to an empty string — the "no coords yet" sentinel the
-	 * editor and `Venue_Map::parse_coord()` already treat as unset.
+	 * editor and `Map::parse_coord()` already treat as unset.
 	 *
 	 * @since 1.0.0
 	 *
@@ -299,12 +327,12 @@ class Venue_Setup {
 				'default'           => '',
 				'revisions_enabled' => true,
 			),
-			// Venue_Map keeps a per-zoom descriptor map here: { "15": { url,
+			// Map keeps a per-zoom descriptor map here: { "15": { url,
 			// hash }, ... }. Exposed read-only via REST so the block editor
 			// can preview the cached static image when the user picks
 			// renderMode="static". Writes are denied ­— the server-side
 			// pipeline is the only thing allowed to populate this meta.
-			Venue_Map::META_KEY     => array(
+			Map::META_KEY           => array(
 				'auth_callback' => '__return_false',
 				'show_in_rest'  => array(
 					'schema' => array(
@@ -385,7 +413,7 @@ class Venue_Setup {
 	 * Filter out read-only meta from REST API requests.
 	 *
 	 * Some venue meta keys are populated by server-side pipelines (e.g. the
-	 * Venue_Map static map descriptors) and should never be written by the
+	 * Map static map descriptors) and should never be written by the
 	 * block editor. Values submitted for those keys are silently discarded
 	 * rather than triggering a permission error from the __return_false auth
 	 * callback.
@@ -398,7 +426,7 @@ class Venue_Setup {
 	 */
 	public function filter_readonly_meta( stdClass $prepared_post, WP_REST_Request $request ): stdClass {
 		$readonly_keys = array(
-			Venue_Map::META_KEY,
+			Map::META_KEY,
 		);
 
 		$meta = $request->get_param( 'meta' );

--- a/includes/core/classes/venue/class-venue.php
+++ b/includes/core/classes/venue/class-venue.php
@@ -2,18 +2,18 @@
 /**
  * Per-post instance class for a single Venue.
  *
- * Mirrors the {@see Event} class: constructed around a specific venue post ID,
- * populates `$this->venue` with the WP_Post when the post type declares
+ * Mirrors the {@see \GatherPress\Core\Event\Event} class: constructed around a specific
+ * venue post ID, populates `$this->venue` with the WP_Post when the post type declares
  * `gatherpress-venue-information` support, and exposes accessors for that
  * venue's stored information, taxonomy term, and slug. Everything not tied to
  * a specific venue instance — post type registration, taxonomy helpers,
- * event→venue lookups — lives on {@see Venue_Setup}.
+ * event→venue lookups — lives on {@see Setup}.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Venue
  * @since 1.0.0
  */
 
-namespace GatherPress\Core;
+namespace GatherPress\Core\Venue;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
@@ -25,8 +25,8 @@ use WP_Term;
 /**
  * Class Venue.
  *
- * Instance anchored to a specific venue post ID. Pair with {@see Venue_Setup}
- * for the WordPress integration layer and venue-type-level utilities.
+ * Instance anchored to a specific venue post ID. Pair with {@see Setup} for
+ * the WordPress integration layer and venue-type-level utilities.
  *
  * @since 1.0.0
  */
@@ -103,9 +103,8 @@ class Venue {
 	/**
 	 * Returns the taxonomy slug that backs this venue's term.
 	 *
-	 * Derived from the venue's post type via
-	 * {@see Venue_Setup::get_taxonomy()}. Empty string when this instance
-	 * does not wrap a real venue.
+	 * Derived from the venue's post type via {@see Setup::get_taxonomy()}.
+	 * Empty string when this instance does not wrap a real venue.
 	 *
 	 * @since 1.0.0
 	 *
@@ -116,7 +115,7 @@ class Venue {
 			return '';
 		}
 
-		return Venue_Setup::get_instance()->get_taxonomy( $this->venue->post_type );
+		return Setup::get_instance()->get_taxonomy( $this->venue->post_type );
 	}
 
 	/**
@@ -124,9 +123,9 @@ class Venue {
 	 *
 	 * Format is the underscore-prefixed post_name (e.g. `my-venue` →
 	 * `_my-venue`). Delegates the formatting to
-	 * {@see Venue_Setup::term_slug_from_post_name()} so there is only one
-	 * source of truth for the slug shape. Empty string when this instance
-	 * does not wrap a real venue.
+	 * {@see Setup::term_slug_from_post_name()} so there is only one source
+	 * of truth for the slug shape. Empty string when this instance does not
+	 * wrap a real venue.
 	 *
 	 * @since 1.0.0
 	 *
@@ -137,7 +136,7 @@ class Venue {
 			return '';
 		}
 
-		return Venue_Setup::get_instance()->term_slug_from_post_name( $this->venue->post_name );
+		return Setup::get_instance()->term_slug_from_post_name( $this->venue->post_name );
 	}
 
 	/**

--- a/includes/core/register-class-aliases.php
+++ b/includes/core/register-class-aliases.php
@@ -22,6 +22,7 @@ spl_autoload_register(
 		// Map of prior fully-qualified class names to their current fully-qualified class names.
 		$aliases = array(
 			'GatherPress\\Core\\Event' => 'GatherPress\\Core\\Event\\Event',
+			'GatherPress\\Core\\Venue' => 'GatherPress\\Core\\Venue\\Venue',
 		);
 
 		if ( ! isset( $aliases[ $class_string ] ) ) {

--- a/phpstan.stubs
+++ b/phpstan.stubs
@@ -48,4 +48,9 @@ namespace {
         require_once __DIR__ . '/includes/core/classes/event/class-event.php';
         class_alias( 'GatherPress\\Core\\Event\\Event', 'GatherPress\\Core\\Event' );
     }
+
+    if ( ! class_exists( 'GatherPress\\Core\\Venue', false ) ) {
+        require_once __DIR__ . '/includes/core/classes/venue/class-venue.php';
+        class_alias( 'GatherPress\\Core\\Venue\\Venue', 'GatherPress\\Core\\Venue' );
+    }
 }

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -53,7 +53,7 @@ const HEIGHT_MAX = 4000;
 const DEFAULT_HEIGHT = 300;
 
 // Presets for the aspect-ratio dropdown. The first entry matches the
-// server-side `Venue_Map::DEFAULT_ASPECT_RATIO` (2/1) so freshly inserted
+// server-side `Venue\Map::DEFAULT_ASPECT_RATIO` (2/1) so freshly inserted
 // blocks keep the behavior that shipped in the first round of static maps.
 const ASPECT_RATIO_PRESETS = [
 	{ label: __( 'Landscape - 2:1', 'gatherpress' ), value: '2/1' },
@@ -65,7 +65,7 @@ const ASPECT_RATIO_PRESETS = [
 ];
 
 // Allow-list for the `scale` block attribute — mirrors
-// `Venue_Map::SCALE_OPTIONS` so JS and PHP can't drift. The Scale
+// `Venue\Map::SCALE_OPTIONS` so JS and PHP can't drift. The Scale
 // SelectControl options are derived from this list; the guard that
 // hides the control when render mode is interactive reads from it too.
 const SCALE_OPTIONS = [ 'cover', 'contain', 'fill' ];

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -175,7 +175,7 @@ export const RegenerateMapButton = ( {
 /**
  * Parse an aspect-ratio string (e.g. "16/9" or "4:3") into a float.
  *
- * Mirrors the server-side `Venue_Map::parse_aspect_ratio()` so the editor
+ * Mirrors the server-side `Venue\Map::parse_aspect_ratio()` so the editor
  * can derive auto dimensions from the ratio without a round-trip to PHP.
  * Returns null for unparsable input.
  *
@@ -203,7 +203,7 @@ export const parseAspectRatio = ( ratio ) => {
 /**
  * Resolve a (width, height) pair from block attribute values.
  *
- * Mirrors `Venue_Map::resolve_dimensions()` so the editor renders the map
+ * Mirrors `Venue\Map::resolve_dimensions()` so the editor renders the map
  * at the same effective pixel size the server will compose. Either
  * dimension can be 0 ("auto") and will be derived from the other side and
  * the aspect ratio. When both are auto, `DEFAULT_HEIGHT` seeds the math.

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -30,8 +30,8 @@
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Settings;
-use GatherPress\Core\Venue_Setup;
-use GatherPress\Core\Venue_Map;
+use GatherPress\Core\Venue\Map as Venue_Map;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 
 if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {
 	return;

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -30,8 +30,8 @@
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Settings;
-use GatherPress\Core\Venue\Map as Venue_Map;
-use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Map;
+use GatherPress\Core\Venue\Setup;
 
 if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {
 	return;
@@ -39,7 +39,7 @@ if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {
 
 $gatherpress_post_id     = (int) get_the_ID();
 $gatherpress_post_type   = (string) get_post_type();
-$gatherpress_venue_setup = Venue_Setup::get_instance();
+$gatherpress_venue_setup = Setup::get_instance();
 $gatherpress_venue_meta  = $gatherpress_venue_setup->get_venue_meta( $gatherpress_post_id, $gatherpress_post_type );
 
 $gatherpress_address = (string) ( $gatherpress_venue_meta['address'] ?? '' );
@@ -48,24 +48,24 @@ if ( '' === $gatherpress_address ) {
 	return;
 }
 
-$gatherpress_render_mode = 'static' === ( $attributes['renderMode'] ?? Venue_Map::DEFAULT_RENDER_MODE )
+$gatherpress_render_mode = 'static' === ( $attributes['renderMode'] ?? Map::DEFAULT_RENDER_MODE )
 	? 'static'
 	: 'interactive';
-$gatherpress_zoom        = (int) ( $attributes['zoom'] ?? Venue_Map::DEFAULT_ZOOM );
+$gatherpress_zoom        = (int) ( $attributes['zoom'] ?? Map::DEFAULT_ZOOM );
 $gatherpress_raw_width   = (int) ( $attributes['width'] ?? 0 );
-$gatherpress_raw_height  = (int) ( $attributes['height'] ?? Venue_Map::DEFAULT_HEIGHT );
-$gatherpress_ratio       = (string) ( $attributes['aspectRatio'] ?? Venue_Map::DEFAULT_ASPECT_RATIO );
+$gatherpress_raw_height  = (int) ( $attributes['height'] ?? Map::DEFAULT_HEIGHT );
+$gatherpress_ratio       = (string) ( $attributes['aspectRatio'] ?? Map::DEFAULT_ASPECT_RATIO );
 
 // Allow-list for the `scale` block attribute. Anything outside this set
 // (a hand-edited block attr, a filter that mutates the value, a migration
 // miss) falls back to `cover` so the inline style stays safe and
 // predictable.
-$gatherpress_scale_candidate = (string) ( $attributes['scale'] ?? Venue_Map::DEFAULT_SCALE );
-$gatherpress_scale           = in_array( $gatherpress_scale_candidate, Venue_Map::SCALE_OPTIONS, true )
+$gatherpress_scale_candidate = (string) ( $attributes['scale'] ?? Map::DEFAULT_SCALE );
+$gatherpress_scale           = in_array( $gatherpress_scale_candidate, Map::SCALE_OPTIONS, true )
 	? $gatherpress_scale_candidate
-	: Venue_Map::DEFAULT_SCALE;
+	: Map::DEFAULT_SCALE;
 
-$gatherpress_static_map_descriptor = Venue_Map::get_instance()->get_descriptor_for_post(
+$gatherpress_static_map_descriptor = Map::get_instance()->get_descriptor_for_post(
 	$gatherpress_post_id,
 	$gatherpress_post_type,
 	$gatherpress_zoom,
@@ -121,14 +121,14 @@ if ( 0 === $gatherpress_raw_width || 0 === $gatherpress_raw_height || $gatherpre
 	// REST validator so the two can never drift apart.
 	$gatherpress_ratio_candidate = '' !== $gatherpress_ratio
 		? $gatherpress_ratio
-		: Venue_Map::DEFAULT_ASPECT_RATIO;
+		: Map::DEFAULT_ASPECT_RATIO;
 	$gatherpress_ratio_is_valid  = (bool) preg_match(
-		Venue_Map::ASPECT_RATIO_PATTERN,
+		Map::ASPECT_RATIO_PATTERN,
 		$gatherpress_ratio_candidate
 	);
 	$gatherpress_styles[]        = sprintf(
 		'aspect-ratio:%s',
-		$gatherpress_ratio_is_valid ? $gatherpress_ratio_candidate : Venue_Map::DEFAULT_ASPECT_RATIO
+		$gatherpress_ratio_is_valid ? $gatherpress_ratio_candidate : Map::DEFAULT_ASPECT_RATIO
 	);
 }
 
@@ -141,9 +141,9 @@ if ( 'interactive' === $gatherpress_render_mode ) {
 		'address'      => $gatherpress_address,
 		'latitude'     => (string) ( $gatherpress_venue_meta['latitude'] ?? '' ),
 		'longitude'    => (string) ( $gatherpress_venue_meta['longitude'] ?? '' ),
-		'mapZoomLevel' => $attributes['zoom'] ?? Venue_Map::DEFAULT_ZOOM,
-		'mapType'      => $attributes['type'] ?? Venue_Map::DEFAULT_MAP_TYPE,
-		'mapHeight'    => $attributes['height'] ?? Venue_Map::DEFAULT_HEIGHT,
+		'mapZoomLevel' => $attributes['zoom'] ?? Map::DEFAULT_ZOOM,
+		'mapType'      => $attributes['type'] ?? Map::DEFAULT_MAP_TYPE,
+		'mapHeight'    => $attributes['height'] ?? Map::DEFAULT_HEIGHT,
 		'mapPlatform'  => Settings::get_instance()->get( 'map_platform' ),
 		'pluginUrl'    => GATHERPRESS_CORE_URL,
 	);

--- a/src/components/VenueInformation.js
+++ b/src/components/VenueInformation.js
@@ -121,7 +121,7 @@ const VenueInformation = () => {
 	useEffect( () => {
 		// Block the Save button while the address is being geocoded. Without
 		// this, a quick save persists the new address with the previous
-		// lat/long and Venue_Map bakes the static PNG at the wrong coords
+		// lat/long and Venue\Map bakes the static PNG at the wrong coords
 		// until a second save rebuilds it. lockPostSaving is idempotent on
 		// the same lock name, so repeat keystrokes don't stack locks.
 		lockPostSaving( GEOCODE_LOCK_NAME );

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -23,7 +23,7 @@ const DEFAULT_VENUE_POST_TYPE = 'gatherpress_venue';
  * Returns the venue taxonomy slug for a given venue post type.
  *
  * The taxonomy is derived by prepending an underscore to the venue post type slug,
- * following the convention established in PHP via Venue_Setup::get_taxonomy().
+ * following the convention established in PHP via Venue\Setup::get_taxonomy().
  * For example, 'gatherpress_venue' becomes '_gatherpress_venue'.
  *
  * @since 1.0.0

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
@@ -10,7 +10,7 @@ namespace GatherPress\Tests\Core\Blocks;
 
 use GatherPress\Core\Blocks\Rsvp;
 use GatherPress\Core\Event;
-use GatherPress\Core\Event\Setup as Event_Setup;
+use GatherPress\Core\Event\Setup;
 use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 
@@ -210,7 +210,7 @@ class Test_Rsvp extends Base {
 		)->get();
 
 		// Trigger to set datetimes.
-		Event_Setup::get_instance()->set_datetimes( $post->ID );
+		Setup::get_instance()->set_datetimes( $post->ID );
 
 		$block = array(
 			'blockName' => 'gatherpress/rsvp-v2',

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -12,7 +12,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Event\Admin_List;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Venue;
-use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Setup;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 use WP_Query;
@@ -1247,7 +1247,7 @@ class Test_Admin_List extends Base {
 		$result = $instance->venue_sorting_join_paged( $original_join );
 
 		// Re-register the taxonomy so subsequent tests are not affected.
-		Venue_Setup::get_instance()->register_taxonomy();
+		Setup::get_instance()->register_taxonomy();
 
 		$this->assertSame(
 			$original_join,

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -12,7 +12,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Event\Admin_List;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Venue;
-use GatherPress\Core\Venue_Setup;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 use WP_Query;

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -13,7 +13,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Event\Query;
 use GatherPress\Core\Topic;
 use GatherPress\Core\Venue;
-use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Setup;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 use WP_Query;
@@ -850,7 +850,7 @@ class Test_Query extends Base {
 			'Failed to assert that terms match the provided venues.'
 		);
 		$this->assertSame(
-			Venue_Setup::get_instance()->get_taxonomy( Venue::POST_TYPE ),
+			Setup::get_instance()->get_taxonomy( Venue::POST_TYPE ),
 			$first_condition['taxonomy'],
 			'Failed to assert the taxonomy matches the built-in venue taxonomy.'
 		);

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -13,7 +13,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Event\Query;
 use GatherPress\Core\Topic;
 use GatherPress\Core\Venue;
-use GatherPress\Core\Venue_Setup;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 use WP_Query;

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
@@ -88,7 +88,7 @@ class Test_Venues extends Base {
 		);
 
 		// New block-default settings feed the venue-map block.json defaults
-		// via Venue_Map::apply_block_attribute_defaults().
+		// via Venue\Map::apply_block_attribute_defaults().
 		foreach ( array(
 			'venue_map_default_render_mode' => 'interactive',
 			'venue_map_default_zoom'        => 18,

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-map-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-map-prewarm.php
@@ -1,25 +1,26 @@
 <?php
 /**
- * Unit tests for GatherPress\Core\Venue_Map_Prewarm.
+ * Unit tests for GatherPress\Core\Venue\Map_Prewarm.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Venue
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core;
+namespace GatherPress\Tests\Core\Venue;
 
-use GatherPress\Core\Venue;
-use GatherPress\Core\Venue_Map;
-use GatherPress\Core\Venue_Map_Prewarm;
+use GatherPress\Core\Venue\Map;
+use GatherPress\Core\Venue\Map_Prewarm;
+use GatherPress\Core\Venue\Setup;
+use GatherPress\Core\Venue\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 
 /**
- * Class Test_Venue_Map_Prewarm.
+ * Class Test_Map_Prewarm.
  *
- * @coversDefaultClass \GatherPress\Core\Venue_Map_Prewarm
+ * @coversDefaultClass \GatherPress\Core\Venue\Map_Prewarm
  */
-class Test_Venue_Map_Prewarm extends Base {
+class Test_Map_Prewarm extends Base {
 	/**
 	 * Clear scheduled warm events between tests — wp_next_scheduled lookups
 	 * otherwise leak across cases and skew dedup assertions.
@@ -29,7 +30,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function tear_down(): void {
-		wp_clear_scheduled_hook( Venue_Map_Prewarm::CRON_ACTION );
+		wp_clear_scheduled_hook( Map_Prewarm::CRON_ACTION );
 		parent::tear_down();
 	}
 
@@ -43,11 +44,11 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_setup_hooks(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 		$hooks    = array(
 			array(
 				'type'     => 'action',
-				'name'     => Venue_Map_Prewarm::CRON_ACTION,
+				'name'     => Map_Prewarm::CRON_ACTION,
 				'priority' => 10,
 				'callback' => array( $instance, 'process_warm_job' ),
 			),
@@ -76,7 +77,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_collect_combos_from_content_ignores_unrelated_markup(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$result = Utility::invoke_hidden_method(
 			$instance,
@@ -105,7 +106,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_collect_combos_from_content_extracts_single_block(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 		$content  = '<!-- wp:gatherpress/venue-map {"zoom":15,"width":0,"height":400,"aspectRatio":"16/9"} /-->';
 
 		$result = Utility::invoke_hidden_method(
@@ -134,7 +135,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_walk_blocks_for_combos_recurses_inner_blocks(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 		$content  = '<!-- wp:gatherpress/venue -->'
 			. '<div class="wp-block-gatherpress-venue">'
 			. '<!-- wp:gatherpress/venue-map {"zoom":10,"width":800,"height":400,"aspectRatio":"2/1"} /-->'
@@ -153,14 +154,14 @@ class Test_Venue_Map_Prewarm extends Base {
 	}
 
 	/**
-	 * Missing block attributes fall back to the Venue_Map defaults.
+	 * Missing block attributes fall back to the Map defaults.
 	 *
 	 * @covers ::extract_block_combo
 	 *
 	 * @return void
 	 */
 	public function test_extract_block_combo_uses_venue_map_defaults(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$result = Utility::invoke_hidden_method(
 			$instance,
@@ -168,10 +169,10 @@ class Test_Venue_Map_Prewarm extends Base {
 			array( array() )
 		);
 
-		$this->assertSame( Venue_Map::DEFAULT_ZOOM, $result['zoom'] );
+		$this->assertSame( Map::DEFAULT_ZOOM, $result['zoom'] );
 		$this->assertSame( 0, $result['width'] );
-		$this->assertSame( Venue_Map::DEFAULT_HEIGHT, $result['height'] );
-		$this->assertSame( Venue_Map::DEFAULT_ASPECT_RATIO, $result['aspect_ratio'] );
+		$this->assertSame( Map::DEFAULT_HEIGHT, $result['height'] );
+		$this->assertSame( Map::DEFAULT_ASPECT_RATIO, $result['aspect_ratio'] );
 	}
 
 	/**
@@ -182,7 +183,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_dedupe_combos_collapses_duplicates(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 		$combos   = array(
 			array(
 				'zoom'         => 15,
@@ -221,7 +222,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_warm_job_schedules_cron_event(): void {
-		$instance      = Venue_Map_Prewarm::get_instance();
+		$instance      = Map_Prewarm::get_instance();
 		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$combo         = array(
 			'zoom'         => 15,
@@ -237,7 +238,7 @@ class Test_Venue_Map_Prewarm extends Base {
 		);
 
 		$scheduled = wp_next_scheduled(
-			Venue_Map_Prewarm::CRON_ACTION,
+			Map_Prewarm::CRON_ACTION,
 			array( $venue_post_id, 15, 800, 400, '2/1' )
 		);
 		$this->assertNotFalse( $scheduled, 'Warm job is scheduled.' );
@@ -252,7 +253,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_warm_job_deduplicates_identical_args(): void {
-		$instance      = Venue_Map_Prewarm::get_instance();
+		$instance      = Map_Prewarm::get_instance();
 		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$combo         = array(
 			'zoom'         => 15,
@@ -263,13 +264,13 @@ class Test_Venue_Map_Prewarm extends Base {
 
 		Utility::invoke_hidden_method( $instance, 'enqueue_warm_job', array( $venue_post_id, $combo ) );
 		$first_timestamp = wp_next_scheduled(
-			Venue_Map_Prewarm::CRON_ACTION,
+			Map_Prewarm::CRON_ACTION,
 			array( $venue_post_id, 15, 800, 400, '2/1' )
 		);
 
 		Utility::invoke_hidden_method( $instance, 'enqueue_warm_job', array( $venue_post_id, $combo ) );
 		$second_timestamp = wp_next_scheduled(
-			Venue_Map_Prewarm::CRON_ACTION,
+			Map_Prewarm::CRON_ACTION,
 			array( $venue_post_id, 15, 800, 400, '2/1' )
 		);
 
@@ -288,7 +289,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_warm_job_filter_short_circuits_wp_cron_path(): void {
-		$instance      = Venue_Map_Prewarm::get_instance();
+		$instance      = Map_Prewarm::get_instance();
 		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$combo         = array(
 			'zoom'         => 15,
@@ -315,13 +316,13 @@ class Test_Venue_Map_Prewarm extends Base {
 
 		$this->assertFalse(
 			wp_next_scheduled(
-				Venue_Map_Prewarm::CRON_ACTION,
+				Map_Prewarm::CRON_ACTION,
 				array( $venue_post_id, 15, 800, 400, '2/1' )
 			),
 			'Default WP-Cron path must be suppressed when the filter returns non-null.'
 		);
 		$this->assertCount( 1, $seen, 'Filter is invoked exactly once per enqueue call.' );
-		$this->assertSame( Venue_Map_Prewarm::CRON_ACTION, $seen[0]['hook'] );
+		$this->assertSame( Map_Prewarm::CRON_ACTION, $seen[0]['hook'] );
 		$this->assertSame(
 			array( $venue_post_id, 15, 800, 400, '2/1' ),
 			$seen[0]['args'],
@@ -342,7 +343,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_warm_job_filter_falsy_non_null_values_still_short_circuit(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		foreach ( array( false, 0, '' ) as $index => $falsy_return ) {
 			$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
@@ -365,7 +366,7 @@ class Test_Venue_Map_Prewarm extends Base {
 
 			$this->assertFalse(
 				wp_next_scheduled(
-					Venue_Map_Prewarm::CRON_ACTION,
+					Map_Prewarm::CRON_ACTION,
 					array( $venue_post_id, 15, 800 + $index, 400, '2/1' )
 				),
 				sprintf(
@@ -386,7 +387,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_warm_job_filter_returning_null_preserves_default_path(): void {
-		$instance      = Venue_Map_Prewarm::get_instance();
+		$instance      = Map_Prewarm::get_instance();
 		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$combo         = array(
 			'zoom'         => 15,
@@ -406,7 +407,7 @@ class Test_Venue_Map_Prewarm extends Base {
 
 		$this->assertNotFalse(
 			wp_next_scheduled(
-				Venue_Map_Prewarm::CRON_ACTION,
+				Map_Prewarm::CRON_ACTION,
 				array( $venue_post_id, 15, 800, 400, '2/1' )
 			),
 			'Null return from the filter must fall through to wp_schedule_single_event().'
@@ -424,7 +425,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_enqueues_for_venue(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		// Create a venue so get_venue_post_ids has at least one result when
 		// the template save would fan out; the test itself doesn't care
@@ -442,7 +443,7 @@ class Test_Venue_Map_Prewarm extends Base {
 		$instance->on_post_saved( $venue_post_id, $post );
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
 			'No combos means no scheduled warm jobs.'
 		);
 	}
@@ -456,7 +457,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_ignores_revisions(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$venue_post_id = $this->factory->post->create(
 			array(
@@ -474,7 +475,7 @@ class Test_Venue_Map_Prewarm extends Base {
 		$instance->on_post_saved( $revision_id, $revision );
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
 			'Revisions do not enqueue warm jobs.'
 		);
 	}
@@ -489,7 +490,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_skips_non_published_posts(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		foreach ( array( 'draft', 'auto-draft', 'trash' ) as $status ) {
 			$venue_post_id = $this->factory->post->create(
@@ -503,22 +504,22 @@ class Test_Venue_Map_Prewarm extends Base {
 		}
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
 			'Non-published saves enqueue nothing.'
 		);
 	}
 
 	/**
-	 * Delegates to Venue_Map::warm from the cron handler — this test only
+	 * Delegates to Map::warm from the cron handler — this test only
 	 * verifies it tolerates a missing venue ID without throwing
-	 * (Venue_Map::warm returns null for invalid input).
+	 * (Map::warm returns null for invalid input).
 	 *
 	 * @covers ::process_warm_job
 	 *
 	 * @return void
 	 */
 	public function test_process_warm_job_is_safe_for_missing_venue(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		// No exception: warm() returns null for non-existent post IDs, and
 		// the cron handler is expected to swallow that outcome silently.
@@ -536,7 +537,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_fan_outs_template_save_to_all_venues(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$venue_a = $this->factory->post->create(
 			array(
@@ -564,14 +565,14 @@ class Test_Venue_Map_Prewarm extends Base {
 
 		$this->assertNotFalse(
 			wp_next_scheduled(
-				Venue_Map_Prewarm::CRON_ACTION,
+				Map_Prewarm::CRON_ACTION,
 				array( $venue_a, 15, 800, 400, '2/1' )
 			),
 			'Venue A received a warm job for the template combo.'
 		);
 		$this->assertNotFalse(
 			wp_next_scheduled(
-				Venue_Map_Prewarm::CRON_ACTION,
+				Map_Prewarm::CRON_ACTION,
 				array( $venue_b, 15, 800, 400, '2/1' )
 			),
 			'Venue B received a warm job for the template combo.'
@@ -588,7 +589,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_skips_template_without_venue_map(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$this->factory->post->create(
 			array(
@@ -608,7 +609,7 @@ class Test_Venue_Map_Prewarm extends Base {
 		$instance->on_post_saved( $template_id, get_post( $template_id ) );
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
 			'Templates without venue-map blocks enqueue nothing.'
 		);
 	}
@@ -624,7 +625,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_theme_switched_runs_without_error(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$this->factory->post->create(
 			array(
@@ -649,7 +650,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_get_venue_post_ids_returns_published_venues(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$published = $this->factory->post->create(
 			array(
@@ -680,8 +681,8 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_event_enqueues_via_linked_venue(): void {
-		$instance    = Venue_Map_Prewarm::get_instance();
-		$venue_setup = \GatherPress\Core\Venue_Setup::get_instance();
+		$instance    = Map_Prewarm::get_instance();
+		$venue_setup = Setup::get_instance();
 
 		$venue_post_id = $this->factory->post->create(
 			array(
@@ -708,7 +709,7 @@ class Test_Venue_Map_Prewarm extends Base {
 
 		$this->assertNotFalse(
 			wp_next_scheduled(
-				Venue_Map_Prewarm::CRON_ACTION,
+				Map_Prewarm::CRON_ACTION,
 				array( $venue_post_id, 12, 600, 300, '2/1' )
 			),
 			'Event save enqueues a warm job against the linked venue.'
@@ -724,7 +725,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_event_skips_when_no_venue_term(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$event_post_id = $this->factory->post->create(
 			array(
@@ -738,7 +739,7 @@ class Test_Venue_Map_Prewarm extends Base {
 		$instance->on_post_saved( $event_post_id, get_post( $event_post_id ) );
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
 			'Event with no venue term enqueues nothing.'
 		);
 	}
@@ -754,7 +755,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_collect_all_template_combos_paginates_event_content(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$this->factory->post->create(
 			array(
@@ -809,10 +810,10 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_get_content_scan_batch_size_applies_filter_and_clamps(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$this->assertSame(
-			Venue_Map_Prewarm::CONTENT_SCAN_BATCH_SIZE,
+			Map_Prewarm::CONTENT_SCAN_BATCH_SIZE,
 			Utility::invoke_hidden_method( $instance, 'get_content_scan_batch_size' ),
 			'Default matches the CONTENT_SCAN_BATCH_SIZE constant.'
 		);
@@ -866,10 +867,10 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_get_scan_batch_size_applies_filter_and_clamps(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$this->assertSame(
-			Venue_Map_Prewarm::SCAN_BATCH_SIZE,
+			Map_Prewarm::SCAN_BATCH_SIZE,
 			Utility::invoke_hidden_method( $instance, 'get_scan_batch_size' ),
 			'Default matches the SCAN_BATCH_SIZE constant.'
 		);
@@ -911,7 +912,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_for_all_venues_paginates(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$venue_ids = array(
 			$this->factory->post->create(
@@ -955,7 +956,7 @@ class Test_Venue_Map_Prewarm extends Base {
 		foreach ( $venue_ids as $venue_post_id ) {
 			$this->assertNotFalse(
 				wp_next_scheduled(
-					Venue_Map_Prewarm::CRON_ACTION,
+					Map_Prewarm::CRON_ACTION,
 					array( $venue_post_id, 11, 500, 250, '2/1' )
 				),
 				sprintf( 'Venue %d received a warm job through the paginated loop.', $venue_post_id )
@@ -973,7 +974,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_collect_and_get_ids_paginate(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$this->factory->post->create(
 			array(
@@ -1032,7 +1033,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_for_venue_schedules_jobs_for_each_combo(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$venue_post_id = $this->factory->post->create(
 			array(
@@ -1060,7 +1061,7 @@ class Test_Venue_Map_Prewarm extends Base {
 
 		$this->assertNotFalse(
 			wp_next_scheduled(
-				Venue_Map_Prewarm::CRON_ACTION,
+				Map_Prewarm::CRON_ACTION,
 				array( $venue_post_id, 13, 700, 350, '2/1' )
 			),
 			'Venue received a warm job for the combo surfaced via enqueue_for_venue.'
@@ -1079,7 +1080,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_scans_short_circuit_without_venue_types(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		// Temporarily unregister the venue-information support so the
 		// gatherpress-venue-information feature has no matching post types.
@@ -1112,7 +1113,7 @@ class Test_Venue_Map_Prewarm extends Base {
 		}
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
 			'No venue types means no scheduled warm jobs.'
 		);
 		$this->assertSame( array(), $ids, 'get_venue_post_ids returns [] when no venue types are registered.' );
@@ -1134,7 +1135,7 @@ class Test_Venue_Map_Prewarm extends Base {
 			$this->markTestSkipped( 'WP_Block_Template not available in this environment.' );
 		}
 
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$template          = new \WP_Block_Template();
 		$template->content = '<!-- wp:gatherpress/venue-map '
@@ -1186,7 +1187,7 @@ class Test_Venue_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_event_skips_when_no_combos(): void {
-		$instance = Venue_Map_Prewarm::get_instance();
+		$instance = Map_Prewarm::get_instance();
 
 		$event_post_id = $this->factory->post->create(
 			array(
@@ -1199,7 +1200,7 @@ class Test_Venue_Map_Prewarm extends Base {
 		$instance->on_post_saved( $event_post_id, get_post( $event_post_id ) );
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Venue_Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
 			'No combos in event content means no cron jobs.'
 		);
 	}

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-map.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-map.php
@@ -1,29 +1,30 @@
 <?php
 /**
- * Unit tests for GatherPress\Core\Venue_Map.
+ * Unit tests for GatherPress\Core\Venue\Map.
  *
  * These tests cover the generator's hash logic, the save/regenerate/cleanup
  * lifecycle, and the hook wiring. The tile fetcher is stubbed via an HTTP
  * short-circuit filter so tests never make a real network call.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Venue
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core;
+namespace GatherPress\Tests\Core\Venue;
 
-use GatherPress\Core\Venue;
-use GatherPress\Core\Venue_Map;
+use GatherPress\Core\Venue\Map;
+use GatherPress\Core\Venue\Setup;
+use GatherPress\Core\Venue\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 
 /**
- * Class Test_Venue_Map.
+ * Class Test_Map.
  *
  * @group multisite
- * @coversDefaultClass \GatherPress\Core\Venue_Map
+ * @coversDefaultClass \GatherPress\Core\Venue\Map
  */
-class Test_Venue_Map extends Base {
+class Test_Map extends Base {
 	/**
 	 * Minimal valid 1×1 PNG used as a stand-in for every tile fetch.
 	 *
@@ -59,7 +60,7 @@ class Test_Venue_Map extends Base {
 		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
 
 		$dirs     = wp_get_upload_dir();
-		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Map::UPLOADS_SUBDIR;
+		$base_dir = trailingslashit( $dirs['basedir'] ) . Map::UPLOADS_SUBDIR;
 
 		if ( is_dir( $base_dir ) ) {
 			foreach ( (array) glob( $base_dir . '/*.png' ) as $file ) {
@@ -122,7 +123,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_setup_hooks(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$hooks    = array(
 			array(
 				'type'     => 'action',
@@ -162,7 +163,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_apply_block_attribute_defaults_overrides_venue_map(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$settings = \GatherPress\Core\Settings::get_instance();
 
 		$settings->set( 'venue_map_default_render_mode', 'static' );
@@ -216,7 +217,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_apply_block_attribute_defaults_rejects_invalid_scale(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$settings = \GatherPress\Core\Settings::get_instance();
 
 		$settings->set( 'venue_map_default_scale', 'none' );
@@ -248,7 +249,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_apply_block_attribute_defaults_ignores_other_blocks(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$metadata = array(
 			'name'       => 'core/paragraph',
 			'attributes' => array(
@@ -271,7 +272,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_apply_block_attribute_defaults_skips_empty_settings(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$settings = \GatherPress\Core\Settings::get_instance();
 
 		$settings->set( 'venue_map_default_render_mode', '' );
@@ -317,7 +318,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_delete_hook(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $post_type ) {
 			$instance->maybe_register_delete_hook( $post_type );
@@ -341,7 +342,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_delete_hook_skips_unsupported_post_type(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$instance->maybe_register_delete_hook( 'post' );
 
@@ -359,18 +360,18 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_hash_for_detects_relevant_input_changes(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$info     = array(
 			'address'   => '1 Infinite Loop',
 			'latitude'  => '37.3318',
 			'longitude' => '-122.0312',
 		);
 
-		$baseline = $instance->hash_for( $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL );
+		$baseline = $instance->hash_for( $info, 15, 800, 400, Map::DEFAULT_TILE_URL );
 
 		$this->assertSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 800, 400, Map::DEFAULT_TILE_URL ),
 			'Hash should be stable when every input is identical.'
 		);
 
@@ -380,25 +381,25 @@ class Test_Venue_Map extends Base {
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $moved_info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $moved_info, 15, 800, 400, Map::DEFAULT_TILE_URL ),
 			'Hash should change when coordinates change.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 14, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 14, 800, 400, Map::DEFAULT_TILE_URL ),
 			'Hash should change when the zoom level changes.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 600, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 600, 400, Map::DEFAULT_TILE_URL ),
 			'Hash should change when the width changes.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 800, 500, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 800, 500, Map::DEFAULT_TILE_URL ),
 			'Hash should change when the height changes.'
 		);
 
@@ -406,7 +407,7 @@ class Test_Venue_Map extends Base {
 		// filenames dedupe across venues at the same location.
 		$this->assertSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 800, 400, Venue_Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 800, 400, Map::DEFAULT_TILE_URL ),
 			'Hash is address-scoped, not post-scoped.'
 		);
 	}
@@ -424,7 +425,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_writes_image_and_descriptor(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop, Cupertino, CA' );
@@ -453,7 +454,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_is_idempotent_when_inputs_unchanged(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -485,7 +486,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_regenerates_when_coordinates_change(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -527,7 +528,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_purges_when_coordinates_disappear(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -565,7 +566,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_bails_without_coordinates(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', 'Somewhere, somewhere' );
@@ -588,7 +589,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_skips_revisions_and_autosaves(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$venue_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta( $venue_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -616,7 +617,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_delete_stored_image_clears_meta(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -643,7 +644,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_all_descriptors_empty_when_nothing_stored(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		$this->assertSame( array(), $instance->get_all_descriptors( $post_id ) );
@@ -657,12 +658,12 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_all_descriptors_filters_malformed_entries(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta(
 			$post_id,
-			Venue_Map::META_KEY,
+			Map::META_KEY,
 			array(
 				'15x600x300'    => array(
 					'url'    => 'https://example.test/a.png',
@@ -698,7 +699,7 @@ class Test_Venue_Map extends Base {
 		// Read path must not mutate the meta — writing on every render would
 		// thrash the post-meta cache and churn the DB. Cleanup is deferred
 		// to the next save path.
-		$raw_after_read = get_post_meta( $post_id, Venue_Map::META_KEY, true );
+		$raw_after_read = get_post_meta( $post_id, Map::META_KEY, true );
 		$this->assertCount(
 			4,
 			$raw_after_read,
@@ -717,12 +718,12 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_all_descriptors_runs_through_filter(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta(
 			$post_id,
-			Venue_Map::META_KEY,
+			Map::META_KEY,
 			array(
 				'15x600x300' => array(
 					'url'    => 'https://example.test/a.png',
@@ -785,7 +786,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_ensure_descriptor_for_combo_drops_malformed_entries_on_write(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -795,7 +796,7 @@ class Test_Venue_Map extends Base {
 		// Seed meta with a mix of good and malformed entries.
 		update_post_meta(
 			$post_id,
-			Venue_Map::META_KEY,
+			Map::META_KEY,
 			array(
 				'junk-row' => 'not-an-array',
 				'no-hash'  => array(
@@ -808,7 +809,7 @@ class Test_Venue_Map extends Base {
 
 		$instance->maybe_generate( $post_id );
 
-		$stored = get_post_meta( $post_id, Venue_Map::META_KEY, true );
+		$stored = get_post_meta( $post_id, Map::META_KEY, true );
 
 		$this->assertIsArray( $stored );
 		$this->assertArrayNotHasKey( 'junk-row', $stored );
@@ -816,9 +817,9 @@ class Test_Venue_Map extends Base {
 
 		$default_key = sprintf(
 			'%dx%dx%d',
-			Venue_Map::DEFAULT_ZOOM,
-			Venue_Map::DEFAULT_HEIGHT * 2,
-			Venue_Map::DEFAULT_HEIGHT
+			Map::DEFAULT_ZOOM,
+			Map::DEFAULT_HEIGHT * 2,
+			Map::DEFAULT_HEIGHT
 		);
 		$this->assertArrayHasKey( $default_key, $stored );
 	}
@@ -833,7 +834,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_lazily_generates_new_combo(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -843,9 +844,9 @@ class Test_Venue_Map extends Base {
 
 		$default_key = sprintf(
 			'%dx%dx%d',
-			Venue_Map::DEFAULT_ZOOM,
-			Venue_Map::DEFAULT_HEIGHT * 2,
-			Venue_Map::DEFAULT_HEIGHT
+			Map::DEFAULT_ZOOM,
+			Map::DEFAULT_HEIGHT * 2,
+			Map::DEFAULT_HEIGHT
 		);
 
 		$descriptors_before = $instance->get_all_descriptors( $post_id );
@@ -861,15 +862,15 @@ class Test_Venue_Map extends Base {
 		// Auto width at 2:1 ratio against DEFAULT_HEIGHT → DEFAULT_HEIGHT*2.
 		$new_key = sprintf(
 			'14x%dx%d',
-			Venue_Map::DEFAULT_HEIGHT * 2,
-			Venue_Map::DEFAULT_HEIGHT
+			Map::DEFAULT_HEIGHT * 2,
+			Map::DEFAULT_HEIGHT
 		);
 		$url     = $instance->get_url_for_post(
 			$post_id,
 			Venue::POST_TYPE,
 			14,
 			0,
-			Venue_Map::DEFAULT_HEIGHT,
+			Map::DEFAULT_HEIGHT,
 			''
 		);
 
@@ -892,7 +893,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_lazily_generates_new_height(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -903,7 +904,7 @@ class Test_Venue_Map extends Base {
 		$tall_url = $instance->get_url_for_post(
 			$post_id,
 			Venue::POST_TYPE,
-			Venue_Map::DEFAULT_ZOOM,
+			Map::DEFAULT_ZOOM,
 			0,
 			500,
 			''
@@ -912,7 +913,7 @@ class Test_Venue_Map extends Base {
 		$this->assertNotEmpty( $tall_url );
 
 		// Auto width at 2:1 ratio on height=500 → 1000.
-		$key = sprintf( '%dx1000x500', Venue_Map::DEFAULT_ZOOM );
+		$key = sprintf( '%dx1000x500', Map::DEFAULT_ZOOM );
 		$all = $instance->get_all_descriptors( $post_id );
 
 		$this->assertArrayHasKey( $key, $all, 'Tall-height combo should be cached under its own key.' );
@@ -931,7 +932,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_cascades_content_changes_to_all_cached_combos(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -944,9 +945,9 @@ class Test_Venue_Map extends Base {
 		// Default combo from DEFAULT_HEIGHT + auto width at 2:1 = 600×300.
 		$default_key = sprintf(
 			'%dx%dx%d',
-			Venue_Map::DEFAULT_ZOOM,
-			Venue_Map::DEFAULT_HEIGHT * 2,
-			Venue_Map::DEFAULT_HEIGHT
+			Map::DEFAULT_ZOOM,
+			Map::DEFAULT_HEIGHT * 2,
+			Map::DEFAULT_HEIGHT
 		);
 		// Second combo: zoom=14, height=500, auto width at 2:1 = 1000×500.
 		$second_key = '14x1000x500';
@@ -1001,7 +1002,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_ensure_descriptor_for_combo_returns_null_when_meta_write_dropped(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -1009,7 +1010,7 @@ class Test_Venue_Map extends Base {
 		add_post_meta( $post_id, 'gatherpress_longitude', '-122.0312' );
 
 		$suppress = static function ( $check, $object_id, $meta_key ) {
-			if ( Venue_Map::META_KEY === $meta_key ) {
+			if ( Map::META_KEY === $meta_key ) {
 				return true; // Pretend the update happened.
 			}
 			return $check;
@@ -1024,9 +1025,9 @@ class Test_Venue_Map extends Base {
 			array(
 				$post_id,
 				$info,
-				Venue_Map::DEFAULT_ZOOM,
-				Venue_Map::DEFAULT_HEIGHT * 2,
-				Venue_Map::DEFAULT_HEIGHT,
+				Map::DEFAULT_ZOOM,
+				Map::DEFAULT_HEIGHT * 2,
+				Map::DEFAULT_HEIGHT,
 			)
 		);
 
@@ -1049,7 +1050,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_ensure_descriptor_for_combo_returns_null_when_save_fails(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$force_error = static function ( $dirs ) {
 			$dirs['error'] = 'Simulated uploads failure.';
@@ -1087,7 +1088,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_is_cached_on_second_call(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -1114,7 +1115,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_resolves_venue_directly(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -1138,8 +1139,8 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_resolves_event_via_linked_venue(): void {
-		$instance    = Venue_Map::get_instance();
-		$venue_setup = \GatherPress\Core\Venue_Setup::get_instance();
+		$instance    = Map::get_instance();
+		$venue_setup = Setup::get_instance();
 
 		$venue = $this->mock->post(
 			array(
@@ -1180,7 +1181,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_returns_empty_for_unrelated_post(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => 'post' ) );
 
 		$this->assertSame( '', $instance->get_url_for_post( $post_id, 'post' ) );
@@ -1194,7 +1195,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_url_for_post_returns_empty_when_no_map_generated(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		$this->assertSame( '', $instance->get_url_for_post( $post_id, Venue::POST_TYPE ) );
@@ -1209,7 +1210,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_warm_returns_null_for_invalid_post_id(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$this->assertNull( $instance->warm( 0, 15, 800, 400, '2/1' ) );
 	}
@@ -1225,7 +1226,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_warm_generates_descriptor_on_valid_input(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -1252,7 +1253,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_warm_reuses_descriptor_on_cache_hit(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -1274,7 +1275,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_filename_for_handles_edge_cases(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		// Empty string → fallback slug.
 		$empty = Utility::invoke_hidden_method( $instance, 'filename_for', array( '', 15, 800, 400 ) );
@@ -1302,7 +1303,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_warm_returns_null_when_venue_has_no_coordinates(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop, Cupertino CA' );
@@ -1320,7 +1321,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_skips_unsupported_post_type(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => 'post' ) );
 
 		$instance->maybe_generate( $post_id );
@@ -1339,7 +1340,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_fetch_tile_returns_null_on_http_error(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		// Replace the success stub with a WP_Error short-circuit just for this test.
 		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
@@ -1349,7 +1350,7 @@ class Test_Venue_Map extends Base {
 		add_filter( 'pre_http_request', $fail, 10 );
 
 		$this->assertNull(
-			$instance->fetch_tile( 15, 1, 1, Venue_Map::DEFAULT_TILE_URL )
+			$instance->fetch_tile( 15, 1, 1, Map::DEFAULT_TILE_URL )
 		);
 
 		remove_filter( 'pre_http_request', $fail, 10 );
@@ -1364,7 +1365,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_fetch_tile_returns_null_on_non_200_response(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
 		$not_found = static function () {
@@ -1382,7 +1383,7 @@ class Test_Venue_Map extends Base {
 		add_filter( 'pre_http_request', $not_found, 10 );
 
 		$this->assertNull(
-			$instance->fetch_tile( 15, 1, 1, Venue_Map::DEFAULT_TILE_URL )
+			$instance->fetch_tile( 15, 1, 1, Map::DEFAULT_TILE_URL )
 		);
 
 		remove_filter( 'pre_http_request', $not_found, 10 );
@@ -1397,11 +1398,11 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_fetch_tile_returns_png_bytes(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$this->assertSame(
 			$this->tile_png,
-			$instance->fetch_tile( 15, 1, 1, Venue_Map::DEFAULT_TILE_URL )
+			$instance->fetch_tile( 15, 1, 1, Map::DEFAULT_TILE_URL )
 		);
 	}
 
@@ -1413,7 +1414,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_returns_gd_image(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$image = $instance->composite_image(
 			37.3318,
@@ -1421,7 +1422,7 @@ class Test_Venue_Map extends Base {
 			15,
 			512,
 			256,
-			Venue_Map::DEFAULT_TILE_URL
+			Map::DEFAULT_TILE_URL
 		);
 
 		$this->assertInstanceOf( \GdImage::class, $image );
@@ -1439,7 +1440,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_stamp_marker_draws_on_canvas(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$canvas   = imagecreatetruecolor( 40, 40 );
 		$instance->stamp_marker( $canvas, 20, 20 );
 
@@ -1462,14 +1463,14 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_save_image_writes_file_and_returns_url(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$canvas   = imagecreatetruecolor( 10, 10 );
 
 		$url = $instance->save_image( $canvas, '1 Infinite Loop', 15, 800, 400 );
 		imagedestroy( $canvas );
 
 		$this->assertNotNull( $url, 'save_image should return a URL on success.' );
-		$this->assertStringContainsString( Venue_Map::UPLOADS_SUBDIR, $url );
+		$this->assertStringContainsString( Map::UPLOADS_SUBDIR, $url );
 		$this->assertStringEndsWith( '1-infinite-loop-15-800-400.png', $url );
 
 		$path = $this->path_for_url( $url );
@@ -1484,7 +1485,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_parse_coord(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$this->assertSame(
 			37.3318,
@@ -1507,7 +1508,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_zoom(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$settings = \GatherPress\Core\Settings::get_instance();
 
 		$settings->set( 'venue_map_default_zoom', 13 );
@@ -1519,7 +1520,7 @@ class Test_Venue_Map extends Base {
 
 		$settings->set( 'venue_map_default_zoom', 0 );
 		$this->assertSame(
-			Venue_Map::DEFAULT_ZOOM,
+			Map::DEFAULT_ZOOM,
 			Utility::invoke_hidden_method( $instance, 'get_zoom' ),
 			'Should fall back to DEFAULT_ZOOM when the setting is unset/zero.'
 		);
@@ -1538,7 +1539,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_zoom_clamps_out_of_range_values(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$settings = \GatherPress\Core\Settings::get_instance();
 
 		$settings->set( 'venue_map_default_zoom', 0 );
@@ -1547,7 +1548,7 @@ class Test_Venue_Map extends Base {
 		};
 		add_filter( 'gatherpress_venue_map_zoom', $too_high );
 		$this->assertSame(
-			Venue_Map::ZOOM_MAX,
+			Map::ZOOM_MAX,
 			Utility::invoke_hidden_method( $instance, 'get_zoom' ),
 			'Zoom beyond ZOOM_MAX must clamp down.'
 		);
@@ -1558,7 +1559,7 @@ class Test_Venue_Map extends Base {
 		};
 		add_filter( 'gatherpress_venue_map_zoom', $too_low );
 		$this->assertSame(
-			Venue_Map::ZOOM_MIN,
+			Map::ZOOM_MIN,
 			Utility::invoke_hidden_method( $instance, 'get_zoom' ),
 			'Zoom below ZOOM_MIN must clamp up.'
 		);
@@ -1574,7 +1575,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_height_clamps_out_of_range_values(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$settings = \GatherPress\Core\Settings::get_instance();
 
 		$settings->set( 'venue_map_default_height', 0 );
@@ -1583,7 +1584,7 @@ class Test_Venue_Map extends Base {
 		};
 		add_filter( 'gatherpress_venue_map_height', $too_big );
 		$this->assertSame(
-			Venue_Map::HEIGHT_MAX,
+			Map::HEIGHT_MAX,
 			Utility::invoke_hidden_method( $instance, 'get_height' ),
 			'Height beyond HEIGHT_MAX must clamp down.'
 		);
@@ -1599,7 +1600,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_height(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$settings = \GatherPress\Core\Settings::get_instance();
 
 		$settings->set( 'venue_map_default_height', 450 );
@@ -1611,7 +1612,7 @@ class Test_Venue_Map extends Base {
 
 		$settings->set( 'venue_map_default_height', 0 );
 		$this->assertSame(
-			Venue_Map::DEFAULT_HEIGHT,
+			Map::DEFAULT_HEIGHT,
 			Utility::invoke_hidden_method( $instance, 'get_height' ),
 			'Should fall back to DEFAULT_HEIGHT when the setting is unset/zero.'
 		);
@@ -1625,10 +1626,10 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_tile_url_template(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$this->assertSame(
-			Venue_Map::DEFAULT_TILE_URL,
+			Map::DEFAULT_TILE_URL,
 			Utility::invoke_hidden_method( $instance, 'get_tile_url_template' )
 		);
 	}
@@ -1641,7 +1642,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_combo_key_formats_zoom_width_and_height(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$this->assertSame(
 			'14x800x500',
@@ -1662,7 +1663,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_cached_combos(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		$this->assertSame(
@@ -1673,7 +1674,7 @@ class Test_Venue_Map extends Base {
 
 		update_post_meta(
 			$post_id,
-			Venue_Map::META_KEY,
+			Map::META_KEY,
 			array(
 				'15x600x300'  => array(
 					'url'    => 'https://example.test/a.png',
@@ -1724,7 +1725,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_aborts_when_time_budget_exhausted(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$fetches = 0;
 		$counter = static function () use ( &$fetches ) {
@@ -1756,7 +1757,7 @@ class Test_Venue_Map extends Base {
 			15,
 			512,
 			256,
-			Venue_Map::DEFAULT_TILE_URL
+			Map::DEFAULT_TILE_URL
 		);
 
 		remove_filter( 'gatherpress_venue_map_composite_time_budget', $budget );
@@ -1789,7 +1790,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_continues_past_failed_fetch(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
 		$fail = static function () {
@@ -1803,7 +1804,7 @@ class Test_Venue_Map extends Base {
 			15,
 			512,
 			256,
-			Venue_Map::DEFAULT_TILE_URL
+			Map::DEFAULT_TILE_URL
 		);
 
 		remove_filter( 'pre_http_request', $fail, 10 );
@@ -1826,7 +1827,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_continues_past_invalid_png(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
 		$garbage = static function () {
@@ -1849,7 +1850,7 @@ class Test_Venue_Map extends Base {
 			15,
 			512,
 			256,
-			Venue_Map::DEFAULT_TILE_URL
+			Map::DEFAULT_TILE_URL
 		);
 
 		remove_filter( 'pre_http_request', $garbage, 10 );
@@ -1868,7 +1869,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_save_image_returns_null_when_uploads_report_error(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$canvas   = imagecreatetruecolor( 10, 10 );
 
 		$force_error = static function ( $dirs ) {
@@ -1896,7 +1897,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_maybe_generate_bails_when_save_fails(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -1931,7 +1932,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_world_pixel_conversions(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$this->assertSame(
 			128.0,
@@ -1953,7 +1954,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_parse_aspect_ratio(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$this->assertEqualsWithDelta(
 			2.0,
@@ -1994,14 +1995,14 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_clamp_width(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$this->assertSame(
-			Venue_Map::WIDTH_MIN,
+			Map::WIDTH_MIN,
 			Utility::invoke_hidden_method( $instance, 'clamp_width', array( 0 ) )
 		);
 		$this->assertSame(
-			Venue_Map::WIDTH_MAX,
+			Map::WIDTH_MAX,
 			Utility::invoke_hidden_method( $instance, 'clamp_width', array( 99999 ) )
 		);
 		$this->assertSame(
@@ -2020,7 +2021,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_resolve_dimensions(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$both = Utility::invoke_hidden_method(
 			$instance,
@@ -2051,8 +2052,8 @@ class Test_Venue_Map extends Base {
 			'resolve_dimensions',
 			array( 0, 0, '2/1' )
 		);
-		$this->assertSame( Venue_Map::DEFAULT_HEIGHT * 2, $both_auto['width'] );
-		$this->assertSame( Venue_Map::DEFAULT_HEIGHT, $both_auto['height'] );
+		$this->assertSame( Map::DEFAULT_HEIGHT * 2, $both_auto['width'] );
+		$this->assertSame( Map::DEFAULT_HEIGHT, $both_auto['height'] );
 
 		// Unparsable ratio string still resolves cleanly — falls back to
 		// the default ratio rather than stranding the generator.
@@ -2070,8 +2071,8 @@ class Test_Venue_Map extends Base {
 			'resolve_dimensions',
 			array( 99999, 99999, '2/1' )
 		);
-		$this->assertSame( Venue_Map::WIDTH_MAX, $too_big['width'] );
-		$this->assertSame( Venue_Map::HEIGHT_MAX, $too_big['height'] );
+		$this->assertSame( Map::WIDTH_MAX, $too_big['width'] );
+		$this->assertSame( Map::HEIGHT_MAX, $too_big['height'] );
 	}
 
 	/**
@@ -2084,7 +2085,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_regenerate_rebuilds_cached_combos(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -2142,7 +2143,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_regenerate_includes_caller_supplied_combo(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -2174,7 +2175,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_regenerate_dedupes_caller_combo_against_cache(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -2184,9 +2185,9 @@ class Test_Venue_Map extends Base {
 
 		$result = $instance->regenerate(
 			$post_id,
-			Venue_Map::DEFAULT_ZOOM,
-			Venue_Map::DEFAULT_HEIGHT * 2,
-			Venue_Map::DEFAULT_HEIGHT,
+			Map::DEFAULT_ZOOM,
+			Map::DEFAULT_HEIGHT * 2,
+			Map::DEFAULT_HEIGHT,
 			''
 		);
 
@@ -2207,7 +2208,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_regenerate_seeds_default_combo_when_nothing_cached(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -2220,9 +2221,9 @@ class Test_Venue_Map extends Base {
 
 		$default_key = sprintf(
 			'%dx%dx%d',
-			Venue_Map::DEFAULT_ZOOM,
-			Venue_Map::DEFAULT_HEIGHT * 2,
-			Venue_Map::DEFAULT_HEIGHT
+			Map::DEFAULT_ZOOM,
+			Map::DEFAULT_HEIGHT * 2,
+			Map::DEFAULT_HEIGHT
 		);
 		$this->assertArrayHasKey( $default_key, $result );
 	}
@@ -2237,7 +2238,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_regenerate_returns_empty_when_no_coordinates(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', 'Somewhere, somewhere' );
@@ -2256,7 +2257,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_rest_regenerate_requires_edit_post(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$instance->register_rest_routes();
 
 		$post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
@@ -2283,7 +2284,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_rest_regenerate_returns_fresh_descriptors(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$instance->register_rest_routes();
 
 		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
@@ -2309,9 +2310,9 @@ class Test_Venue_Map extends Base {
 
 		$default_key = sprintf(
 			'%dx%dx%d',
-			Venue_Map::DEFAULT_ZOOM,
-			Venue_Map::DEFAULT_HEIGHT * 2,
-			Venue_Map::DEFAULT_HEIGHT
+			Map::DEFAULT_ZOOM,
+			Map::DEFAULT_HEIGHT * 2,
+			Map::DEFAULT_HEIGHT
 		);
 		$this->assertArrayHasKey( $default_key, (array) $data['descriptors'] );
 	}
@@ -2326,7 +2327,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_rest_regenerate_reports_no_address_reason(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$instance->register_rest_routes();
 
 		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
@@ -2365,7 +2366,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_rest_regenerate_reports_generation_failed_when_saves_fail(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$instance->register_rest_routes();
 
 		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
@@ -2414,7 +2415,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_rest_regenerate_aspect_ratio_validator(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$instance->register_rest_routes();
 
 		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
@@ -2505,7 +2506,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_rest_regenerate_reports_awaiting_geocode_reason(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$instance->register_rest_routes();
 
 		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
@@ -2538,7 +2539,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_filename_for_appends_density_suffix_for_retina(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$one_x = Utility::invoke_hidden_method(
 			$instance,
@@ -2565,7 +2566,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_density_two_doubles_canvas(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		// `short_circuit_tile_requests` (installed in setUp) stubs every
 		// outbound tile request with the shared 1×1 PNG, so this call
@@ -2577,7 +2578,7 @@ class Test_Venue_Map extends Base {
 			15,
 			400,
 			200,
-			Venue_Map::DEFAULT_TILE_URL,
+			Map::DEFAULT_TILE_URL,
 			2
 		);
 
@@ -2598,7 +2599,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_density_two_fetches_zoom_plus_one_tiles(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$zooms_seen = array();
 		$spy        = function ( $preempt, $args, $url ) use ( &$zooms_seen ) {
@@ -2632,7 +2633,7 @@ class Test_Venue_Map extends Base {
 			15,
 			400,
 			200,
-			Venue_Map::DEFAULT_TILE_URL,
+			Map::DEFAULT_TILE_URL,
 			2
 		);
 
@@ -2660,7 +2661,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_stamp_marker_scales_radii(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$canvas   = imagecreatetruecolor( 80, 80 );
 
 		// Seed the canvas with a distinctive background so we can tell a
@@ -2696,7 +2697,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_ensure_descriptor_for_combo_emits_retina_variant(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -2731,7 +2732,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_ensure_descriptor_for_combo_skips_retina_when_filter_disables(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -2752,7 +2753,7 @@ class Test_Venue_Map extends Base {
 
 		// No sibling @2x.png was ever written.
 		$dirs     = wp_get_upload_dir();
-		$base_dir = trailingslashit( $dirs['basedir'] ) . Venue_Map::UPLOADS_SUBDIR;
+		$base_dir = trailingslashit( $dirs['basedir'] ) . Map::UPLOADS_SUBDIR;
 		$retina   = glob( $base_dir . '/*@2x.png' );
 
 		$this->assertEmpty( $retina, 'Disabling the filter must not leave any @2x files on disk.' );
@@ -2769,12 +2770,12 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_all_descriptors_normalizes_missing_url_2x(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		update_post_meta(
 			$post_id,
-			Venue_Map::META_KEY,
+			Map::META_KEY,
 			array(
 				'15x600x300' => array(
 					'url'    => 'https://example.test/legacy.png',
@@ -2811,7 +2812,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_descriptor_for_post_returns_full_descriptor(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -2846,7 +2847,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_descriptor_for_post_returns_null_for_unrelated_post(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => 'post' ) );
 
 		$this->assertNull( $instance->get_descriptor_for_post( $post_id, 'post' ) );
@@ -2863,8 +2864,8 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_descriptor_for_post_resolves_event_via_linked_venue(): void {
-		$instance    = Venue_Map::get_instance();
-		$venue_setup = \GatherPress\Core\Venue_Setup::get_instance();
+		$instance    = Map::get_instance();
+		$venue_setup = Setup::get_instance();
 
 		$venue = $this->mock->post(
 			array(
@@ -2918,7 +2919,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_ensure_descriptor_for_combo_skips_retina_at_zoom_ceiling(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -2928,7 +2929,7 @@ class Test_Venue_Map extends Base {
 		$descriptor = $instance->get_descriptor_for_post(
 			$post_id,
 			Venue::POST_TYPE,
-			Venue_Map::ZOOM_MAX,
+			Map::ZOOM_MAX,
 			800,
 			400,
 			'2/1'
@@ -2964,7 +2965,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_clamps_tile_zoom_to_ceiling(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$zooms_seen = array();
 		$spy        = function ( $preempt, $args, $url ) use ( &$zooms_seen ) {
@@ -2992,11 +2993,11 @@ class Test_Venue_Map extends Base {
 		$image = $instance->composite_image(
 			37.3318,
 			-122.0312,
-			Venue_Map::ZOOM_MAX,
+			Map::ZOOM_MAX,
 			400,
 			200,
-			Venue_Map::DEFAULT_TILE_URL,
-			Venue_Map::RETINA_DENSITY
+			Map::DEFAULT_TILE_URL,
+			Map::RETINA_DENSITY
 		);
 
 		remove_filter( 'pre_http_request', $spy, 10 );
@@ -3006,7 +3007,7 @@ class Test_Venue_Map extends Base {
 
 		$this->assertNotEmpty( $zooms_seen, 'Retina composite at the ceiling must still attempt tile fetches.' );
 		$this->assertSame(
-			array( Venue_Map::ZOOM_MAX ),
+			array( Map::ZOOM_MAX ),
 			array_values( array_unique( $zooms_seen ) ),
 			'Tile fetches must clamp to ZOOM_MAX instead of overshooting to zoom+1 above the provider ceiling.'
 		);
@@ -3023,7 +3024,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_composite_image_coerces_unsupported_density_back_to_one(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 
 		$image = $instance->composite_image(
 			37.3318,
@@ -3031,7 +3032,7 @@ class Test_Venue_Map extends Base {
 			15,
 			400,
 			200,
-			Venue_Map::DEFAULT_TILE_URL,
+			Map::DEFAULT_TILE_URL,
 			3
 		);
 
@@ -3062,7 +3063,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_ensure_descriptor_for_combo_reuses_valid_1x_when_filling_in_retina(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
@@ -3109,7 +3110,7 @@ class Test_Venue_Map extends Base {
 	 * @return void
 	 */
 	public function test_get_descriptor_for_post_returns_null_when_venue_has_no_coordinates(): void {
-		$instance = Venue_Map::get_instance();
+		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', 'Somewhere' );

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -1,26 +1,70 @@
 <?php
 /**
- * Class handles unit tests for GatherPress\Core\Venue_Setup.
+ * Class handles unit tests for GatherPress\Core\Venue\Setup.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Venue
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core;
+namespace GatherPress\Tests\Core\Venue;
 
 use GatherPress\Core\Event;
-use GatherPress\Core\Venue;
-use GatherPress\Core\Venue_Setup;
+use GatherPress\Core\Venue\Map;
+use GatherPress\Core\Venue\Map_Prewarm;
+use GatherPress\Core\Venue\Setup;
+use GatherPress\Core\Venue\Venue;
 use GatherPress\Tests\Base;
+use PMC\Unit_Test\Utility;
 use WP_Block_Patterns_Registry;
 
 /**
- * Class Test_Venue_Setup.
+ * Class Test_Setup.
  *
  * @group multisite
- * @coversDefaultClass \GatherPress\Core\Venue_Setup
+ * @coversDefaultClass \GatherPress\Core\Venue\Setup
  */
-class Test_Venue_Setup extends Base {
+class Test_Setup extends Base {
+	/**
+	 * Venue\Setup now owns the instantiation of the Venue\* sibling
+	 * singletons (Map, Map_Prewarm) so the outer
+	 * `Setup::instantiate_classes()` can hand off with a single
+	 * `Venue\Setup::get_instance()` call. Per-sibling proof-of-construction
+	 * via their `setup_hooks()`-registered hooks — catches the case where
+	 * a sibling silently drops out of `Venue\Setup::instantiate_classes()`.
+	 *
+	 * @covers ::__construct
+	 * @covers ::instantiate_classes
+	 *
+	 * @return void
+	 */
+	public function test_instantiate_classes_registers_siblings(): void {
+		// Force the method to run inside the test's coverage window —
+		// Setup is a singleton cached during plugin bootstrap, so
+		// `get_instance()` here returns the cached instance and doesn't
+		// re-fire the constructor.
+		Utility::invoke_hidden_method( Setup::get_instance(), 'instantiate_classes' );
+
+		$expected_hooks = array(
+			Map::class         => array(
+				'rest_api_init',
+				array( Map::get_instance(), 'register_rest_routes' ),
+			),
+			Map_Prewarm::class => array(
+				'switch_theme',
+				array( Map_Prewarm::get_instance(), 'on_theme_switched' ),
+			),
+		);
+
+		foreach ( $expected_hooks as $class_name => $expected ) {
+			list( $hook, $callback ) = $expected;
+			$this->assertSame(
+				10,
+				has_action( $hook, $callback ),
+				sprintf( '%s must be instantiated so its %s hook registers.', $class_name, $hook )
+			);
+		}
+	}
+
 	/**
 	 * Coverage for __construct and setup_hooks.
 	 *
@@ -30,7 +74,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_setup_hooks(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$hooks    = array(
 			array(
 				'type'     => 'action',
@@ -90,7 +134,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_post_type_hooks(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $post_type ) {
 			$instance->maybe_register_post_type_hooks( $post_type );
@@ -121,7 +165,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_post_type_hooks_skips_unsupported_post_type(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$instance->maybe_register_post_type_hooks( 'post' );
 
@@ -143,7 +187,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_register_post_type(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		unregister_post_type( Venue::POST_TYPE );
 
@@ -163,7 +207,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_post_meta(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$venue_information_keys = array(
 			'gatherpress_address',
@@ -228,7 +272,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_register_post_meta_without_revisions_support(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$test_pt  = 'test_venue_no_rev';
 
 		register_post_type(
@@ -275,7 +319,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_filter_readonly_meta(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$request  = new \WP_REST_Request();
 
 		$request->set_param(
@@ -328,7 +372,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_filter_readonly_meta_no_meta_param(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$request  = new \WP_REST_Request();
 		$prepared = new \stdClass();
 
@@ -349,7 +393,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_sanitize_coordinate(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$this->assertSame(
 			'40.7128',
@@ -386,7 +430,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_register_taxonomy(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		unregister_taxonomy( Venue::TAXONOMY );
 
@@ -425,7 +469,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_add_venue_term(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$venue    = $this->mock->post( array( 'post_type' => Venue::POST_TYPE ) )->get();
 		$term     = term_exists( $instance->term_slug_from_post_name( $venue->post_name ), Venue::TAXONOMY );
 
@@ -469,7 +513,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_update_term_slug(): void {
-		$instance    = Venue_Setup::get_instance();
+		$instance    = Setup::get_instance();
 		$post_before = $this->mock->post()->get();
 		$post_after  = clone $post_before;
 
@@ -586,7 +630,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_delete_venue_term(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$venue    = $this->mock->post( array( 'post_type' => Venue::POST_TYPE ) )->get();
 
 		$this->assertIsArray(
@@ -618,7 +662,7 @@ class Test_Venue_Setup extends Base {
 		)->get();
 		wp_set_post_terms( $event->ID, 'dummy-venue', Venue::TAXONOMY );
 
-		$venue_meta = Venue_Setup::get_instance()->get_venue_meta( $event->ID, Event::POST_TYPE );
+		$venue_meta = Setup::get_instance()->get_venue_meta( $event->ID, Event::POST_TYPE );
 
 		// Generic test for an in person event.
 		$this->assertFalse( $venue_meta['isOnlineEventTerm'] );
@@ -633,7 +677,7 @@ class Test_Venue_Setup extends Base {
 			)
 		)->get();
 
-		$venue_meta = Venue_Setup::get_instance()->get_venue_meta( $venue->ID, Venue::POST_TYPE );
+		$venue_meta = Setup::get_instance()->get_venue_meta( $venue->ID, Venue::POST_TYPE );
 
 		// Test for a venue post.
 		$this->assertEquals(
@@ -667,7 +711,7 @@ class Test_Venue_Setup extends Base {
 		add_post_meta( $venue->ID, 'gatherpress_latitude', '40.7128' );
 		add_post_meta( $venue->ID, 'gatherpress_longitude', '-74.006' );
 
-		$venue_meta = Venue_Setup::get_instance()->get_venue_meta( $venue->ID, Venue::POST_TYPE );
+		$venue_meta = Setup::get_instance()->get_venue_meta( $venue->ID, Venue::POST_TYPE );
 
 		$this->assertEquals(
 			$venue_title,
@@ -712,7 +756,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_apply_venue_template(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Create a venue post with empty content (simulating REST API creation).
 		$post_id = $this->factory->post->create(
@@ -754,7 +798,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_apply_venue_template_skips_updates(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Factory creation triggers the save_post hook with $update=false which
 		// seeds the template. Reset content directly to simulate the user having
@@ -800,7 +844,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_apply_venue_template_skips_non_empty(): void {
-		$instance         = Venue_Setup::get_instance();
+		$instance         = Setup::get_instance();
 		$existing_content = '<!-- wp:paragraph --><p>Existing content.</p><!-- /wp:paragraph -->';
 
 		$post_id = $this->factory->post->create(
@@ -835,7 +879,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_apply_venue_template_skips_drafts(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$post_id = $this->factory->post->create(
 			array(
@@ -869,7 +913,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_apply_venue_template_skips_unregistered_pattern(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$registry = WP_Block_Patterns_Registry::get_instance();
 
 		// Unregister the venue-template pattern.
@@ -915,7 +959,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_add_editor_settings(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Test with an empty settings array.
 		$result = $instance->add_editor_settings( array() );
@@ -966,7 +1010,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_add_venue_term_unsupported_post_type(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$post     = $this->mock->post( array( 'post_type' => 'post' ) )->get();
 
 		// Calling add_venue_term on a standard 'post' should return early and create no term.
@@ -992,7 +1036,7 @@ class Test_Venue_Setup extends Base {
 				'post_name' => 'unit-test',
 			)
 		)->get();
-		$result = Venue_Setup::get_instance()->get_venue_post_from_term_slug( '_unit-test' );
+		$result = Setup::get_instance()->get_venue_post_from_term_slug( '_unit-test' );
 
 		$this->assertEquals(
 			$venue->ID,
@@ -1009,7 +1053,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_venue_post_from_event_post_id(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$venue    = $this->mock->post(
 			array(
 				'post_type'  => Venue::POST_TYPE,
@@ -1034,7 +1078,7 @@ class Test_Venue_Setup extends Base {
 
 		wp_set_post_terms( $event->ID, $term_slug, Venue::TAXONOMY );
 
-		$result = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $event->ID );
+		$result = Setup::get_instance()->get_venue_post_from_event_post_id( $event->ID );
 
 		$this->assertInstanceOf(
 			'WP_Post',
@@ -1063,7 +1107,7 @@ class Test_Venue_Setup extends Base {
 			)
 		)->get();
 
-		$result = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $event->ID );
+		$result = Setup::get_instance()->get_venue_post_from_event_post_id( $event->ID );
 
 		$this->assertNull(
 			$result,
@@ -1080,7 +1124,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_venue_post_from_event_post_id_skips_online_event_sentinel(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$venue    = $this->mock->post(
 			array(
 				'post_type'  => Venue::POST_TYPE,
@@ -1107,7 +1151,7 @@ class Test_Venue_Setup extends Base {
 		// old `$venue_terms[0]` logic when the sentinel came first.
 		wp_set_post_terms( $event->ID, array( 'online-event', $venue_term_slug ), Venue::TAXONOMY );
 
-		$result = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $event->ID );
+		$result = Setup::get_instance()->get_venue_post_from_event_post_id( $event->ID );
 
 		$this->assertInstanceOf(
 			'WP_Post',
@@ -1131,7 +1175,7 @@ class Test_Venue_Setup extends Base {
 	public function test_term_slug_from_post_name(): void {
 		$this->assertSame(
 			'_unit-test',
-			Venue_Setup::get_instance()->term_slug_from_post_name( 'unit-test' ),
+			Setup::get_instance()->term_slug_from_post_name( 'unit-test' ),
 			'Failed to assert that term_slug_from_post_name prepends an underscore.'
 		);
 	}
@@ -1144,7 +1188,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_taxonomy(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// No argument falls back to the default venue post type.
 		$this->assertSame(
@@ -1178,7 +1222,7 @@ class Test_Venue_Setup extends Base {
 	public function test_get_venue_post_type(): void {
 		$this->assertSame(
 			Venue::POST_TYPE,
-			Venue_Setup::get_instance()->get_venue_post_type(),
+			Setup::get_instance()->get_venue_post_type(),
 			'Failed to assert that get_venue_post_type returns the default venue post type.'
 		);
 	}
@@ -1197,7 +1241,7 @@ class Test_Venue_Setup extends Base {
 		// test run that used the default (empty-string) key.
 		$this->assertSame(
 			'custom_venue_type',
-			Venue_Setup::get_instance()->get_venue_post_type( 'test_custom_event_type' ),
+			Setup::get_instance()->get_venue_post_type( 'test_custom_event_type' ),
 			'Failed to assert that get_venue_post_type returns the filtered post type.'
 		);
 
@@ -1212,7 +1256,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_venue_post_type_map(): void {
-		$map = Venue_Setup::get_instance()->get_venue_post_type_map();
+		$map = Setup::get_instance()->get_venue_post_type_map();
 
 		$this->assertIsArray(
 			$map,
@@ -1238,7 +1282,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_localized_post_type_slug(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$this->assertSame(
 			'venue',
@@ -1326,7 +1370,7 @@ class Test_Venue_Setup extends Base {
 
 		add_filter( 'locale', $locale_filter );
 
-		$slug = Venue_Setup::get_instance()->get_localized_post_type_slug();
+		$slug = Setup::get_instance()->get_localized_post_type_slug();
 
 		$this->assertNotEmpty( $slug, 'Failed to assert slug is not empty.' );
 
@@ -1347,7 +1391,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_add_venue_term_skips_when_term_already_exists(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$venue    = $this->mock->post( array( 'post_type' => Venue::POST_TYPE ) )->get();
 
 		// First save creates the term.
@@ -1377,7 +1421,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_maybe_update_term_slug_no_changes(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 		$venue    = $this->mock->post( array( 'post_type' => Venue::POST_TYPE ) )->get();
 
 		// Call with identical before/after — neither slug nor title changed.
@@ -1400,7 +1444,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_delete_venue_term_unsupported_post_type(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		// Seed a sentinel term so we can prove the method didn't touch it.
 		if ( ! term_exists( 'online-event', Venue::TAXONOMY ) ) {
@@ -1425,7 +1469,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_venue_meta_event_with_linked_venue(): void {
-		$instance    = Venue_Setup::get_instance();
+		$instance    = Setup::get_instance();
 		$venue_title = 'Linked Venue';
 		$venue       = $this->mock->post(
 			array(
@@ -1476,7 +1520,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_is_venue_term_slug(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		$this->assertTrue( $instance->is_venue_term_slug( '_my-venue' ) );
 		$this->assertFalse( $instance->is_venue_term_slug( 'online-event' ) );
@@ -1493,7 +1537,7 @@ class Test_Venue_Setup extends Base {
 	public function test_taxonomy_for_event_post_type(): void {
 		$this->assertSame(
 			Venue::TAXONOMY,
-			Venue_Setup::get_instance()->taxonomy_for_event_post_type( Event::POST_TYPE ),
+			Setup::get_instance()->taxonomy_for_event_post_type( Event::POST_TYPE ),
 			'Expected the default event post type to resolve to the default venue taxonomy.'
 		);
 	}
@@ -1509,7 +1553,7 @@ class Test_Venue_Setup extends Base {
 	 * @return void
 	 */
 	public function test_get_venue_post_from_event_post_id_only_sentinel_terms(): void {
-		$instance = Venue_Setup::get_instance();
+		$instance = Setup::get_instance();
 
 		if ( ! term_exists( 'online-event', Venue::TAXONOMY ) ) {
 			wp_insert_term( 'Online event', Venue::TAXONOMY, array( 'slug' => 'online-event' ) );

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-venue.php
@@ -1,28 +1,57 @@
 <?php
 /**
- * Class handles unit tests for GatherPress\Core\Venue.
+ * Class handles unit tests for GatherPress\Core\Venue\Venue.
  *
  * Covers the instance class — constructor and per-post accessors. Anything
  * that isn't tied to a specific venue instance (WP integration, post-type-level
- * utilities, lookups) is covered by `Test_Venue_Setup`.
+ * utilities, lookups) is covered by `Test_Setup`.
  *
- * @package GatherPress\Core
+ * @package GatherPress\Core\Venue
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core;
+namespace GatherPress\Tests\Core\Venue;
 
-use GatherPress\Core\Venue;
+use GatherPress\Core\Venue\Venue;
 use GatherPress\Tests\Base;
+use ReflectionClass;
 use WP_Term;
 
 /**
  * Class Test_Venue.
  *
  * @group multisite
- * @coversDefaultClass \GatherPress\Core\Venue
+ * @coversDefaultClass \GatherPress\Core\Venue\Venue
  */
 class Test_Venue extends Base {
+	/**
+	 * Asserts that the prior fully-qualified class name `GatherPress\Core\Venue` continues
+	 * to resolve to the current class `GatherPress\Core\Venue\Venue` via the alias map in
+	 * `includes/core/register-class-aliases.php`. Removing the alias entry would silently
+	 * break external consumers (other plugins, theme code) that reference the prior FQN —
+	 * this test fails loudly first.
+	 *
+	 * @return void
+	 */
+	public function test_prior_fqn_resolves_to_current_class(): void {
+		$prior_fqn = 'GatherPress\\Core\\Venue';
+
+		$this->assertTrue(
+			class_exists( $prior_fqn ),
+			'The prior fully-qualified class name should resolve via the alias map.'
+		);
+
+		$reflection = new ReflectionClass( $prior_fqn );
+		$this->assertSame(
+			Venue::class,
+			$reflection->getName(),
+			'The prior FQN should resolve to the current Venue class.'
+		);
+
+		// Read a class constant through the prior FQN to confirm runtime usability.
+		$this->assertSame( Venue::POST_TYPE, constant( $prior_fqn . '::POST_TYPE' ) );
+	}
+
 	/**
 	 * Construct a Venue instance from a post ID and read it back.
 	 *


### PR DESCRIPTION
### Description of the Change

Second of three PRs implementing [#1502](https://github.com/GatherPress/gatherpress/issues/1502) — flattens the `Venue_*` classes from `GatherPress\Core` into a subnamespace matching the existing `Settings` / `Settings\*` pattern and the just-landed `Event\*` shape from [#1508](https://github.com/GatherPress/gatherpress/pull/1508). Rsvp lands as the final follow-up PR.

**Moved + renamed (`git mv` — rename history is preserved for `git log --follow`):**

| Old | New |
|---|---|
| `GatherPress\Core\Venue` at `classes/class-venue.php` | `GatherPress\Core\Venue\Venue` at `classes/venue/class-venue.php` |
| `GatherPress\Core\Venue_Map` at `classes/class-venue-map.php` | `GatherPress\Core\Venue\Map` at `classes/venue/class-map.php` |
| `GatherPress\Core\Venue_Map_Prewarm` at `classes/class-venue-map-prewarm.php` | `GatherPress\Core\Venue\Map_Prewarm` at `classes/venue/class-map-prewarm.php` |
| `GatherPress\Core\Venue_Setup` at `classes/class-venue-setup.php` | `GatherPress\Core\Venue\Setup` at `classes/venue/class-setup.php` |

Per the issue update, `Venue_Map_Prewarm` lands as `Venue\Map_Prewarm` rather than further-nested `Venue\Map\Prewarm` — splitting Map into its own subdirectory was overkill for two map classes.

Test files moved in lockstep to `test/unit/php/includes/tests/core/classes/venue/` with matching class renames (`Test_Venue_Setup` → `Test_Setup`, `Test_Venue_Map` → `Test_Map`, etc.) and updated `@coversDefaultClass` annotations.

**Hub pattern mirrors Event/Settings.** `Venue\Setup` gained an `instantiate_classes()` method that creates its sibling singletons (`Map`, `Map_Prewarm`). The outer `Setup::instantiate_classes()` drops from three `Venue_*::get_instance()` lines to a single `Venue\Setup::get_instance()` line. Adding a new `Venue\*` class in the future lands as one line in `Venue\Setup::instantiate_classes()` rather than two edits (Setup list + new class file).

Before:

```php
// class-setup.php
Venue_Map::get_instance();
Venue_Map_Prewarm::get_instance();
Venue_Setup::get_instance();
```

After:

```php
// class-setup.php
Venue\Setup::get_instance();

// venue/class-setup.php
protected function instantiate_classes(): void {
    Map::get_instance();
    Map_Prewarm::get_instance();
}
```

**Class alias for the parent `Venue`.** Same shim as Event: `GatherPress\Core\Venue` is added to `register-class-aliases.php` so the prior FQN keeps resolving to the new `GatherPress\Core\Venue\Venue` class for downstream consumers (other plugins, theme code) without needing lockstep updates. `phpstan.stubs` mirrors the runtime alias so static analysis stays clean.

**Cross-namespace `use` statements.** Moved files now need explicit imports for classes that used to resolve via same-namespace lookup from `GatherPress\Core` — added `use` statements for `Event\Event`, `Settings`, `Utility`, and `Validate` where each file references them. Inside the new `Venue\` namespace, `Settings::get_instance()` would otherwise resolve to the non-existent `GatherPress\Core\Venue\Settings`, which PHPStan caught.

**Aliased imports at consumer sites** to avoid touching unrelated call sites — same pattern as the Event PR. Files that referenced `Venue_Setup::` or `Venue_Map::` heavily keep their existing local symbol names by aliasing at the `use` site:

```php
// e.g. includes/core/classes/blocks/class-venue.php
use GatherPress\Core\Venue\Setup as Venue_Setup;  // was: use GatherPress\Core\Venue_Setup;
use GatherPress\Core\Venue\Venue as Venue_Core;   // was: use GatherPress\Core\Venue as Venue_Core;
```

Affected consumers: `includes/core/classes/blocks/class-online-event.php`, `blocks/class-venue.php`, `settings/class-events.php`, `settings/class-venues.php`, `event/class-admin-list.php`, `event/class-event.php`, `event/class-query.php`, `src/blocks/venue-map/render.php`, plus matching test files.

**JS comment-only references** in `src/blocks/venue-map/edit.js`, `helpers.js`, `src/components/VenueInformation.js`, and `src/helpers/venue.js` were updated to use the new `Venue\Map` / `Venue\Setup` form so cross-language references stay consistent — no behavior change.

**Not in this PR** (deferred to the final follow-up on #1502):

- `Rsvp_*` → `Rsvp\*` (Cleanup, Form, Query, Setup, Token — 5 subclasses + outer `Setup` collision to handle inside `Rsvp\Setup`)
- Auto-generated developer hook docs at `docs/developer/hooks/` — line numbers for every hook in the moved Venue files will shift, but the `extract-wp-hooks-as-docs.yml` workflow regenerates these automatically on merge to `develop` per the repo convention. Not included in this PR.

Part of #1502 — keeping the ticket open for the Rsvp follow-up.

### How to test the Change

1. Check out the branch and run a fresh `npm run build` so `build/blocks/venue-map/render.php` picks up the new `use` statements (the build copy is what WordPress executes; the rename otherwise fatals with `Class "GatherPress\Core\Venue_Setup" not found`).
2. Run the full PHP test suite (`npm run test:unit:php` + `npm run test:unit:php:multisite`) plus JS (`npm run test:unit:js`). Two new tests join: `GatherPress\Tests\Core\Venue\Test_Setup::test_instantiate_classes_registers_siblings` proves each `Venue\*` sibling got instantiated by checking for its distinctive registered hook (`rest_api_init` for `Map`, `switch_theme` for `Map_Prewarm`); `Test_Venue::test_prior_fqn_resolves_to_current_class` guards the `Venue` → `Venue\Venue` alias.
3. Activate the plugin on a site with existing venues and click around the Venues admin list. Open and save a venue — confirms `Venue\Setup` is still registering the post type, taxonomy, meta, and the term-lifecycle save hooks.
4. Drop a `gatherpress/venue-map` block on a venue page or Single Venue FSE template, save, and load the front end — confirms the venue-map render path (`src/blocks/venue-map/render.php`) still resolves `Venue_Setup` and `Venue_Map` through the aliased imports, and that the static PNG pipeline (`Map::warm()`) plus the prewarm cron path (`Map_Prewarm::on_post_saved()`) still fire.
5. Hit the venue REST endpoints once (e.g. `GET /wp-json/wp/v2/gatherpress_venues`) to confirm the venue post type and meta registration on `Venue\Setup` are still wired.
6. Check Events → Settings → Venues to confirm the `Venue_Map` alias in `settings/class-venues.php` keeps the venue-map default settings (zoom, height, render mode, scale, map type) populating correctly.
7. `git log --follow includes/core/classes/venue/class-setup.php` should still trace back through the rename to the original `class-venue-setup.php` history. Same for the other three moves.

### Changelog Entry

> Changed - Internal: flattened `Venue_*` classes into the `GatherPress\Core\Venue` subnamespace (`Venue_Map` → `Venue\Map`, `Venue_Map_Prewarm` → `Venue\Map_Prewarm`, `Venue_Setup` → `Venue\Setup`, parent `Venue` → `Venue\Venue` with FQN alias) matching the existing `Settings\*` and just-landed `Event\*` patterns. `Venue\Setup` now owns its sibling instantiation via `Venue\Setup::instantiate_classes()`, collapsing three lines of `Setup::instantiate_classes()` into one. No user-facing behavior change.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.