### PR TITLE
Refactor venue Map into swappable provider strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,10 @@ Based on WordPress Coding Standards (WPCS), always ensure:
 - **Type handling**: WordPress functions may return multiple types; handle all cases with proper type checking
     - Use `is_wp_error()`, `is_numeric()`, and similar WordPress/PHP functions
     - Cast types explicitly when needed: `(int) $comment->comment_post_ID`
+- **PHPCS warnings count as failures**: `npm run lint:php` exits non-zero on warnings, not just errors. The most common one is `Generic.Files.LineLength.TooLong` (120-char limit). Don't dismiss warnings as cosmetic — fix them before declaring lint passes.
+    - Long `@return array<string, array<...>>` PHPDoc types: extract the array shape into a `@phpstan-type` alias at the top of the class, then reference the alias.
+    - Long expression lines: break at logical points (after `return`, after `=`, around operators) and indent the continuation with one tab beyond the statement start.
+    - Long `sprintf()` / translator string args: split the format string across `__()` calls with concatenation, or store the format in a variable on its own line.
 
 ### Test Coverage
 

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -168,7 +168,7 @@ Because each field is its own meta key, you can bind core blocks (paragraph, hea
 
 Enables map display for a venue post type. This includes:
 
-- Registration of map meta fields (`gatherpress_venue_map_show`, `gatherpress_venue_map_zoom`, `gatherpress_venue_map_height`)
+- Registration of map meta fields (`gatherpress_map_show`, `gatherpress_map_zoom`, `gatherpress_map_height`)
 - Venue Map block rendering
 
 #### Usage for gatherpress-venue-map

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -16,7 +16,7 @@ namespace GatherPress\Core\Settings;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue\Map;
+use GatherPress\Core\Venue\Map\Map;
 
 /**
  * Class Venues.

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -16,7 +16,7 @@ namespace GatherPress\Core\Settings;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map;
 
 /**
  * Class Venues.

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -21,7 +21,7 @@ use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Validate;
-use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Setup as Map_Setup;
 use stdClass;
 use WP_Block_Patterns_Registry;

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -21,6 +21,8 @@ use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Validate;
+use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map\Setup as Map_Setup;
 use stdClass;
 use WP_Block_Patterns_Registry;
 use WP_Post;
@@ -31,9 +33,9 @@ use WP_Term;
  * Class Setup.
  *
  * Registers the Venue post type + taxonomy and wires the WordPress hooks that
- * keep venue data consistent (term lifecycle, template content). Also owns
- * instantiation of the Venue\* sibling singletons (Map, Map_Prewarm) so the
- * outer `Setup::instantiate_classes()` can hand off the whole venue subsystem
+ * keep venue data consistent (term lifecycle, template content). Hands off
+ * the map subsystem to `Map\Setup` so the outer `Setup::instantiate_classes()`
+ * can hand off the whole venue subsystem
  * with a single `Venue\Setup::get_instance()` line — same shape as
  * `Settings::instantiate_classes()`.
  *
@@ -127,8 +129,7 @@ class Setup {
 	 * @return void
 	 */
 	protected function instantiate_classes(): void {
-		Map::get_instance();
-		Map_Prewarm::get_instance();
+		Map_Setup::get_instance();
 	}
 
 	/**

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -388,7 +388,7 @@ class Setup {
 
 		$venue_map_meta = array(
 			// Map display settings.
-			'gatherpress_venue_map_show'   => array(
+			'gatherpress_map_show'   => array(
 				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
 				'show_in_rest'      => true,
@@ -396,7 +396,7 @@ class Setup {
 				'type'              => 'boolean',
 				'default'           => true,
 			),
-			'gatherpress_venue_map_zoom'   => array(
+			'gatherpress_map_zoom'   => array(
 				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,
@@ -404,7 +404,7 @@ class Setup {
 				'type'              => 'integer',
 				'default'           => 10,
 			),
-			'gatherpress_venue_map_height' => array(
+			'gatherpress_map_height' => array(
 				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),
 				'sanitize_callback' => 'absint',
 				'show_in_rest'      => true,

--- a/includes/core/classes/venue/map/class-manager.php
+++ b/includes/core/classes/venue/map/class-manager.php
@@ -110,7 +110,7 @@ class Manager {
 				__METHOD__,
 				sprintf(
 					/* translators: %s: provider slug. */
-					esc_html__( 'A venue map provider is already registered for slug "%s"; the second registration was ignored.', 'gatherpress' ),
+					esc_html__( 'A venue map provider is already registered for slug "%s".', 'gatherpress' ),
 					esc_html( $slug )
 				),
 				'1.0.0'

--- a/includes/core/classes/venue/map/class-manager.php
+++ b/includes/core/classes/venue/map/class-manager.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Venue map provider registry.
+ *
+ * Singleton registry that owns the provider instances backing the static
+ * map pipeline. Mirrors the {@see \GatherPress\Core\Rsvp\Manager} pattern:
+ * a per-request registry that hooks `gatherpress_loaded` to register
+ * built-in providers (OSM today) and fire a follow-on action so companion
+ * plugins can register their own.
+ *
+ * @package GatherPress\Core\Venue\Map
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Core\Venue\Map;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Settings;
+use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Venue\Map\Provider\Base as Map_Provider;
+use GatherPress\Core\Venue\Map\Provider\OSM;
+
+/**
+ * Class Manager.
+ *
+ * Provider registry. `register_core_providers()` registers OSM as the
+ * always-available default. Companion plugins can register additional
+ * providers (Google, MapBox, MapTiler, etc.) by hooking
+ * `gatherpress_register_map_providers` and calling `register()` on the
+ * passed Manager instance — same pattern as RSVP types.
+ *
+ * The active provider is resolved from the `map_platform` setting at
+ * `Settings → Venues → Maps`. If that setting points at a slug that no
+ * registered provider claims (e.g. Google before its provider class lands
+ * in #1528), the manager logs a `_doing_it_wrong()` and falls back to OSM
+ * so the front end keeps rendering.
+ *
+ * @since 1.0.0
+ */
+class Manager {
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Registered provider instances keyed by slug.
+	 *
+	 * @since 1.0.0
+	 * @var Map_Provider[]
+	 */
+	private array $providers = array();
+
+	/**
+	 * Class constructor.
+	 *
+	 * Wires the `gatherpress_loaded` listeners that register built-in
+	 * providers and fire the companion-plugin registration action.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Set up hooks for provider registration.
+	 *
+	 * Two-phase: priority 1 registers core providers (always present),
+	 * priority 5 fires the companion-plugin action so third-party
+	 * providers register on top.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks(): void {
+		add_action( 'gatherpress_loaded', array( $this, 'register_core_providers' ), 1 );
+		add_action( 'gatherpress_loaded', array( $this, 'do_register_action' ), 5 );
+	}
+
+	/**
+	 * Register a provider instance.
+	 *
+	 * Idempotent — re-registering the same slug is a no-op so accidental
+	 * double-registration during companion-plugin development doesn't
+	 * silently overwrite the original.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param Map_Provider $provider Provider instance.
+	 * @return void
+	 */
+	public function register( Map_Provider $provider ): void {
+		$slug = $provider->get_slug();
+
+		if ( '' === $slug ) {
+			return;
+		}
+
+		if ( isset( $this->providers[ $slug ] ) ) {
+			return;
+		}
+
+		$this->providers[ $slug ] = $provider;
+	}
+
+	/**
+	 * Whether a provider with the given slug is registered.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $slug Provider slug.
+	 * @return bool
+	 */
+	public function is_registered( string $slug ): bool {
+		return isset( $this->providers[ $slug ] );
+	}
+
+	/**
+	 * Get a registered provider by slug, or null when missing.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $slug Provider slug.
+	 * @return Map_Provider|null
+	 */
+	public function get( string $slug ): ?Map_Provider {
+		return $this->providers[ $slug ] ?? null;
+	}
+
+	/**
+	 * All registered providers, keyed by slug.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Map_Provider[]
+	 */
+	public function get_all(): array {
+		return $this->providers;
+	}
+
+	/**
+	 * Slugs of every registered provider, in registration order.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string[]
+	 */
+	public function get_slugs(): array {
+		return array_keys( $this->providers );
+	}
+
+	/**
+	 * Resolve the provider active for static-map rendering on this site.
+	 *
+	 * Reads `map_platform` from settings; falls back to OSM when:
+	 *  - the setting is empty
+	 *  - the configured slug isn't registered (e.g. Google before #1528 lands)
+	 *  - even OSM isn't registered yet (returns null — bootstrap hasn't run)
+	 *
+	 * Logs a `_doing_it_wrong()` warning when the configured slug isn't
+	 * registered so site owners surface the misconfiguration in their
+	 * debug log instead of just silently defaulting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return Map_Provider|null
+	 */
+	public function get_active(): ?Map_Provider {
+		$slug = (string) Settings::get_instance()->get( 'map_platform' );
+
+		if ( '' !== $slug && isset( $this->providers[ $slug ] ) ) {
+			return $this->providers[ $slug ];
+		}
+
+		// Configured slug isn't registered — surface for site owners and
+		// fall back so the front end still renders something.
+		if ( '' !== $slug && ! isset( $this->providers[ $slug ] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: configured map platform slug. */
+					esc_html__( 'No venue map provider registered for slug "%s"; falling back to OSM.', 'gatherpress' ),
+					esc_html( $slug )
+				),
+				'1.0.0'
+			);
+		}
+
+		return $this->providers['osm'] ?? null;
+	}
+
+	/**
+	 * Slug of the currently active provider, or empty string when none.
+	 *
+	 * Convenience for callers (`Map::get_descriptor_for_post`,
+	 * `Map::ensure_descriptor_for_combo`) that need the slug as a meta
+	 * key without holding onto the provider instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function get_active_slug(): string {
+		$active = $this->get_active();
+
+		return null === $active ? '' : $active->get_slug();
+	}
+
+	/**
+	 * Register the always-available core providers.
+	 *
+	 * Fires on `gatherpress_loaded` priority 1. Companion plugins should
+	 * NOT hook this — use `gatherpress_register_map_providers` (priority 5)
+	 * instead so core registration is already complete.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function register_core_providers(): void {
+		$this->register( new OSM() );
+	}
+
+	/**
+	 * Fire the action for companion plugins to register their providers.
+	 *
+	 * Companion plugins hook `gatherpress_register_map_providers` and call
+	 * `$registry->register( new My_Map_Provider() )` on the passed Manager
+	 * instance. Runs at priority 5 — after core providers (priority 1) so
+	 * the registry is populated when third-party code observes it.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function do_register_action(): void {
+		/**
+		 * Fires when venue map providers are being registered.
+		 *
+		 * Companion plugins should hook this and register their providers
+		 * by calling `$registry->register( new My_Map_Provider() )`. Core
+		 * providers (OSM) are already registered by this point.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param Manager $registry Provider registry.
+		 */
+		do_action( 'gatherpress_register_map_providers', $this );
+	}
+}

--- a/includes/core/classes/venue/map/class-manager.php
+++ b/includes/core/classes/venue/map/class-manager.php
@@ -80,6 +80,7 @@ class Manager {
 	 * @return void
 	 */
 	protected function setup_hooks(): void {
+		// Priority 0 so the registry is populated before any default-priority `init` listener reads it.
 		add_action( 'init', array( $this, 'do_register_action' ), 0 );
 	}
 

--- a/includes/core/classes/venue/map/class-manager.php
+++ b/includes/core/classes/venue/map/class-manager.php
@@ -3,10 +3,10 @@
  * Venue map provider registry.
  *
  * Singleton registry that owns the provider instances backing the static
- * map pipeline. Mirrors the {@see \GatherPress\Core\Rsvp\Manager} pattern:
- * a per-request registry that hooks `gatherpress_loaded` to register
- * built-in providers (OSM today) and fire a follow-on action so companion
- * plugins can register their own.
+ * map pipeline. Built-in providers (OSM today) are registered immediately
+ * in the constructor so the registry is usable from any later hook;
+ * companion plugins hook the `gatherpress_register_map_providers` action
+ * (fired on `init` priority 0) to register their own providers on top.
  *
  * @package GatherPress\Core\Venue\Map
  * @since 1.0.0
@@ -56,29 +56,31 @@ class Manager {
 	/**
 	 * Class constructor.
 	 *
-	 * Wires the `gatherpress_loaded` listeners that register built-in
-	 * providers and fire the companion-plugin registration action.
+	 * Registers built-in providers immediately so the registry is usable
+	 * the moment the singleton exists, then hooks the companion-plugin
+	 * registration action on `init` so third-party plugins (which load
+	 * after GatherPress's bootstrap) get a chance to register.
 	 *
 	 * @since 1.0.0
 	 */
 	protected function __construct() {
+		$this->register_core_providers();
 		$this->setup_hooks();
 	}
 
 	/**
-	 * Set up hooks for provider registration.
+	 * Set up hooks for companion-plugin provider registration.
 	 *
-	 * Two-phase: priority 1 registers core providers (always present),
-	 * priority 5 fires the companion-plugin action so third-party
-	 * providers register on top.
+	 * `init` priority 0 — early enough that anything else hooked on
+	 * `init` (default priority 10) sees the full registry, late enough
+	 * that all plugins have loaded and can listen for the action.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
 	protected function setup_hooks(): void {
-		add_action( 'gatherpress_loaded', array( $this, 'register_core_providers' ), 1 );
-		add_action( 'gatherpress_loaded', array( $this, 'do_register_action' ), 5 );
+		add_action( 'init', array( $this, 'do_register_action' ), 0 );
 	}
 
 	/**
@@ -213,9 +215,9 @@ class Manager {
 	/**
 	 * Register the always-available core providers.
 	 *
-	 * Fires on `gatherpress_loaded` priority 1. Companion plugins should
-	 * NOT hook this — use `gatherpress_register_map_providers` (priority 5)
-	 * instead so core registration is already complete.
+	 * Called from the constructor so the registry is populated as soon as
+	 * the singleton exists. Companion plugins should NOT call this — use
+	 * the `gatherpress_register_map_providers` action instead.
 	 *
 	 * @since 1.0.0
 	 *
@@ -230,8 +232,8 @@ class Manager {
 	 *
 	 * Companion plugins hook `gatherpress_register_map_providers` and call
 	 * `$registry->register( new My_Map_Provider() )` on the passed Manager
-	 * instance. Runs at priority 5 — after core providers (priority 1) so
-	 * the registry is populated when third-party code observes it.
+	 * instance. Fires on `init` priority 0 so the registry is populated
+	 * before anything else hooked on `init` observes it.
 	 *
 	 * @since 1.0.0
 	 *

--- a/includes/core/classes/venue/map/class-manager.php
+++ b/includes/core/classes/venue/map/class-manager.php
@@ -89,7 +89,9 @@ class Manager {
 	 *
 	 * Idempotent — re-registering the same slug is a no-op so accidental
 	 * double-registration during companion-plugin development doesn't
-	 * silently overwrite the original.
+	 * silently overwrite the original. Logs a `_doing_it_wrong()` on the
+	 * collision so the conflict surfaces in the debug log instead of
+	 * disappearing.
 	 *
 	 * @since 1.0.0
 	 *
@@ -104,6 +106,15 @@ class Manager {
 		}
 
 		if ( isset( $this->providers[ $slug ] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: provider slug. */
+					esc_html__( 'A venue map provider is already registered for slug "%s"; the second registration was ignored.', 'gatherpress' ),
+					esc_html( $slug )
+				),
+				'1.0.0'
+			);
 			return;
 		}
 
@@ -244,9 +255,13 @@ class Manager {
 		/**
 		 * Fires when venue map providers are being registered.
 		 *
-		 * Companion plugins should hook this and register their providers
-		 * by calling `$registry->register( new My_Map_Provider() )`. Core
-		 * providers (OSM) are already registered by this point.
+		 * Fires on `init` priority 0 — after all plugins have loaded but
+		 * before any default-priority `init` listener observes the
+		 * registry. Companion plugins should hook this (NOT `plugins_loaded`,
+		 * which is too early — the manager singleton may not yet exist)
+		 * and register their providers by calling
+		 * `$registry->register( new My_Map_Provider() )`. Core providers
+		 * (OSM) are already registered by this point.
 		 *
 		 * @since 1.0.0
 		 *

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -1,32 +1,38 @@
 <?php
 /**
- * Home for venue map server-side concerns.
+ * Static-map orchestrator for the venue subsystem.
  *
- * Today this singleton owns the pre-rendered static-map PNG pipeline:
- * fetching a small set of CartoDB basemap tiles around the venue's
- * coordinates, compositing them into a single PNG with a marker stamped at
- * the venue's exact position, and storing the result under
- * `wp-content/uploads/gatherpress/static-maps/`. The file URL and an
- * input-hash are persisted (per zoom+height combo) in venue post meta so
- * the front-end can serve the image directly and so subsequent saves
- * regenerate only when inputs (address, coordinates, tile URL, size)
- * actually change.
+ * Owns the lifecycle of pre-rendered PNGs: which (zoom, width, height)
+ * combos exist for a venue, where they live on disk, when they're stale,
+ * and how the front end resolves them for a given post context. The
+ * provider-specific work — fetching tiles, compositing, marker stamping,
+ * or whatever a Google/Mapbox provider would do — is delegated to the
+ * active {@see Provider\Base} resolved through {@see Manager}.
  *
- * The class is named for its broader role — venue-map — so future
- * map-related additions (REST endpoint for the editor preview, interactive
- * map server-side bits, async regeneration, etc.) have a natural home.
+ * Post-meta shape is provider-keyed:
  *
- * @package GatherPress\Core\Venue
+ *     [
+ *         'osm' => [ '15-800-300' => [url, url_2x, hash, ...], ... ],
+ *         'google' => [ ... ],
+ *     ]
+ *
+ * so PNGs from different providers coexist on disk and the render path
+ * can fall back to whichever variant is available when a site switches
+ * `map_platform` mid-flight.
+ *
+ * @package GatherPress\Core\Venue\Map
  * @since 1.0.0
  */
 
-namespace GatherPress\Core\Venue;
+namespace GatherPress\Core\Venue\Map;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Venue\Setup;
+use GatherPress\Core\Venue\Venue;
 use WP_Post;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -35,10 +41,10 @@ use WP_REST_Server;
 /**
  * Class Map.
  *
- * Singleton hosting the venue map server-side pipeline. Currently owns the
- * static PNG cache keyed by (zoom, height) combo; structured so that
- * additional map-related methods (REST, async jobs, etc.) can land here
- * without proliferating classes.
+ * Singleton orchestrator. Routes lifecycle events (save/delete/regenerate
+ * /prewarm) through the active provider, persists descriptors per
+ * provider, and serves them back to render paths with a fallback chain
+ * when the active provider hasn't rendered a given combo yet.
  *
  * @since 1.0.0
  */
@@ -179,23 +185,11 @@ class Map {
 	const ASPECT_RATIO_PATTERN = '#\A\s*[1-9][0-9]*\s*[/:]\s*[1-9][0-9]*\s*\z#';
 
 	/**
-	 * Total wall-clock budget (in seconds) for a single composite_image()
-	 * call. CartoDB typically serves tiles in well under 500ms, but a slow
-	 * tile host, a DNS hiccup, or a bad proxy can chain wp_safe_remote_get()
-	 * timeouts together and pin a save for tens of seconds. When the
-	 * budget is exceeded mid-composite, remaining tiles are skipped and the
-	 * gray background shows through instead — degraded, not hung.
-	 *
-	 * @since 1.0.0
-	 * @var int
-	 */
-	const COMPOSITE_TIME_BUDGET = 10;
-
-	/**
 	 * Default `type` attribute for the venue-map block.
 	 *
-	 * Google Maps–specific (roadmap / satellite / hybrid / terrain). Ignored by
-	 * the static renderer and by Leaflet/OSM.
+	 * Google Maps–specific (roadmap / satellite / hybrid / terrain). The OSM
+	 * provider only renders `roadmap`; future Google provider will respect
+	 * the full set per `Provider\Base::supports_map_type()`.
 	 *
 	 * @since 1.0.0
 	 * @var string
@@ -203,23 +197,12 @@ class Map {
 	const DEFAULT_MAP_TYPE = 'roadmap';
 
 	/**
-	 * Slippy-tile dimension in pixels. CartoDB basemaps use 256×256.
-	 *
-	 * @since 1.0.0
-	 * @var int
-	 */
-	const TILE_SIZE = 256;
-
-	/**
 	 * Pixel-density multiplier for the retina (2×) static-map variant.
 	 *
-	 * Drives the `@{density}x` filename suffix, the canvas-size multiplier
-	 * in `composite_image()`, the marker-scale argument in `stamp_marker()`,
-	 * and the zoom offset when fetching tiles (tiles are pulled from
-	 * `base_zoom + log2(RETINA_DENSITY)` for true 2× detail rather than
-	 * upscaled pixels). Kept as a constant so the generator and the
-	 * filename composer can never drift out of lock-step — any future bump
-	 * (3×, 4×) lands in one place.
+	 * Drives the `@{density}x` filename suffix and the second pass through
+	 * the active provider's `render()` for retina variants. Providers that
+	 * can't satisfy a given (zoom, density) combo return null and the
+	 * orchestrator drops the 2× variant for that combo.
 	 *
 	 * @since 1.0.0
 	 * @var int
@@ -227,13 +210,10 @@ class Map {
 	const RETINA_DENSITY = 2;
 
 	/**
-	 * Densities `composite_image()` knows how to produce.
-	 *
-	 * The tile-zoom offset is `log2($density)`, so only power-of-two values
-	 * give a whole-number zoom delta. Anything outside this allow-list is
-	 * coerced back to 1 so a caller can't accidentally generate a
-	 * canvas-doubled-but-tile-zoom-unchanged image (which would be a cheap
-	 * upscale and waste disk).
+	 * Densities the orchestrator asks providers to render at. Only
+	 * power-of-two values give a whole-number tile-zoom offset for tile-
+	 * based providers (OSM); other providers (Google) ignore the
+	 * constraint and just pass through to `scale={n}`.
 	 *
 	 * @since 1.0.0
 	 * @var int[]
@@ -245,7 +225,7 @@ class Map {
 	 *
 	 * The block exposes height but not width (blocks render 100% of their
 	 * container). We still need *some* pixel width for the PNG, so the
-	 * generator derives it from the block's chosen height at this ratio —
+	 * orchestrator derives it from the block's chosen height at this ratio —
 	 * 2:1 by default, which gives a comfortably landscape map without the
 	 * venue marker feeling tight against the edges.
 	 *
@@ -255,22 +235,26 @@ class Map {
 	const IMAGE_ASPECT_RATIO = 2.0;
 
 	/**
-	 * CartoDB Positron tile URL template. `{z}`, `{x}`, `{y}` are substituted.
-	 *
-	 * @since 1.0.0
-	 * @var string
-	 */
-	const DEFAULT_TILE_URL = 'https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png';
-
-	/**
 	 * Post meta key under which the static-map descriptors are stored.
 	 *
-	 * Stored value is an associative array keyed by `{zoom}x{width}x{height}`
-	 * with entries of shape
-	 * `array{ url: string, url_2x: string, hash: string, zoom: int, width: int, height: int }`.
-	 * `url_2x` is empty string when the retina variant is disabled or failed
-	 * to generate; pre-retina descriptors written by older versions omit the
-	 * key entirely and are normalized by {@see self::get_all_descriptors()}.
+	 * Stored value is provider-keyed:
+	 *
+	 *     [
+	 *         '<provider_slug>' => [
+	 *             '<zoom>x<width>x<height>' => array{
+	 *                 url: string, url_2x: string, hash: string,
+	 *                 zoom: int, width: int, height: int,
+	 *             },
+	 *             ...
+	 *         ],
+	 *         ...
+	 *     ]
+	 *
+	 * The provider-key layer lets a site keep older OSM PNGs around as
+	 * fallbacks while a new Google provider's PNGs render in the
+	 * background after a `map_platform` switch. `url_2x` is empty string
+	 * when the retina variant failed or the provider can't produce one
+	 * for the given combo.
 	 *
 	 * @since 1.0.0
 	 * @var string
@@ -312,6 +296,41 @@ class Map {
 		add_action( 'registered_post_type', array( $this, 'maybe_register_delete_hook' ) );
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 		add_filter( 'block_type_metadata', array( $this, 'apply_block_attribute_defaults' ) );
+		// React to provider changes so a `map_platform` switch schedules
+		// the same prewarm pass that runs on theme switches.
+		add_action( 'update_option_gatherpress_settings', array( $this, 'maybe_handle_settings_change' ), 10, 2 );
+	}
+
+	/**
+	 * Schedule a re-prewarm sweep when `map_platform` changes value.
+	 *
+	 * Called by the `update_option_gatherpress_settings` action whenever
+	 * the GatherPress settings option is written. Only the provider switch
+	 * matters here — non-provider edits to the option are no-ops. Existing
+	 * PNGs stay on disk during the transition: the front-end's fallback
+	 * chain in {@see self::get_descriptor_for_post()} keeps showing the
+	 * old-provider image until the new provider's PNG lands via prewarm.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array|mixed $old_value Previous settings option value.
+	 * @param array|mixed $new_value New settings option value.
+	 * @return void
+	 */
+	public function maybe_handle_settings_change( $old_value, $new_value ): void {
+		$old_platform = is_array( $old_value ) ? (string) ( $old_value['gatherpress']['map_platform'] ?? '' ) : '';
+		$new_platform = is_array( $new_value ) ? (string) ( $new_value['gatherpress']['map_platform'] ?? '' ) : '';
+
+		if ( $old_platform === $new_platform ) {
+			return;
+		}
+
+		// Defer to the prewarm subsystem — same path used on theme switch.
+		// Wrapped so a missing `Prewarm` (e.g. tests that haven't booted
+		// the venue subsystem) doesn't fatal a plain settings save.
+		if ( class_exists( Prewarm::class ) ) {
+			Prewarm::get_instance()->on_theme_switched();
+		}
 	}
 
 	/**
@@ -633,7 +652,7 @@ class Map {
 	 * @param int|null $extra_width        Optional extra width (0 = auto).
 	 * @param int|null $extra_height       Optional extra height (0 = auto).
 	 * @param string   $extra_aspect_ratio Optional aspect ratio hint for the extra combo.
-	 * @return array<string, array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}>
+	 * @return array<string, array<string, array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}>>
 	 */
 	public function regenerate(
 		int $post_id,
@@ -849,19 +868,49 @@ class Map {
 			return null;
 		}
 
-		$resolved = $this->resolve_dimensions(
+		$resolved      = $this->resolve_dimensions(
 			(int) ( $width ?? 0 ),
 			(int) ( $height ?? $this->get_height() ),
 			'' !== $aspect_ratio ? $aspect_ratio : self::DEFAULT_ASPECT_RATIO
 		);
+		$resolved_zoom = $zoom ?? $this->get_zoom();
 
-		return $this->ensure_descriptor_for_combo(
+		$active_descriptor = $this->ensure_descriptor_for_combo(
 			$venue_post_id,
 			$info,
-			$zoom ?? $this->get_zoom(),
+			$resolved_zoom,
 			$resolved['width'],
 			$resolved['height']
 		);
+
+		if ( null !== $active_descriptor ) {
+			return $active_descriptor;
+		}
+
+		// Active provider couldn't render this combo (e.g. tile host
+		// unreachable, GD missing, brand-new provider not yet warmed). Walk
+		// other providers' stored entries for the same combo so a switch
+		// from OSM to Google still shows the OSM PNG until the new one
+		// lands. Return the first matching entry; ordering follows whatever
+		// post meta gives us (last-saved-wins by storage order).
+		$key         = $this->combo_key(
+			$this->clamp_zoom( $resolved_zoom ),
+			$this->clamp_width( $resolved['width'] ),
+			$this->clamp_height( $resolved['height'] )
+		);
+		$all         = $this->get_all_descriptors( $venue_post_id );
+		$active_slug = Manager::get_instance()->get_active_slug();
+
+		foreach ( $all as $slug => $combos ) {
+			if ( $slug === $active_slug ) {
+				continue;
+			}
+			if ( isset( $combos[ $key ] ) ) {
+				return $combos[ $key ];
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -960,22 +1009,25 @@ class Map {
 	 */
 	public function get_stored_descriptor( int $post_id ): ?array {
 		$all      = $this->get_all_descriptors( $post_id );
+		$slug     = Manager::get_instance()->get_active_slug();
 		$defaults = $this->resolve_dimensions(
 			0,
 			$this->get_height(),
 			self::DEFAULT_ASPECT_RATIO
 		);
 
-		return $all[ $this->combo_key(
+		$key = $this->combo_key(
 			$this->get_zoom(),
 			$defaults['width'],
 			$defaults['height']
-		) ] ?? null;
+		);
+
+		return $all[ $slug ][ $key ] ?? null;
 	}
 
 	/**
-	 * Return every stored descriptor for the venue, keyed by
-	 * `{zoom}x{width}x{height}`.
+	 * Return every stored descriptor for the venue, keyed by provider slug
+	 * then by `{zoom}x{width}x{height}`.
 	 *
 	 * Filters out malformed entries so callers can iterate without defensive
 	 * shape checks. The read path itself does not persist the cleaned map —
@@ -987,7 +1039,7 @@ class Map {
 	 * @since 1.0.0
 	 *
 	 * @param int $post_id The venue post ID.
-	 * @return array<string, array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}>
+	 * @return array<string, array<string, array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}>>
 	 */
 	public function get_all_descriptors( int $post_id ): array {
 		$raw = get_post_meta( $post_id, self::META_KEY, true );
@@ -998,34 +1050,36 @@ class Map {
 
 		$descriptors = array();
 
-		foreach ( $raw as $key => $entry ) {
-			if ( ! is_array( $entry ) || empty( $entry['url'] ) || empty( $entry['hash'] ) ) {
+		foreach ( $raw as $provider_slug => $combos ) {
+			if ( ! is_string( $provider_slug ) || '' === $provider_slug || ! is_array( $combos ) ) {
 				continue;
 			}
 
-			$zoom   = isset( $entry['zoom'] ) ? (int) $entry['zoom'] : 0;
-			$width  = isset( $entry['width'] ) ? (int) $entry['width'] : 0;
-			$height = isset( $entry['height'] ) ? (int) $entry['height'] : 0;
+			foreach ( $combos as $key => $entry ) {
+				if ( ! is_array( $entry ) || empty( $entry['url'] ) || empty( $entry['hash'] ) ) {
+					continue;
+				}
 
-			// Without concrete zoom/width/height on the entry there's no way
-			// to know which block configuration the file belongs to — skip
-			// rather than guess.
-			if ( $zoom <= 0 || $width <= 0 || $height <= 0 ) {
-				continue;
+				$zoom   = isset( $entry['zoom'] ) ? (int) $entry['zoom'] : 0;
+				$width  = isset( $entry['width'] ) ? (int) $entry['width'] : 0;
+				$height = isset( $entry['height'] ) ? (int) $entry['height'] : 0;
+
+				// Without concrete zoom/width/height on the entry there's no way
+				// to know which block configuration the file belongs to — skip
+				// rather than guess.
+				if ( $zoom <= 0 || $width <= 0 || $height <= 0 ) {
+					continue;
+				}
+
+				$descriptors[ $provider_slug ][ (string) $key ] = array(
+					'url'    => (string) $entry['url'],
+					'url_2x' => isset( $entry['url_2x'] ) ? (string) $entry['url_2x'] : '',
+					'hash'   => (string) $entry['hash'],
+					'zoom'   => $zoom,
+					'width'  => $width,
+					'height' => $height,
+				);
 			}
-
-			// `url_2x` is nullable for back-compat: pre-retina descriptors
-			// written before this plugin version don't carry the key at all.
-			// Normalize to an empty string so downstream callers can check
-			// with a single `'' !== $url_2x` branch.
-			$descriptors[ (string) $key ] = array(
-				'url'    => (string) $entry['url'],
-				'url_2x' => isset( $entry['url_2x'] ) ? (string) $entry['url_2x'] : '',
-				'hash'   => (string) $entry['hash'],
-				'zoom'   => $zoom,
-				'width'  => $width,
-				'height' => $height,
-			);
 		}
 
 		/**
@@ -1034,25 +1088,28 @@ class Map {
 		 * Companion plugins, multi-locale setups, or storage-layer overrides
 		 * can use this to drop entries they consider stale, add synthetic
 		 * descriptors (e.g. pre-rendered PNG files in a CDN), or rewrite URLs.
+		 * Outer key is provider slug, inner key is `{zoom}x{width}x{height}`.
 		 * Callers of this method already tolerate empty maps, so returning
 		 * `[]` is a valid "suppress all" escape hatch.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param array<string, array<string, mixed>> $descriptors Parsed descriptor map keyed by combo.
-		 * @param int                                 $post_id     Venue post ID.
+		 * @param array<string, array<string, array<string, mixed>>> $descriptors Provider-keyed descriptor map.
+		 * @param int                                                $post_id     Venue post ID.
 		 */
 		return (array) apply_filters( 'gatherpress_venue_map_descriptors', $descriptors, $post_id );
 	}
 
 	/**
-	 * Parse stored meta into the list of (zoom, width, height) combos
-	 * already cached.
+	 * Parse stored meta into the deduped list of (zoom, width, height) combos
+	 * any provider has ever rendered for this venue.
 	 *
 	 * Used by {@see self::maybe_generate()} to cascade content changes (new
 	 * address, new coordinates) across every variant a venue has ever been
-	 * rendered at, so blocks pointing at a non-default combo aren't stranded
-	 * with a stale image.
+	 * rendered at, regardless of which provider rendered it. After a
+	 * `map_platform` switch, the active provider gets re-rendered for every
+	 * combo any earlier provider had — so blocks pointing at non-default
+	 * combos aren't stranded.
 	 *
 	 * @since 1.0.0
 	 *
@@ -1060,14 +1117,26 @@ class Map {
 	 * @return array<int, array{zoom: int, width: int, height: int}>
 	 */
 	public function get_cached_combos( int $post_id ): array {
+		$seen   = array();
 		$combos = array();
 
-		foreach ( $this->get_all_descriptors( $post_id ) as $descriptor ) {
-			$combos[] = array(
-				'zoom'   => $descriptor['zoom'],
-				'width'  => $descriptor['width'],
-				'height' => $descriptor['height'],
-			);
+		foreach ( $this->get_all_descriptors( $post_id ) as $provider_combos ) {
+			foreach ( $provider_combos as $descriptor ) {
+				$key = $this->combo_key(
+					(int) $descriptor['zoom'],
+					(int) $descriptor['width'],
+					(int) $descriptor['height']
+				);
+				if ( isset( $seen[ $key ] ) ) {
+					continue;
+				}
+				$seen[ $key ] = true;
+				$combos[]     = array(
+					'zoom'   => (int) $descriptor['zoom'],
+					'width'  => (int) $descriptor['width'],
+					'height' => (int) $descriptor['height'],
+				);
+			}
 		}
 
 		return $combos;
@@ -1112,6 +1181,11 @@ class Map {
 		int $width,
 		int $height
 	): ?array {
+		$provider = Manager::get_instance()->get_active();
+		if ( null === $provider ) {
+			return null;
+		}
+
 		// Callers (maybe_generate, get_url_for_post) must have validated the
 		// coordinates via parse_coord() already — cast directly.
 		$latitude  = (float) $info['latitude'];
@@ -1125,23 +1199,17 @@ class Map {
 		$width  = $this->clamp_width( $width );
 		$height = $this->clamp_height( $height );
 
-		$tiles   = $this->get_tile_url_template();
+		$slug    = $provider->get_slug();
 		$address = (string) ( $info['address'] ?? '' );
-		$hash    = $this->hash_for( $info, $zoom, $width, $height, $tiles );
+		$hash    = $this->hash_for( $info, $zoom, $width, $height, $slug );
 		$key     = $this->combo_key( $zoom, $width, $height );
 
 		$all      = $this->get_all_descriptors( $post_id );
-		$existing = $all[ $key ] ?? null;
+		$existing = $all[ $slug ][ $key ] ?? null;
 
-		// Retina generation requires a zoom level with tiles available at
-		// `zoom + log2(RETINA_DENSITY)`. At the zoom ceiling the derived
-		// tile zoom would exceed what the provider serves, every fetch
-		// 404s, and we'd persist a solid-gray PNG — skip instead.
-		// Cached locally so we never invoke the filter twice per call.
-		$retina_enabled = $this->should_generate_retina()
-			&& ( $zoom + (int) log( self::RETINA_DENSITY, 2 ) ) <= self::ZOOM_MAX;
+		$retina_enabled = $this->should_generate_retina();
 
-		$expected_url = $this->build_image_url( $address, $zoom, $width, $height );
+		$expected_url = $this->build_image_url( $address, $zoom, $width, $height, $slug, 1 );
 		$has_valid_1x = null !== $existing
 			&& $existing['hash'] === $hash
 			&& $existing['url'] === $expected_url;
@@ -1151,25 +1219,24 @@ class Map {
 			return $existing;
 		}
 
-		// Only recomposite the 1× when it's genuinely missing or stale.
+		// Only re-render the 1× when it's genuinely missing or stale.
 		// Legacy descriptors (pre-retina) land on the `has_valid_1x &&
 		// needs_retina` path — their 1× PNG is still valid so we skip the
-		// redundant fetch/save and only fill in the retina sibling.
+		// redundant render and only fill in the retina sibling.
 		$url = null;
 		if ( $has_valid_1x ) {
 			$url = $existing['url'];
 		} else {
-			$image = $this->composite_image( $latitude, $longitude, $zoom, $width, $height, $tiles );
+			$image = $provider->render( $latitude, $longitude, $zoom, $width, $height, 1 );
 
-			// Downstream of the GD-missing branch in composite_image(); only
-			// reached on PHP builds without the GD extension.
-			if ( null === $image ) { // @codeCoverageIgnore
-				return null; // @codeCoverageIgnore
+			// Provider returned null — GD missing, network failure, or the
+			// provider can't satisfy this combo. Surface as "no descriptor"
+			// rather than persisting a half-baked entry.
+			if ( null === $image ) {
+				return null;
 			}
 
-			$this->stamp_marker( $image, (int) round( $width / 2 ), (int) round( $height / 2 ) );
-
-			$url = $this->save_image( $image, $address, $zoom, $width, $height );
+			$url = $this->save_image( $image, $address, $zoom, $width, $height, 1, $slug );
 			imagedestroy( $image );
 
 			if ( null === $url ) {
@@ -1177,43 +1244,29 @@ class Map {
 			}
 		}
 
-		// Retina variant: separate composite at 2× density (zoom+1 tiles,
-		// double-sized canvas) with its own wall-clock budget. Failure here
-		// is non-fatal — we keep the 1× URL and just leave `url_2x` empty so
-		// the front-end falls back to a plain `src`. Reuses the same hash:
-		// the 2× is fully derived from the same inputs.
+		// Retina variant: ask the provider for a density-2 render. Failure
+		// here is non-fatal — we keep the 1× URL and just leave `url_2x`
+		// empty so the front-end falls back to a plain `src`. Reuses the
+		// same hash: the 2× is fully derived from the same inputs.
 		$url_2x = '';
 		if ( $retina_enabled ) {
-			$canvas_width  = $width * self::RETINA_DENSITY;
-			$canvas_height = $height * self::RETINA_DENSITY;
-			$image_2x      = $this->composite_image(
+			$image_2x = $provider->render(
 				$latitude,
 				$longitude,
 				$zoom,
 				$width,
 				$height,
-				$tiles,
 				self::RETINA_DENSITY
 			);
 			if ( null !== $image_2x ) {
-				// Use the same `round( canvas / 2 )` pattern as the 1× call
-				// so both paths share a single marker-center convention;
-				// even canvas sizes make the results identical, the
-				// symmetry is for maintenance.
-				$this->stamp_marker(
-					$image_2x,
-					(int) round( $canvas_width / 2 ),
-					(int) round( $canvas_height / 2 ),
-					(float) self::RETINA_DENSITY
-				);
-
 				$saved_2x = $this->save_image(
 					$image_2x,
 					$address,
 					$zoom,
 					$width,
 					$height,
-					self::RETINA_DENSITY
+					self::RETINA_DENSITY,
+					$slug
 				);
 				imagedestroy( $image_2x );
 				if ( null !== $saved_2x ) {
@@ -1222,7 +1275,7 @@ class Map {
 			}
 		}
 
-		$all[ $key ] = array(
+		$all[ $slug ][ $key ] = array(
 			'url'    => $url,
 			'url_2x' => $url_2x,
 			'hash'   => $hash,
@@ -1241,13 +1294,13 @@ class Map {
 		// venues, so we don't proactively unlink on write-verify failure.
 		$stored = get_post_meta( $post_id, self::META_KEY, true );
 		if ( ! is_array( $stored )
-			|| ! isset( $stored[ $key ]['url'] )
-			|| $stored[ $key ]['url'] !== $url
+			|| ! isset( $stored[ $slug ][ $key ]['url'] )
+			|| $stored[ $slug ][ $key ]['url'] !== $url
 		) {
 			return null;
 		}
 
-		return $all[ $key ];
+		return $all[ $slug ][ $key ];
 	}
 
 	/**
@@ -1286,14 +1339,14 @@ class Map {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array  $info  Parsed venue information.
-	 * @param int    $zoom  Map zoom level.
-	 * @param int    $width Output width.
-	 * @param int    $height Output height.
-	 * @param string $tiles Tile URL template.
+	 * @param array  $info     Parsed venue information.
+	 * @param int    $zoom     Map zoom level.
+	 * @param int    $width    Output width.
+	 * @param int    $height   Output height.
+	 * @param string $provider Provider slug (e.g. `osm`).
 	 * @return string MD5 hex digest.
 	 */
-	public function hash_for( array $info, int $zoom, int $width, int $height, string $tiles ): string {
+	public function hash_for( array $info, int $zoom, int $width, int $height, string $provider ): string {
 		// md5() here is a non-cryptographic cache-key discriminator, matching class-geocoding.php.
 		// CAUTION: the order and types of the values composed below define the
 		// cache key for every static-map PNG on disk. Reordering or changing a
@@ -1309,7 +1362,7 @@ class Map {
 					(string) $zoom,
 					(string) $width,
 					(string) $height,
-					$tiles,
+					$provider,
 				)
 			)
 		);
@@ -1326,11 +1379,12 @@ class Map {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $address Venue address string.
-	 * @param int    $zoom    Map zoom level.
-	 * @param int    $width   Output width (at density 1).
-	 * @param int    $height  Output height (at density 1).
-	 * @param int    $density Pixel-density multiplier. 1 = standard, 2 = retina.
+	 * @param string $address  Venue address string.
+	 * @param int    $zoom     Map zoom level.
+	 * @param int    $width    Output width (at density 1).
+	 * @param int    $height   Output height (at density 1).
+	 * @param string $provider Provider slug (e.g. `osm`).
+	 * @param int    $density  Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @return string Full public URL for the PNG.
 	 */
 	protected function build_image_url(
@@ -1338,12 +1392,13 @@ class Map {
 		int $zoom,
 		int $width,
 		int $height,
+		string $provider,
 		int $density = 1
 	): string {
 		$dirs     = wp_get_upload_dir();
 		$base_url = trailingslashit( $dirs['baseurl'] ) . self::UPLOADS_SUBDIR;
 
-		return trailingslashit( $base_url ) . $this->filename_for( $address, $zoom, $width, $height, $density );
+		return trailingslashit( $base_url ) . $this->filename_for( $address, $zoom, $width, $height, $provider, $density );
 	}
 
 	/**
@@ -1358,14 +1413,23 @@ class Map {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $address Venue address.
-	 * @param int    $zoom    Map zoom level.
-	 * @param int    $width   Output width (at density 1).
-	 * @param int    $height  Output height (at density 1).
-	 * @param int    $density Pixel-density multiplier. 1 = standard, 2 = retina.
+	 * @param string $address  Venue address.
+	 * @param int    $zoom     Map zoom level.
+	 * @param int    $width    Output width (at density 1).
+	 * @param int    $height   Output height (at density 1).
+	 * @param string $provider Provider slug (e.g. `osm`) — namespaces the file
+	 *                         so OSM and Google PNGs can coexist on disk.
+	 * @param int    $density  Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @return string Filename including the `.png` extension.
 	 */
-	protected function filename_for( string $address, int $zoom, int $width, int $height, int $density = 1 ): string {
+	protected function filename_for(
+		string $address,
+		int $zoom,
+		int $width,
+		int $height,
+		string $provider,
+		int $density = 1
+	): string {
 		// `sanitize_title()` URL-slugifies; pass the result through
 		// `sanitize_file_name()` as defense-in-depth so any path-sensitive
 		// characters that slip past (or future changes to sanitize_title's
@@ -1382,232 +1446,37 @@ class Map {
 
 		$suffix = $density > 1 ? sprintf( '@%dx', $density ) : '';
 
-		return sprintf( '%s-%d-%d-%d%s.png', $slug, $zoom, $width, $height, $suffix );
+		return sprintf( '%s-%s-%d-%d-%d%s.png', $slug, $provider, $zoom, $width, $height, $suffix );
 	}
 
 	/**
-	 * Fetch, decode, and return the raw PNG bytes for a tile at (z, x, y).
+	 * Save a finished GD image to the uploads directory and return its URL.
 	 *
-	 * Returns null on any HTTP failure so callers can skip that tile without
-	 * aborting the whole composite; the resulting image will simply have a
-	 * blank patch where the fetch failed.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int    $zoom    Tile zoom.
-	 * @param int    $x       Tile x coordinate.
-	 * @param int    $y       Tile y coordinate.
-	 * @param string $tiles   Tile URL template containing `{z}`, `{x}`, `{y}`.
-	 * @return string|null PNG bytes, or null on failure.
-	 */
-	public function fetch_tile( int $zoom, int $x, int $y, string $tiles ): ?string {
-		$url = strtr(
-			$tiles,
-			array(
-				'{z}' => (string) $zoom,
-				'{x}' => (string) $x,
-				'{y}' => (string) $y,
-			)
-		);
-
-		$response = wp_safe_remote_get( $url, array( 'timeout' => 5 ) );
-
-		if ( is_wp_error( $response ) ) {
-			return null;
-		}
-
-		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
-			return null;
-		}
-
-		$body = (string) wp_remote_retrieve_body( $response );
-
-		return '' !== $body ? $body : null;
-	}
-
-	/**
-	 * Composite the tiles needed to cover the output image centered on (lat, lng).
-	 *
-	 * Builds a blank canvas of the requested size, fetches every tile whose
-	 * bounds intersect the canvas window, and copies each into its correct
-	 * pixel offset. Caller is responsible for `imagedestroy()` on the result.
-	 *
-	 * At `$density > 1` the method produces a retina variant: tiles are
-	 * fetched at `zoom + log2($density)` (so a 2× pass uses `zoom + 1` tiles)
-	 * and the canvas is sized at `$width * $density` × `$height * $density`.
-	 * That's true retina detail — the denser zoom level renders labels and
-	 * road lines at native 2× resolution rather than just upscaling the 1×
-	 * tile set. `$density` must be a power of two.
+	 * Filename is derived from `(address, provider, zoom, width, height)` so
+	 * different providers' PNGs coexist on disk and two venues at the same
+	 * address share one file at matching dimensions. `imagepng` overwrites
+	 * in place, which is fine for the regenerate flow since the inputs
+	 * that'd change visible output also change the hash in the descriptor.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param float  $lat     Latitude in degrees.
-	 * @param float  $lng     Longitude in degrees.
-	 * @param int    $zoom    Zoom level (same zoom Leaflet would use for the same CSS viewport).
-	 * @param int    $width   Output pixel width at density 1.
-	 * @param int    $height  Output pixel height at density 1.
-	 * @param string $tiles   Tile URL template.
-	 * @param int    $density Pixel-density multiplier. 1 = standard, 2 = retina.
-	 * @return \GdImage|resource|null Composited image, or null when GD is unavailable.
-	 *                                GdImage on PHP 8+, resource on PHP 7.4.
-	 */
-	public function composite_image(
-		float $lat,
-		float $lng,
-		int $zoom,
-		int $width,
-		int $height,
-		string $tiles,
-		int $density = 1
-	) {
-		// PHP built without the GD extension. Can't simulate in a unit test without making the runtime itself broken.
-		if ( ! function_exists( 'imagecreatetruecolor' ) ) { // @codeCoverageIgnore
-			return null; // @codeCoverageIgnore
-		}
-
-		// Coerce unsupported densities back to 1. Allowing, say, density=3
-		// with `(int) log(3, 2) === 1` would paint a 3×-sized canvas using
-		// only 2× tiles — a cheap upscale that wastes disk for no gain.
-		// Allow-listing keeps the tile-zoom offset a whole number.
-		if ( ! in_array( $density, self::SUPPORTED_DENSITIES, true ) ) {
-			$density = 1;
-		}
-
-		// Tile zoom climbs with density so the retina variant renders true
-		// zoom+1 detail (sharp labels and lines) rather than upscaled 1×
-		// pixels. Clamp to ZOOM_MAX as defense-in-depth: at the zoom
-		// ceiling the caller should have skipped retina generation
-		// upstream, but if we're ever invoked directly at high zoom we'd
-		// rather render a degraded upscale than hit the tile server with
-		// zoom-beyond-max requests (every fetch 404s → gray canvas).
-		$tile_zoom = min( self::ZOOM_MAX, $zoom + (int) log( $density, 2 ) );
-
-		$canvas_width  = $width * $density;
-		$canvas_height = $height * $density;
-
-		$venue_world_x = $this->lng_to_world_pixel( $lng, $tile_zoom );
-		$venue_world_y = $this->lat_to_world_pixel( $lat, $tile_zoom );
-
-		$left_pixel = (int) round( $venue_world_x - $canvas_width / 2 );
-		$top_pixel  = (int) round( $venue_world_y - $canvas_height / 2 );
-
-		$left_tile   = (int) floor( $left_pixel / self::TILE_SIZE );
-		$top_tile    = (int) floor( $top_pixel / self::TILE_SIZE );
-		$right_tile  = (int) floor( ( $left_pixel + $canvas_width - 1 ) / self::TILE_SIZE );
-		$bottom_tile = (int) floor( ( $top_pixel + $canvas_height - 1 ) / self::TILE_SIZE );
-
-		$canvas = imagecreatetruecolor( $canvas_width, $canvas_height );
-
-		// Background: neutral gray so missing tiles blend rather than glaring black.
-		$bg = imagecolorallocate( $canvas, 238, 238, 238 );
-		imagefilledrectangle( $canvas, 0, 0, $canvas_width - 1, $canvas_height - 1, $bg );
-
-		/**
-		 * Filter the wall-clock budget (in seconds) for a single
-		 * composite_image() call. When the deadline is exceeded mid-loop,
-		 * remaining tiles are skipped and the gray background shows
-		 * through. Accepts int or float.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param float $budget Default budget from COMPOSITE_TIME_BUDGET.
-		 */
-		$budget   = (float) apply_filters(
-			'gatherpress_venue_map_composite_time_budget',
-			self::COMPOSITE_TIME_BUDGET
-		);
-		$deadline = microtime( true ) + $budget;
-
-		for ( $tx = $left_tile; $tx <= $right_tile; $tx++ ) {
-			for ( $ty = $top_tile; $ty <= $bottom_tile; $ty++ ) {
-				// Budget guard: once the total wall-clock time for this
-				// composite exceeds COMPOSITE_TIME_BUDGET, stop fetching
-				// and let the gray background show through for any tiles
-				// we haven't filled in yet. Bounds the worst-case stall
-				// from a slow tile host.
-				if ( microtime( true ) >= $deadline ) {
-					break 2;
-				}
-
-				$tile_png = $this->fetch_tile( $tile_zoom, $tx, $ty, $tiles );
-
-				if ( null === $tile_png ) {
-					continue;
-				}
-
-				$tile = imagecreatefromstring( $tile_png );
-
-				if ( false === $tile ) {
-					continue;
-				}
-
-				$dst_x = $tx * self::TILE_SIZE - $left_pixel;
-				$dst_y = $ty * self::TILE_SIZE - $top_pixel;
-
-				imagecopy( $canvas, $tile, $dst_x, $dst_y, 0, 0, self::TILE_SIZE, self::TILE_SIZE );
-				imagedestroy( $tile );
-			}
-		}
-
-		return $canvas;
-	}
-
-	/**
-	 * Draw a simple pin marker at the given pixel coordinates.
-	 *
-	 * Passing `$scale > 1` proportionally scales the marker's three concentric
-	 * ellipses so a retina (2×) composite keeps the marker visually the same
-	 * size as the 1× render rather than shrinking to a pinprick.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param \GdImage|resource $canvas Destination canvas (GdImage on PHP 8+, resource on PHP 7.4).
-	 * @param int               $x      Pixel X position (marker center).
-	 * @param int               $y      Pixel Y position (marker center).
-	 * @param float             $scale  Multiplier applied to the marker radii. 1.0 keeps the original size.
-	 * @return void
-	 */
-	public function stamp_marker( $canvas, int $x, int $y, float $scale = 1.0 ): void {
-		$white = imagecolorallocate( $canvas, 255, 255, 255 );
-		$red   = imagecolorallocate( $canvas, 220, 53, 69 );
-		$dark  = imagecolorallocate( $canvas, 30, 30, 30 );
-
-		$outer = max( 1, (int) round( 20 * $scale ) );
-		$inner = max( 1, (int) round( 16 * $scale ) );
-		$dot   = max( 1, (int) round( 6 * $scale ) );
-
-		imagefilledellipse( $canvas, $x, $y, $outer, $outer, $white );
-		imagefilledellipse( $canvas, $x, $y, $inner, $inner, $red );
-		imageellipse( $canvas, $x, $y, $inner, $inner, $dark );
-		imagefilledellipse( $canvas, $x, $y, $dot, $dot, $white );
-	}
-
-	/**
-	 * Save the composited image to the uploads directory and return its URL.
-	 *
-	 * Filename is derived from `(address, zoom, width, height)` — two venues
-	 * that resolve to the same address slug at matching dimensions share one
-	 * file on disk. `imagepng` overwrites in place, which is fine for our
-	 * regenerate flow since the inputs that'd change visible output also
-	 * change the hash in the descriptor meta.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param \GdImage|resource $image   The finished composite (GdImage on PHP 8+, resource on PHP 7.4).
-	 * @param string            $address Venue address (slugified for the filename).
-	 * @param int               $zoom    Map zoom level.
-	 * @param int               $width   Output width (at density 1).
-	 * @param int               $height  Output height (at density 1).
-	 * @param int               $density Pixel-density multiplier. 1 = standard, 2 = retina.
+	 * @param \GdImage $image    Finished image from a provider's `render()`.
+	 * @param string   $address  Venue address (slugified for the filename).
+	 * @param int      $zoom     Map zoom level.
+	 * @param int      $width    Output width (at density 1).
+	 * @param int      $height   Output height (at density 1).
+	 * @param int      $density  Pixel-density multiplier. 1 = standard, 2 = retina.
+	 * @param string   $provider Provider slug.
 	 * @return string|null Public URL of the saved file, or null on failure.
 	 */
 	public function save_image(
-		$image,
+		\GdImage $image,
 		string $address,
 		int $zoom,
 		int $width,
 		int $height,
-		int $density = 1
+		int $density,
+		string $provider
 	): ?string {
 		$dirs = wp_get_upload_dir();
 
@@ -1623,7 +1492,7 @@ class Map {
 			return null; // @codeCoverageIgnore
 		}
 
-		$filename = $this->filename_for( $address, $zoom, $width, $height, $density );
+		$filename = $this->filename_for( $address, $zoom, $width, $height, $provider, $density );
 		$path     = trailingslashit( $base_dir ) . $filename;
 		$url      = trailingslashit( $base_url ) . $filename;
 
@@ -1813,51 +1682,5 @@ class Map {
 			'width'  => $this->clamp_width( $width ),
 			'height' => $this->clamp_height( $height ),
 		);
-	}
-
-	/**
-	 * Tile URL template used by the static renderer. Filterable.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string
-	 */
-	protected function get_tile_url_template(): string {
-		/**
-		 * Filter the tile URL template used by the static venue map.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string $template Tile URL with `{z}`, `{x}`, `{y}` placeholders.
-		 */
-		return (string) apply_filters( 'gatherpress_venue_map_tile_url', self::DEFAULT_TILE_URL );
-	}
-
-	/**
-	 * Convert longitude to absolute pixel X in world pixel space at `$zoom`.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param float $lng  Longitude in degrees.
-	 * @param int   $zoom Zoom level.
-	 * @return float
-	 */
-	protected function lng_to_world_pixel( float $lng, int $zoom ): float {
-		return ( ( $lng + 180.0 ) / 360.0 ) * self::TILE_SIZE * ( 2 ** $zoom );
-	}
-
-	/**
-	 * Convert latitude to absolute pixel Y in world pixel space at `$zoom`.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param float $lat  Latitude in degrees.
-	 * @param int   $zoom Zoom level.
-	 * @return float
-	 */
-	protected function lat_to_world_pixel( float $lat, int $zoom ): float {
-		$rad = deg2rad( $lat );
-
-		return ( 1 - log( tan( $rad ) + 1 / cos( $rad ) ) / M_PI ) / 2 * self::TILE_SIZE * ( 2 ** $zoom );
 	}
 }

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -1465,17 +1465,17 @@ class Map {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param \GdImage $image    Finished image from a provider's `render()`.
-	 * @param string   $address  Venue address (slugified for the filename).
-	 * @param int      $zoom     Map zoom level.
-	 * @param int      $width    Output width (at density 1).
-	 * @param int      $height   Output height (at density 1).
-	 * @param int      $density  Pixel-density multiplier. 1 = standard, 2 = retina.
-	 * @param string   $provider Provider slug.
+	 * @param \GdImage|resource $image    Finished image from a provider's `render()`.
+	 * @param string            $address  Venue address (slugified for the filename).
+	 * @param int               $zoom     Map zoom level.
+	 * @param int               $width    Output width (at density 1).
+	 * @param int               $height   Output height (at density 1).
+	 * @param int               $density  Pixel-density multiplier. 1 = standard, 2 = retina.
+	 * @param string            $provider Provider slug.
 	 * @return string|null Public URL of the saved file, or null on failure.
 	 */
 	public function save_image(
-		\GdImage $image,
+		$image,
 		string $address,
 		int $zoom,
 		int $width,

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -33,6 +33,7 @@ use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue;
+use GdImage;
 use WP_Post;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -263,7 +264,7 @@ class Map {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const META_KEY = 'gatherpress_venue_static_map';
+	const META_KEY = 'gatherpress_static_map';
 
 	/**
 	 * Subdirectory of `wp-content/uploads` where generated PNG files are written.
@@ -322,8 +323,8 @@ class Map {
 	 * @return void
 	 */
 	public function maybe_handle_settings_change( $old_value, $new_value ): void {
-		$old_platform = is_array( $old_value ) ? (string) ( $old_value['gatherpress']['map_platform'] ?? '' ) : '';
-		$new_platform = is_array( $new_value ) ? (string) ( $new_value['gatherpress']['map_platform'] ?? '' ) : '';
+		$old_platform = is_array( $old_value ) ? (string) ( $old_value['map_platform'] ?? '' ) : '';
+		$new_platform = is_array( $new_value ) ? (string) ( $new_value['map_platform'] ?? '' ) : '';
 
 		if ( $old_platform === $new_platform ) {
 			return;
@@ -1465,13 +1466,13 @@ class Map {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param \GdImage|resource $image    Finished image from a provider's `render()`.
-	 * @param string            $address  Venue address (slugified for the filename).
-	 * @param int               $zoom     Map zoom level.
-	 * @param int               $width    Output width (at density 1).
-	 * @param int               $height   Output height (at density 1).
-	 * @param int               $density  Pixel-density multiplier. 1 = standard, 2 = retina.
-	 * @param string            $provider Provider slug.
+	 * @param GdImage|resource $image    Finished image from a provider's `render()`.
+	 * @param string           $address  Venue address (slugified for the filename).
+	 * @param int              $zoom     Map zoom level.
+	 * @param int              $width    Output width (at density 1).
+	 * @param int              $height   Output height (at density 1).
+	 * @param int              $density  Pixel-density multiplier. 1 = standard, 2 = retina.
+	 * @param string           $provider Provider slug.
 	 * @return string|null Public URL of the saved file, or null on failure.
 	 */
 	public function save_image(
@@ -1529,7 +1530,7 @@ class Map {
 	 *
 	 * Prefers the site-wide setting; falls back to {@see self::DEFAULT_ZOOM}
 	 * when the setting is unset or zero. Result is piped through the
-	 * `gatherpress_venue_map_zoom` filter so code-level overrides
+	 * `gatherpress_map_zoom` filter so code-level overrides
 	 * (themes, site-specific plugins) can still take precedence.
 	 *
 	 * @since 1.0.0
@@ -1547,7 +1548,7 @@ class Map {
 		 *
 		 * @param int $zoom Default zoom level.
 		 */
-		$zoom = (int) apply_filters( 'gatherpress_venue_map_zoom', $default );
+		$zoom = (int) apply_filters( 'gatherpress_map_zoom', $default );
 
 		return $this->clamp_zoom( $zoom );
 	}
@@ -1557,7 +1558,7 @@ class Map {
 	 *
 	 * Mirrors {@see self::get_zoom()} — Settings value wins, falls back to
 	 * {@see self::DEFAULT_HEIGHT}, then runs through
-	 * `gatherpress_venue_map_height` for code-level overrides. Because the
+	 * `gatherpress_map_height` for code-level overrides. Because the
 	 * PNG is rendered at exactly this height (no oversampling), the generator
 	 * and the block see the same value and Leaflet's zoom matches the
 	 * static map's zoom visually.
@@ -1577,7 +1578,7 @@ class Map {
 		 *
 		 * @param int $height Default height in pixels.
 		 */
-		$height = (int) apply_filters( 'gatherpress_venue_map_height', $default );
+		$height = (int) apply_filters( 'gatherpress_map_height', $default );
 
 		return $this->clamp_height( $height );
 	}

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -2,7 +2,7 @@
 /**
  * Static-map orchestrator for the venue subsystem.
  *
- * Owns the lifecycle of pre-rendered PNGs: which (zoom, width, height)
+ * Owns the lifecycle of pre-rendered PNG files: which (zoom, width, height)
  * combos exist for a venue, where they live on disk, when they're stale,
  * and how the front end resolves them for a given post context. The
  * provider-specific work — fetching tiles, compositing, marker stamping,
@@ -16,7 +16,7 @@
  *         'google' => [ ... ],
  *     ]
  *
- * so PNGs from different providers coexist on disk and the render path
+ * so PNG files from different providers coexist on disk and the render path
  * can fall back to whichever variant is available when a site switches
  * `map_platform` mid-flight.
  *
@@ -47,6 +47,10 @@ use WP_REST_Server;
  * when the active provider hasn't rendered a given combo yet.
  *
  * @since 1.0.0
+ *
+ * @phpstan-type Descriptor array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}
+ * @phpstan-type DescriptorMap array<string, Descriptor>
+ * @phpstan-type ProviderDescriptorMap array<string, DescriptorMap>
  */
 class Map {
 	/**
@@ -250,8 +254,8 @@ class Map {
 	 *         ...
 	 *     ]
 	 *
-	 * The provider-key layer lets a site keep older OSM PNGs around as
-	 * fallbacks while a new Google provider's PNGs render in the
+	 * The provider-key layer lets a site keep older OSM PNG files around as
+	 * fallbacks while a new Google provider's PNG files render in the
 	 * background after a `map_platform` switch. `url_2x` is empty string
 	 * when the retina variant failed or the provider can't produce one
 	 * for the given combo.
@@ -307,7 +311,7 @@ class Map {
 	 * Called by the `update_option_gatherpress_settings` action whenever
 	 * the GatherPress settings option is written. Only the provider switch
 	 * matters here — non-provider edits to the option are no-ops. Existing
-	 * PNGs stay on disk during the transition: the front-end's fallback
+	 * PNG files stay on disk during the transition: the front-end's fallback
 	 * chain in {@see self::get_descriptor_for_post()} keeps showing the
 	 * old-provider image until the new provider's PNG lands via prewarm.
 	 *
@@ -652,7 +656,7 @@ class Map {
 	 * @param int|null $extra_width        Optional extra width (0 = auto).
 	 * @param int|null $extra_height       Optional extra height (0 = auto).
 	 * @param string   $extra_aspect_ratio Optional aspect ratio hint for the extra combo.
-	 * @return array<string, array<string, array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}>>
+	 * @return ProviderDescriptorMap
 	 */
 	public function regenerate(
 		int $post_id,
@@ -1039,7 +1043,7 @@ class Map {
 	 * @since 1.0.0
 	 *
 	 * @param int $post_id The venue post ID.
-	 * @return array<string, array<string, array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}>>
+	 * @return ProviderDescriptorMap
 	 */
 	public function get_all_descriptors( int $post_id ): array {
 		$raw = get_post_meta( $post_id, self::META_KEY, true );
@@ -1397,8 +1401,9 @@ class Map {
 	): string {
 		$dirs     = wp_get_upload_dir();
 		$base_url = trailingslashit( $dirs['baseurl'] ) . self::UPLOADS_SUBDIR;
+		$filename = $this->filename_for( $address, $zoom, $width, $height, $provider, $density );
 
-		return trailingslashit( $base_url ) . $this->filename_for( $address, $zoom, $width, $height, $provider, $density );
+		return trailingslashit( $base_url ) . $filename;
 	}
 
 	/**
@@ -1418,7 +1423,7 @@ class Map {
 	 * @param int    $width    Output width (at density 1).
 	 * @param int    $height   Output height (at density 1).
 	 * @param string $provider Provider slug (e.g. `osm`) — namespaces the file
-	 *                         so OSM and Google PNGs can coexist on disk.
+	 *                         so OSM and Google PNG files can coexist on disk.
 	 * @param int    $density  Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @return string Filename including the `.png` extension.
 	 */
@@ -1453,7 +1458,7 @@ class Map {
 	 * Save a finished GD image to the uploads directory and return its URL.
 	 *
 	 * Filename is derived from `(address, provider, zoom, width, height)` so
-	 * different providers' PNGs coexist on disk and two venues at the same
+	 * different providers' PNG files coexist on disk and two venues at the same
 	 * address share one file at matching dimensions. `imagepng` overwrites
 	 * in place, which is fine for the regenerate flow since the inputs
 	 * that'd change visible output also change the hash in the descriptor.

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -330,11 +330,14 @@ class Map {
 			return;
 		}
 
-		// Defer to the prewarm subsystem — same path used on theme switch.
-		// Wrapped so a missing `Prewarm` (e.g. tests that haven't booted
-		// the venue subsystem) doesn't fatal a plain settings save.
+		// Defer to a one-shot cron tick rather than running the full
+		// template + venue rescan inline. A site with thousands of
+		// venues × combos would otherwise fan out a huge number of cron
+		// events synchronously inside the admin save that triggered us.
+		// Wrapped so a missing `Prewarm` (tests that haven't booted the
+		// venue subsystem) doesn't fatal a plain settings save.
 		if ( class_exists( Prewarm::class ) ) {
-			Prewarm::get_instance()->on_theme_switched();
+			Prewarm::get_instance()->schedule_full_sweep();
 		}
 	}
 

--- a/includes/core/classes/venue/map/class-prewarm.php
+++ b/includes/core/classes/venue/map/class-prewarm.php
@@ -55,6 +55,18 @@ class Prewarm {
 	const CRON_ACTION = 'gatherpress_warm_venue_map';
 
 	/**
+	 * One-shot cron action that re-runs the full template scan + venue
+	 * enumeration, used when the active provider changes mid-flight. A
+	 * single deferred tick is cheaper than fanning out the per-(venue,
+	 * combo) cron events synchronously inside the admin save that
+	 * triggered the platform switch.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const FULL_SWEEP_ACTION = 'gatherpress_map_reprewarm';
+
+	/**
 	 * Block name this class watches for.
 	 *
 	 * @since 1.0.0
@@ -156,6 +168,7 @@ class Prewarm {
 	 */
 	protected function setup_hooks(): void {
 		add_action( self::CRON_ACTION, array( $this, 'process_warm_job' ), 10, 5 );
+		add_action( self::FULL_SWEEP_ACTION, array( $this, 'on_theme_switched' ) );
 
 		// Priority 12 — after Map::maybe_generate() (priority 11) has
 		// synchronously rendered whatever combos were already cached on the
@@ -163,6 +176,27 @@ class Prewarm {
 		// been rendered at.
 		add_action( 'wp_after_insert_post', array( $this, 'on_post_saved' ), 12, 2 );
 		add_action( 'switch_theme', array( $this, 'on_theme_switched' ) );
+	}
+
+	/**
+	 * Schedule the full template + venue rescan to run on the next cron
+	 * tick. Used by callers that need a re-sweep but shouldn't pay the
+	 * cost inline — `Map::maybe_handle_settings_change()` after a
+	 * `map_platform` switch is the primary caller.
+	 *
+	 * Idempotent: if a sweep is already scheduled, no second event is
+	 * queued, so a flurry of platform-saves coalesces into one tick.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function schedule_full_sweep(): void {
+		if ( false !== wp_next_scheduled( self::FULL_SWEEP_ACTION ) ) {
+			return;
+		}
+
+		wp_schedule_single_event( time() + 1, self::FULL_SWEEP_ACTION );
 	}
 
 	/**
@@ -291,14 +325,17 @@ class Prewarm {
 		while ( true ) {
 			$batch = get_posts(
 				array(
-					'post_type'      => $types,
-					'post_status'    => 'publish',
-					'posts_per_page' => $batch_size,
-					'paged'          => $page,
-					'fields'         => 'ids',
-					'orderby'        => 'ID',
-					'order'          => 'ASC',
-					'no_found_rows'  => true,
+					'post_type'              => $types,
+					'post_status'            => 'publish',
+					'posts_per_page'         => $batch_size,
+					'paged'                  => $page,
+					'fields'                 => 'ids',
+					'orderby'                => 'ID',
+					'order'                  => 'ASC',
+					'no_found_rows'          => true,
+					// Only IDs are used — skip meta and term cache priming.
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
 				)
 			);
 
@@ -432,13 +469,16 @@ class Prewarm {
 			while ( true ) {
 				$batch = get_posts(
 					array(
-						'post_type'      => $venue_carrying_types,
-						'post_status'    => 'publish',
-						'posts_per_page' => $batch_size,
-						'paged'          => $page,
-						'orderby'        => 'ID',
-						'order'          => 'ASC',
-						'no_found_rows'  => true,
+						'post_type'              => $venue_carrying_types,
+						'post_status'            => 'publish',
+						'posts_per_page'         => $batch_size,
+						'paged'                  => $page,
+						'orderby'                => 'ID',
+						'order'                  => 'ASC',
+						'no_found_rows'          => true,
+						// Only post_content is read — skip meta/term priming.
+						'update_post_meta_cache' => false,
+						'update_post_term_cache' => false,
 					)
 				);
 
@@ -586,14 +626,17 @@ class Prewarm {
 		while ( true ) {
 			$batch = get_posts(
 				array(
-					'post_type'      => $types,
-					'post_status'    => 'publish',
-					'posts_per_page' => $batch_size,
-					'paged'          => $page,
-					'fields'         => 'ids',
-					'orderby'        => 'ID',
-					'order'          => 'ASC',
-					'no_found_rows'  => true,
+					'post_type'              => $types,
+					'post_status'            => 'publish',
+					'posts_per_page'         => $batch_size,
+					'paged'                  => $page,
+					'fields'                 => 'ids',
+					'orderby'                => 'ID',
+					'order'                  => 'ASC',
+					'no_found_rows'          => true,
+					// Only IDs are used — skip meta and term cache priming.
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
 				)
 			);
 

--- a/includes/core/classes/venue/map/class-prewarm.php
+++ b/includes/core/classes/venue/map/class-prewarm.php
@@ -19,27 +19,28 @@
  * Scheduling is WP-Cron for now. Action Scheduler integration will
  * replace this layer once it's pulled into the plugin.
  *
- * @package GatherPress\Core\Venue
+ * @package GatherPress\Core\Venue\Map
  * @since 1.0.0
  */
 
-namespace GatherPress\Core\Venue;
+namespace GatherPress\Core\Venue\Map;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 use WP_Post;
 
 /**
- * Class Map_Prewarm.
+ * Class Prewarm.
  *
  * Scans templates + events for venue-map combos, enqueues cron jobs to
  * warm each (venue, combo) via {@see Map::warm()}.
  *
  * @since 1.0.0
  */
-class Map_Prewarm {
+class Prewarm {
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -213,7 +214,7 @@ class Map_Prewarm {
 				return;
 			}
 
-			$venue = Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
+			$venue = Venue_Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
 
 			if ( $venue instanceof WP_Post ) {
 				foreach ( $combos as $combo ) {

--- a/includes/core/classes/venue/map/class-setup.php
+++ b/includes/core/classes/venue/map/class-setup.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Hub for the venue map subsystem.
+ *
+ * Owns instantiation of the Map\* sibling singletons (Manager, Map,
+ * Prewarm) so the outer `Venue\Setup::instantiate_classes()` can hand
+ * off the whole map subsystem with a single line — same shape as
+ * `Event\Setup`, `Rsvp\Setup`, `Venue\Setup`. Adding a new Map\* class
+ * in the future lands as one line in `Map\Setup::instantiate_classes()`
+ * rather than touching `Venue\Setup`.
+ *
+ * @package GatherPress\Core\Venue\Map
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Core\Venue\Map;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Traits\Singleton;
+
+/**
+ * Class Setup.
+ *
+ * Singleton hub for the venue map subsystem.
+ *
+ * @since 1.0.0
+ */
+class Setup {
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Class constructor.
+	 *
+	 * Instantiates the sibling Map\* singletons. The instances each wire
+	 * their own hooks in their own `setup_hooks()` calls — this hub does
+	 * nothing else.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function __construct() {
+		$this->instantiate_classes();
+	}
+
+	/**
+	 * Instantiate each Map\* sibling singleton.
+	 *
+	 * Order matters once: `Manager` registers `gatherpress_loaded`
+	 * listeners that populate the provider registry — it must construct
+	 * before the action fires from the outer `Setup::__construct()`. The
+	 * other siblings have no such dependency, so registration order
+	 * after Manager is alphabetical.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function instantiate_classes(): void {
+		Manager::get_instance();
+		Map::get_instance();
+		Prewarm::get_instance();
+	}
+}

--- a/includes/core/classes/venue/map/class-setup.php
+++ b/includes/core/classes/venue/map/class-setup.php
@@ -49,11 +49,10 @@ class Setup {
 	/**
 	 * Instantiate each Map\* sibling singleton.
 	 *
-	 * Order matters once: `Manager` registers `gatherpress_loaded`
-	 * listeners that populate the provider registry — it must construct
-	 * before the action fires from the outer `Setup::__construct()`. The
-	 * other siblings have no such dependency, so registration order
-	 * after Manager is alphabetical.
+	 * Manager registers core providers in its own constructor, so it
+	 * must instantiate before Map and Prewarm — both of which call into
+	 * the registry on later hooks. Sibling order after Manager is
+	 * alphabetical; none of the others depend on each other.
 	 *
 	 * @since 1.0.0
 	 *

--- a/includes/core/classes/venue/map/provider/class-base.php
+++ b/includes/core/classes/venue/map/provider/class-base.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Base contract for venue-map provider strategies.
+ *
+ * A provider is the swappable bit of the static-map pipeline: given a
+ * coordinate plus dimensions, it returns a finished GD image (already
+ * marker-stamped, retina-aware) that the Map orchestrator persists to
+ * disk and tracks via post meta. Everything else — descriptor management,
+ * filename composition, save-post lifecycle, hash invalidation — lives on
+ * the orchestrator and works the same regardless of which provider is
+ * active.
+ *
+ * @package GatherPress\Core\Venue\Map\Provider
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Core\Venue\Map\Provider;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GdImage;
+
+/**
+ * Class Base.
+ *
+ * Abstract parent of every venue-map provider. Concrete subclasses
+ * implement `get_slug()` and `render()`; everything else has sensible
+ * defaults so a minimal "roadmap-only, no attribution" provider compiles
+ * with three method bodies.
+ *
+ * @since 1.0.0
+ */
+abstract class Base {
+	/**
+	 * Stable identifier used in post meta keys, filename slugs, and the
+	 * `map_platform` setting.
+	 *
+	 * Lowercase ASCII; treat as URL-safe. Two providers MUST NOT share a
+	 * slug — `Manager::register()` silently drops the second registration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	abstract public function get_slug(): string;
+
+	/**
+	 * Human-readable label shown in the Settings → Venues → Maps platform
+	 * dropdown. Translator-facing — wrap in `__()`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	abstract public function get_label(): string;
+
+	/**
+	 * Render a finished, marker-stamped, possibly-retina static map.
+	 *
+	 * Implementations MUST return a `GdImage` of exactly
+	 * `($width * $density) × ($height * $density)` pixels with the venue
+	 * marker already drawn, OR null when rendering fails (network error,
+	 * tile-fetch deadline exceeded, GD missing, unsupported zoom × density
+	 * combo, etc.). The caller treats null as "skip this combo" — it does
+	 * NOT fall back to another provider.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param float $latitude  Venue latitude in decimal degrees.
+	 * @param float $longitude Venue longitude in decimal degrees.
+	 * @param int   $zoom      Map zoom level (already clamped by the orchestrator).
+	 * @param int   $width     Logical pixel width (at density 1).
+	 * @param int   $height    Logical pixel height (at density 1).
+	 * @param int   $density   Pixel-density multiplier. 1 = standard, 2 = retina.
+	 * @return GdImage|null Finished image, or null on failure.
+	 */
+	abstract public function render(
+		float $latitude,
+		float $longitude,
+		int $zoom,
+		int $width,
+		int $height,
+		int $density = 1
+	): ?GdImage;
+
+	/**
+	 * Attribution markup the front end MUST display alongside the static
+	 * map image. Required by OpenStreetMap; empty for providers (Google)
+	 * that bake attribution directly into the rendered PNG.
+	 *
+	 * Output is treated as trusted HTML — implementations are responsible
+	 * for escaping any dynamic values they substitute in.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string Attribution HTML, or empty string when none required.
+	 */
+	public function attribution_html(): string {
+		return '';
+	}
+
+	/**
+	 * Whether this provider can render the requested map type.
+	 *
+	 * Drives the editor's Map Type dropdown — types not supported by the
+	 * active provider are filtered out. OSM only ships `roadmap`; Google
+	 * ships all four common types.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $map_type Map type slug — one of `roadmap`, `satellite`, `hybrid`, `terrain`.
+	 * @return bool
+	 */
+	public function supports_map_type( string $map_type ): bool {
+		return in_array( $map_type, $this->supported_map_types(), true );
+	}
+
+	/**
+	 * The full list of map types this provider supports. Default-only
+	 * implementation declares roadmap; override to add satellite/etc.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string[]
+	 */
+	public function supported_map_types(): array {
+		return array( 'roadmap' );
+	}
+}

--- a/includes/core/classes/venue/map/provider/class-base.php
+++ b/includes/core/classes/venue/map/provider/class-base.php
@@ -19,8 +19,6 @@ namespace GatherPress\Core\Venue\Map\Provider;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-use GdImage;
-
 /**
  * Class Base.
  *
@@ -58,12 +56,17 @@ abstract class Base {
 	/**
 	 * Render a finished, marker-stamped, possibly-retina static map.
 	 *
-	 * Implementations MUST return a `GdImage` of exactly
+	 * Implementations MUST return a GD image of exactly
 	 * `($width * $density) × ($height * $density)` pixels with the venue
 	 * marker already drawn, OR null when rendering fails (network error,
 	 * tile-fetch deadline exceeded, GD missing, unsupported zoom × density
 	 * combo, etc.). The caller treats null as "skip this combo" — it does
 	 * NOT fall back to another provider.
+	 *
+	 * Return type is intentionally untyped at the PHP signature level so the
+	 * abstract is loadable on PHP 7.4 (where the GD extension returns a
+	 * `resource`, not a `GdImage` — the latter class is 8.0+). PHPStan reads
+	 * the docblock instead.
 	 *
 	 * @since 1.0.0
 	 *
@@ -73,7 +76,7 @@ abstract class Base {
 	 * @param int   $width     Logical pixel width (at density 1).
 	 * @param int   $height    Logical pixel height (at density 1).
 	 * @param int   $density   Pixel-density multiplier. 1 = standard, 2 = retina.
-	 * @return GdImage|null Finished image, or null on failure.
+	 * @return \GdImage|resource|null Finished image, or null on failure.
 	 */
 	abstract public function render(
 		float $latitude,
@@ -82,7 +85,7 @@ abstract class Base {
 		int $width,
 		int $height,
 		int $density = 1
-	): ?GdImage;
+	);
 
 	/**
 	 * Attribution markup the front end MUST display alongside the static

--- a/includes/core/classes/venue/map/provider/class-base.php
+++ b/includes/core/classes/venue/map/provider/class-base.php
@@ -19,6 +19,8 @@ namespace GatherPress\Core\Venue\Map\Provider;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GdImage;
+
 /**
  * Class Base.
  *
@@ -76,7 +78,7 @@ abstract class Base {
 	 * @param int   $width     Logical pixel width (at density 1).
 	 * @param int   $height    Logical pixel height (at density 1).
 	 * @param int   $density   Pixel-density multiplier. 1 = standard, 2 = retina.
-	 * @return \GdImage|resource|null Finished image, or null on failure.
+	 * @return GdImage|resource|null Finished image, or null on failure.
 	 */
 	abstract public function render(
 		float $latitude,

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -182,7 +182,17 @@ class OSM extends Base {
 					continue;
 				}
 
-				$tile = imagecreatefromstring( $tile_png );
+				// Wrap the decode — `imagecreatefromstring()` can emit a
+				// PHP warning (and on some builds a notice-converted-to-
+				// exception in tests) for malformed bytes from a tile
+				// host or a misconfigured `gatherpress_venue_map_tile_url`.
+				// Treat any failure as "skip this tile" rather than
+				// fatalling the whole composite.
+				try {
+					$tile = imagecreatefromstring( $tile_png );
+				} catch ( \Throwable $e ) {
+					$tile = false;
+				}
 
 				if ( false === $tile ) {
 					continue;

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -1,0 +1,343 @@
+<?php
+/**
+ * OpenStreetMap-backed venue map provider.
+ *
+ * Renders static maps by fetching CartoDB-served OSM basemap tiles
+ * (`{z}/{x}/{y}.png`), compositing them into a single canvas centered on
+ * the venue's coordinates, and stamping a marker at the canvas center.
+ * Retina (2×) variants render at `tile_zoom = zoom + 1` so labels and
+ * road lines come from native higher-detail tiles rather than upscaled
+ * 1× pixels.
+ *
+ * @package GatherPress\Core\Venue\Map\Provider
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Core\Venue\Map\Provider;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Venue\Map\Map;
+use GdImage;
+
+/**
+ * Class OSM.
+ *
+ * Tile-composite static map provider. Reads CartoDB's keyless OSM
+ * basemap by default; the tile-URL template is filterable so a site can
+ * point at a different XYZ tile server (Stamen, Maptiler, self-hosted)
+ * without changing code.
+ *
+ * @since 1.0.0
+ */
+class OSM extends Base {
+	/**
+	 * Default XYZ tile URL template. CartoDB's "light_all" basemap —
+	 * keyless, fast CDN, fits the GatherPress aesthetic.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const DEFAULT_TILE_URL = 'https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png';
+
+	/**
+	 * Tile dimension in pixels (Web Mercator standard).
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const TILE_SIZE = 256;
+
+	/**
+	 * Wall-clock budget in seconds for a single render() call. When the
+	 * deadline is exceeded mid-loop, remaining tiles are skipped and the
+	 * gray canvas background shows through.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const COMPOSITE_TIME_BUDGET = 10;
+
+	/**
+	 * Provider slug used in post meta keys, filenames, and the
+	 * `map_platform` setting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function get_slug(): string {
+		return 'osm';
+	}
+
+	/**
+	 * Human-readable label shown in the Settings → Venues → Maps platform
+	 * dropdown.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function get_label(): string {
+		return __( 'OpenStreetMap', 'gatherpress' );
+	}
+
+	/**
+	 * Composite OSM tiles around the venue, stamp a marker at the canvas
+	 * center, and return the finished GD image. Returns null when GD is
+	 * unavailable, when the requested density is unsupported, or when the
+	 * retina variant would require a tile zoom past `Map::ZOOM_MAX`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param float $latitude  Venue latitude in decimal degrees.
+	 * @param float $longitude Venue longitude in decimal degrees.
+	 * @param int   $zoom      Map zoom level (already clamped by the orchestrator).
+	 * @param int   $width     Logical pixel width (at density 1).
+	 * @param int   $height    Logical pixel height (at density 1).
+	 * @param int   $density   Pixel-density multiplier. 1 = standard, 2 = retina.
+	 * @return GdImage|null Finished image, or null on failure.
+	 */
+	public function render(
+		float $latitude,
+		float $longitude,
+		int $zoom,
+		int $width,
+		int $height,
+		int $density = 1
+	): ?GdImage {
+		// PHP built without the GD extension. Can't simulate in a unit test without making the runtime itself broken.
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) { // @codeCoverageIgnore
+			return null; // @codeCoverageIgnore
+		}
+
+		// Coerce unsupported densities back to 1. Allowing, say, density=3
+		// with `(int) log(3, 2) === 1` would paint a 3×-sized canvas using
+		// only 2× tiles — a cheap upscale that wastes disk for no gain.
+		if ( ! in_array( $density, Map::SUPPORTED_DENSITIES, true ) ) {
+			$density = 1;
+		}
+
+		// Tile zoom climbs with density so the retina variant renders true
+		// zoom+1 detail. If that would exceed the provider's serveable
+		// zoom range, skip — orchestrator treats null as "no retina at
+		// this combo" and moves on with just the 1× image.
+		$tile_zoom = $zoom + (int) log( $density, 2 );
+
+		if ( $tile_zoom > Map::ZOOM_MAX ) {
+			return null;
+		}
+
+		$canvas_width  = $width * $density;
+		$canvas_height = $height * $density;
+
+		$venue_world_x = $this->lng_to_world_pixel( $longitude, $tile_zoom );
+		$venue_world_y = $this->lat_to_world_pixel( $latitude, $tile_zoom );
+
+		$left_pixel = (int) round( $venue_world_x - $canvas_width / 2 );
+		$top_pixel  = (int) round( $venue_world_y - $canvas_height / 2 );
+
+		$left_tile   = (int) floor( $left_pixel / self::TILE_SIZE );
+		$top_tile    = (int) floor( $top_pixel / self::TILE_SIZE );
+		$right_tile  = (int) floor( ( $left_pixel + $canvas_width - 1 ) / self::TILE_SIZE );
+		$bottom_tile = (int) floor( ( $top_pixel + $canvas_height - 1 ) / self::TILE_SIZE );
+
+		$canvas = imagecreatetruecolor( $canvas_width, $canvas_height );
+
+		// Background: neutral gray so missing tiles blend rather than glaring black.
+		$bg = imagecolorallocate( $canvas, 238, 238, 238 );
+		imagefilledrectangle( $canvas, 0, 0, $canvas_width - 1, $canvas_height - 1, $bg );
+
+		$tiles = $this->get_tile_url_template();
+
+		/**
+		 * Filter the wall-clock budget (in seconds) for a single OSM
+		 * render() call. When the deadline is exceeded mid-loop, remaining
+		 * tiles are skipped and the gray background shows through.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param float $budget Default budget from COMPOSITE_TIME_BUDGET.
+		 */
+		$budget   = (float) apply_filters(
+			'gatherpress_venue_map_composite_time_budget',
+			self::COMPOSITE_TIME_BUDGET
+		);
+		$deadline = microtime( true ) + $budget;
+
+		for ( $tx = $left_tile; $tx <= $right_tile; $tx++ ) {
+			for ( $ty = $top_tile; $ty <= $bottom_tile; $ty++ ) {
+				if ( microtime( true ) >= $deadline ) {
+					break 2;
+				}
+
+				$tile_png = $this->fetch_tile( $tile_zoom, $tx, $ty, $tiles );
+
+				if ( null === $tile_png ) {
+					continue;
+				}
+
+				$tile = imagecreatefromstring( $tile_png );
+
+				if ( false === $tile ) {
+					continue;
+				}
+
+				$dst_x = $tx * self::TILE_SIZE - $left_pixel;
+				$dst_y = $ty * self::TILE_SIZE - $top_pixel;
+
+				imagecopy( $canvas, $tile, $dst_x, $dst_y, 0, 0, self::TILE_SIZE, self::TILE_SIZE );
+				imagedestroy( $tile );
+			}
+		}
+
+		$this->stamp_marker(
+			$canvas,
+			(int) round( $canvas_width / 2 ),
+			(int) round( $canvas_height / 2 ),
+			(float) $density
+		);
+
+		return $canvas;
+	}
+
+	/**
+	 * Required attribution for OSM + CartoDB. Front end displays this
+	 * alongside the static map image.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function attribution_html(): string {
+		return sprintf(
+			'© <a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a> | © <a href="%3$s" target="_blank" rel="noopener noreferrer">%4$s</a>',
+			esc_url( 'https://www.openstreetmap.org/copyright' ),
+			esc_html__( 'OpenStreetMap contributors', 'gatherpress' ),
+			esc_url( 'https://carto.com/' ),
+			esc_html__( 'CARTO', 'gatherpress' )
+		);
+	}
+
+	/**
+	 * Fetch, decode, and return the raw PNG bytes for a tile at (z, x, y).
+	 *
+	 * Returns null on any HTTP failure so the calling render() can skip
+	 * that tile without aborting the whole composite; the resulting image
+	 * will simply have a blank patch where the fetch failed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $zoom  Tile zoom.
+	 * @param int    $x     Tile x coordinate.
+	 * @param int    $y     Tile y coordinate.
+	 * @param string $tiles Tile URL template containing `{z}`, `{x}`, `{y}`.
+	 * @return string|null PNG bytes, or null on failure.
+	 */
+	public function fetch_tile( int $zoom, int $x, int $y, string $tiles ): ?string {
+		$url = strtr(
+			$tiles,
+			array(
+				'{z}' => (string) $zoom,
+				'{x}' => (string) $x,
+				'{y}' => (string) $y,
+			)
+		);
+
+		$response = wp_safe_remote_get( $url, array( 'timeout' => 5 ) );
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$body = (string) wp_remote_retrieve_body( $response );
+
+		return '' !== $body ? $body : null;
+	}
+
+	/**
+	 * Draw a simple pin marker at the given pixel coordinates.
+	 *
+	 * Passing `$scale > 1` proportionally scales the marker's three
+	 * concentric ellipses so a retina (2×) composite keeps the marker
+	 * visually the same size as the 1× render rather than shrinking to
+	 * a pinprick.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param GdImage $canvas Destination canvas.
+	 * @param int     $x      Pixel X position (marker center).
+	 * @param int     $y      Pixel Y position (marker center).
+	 * @param float   $scale  Multiplier applied to the marker radii.
+	 * @return void
+	 */
+	public function stamp_marker( GdImage $canvas, int $x, int $y, float $scale = 1.0 ): void {
+		$white = imagecolorallocate( $canvas, 255, 255, 255 );
+		$red   = imagecolorallocate( $canvas, 220, 53, 69 );
+		$dark  = imagecolorallocate( $canvas, 30, 30, 30 );
+
+		$outer = max( 1, (int) round( 20 * $scale ) );
+		$inner = max( 1, (int) round( 16 * $scale ) );
+		$dot   = max( 1, (int) round( 6 * $scale ) );
+
+		imagefilledellipse( $canvas, $x, $y, $outer, $outer, $white );
+		imagefilledellipse( $canvas, $x, $y, $inner, $inner, $red );
+		imageellipse( $canvas, $x, $y, $inner, $inner, $dark );
+		imagefilledellipse( $canvas, $x, $y, $dot, $dot, $white );
+	}
+
+	/**
+	 * Tile URL template. Filterable so site owners can repoint at a
+	 * different XYZ provider (self-hosted, Stamen, Maptiler, etc.) without
+	 * forking the provider class.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	protected function get_tile_url_template(): string {
+		/**
+		 * Filter the tile URL template used by the OSM static map provider.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $template Tile URL with `{z}`, `{x}`, `{y}` placeholders.
+		 */
+		return (string) apply_filters( 'gatherpress_venue_map_tile_url', self::DEFAULT_TILE_URL );
+	}
+
+	/**
+	 * Convert longitude to absolute pixel X in world pixel space at `$zoom`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param float $lng  Longitude in degrees.
+	 * @param int   $zoom Zoom level.
+	 * @return float
+	 */
+	protected function lng_to_world_pixel( float $lng, int $zoom ): float {
+		return ( ( $lng + 180.0 ) / 360.0 ) * self::TILE_SIZE * ( 2 ** $zoom );
+	}
+
+	/**
+	 * Convert latitude to absolute pixel Y in world pixel space at `$zoom`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param float $lat  Latitude in degrees.
+	 * @param int   $zoom Zoom level.
+	 * @return float
+	 */
+	protected function lat_to_world_pixel( float $lat, int $zoom ): float {
+		$rad = deg2rad( $lat );
+
+		return (
+			1.0 - log( tan( $rad ) + 1.0 / cos( $rad ) ) / M_PI
+		) / 2.0 * self::TILE_SIZE * ( 2 ** $zoom );
+	}
+}

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -19,6 +19,7 @@ namespace GatherPress\Core\Venue\Map\Provider;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Venue\Map\Map;
+use GdImage;
 
 /**
  * Class OSM.
@@ -100,7 +101,7 @@ class OSM extends Base {
 	 * @param int   $width     Logical pixel width (at density 1).
 	 * @param int   $height    Logical pixel height (at density 1).
 	 * @param int   $density   Pixel-density multiplier. 1 = standard, 2 = retina.
-	 * @return \GdImage|resource|null Finished image, or null on failure.
+	 * @return GdImage|resource|null Finished image, or null on failure.
 	 */
 	public function render(
 		float $latitude,
@@ -279,10 +280,10 @@ class OSM extends Base {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param \GdImage|resource $canvas Destination canvas.
-	 * @param int               $x      Pixel X position (marker center).
-	 * @param int               $y      Pixel Y position (marker center).
-	 * @param float             $scale  Multiplier applied to the marker radii.
+	 * @param GdImage|resource $canvas Destination canvas.
+	 * @param int              $x      Pixel X position (marker center).
+	 * @param int              $y      Pixel Y position (marker center).
+	 * @param float            $scale  Multiplier applied to the marker radii.
 	 * @return void
 	 */
 	public function stamp_marker( $canvas, int $x, int $y, float $scale = 1.0 ): void {

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -18,7 +18,7 @@ namespace GatherPress\Core\Venue\Map\Provider;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map;
 use GdImage;
 
 /**
@@ -225,14 +225,9 @@ class OSM extends Base {
 	 * @return string
 	 */
 	public function attribution_html(): string {
-		$link_attrs = 'target="_blank" rel="noopener noreferrer"';
-		$format     = sprintf(
-			'© <a href="%%1$s" %1$s>%%2$s</a> | © <a href="%%3$s" %1$s>%%4$s</a>',
-			$link_attrs
-		);
-
 		return sprintf(
-			$format,
+			'© <a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>'
+			. ' | © <a href="%3$s" target="_blank" rel="noopener noreferrer">%4$s</a>',
 			esc_url( 'https://www.openstreetmap.org/copyright' ),
 			esc_html__( 'OpenStreetMap contributors', 'gatherpress' ),
 			esc_url( 'https://carto.com/' ),

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -211,8 +211,14 @@ class OSM extends Base {
 	 * @return string
 	 */
 	public function attribution_html(): string {
+		$link_attrs = 'target="_blank" rel="noopener noreferrer"';
+		$format     = sprintf(
+			'© <a href="%%1$s" %1$s>%%2$s</a> | © <a href="%%3$s" %1$s>%%4$s</a>',
+			$link_attrs
+		);
+
 		return sprintf(
-			'© <a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a> | © <a href="%3$s" target="_blank" rel="noopener noreferrer">%4$s</a>',
+			$format,
 			esc_url( 'https://www.openstreetmap.org/copyright' ),
 			esc_html__( 'OpenStreetMap contributors', 'gatherpress' ),
 			esc_url( 'https://carto.com/' ),

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -20,6 +20,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Venue\Map;
 use GdImage;
+use Throwable;
 
 /**
  * Class OSM.
@@ -182,17 +183,7 @@ class OSM extends Base {
 					continue;
 				}
 
-				// Wrap the decode — `imagecreatefromstring()` can emit a
-				// PHP warning (and on some builds a notice-converted-to-
-				// exception in tests) for malformed bytes from a tile
-				// host or a misconfigured `gatherpress_venue_map_tile_url`.
-				// Treat any failure as "skip this tile" rather than
-				// fatalling the whole composite.
-				try {
-					$tile = imagecreatefromstring( $tile_png );
-				} catch ( \Throwable $e ) {
-					$tile = false;
-				}
+				$tile = $this->decode_tile( $tile_png );
 
 				if ( false === $tile ) {
 					continue;
@@ -233,6 +224,36 @@ class OSM extends Base {
 			esc_url( 'https://carto.com/' ),
 			esc_html__( 'CARTO', 'gatherpress' )
 		);
+	}
+
+	/**
+	 * Decode raw PNG bytes into a GD image. Wraps `imagecreatefromstring()`
+	 * so the calling composite never fatals on a bad tile.
+	 *
+	 * Failure modes by environment:
+	 * - PHP 7.4 production: returns `false`, emits an `E_WARNING` on bad
+	 *   input. No throw — the wrapper returns `false` straight from the
+	 *   `try`, the catch doesn't fire.
+	 * - PHP 7.4 under PHPUnit: the `E_WARNING` is converted to a
+	 *   `PHPUnit\Framework\Error\Warning` (a `Throwable`) by the test
+	 *   runner. The catch fires and returns `false`.
+	 * - PHP 8.0+: throws `ValueError` for empty input or malformed
+	 *   payloads. The catch fires and returns `false`.
+	 *
+	 * Either way, the caller sees `false` and treats it as "skip this
+	 * tile".
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $bytes Raw PNG bytes from `fetch_tile()`.
+	 * @return GdImage|resource|false Decoded image, or false when the bytes don't decode.
+	 */
+	protected function decode_tile( string $bytes ) {
+		try {
+			return imagecreatefromstring( $bytes );
+		} catch ( Throwable $e ) {
+			return false;
+		}
 	}
 
 	/**

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -19,7 +19,6 @@ namespace GatherPress\Core\Venue\Map\Provider;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Venue\Map\Map;
-use GdImage;
 
 /**
  * Class OSM.
@@ -89,6 +88,10 @@ class OSM extends Base {
 	 * unavailable, when the requested density is unsupported, or when the
 	 * retina variant would require a tile zoom past `Map::ZOOM_MAX`.
 	 *
+	 * Return type is intentionally untyped at the PHP signature level for
+	 * PHP 7.4 compatibility (GD returns a `resource` there, not a
+	 * `GdImage`).
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param float $latitude  Venue latitude in decimal degrees.
@@ -97,7 +100,7 @@ class OSM extends Base {
 	 * @param int   $width     Logical pixel width (at density 1).
 	 * @param int   $height    Logical pixel height (at density 1).
 	 * @param int   $density   Pixel-density multiplier. 1 = standard, 2 = retina.
-	 * @return GdImage|null Finished image, or null on failure.
+	 * @return \GdImage|resource|null Finished image, or null on failure.
 	 */
 	public function render(
 		float $latitude,
@@ -106,7 +109,7 @@ class OSM extends Base {
 		int $width,
 		int $height,
 		int $density = 1
-	): ?GdImage {
+	) {
 		// PHP built without the GD extension. Can't simulate in a unit test without making the runtime itself broken.
 		if ( ! function_exists( 'imagecreatetruecolor' ) ) { // @codeCoverageIgnore
 			return null; // @codeCoverageIgnore
@@ -276,13 +279,13 @@ class OSM extends Base {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param GdImage $canvas Destination canvas.
-	 * @param int     $x      Pixel X position (marker center).
-	 * @param int     $y      Pixel Y position (marker center).
-	 * @param float   $scale  Multiplier applied to the marker radii.
+	 * @param \GdImage|resource $canvas Destination canvas.
+	 * @param int               $x      Pixel X position (marker center).
+	 * @param int               $y      Pixel Y position (marker center).
+	 * @param float             $scale  Multiplier applied to the marker radii.
 	 * @return void
 	 */
-	public function stamp_marker( GdImage $canvas, int $x, int $y, float $scale = 1.0 ): void {
+	public function stamp_marker( $canvas, int $x, int $y, float $scale = 1.0 ): void {
 		$white = imagecolorallocate( $canvas, 255, 255, 255 );
 		$red   = imagecolorallocate( $canvas, 220, 53, 69 );
 		$dark  = imagecolorallocate( $canvas, 30, 30, 30 );

--- a/includes/core/register-class-aliases.php
+++ b/includes/core/register-class-aliases.php
@@ -21,9 +21,10 @@ spl_autoload_register(
 	static function ( string $class_string ): void {
 		// Map of prior fully-qualified class names to their current fully-qualified class names.
 		$aliases = array(
-			'GatherPress\\Core\\Event' => 'GatherPress\\Core\\Event\\Event',
-			'GatherPress\\Core\\Rsvp'  => 'GatherPress\\Core\\Rsvp\\Rsvp',
-			'GatherPress\\Core\\Venue' => 'GatherPress\\Core\\Venue\\Venue',
+			'GatherPress\\Core\\Event'      => 'GatherPress\\Core\\Event\\Event',
+			'GatherPress\\Core\\Rsvp'       => 'GatherPress\\Core\\Rsvp\\Rsvp',
+			'GatherPress\\Core\\Venue'      => 'GatherPress\\Core\\Venue\\Venue',
+			'GatherPress\\Core\\Venue\\Map' => 'GatherPress\\Core\\Venue\\Map\\Map',
 		);
 
 		if ( ! isset( $aliases[ $class_string ] ) ) {

--- a/phpstan.stubs
+++ b/phpstan.stubs
@@ -58,4 +58,10 @@ namespace {
         require_once __DIR__ . '/includes/core/classes/venue/class-venue.php';
         class_alias( 'GatherPress\\Core\\Venue\\Venue', 'GatherPress\\Core\\Venue' );
     }
+
+    if ( ! class_exists( 'GatherPress\\Core\\Venue\\Map', false ) ) {
+        require_once __DIR__ . '/includes/core/classes/traits/class-singleton.php';
+        require_once __DIR__ . '/includes/core/classes/venue/map/class-map.php';
+        class_alias( 'GatherPress\\Core\\Venue\\Map\\Map', 'GatherPress\\Core\\Venue\\Map' );
+    }
 }

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -194,8 +194,8 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 					venueMeta: meta,
 					savedVenueMeta: savedPost?.meta || {},
 					staticMapDescriptors:
-						editedVenuePost?.meta?.gatherpress_venue_static_map ||
-						meta?.gatherpress_venue_static_map ||
+						editedVenuePost?.meta?.gatherpress_static_map ||
+						meta?.gatherpress_static_map ||
 						{},
 					venuePostId: effectiveVenuePostId,
 					venuePostType: resolvedVenuePostType,
@@ -216,7 +216,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 				venueMeta: meta,
 				savedVenueMeta: meta,
 				staticMapDescriptors:
-					meta?.gatherpress_venue_static_map || {},
+					meta?.gatherpress_static_map || {},
 				venuePostId: effectiveVenuePostId,
 				venuePostType: context?.postType || '',
 			};

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -42,6 +42,7 @@ import {
 import {
 	RegenerateMapButton,
 	parseAspectRatio,
+	pickDescriptorForCombo,
 	resolveDimensions,
 	usePlaceholderPolling,
 } from './helpers';
@@ -297,7 +298,11 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 		} );
 
 	const comboKey = `${ zoom }x${ effectiveWidth }x${ effectiveHeight }`;
-	const staticMapDescriptor = staticMapDescriptors?.[ comboKey ];
+	const staticMapDescriptor = pickDescriptorForCombo(
+		staticMapDescriptors,
+		comboKey,
+		mapPlatform || 'osm'
+	);
 	const staticMapUrl = staticMapDescriptor?.url || '';
 	const isStaticMode = 'static' === renderMode;
 	const showStaticImage =

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -173,6 +173,39 @@ export const RegenerateMapButton = ( {
 };
 
 /**
+ * Pick the best descriptor for a (provider, combo) lookup, with the same
+ * fallback chain the PHP orchestrator uses in `Map::get_descriptor_for_post`:
+ * active provider first, then any other provider's stored descriptor for
+ * the same combo. Lets a site that just flipped `map_platform` keep
+ * showing the previous provider's PNG until the new one renders.
+ *
+ * @since 1.0.0
+ *
+ * @param {Object} descriptors  Provider-keyed descriptor map: `{ osm: { combo_key: { url, ... } } }`.
+ * @param {string} comboKey     Combo key in the form `{zoom}x{width}x{height}`.
+ * @param {string} activeSlug   Slug of the currently active provider (e.g. `'osm'`).
+ * @return {Object|undefined} Descriptor object, or undefined when no provider has one.
+ */
+export const pickDescriptorForCombo = ( descriptors, comboKey, activeSlug ) => {
+	const active = descriptors?.[ activeSlug ]?.[ comboKey ];
+	if ( active ) {
+		return active;
+	}
+
+	for ( const slug of Object.keys( descriptors || {} ) ) {
+		if ( slug === activeSlug ) {
+			continue;
+		}
+		const candidate = descriptors[ slug ]?.[ comboKey ];
+		if ( candidate ) {
+			return candidate;
+		}
+	}
+
+	return undefined;
+};
+
+/**
  * Parse an aspect-ratio string (e.g. "16/9" or "4:3") into a float.
  *
  * Mirrors the server-side `Venue\Map::parse_aspect_ratio()` so the editor

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -181,9 +181,9 @@ export const RegenerateMapButton = ( {
  *
  * @since 1.0.0
  *
- * @param {Object} descriptors  Provider-keyed descriptor map: `{ osm: { combo_key: { url, ... } } }`.
- * @param {string} comboKey     Combo key in the form `{zoom}x{width}x{height}`.
- * @param {string} activeSlug   Slug of the currently active provider (e.g. `'osm'`).
+ * @param {Object} descriptors Provider-keyed descriptor map: `{ osm: { combo_key: { url, ... } } }`.
+ * @param {string} comboKey    Combo key in the form `{zoom}x{width}x{height}`.
+ * @param {string} activeSlug  Slug of the currently active provider (e.g. `'osm'`).
  * @return {Object|undefined} Descriptor object, or undefined when no provider has one.
  */
 export const pickDescriptorForCombo = ( descriptors, comboKey, activeSlug ) => {

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -139,7 +139,7 @@ export const RegenerateMapButton = ( {
 							...current,
 							meta: {
 								...( current.meta || {} ),
-								gatherpress_venue_static_map:
+								gatherpress_static_map:
 									response?.descriptors || {},
 							},
 						},

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -30,7 +30,7 @@
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Settings;
-use GatherPress\Core\Venue\Map;
+use GatherPress\Core\Venue\Map\Map;
 use GatherPress\Core\Venue\Setup;
 
 if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -30,7 +30,7 @@
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Settings;
-use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Setup;
 
 if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -177,7 +177,7 @@ describe( 'RegenerateMapButton', () => {
 		expect( name ).toBe( 'gatherpress_venue' );
 		expect( records[ 0 ].id ).toBe( 42 );
 		expect(
-			records[ 0 ].meta.gatherpress_venue_static_map[ '18x300' ].url
+			records[ 0 ].meta.gatherpress_static_map[ '18x300' ].url
 		).toBe( 'https://example.test/42-abc.png' );
 		// Existing meta fields must be preserved.
 		expect( records[ 0 ].meta.gatherpress_address ).toBe( '' );
@@ -296,7 +296,7 @@ describe( 'RegenerateMapButton', () => {
 		} );
 
 		const [ , , records ] = mockReceiveEntityRecords.mock.calls[ 0 ];
-		expect( records[ 0 ].meta.gatherpress_venue_static_map ).toEqual( {
+		expect( records[ 0 ].meta.gatherpress_static_map ).toEqual( {
 			'18x300': {
 				url: 'https://example.test/42-abc.png',
 				hash: 'abc',
@@ -320,7 +320,7 @@ describe( 'RegenerateMapButton', () => {
 		} );
 
 		const [ , , records ] = mockReceiveEntityRecords.mock.calls[ 0 ];
-		expect( records[ 0 ].meta.gatherpress_venue_static_map ).toEqual( {} );
+		expect( records[ 0 ].meta.gatherpress_static_map ).toEqual( {} );
 	} );
 
 	it( 'surfaces an error notice when the server reports generation_failed', async () => {

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -55,6 +55,7 @@ import {
 	POLL_INTERVAL_MS,
 	RegenerateMapButton,
 	parseAspectRatio,
+	pickDescriptorForCombo,
 	resolveDimensions,
 	usePlaceholderPolling,
 } from '@src/blocks/venue-map/helpers';
@@ -359,6 +360,76 @@ describe( 'parseAspectRatio', () => {
 	it( 'returns null when either side is zero', () => {
 		expect( parseAspectRatio( '0/1' ) ).toBeNull();
 		expect( parseAspectRatio( '4/0' ) ).toBeNull();
+	} );
+} );
+
+describe( 'pickDescriptorForCombo', () => {
+	const osmDescriptor = {
+		url: 'https://example.test/osm.png',
+		url_2x: 'https://example.test/osm@2x.png',
+		hash: 'abc',
+		zoom: 18,
+		width: 600,
+		height: 300,
+	};
+	const googleDescriptor = {
+		url: 'https://example.test/google.png',
+		url_2x: 'https://example.test/google@2x.png',
+		hash: 'def',
+		zoom: 18,
+		width: 600,
+		height: 300,
+	};
+
+	it( 'returns the active provider descriptor when present', () => {
+		const descriptors = {
+			osm: { '18x600x300': osmDescriptor },
+			google: { '18x600x300': googleDescriptor },
+		};
+
+		expect(
+			pickDescriptorForCombo( descriptors, '18x600x300', 'google' )
+		).toBe( googleDescriptor );
+	} );
+
+	it( 'falls back to another provider when the active one is missing the combo', () => {
+		const descriptors = {
+			osm: { '18x600x300': osmDescriptor },
+		};
+
+		expect(
+			pickDescriptorForCombo( descriptors, '18x600x300', 'google' )
+		).toBe( osmDescriptor );
+	} );
+
+	it( 'returns undefined when no provider has the combo', () => {
+		const descriptors = {
+			osm: { '15x800x400': osmDescriptor },
+		};
+
+		expect(
+			pickDescriptorForCombo( descriptors, '18x600x300', 'osm' )
+		).toBeUndefined();
+	} );
+
+	it( 'tolerates a missing or empty descriptor map', () => {
+		expect(
+			pickDescriptorForCombo( undefined, '18x600x300', 'osm' )
+		).toBeUndefined();
+		expect(
+			pickDescriptorForCombo( {}, '18x600x300', 'osm' )
+		).toBeUndefined();
+	} );
+
+	it( 'skips the active slug when scanning for fallbacks', () => {
+		const descriptors = {
+			osm: { '18x600x300': osmDescriptor },
+			google: {},
+		};
+
+		expect(
+			pickDescriptorForCombo( descriptors, '18x600x300', 'google' )
+		).toBe( osmDescriptor );
 	} );
 } );
 

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -9,8 +9,7 @@
 namespace GatherPress\Tests\Core\Venue;
 
 use GatherPress\Core\Event;
-use GatherPress\Core\Venue\Map;
-use GatherPress\Core\Venue\Map_Prewarm;
+use GatherPress\Core\Venue\Map\Setup as Map_Setup;
 use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue;
 use GatherPress\Tests\Base;
@@ -25,44 +24,28 @@ use WP_Block_Patterns_Registry;
  */
 class Test_Setup extends Base {
 	/**
-	 * Venue\Setup now owns the instantiation of the Venue\* sibling
-	 * singletons (Map, Map_Prewarm) so the outer
-	 * `Setup::instantiate_classes()` can hand off with a single
-	 * `Venue\Setup::get_instance()` call. Per-sibling proof-of-construction
-	 * via their `setup_hooks()`-registered hooks — catches the case where
-	 * a sibling silently drops out of `Venue\Setup::instantiate_classes()`.
+	 * Venue\Setup hands the map subsystem off to `Map\Setup`, which in
+	 * turn instantiates Manager / Map / Prewarm. Test that `Map\Setup`
+	 * is constructed when Venue\Setup wires its siblings. Per-sibling
+	 * registration is proved by `Test_Map_Setup`.
 	 *
 	 * @covers ::__construct
 	 * @covers ::instantiate_classes
 	 *
 	 * @return void
 	 */
-	public function test_instantiate_classes_registers_siblings(): void {
+	public function test_instantiate_classes_hands_off_to_map_setup(): void {
 		// Force the method to run inside the test's coverage window —
 		// Setup is a singleton cached during plugin bootstrap, so
 		// `get_instance()` here returns the cached instance and doesn't
 		// re-fire the constructor.
 		Utility::invoke_hidden_method( Setup::get_instance(), 'instantiate_classes' );
 
-		$expected_hooks = array(
-			Map::class         => array(
-				'rest_api_init',
-				array( Map::get_instance(), 'register_rest_routes' ),
-			),
-			Map_Prewarm::class => array(
-				'switch_theme',
-				array( Map_Prewarm::get_instance(), 'on_theme_switched' ),
-			),
+		$this->assertInstanceOf(
+			Map_Setup::class,
+			Map_Setup::get_instance(),
+			'Map\Setup must be instantiated so the map subsystem is wired.'
 		);
-
-		foreach ( $expected_hooks as $class_name => $expected ) {
-			list( $hook, $callback ) = $expected;
-			$this->assertSame(
-				10,
-				has_action( $hook, $callback ),
-				sprintf( '%s must be instantiated so its %s hook registers.', $class_name, $hook )
-			);
-		}
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -198,14 +198,14 @@ class Test_Setup extends Base {
 			'gatherpress_longitude',
 			'gatherpress_phone',
 			'gatherpress_website',
-			'gatherpress_venue_static_map',
+			'gatherpress_static_map',
 		);
 
 		foreach ( $venue_information_keys as $key ) {
 			unregister_post_meta( Venue::POST_TYPE, $key );
 		}
 
-		unregister_post_meta( Venue::POST_TYPE, 'gatherpress_venue_map_show' );
+		unregister_post_meta( Venue::POST_TYPE, 'gatherpress_map_show' );
 
 		$meta = get_registered_meta_keys( 'post', Venue::POST_TYPE );
 
@@ -218,9 +218,9 @@ class Test_Setup extends Base {
 		}
 
 		$this->assertArrayNotHasKey(
-			'gatherpress_venue_map_show',
+			'gatherpress_map_show',
 			$meta,
-			'Failed to assert that gatherpress_venue_map_show does not exist.'
+			'Failed to assert that gatherpress_map_show does not exist.'
 		);
 
 		$instance->maybe_register_post_meta( Venue::POST_TYPE );
@@ -236,9 +236,9 @@ class Test_Setup extends Base {
 		}
 
 		$this->assertArrayHasKey(
-			'gatherpress_venue_map_show',
+			'gatherpress_map_show',
 			$meta,
-			'Failed to assert that gatherpress_venue_map_show exists for gatherpress-venue-map support.'
+			'Failed to assert that gatherpress_map_show exists for gatherpress-venue-map support.'
 		);
 	}
 
@@ -308,7 +308,7 @@ class Test_Setup extends Base {
 		$request->set_param(
 			'meta',
 			array(
-				'gatherpress_venue_static_map' => array(
+				'gatherpress_static_map' => array(
 					'15' => array(
 						'url'  => 'evil.png',
 						'hash' => 'x',
@@ -327,9 +327,9 @@ class Test_Setup extends Base {
 		$meta = $request->get_param( 'meta' );
 
 		$this->assertArrayNotHasKey(
-			'gatherpress_venue_static_map',
+			'gatherpress_static_map',
 			$meta,
-			'gatherpress_venue_static_map is server-generated and must not be writable via REST.'
+			'gatherpress_static_map is server-generated and must not be writable via REST.'
 		);
 		$this->assertArrayHasKey(
 			'gatherpress_address',

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -314,8 +314,8 @@ class Test_Setup extends Base {
 						'hash' => 'x',
 					),
 				),
-				'gatherpress_address'          => 'Real St',
-				'gatherpress_latitude'         => '12.345',
+				'gatherpress_address'    => 'Real St',
+				'gatherpress_latitude'   => '12.345',
 			)
 		);
 

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
@@ -263,13 +263,17 @@ class Test_Manager extends Base {
 
 	/**
 	 * When even OSM isn't registered yet (bootstrap hasn't run),
-	 * `get_active()` returns null rather than throwing.
+	 * `get_active()` returns null rather than throwing. The persisted
+	 * `map_platform` default is `osm`, so the misconfigured-slug path
+	 * fires `_doing_it_wrong` on the way through — expected.
 	 *
 	 * @covers ::get_active
 	 *
 	 * @return void
 	 */
 	public function test_get_active_returns_null_when_no_providers(): void {
+		$this->setExpectedIncorrectUsage( Manager::class . '::get_active' );
+
 		$instance = Manager::get_instance();
 		Utility::set_and_get_hidden_property( $instance, 'providers', array() );
 
@@ -278,13 +282,17 @@ class Test_Manager extends Base {
 
 	/**
 	 * `get_active_slug()` returns the active provider's slug, or empty
-	 * string when there's no active provider.
+	 * string when there's no active provider. The empty-registry leg
+	 * trips the misconfigured-slug warning because the persisted
+	 * `map_platform` default is `osm` — expected.
 	 *
 	 * @covers ::get_active_slug
 	 *
 	 * @return void
 	 */
 	public function test_get_active_slug_mirrors_get_active(): void {
+		$this->setExpectedIncorrectUsage( Manager::class . '::get_active' );
+
 		$instance = Manager::get_instance();
 		$this->assertSame( 'osm', $instance->get_active_slug() );
 

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
@@ -1,0 +1,361 @@
+<?php
+/**
+ * Unit tests for GatherPress\Core\Venue\Map\Manager.
+ *
+ * @package GatherPress\Core\Venue\Map
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Core\Venue\Map;
+
+use GatherPress\Core\Settings;
+use GatherPress\Core\Venue\Map\Manager;
+use GatherPress\Core\Venue\Map\Provider\Base as Map_Provider;
+use GatherPress\Core\Venue\Map\Provider\OSM;
+use GatherPress\Tests\Base;
+use PMC\Unit_Test\Utility;
+
+/**
+ * Class Test_Manager.
+ *
+ * @coversDefaultClass \GatherPress\Core\Venue\Map\Manager
+ */
+class Test_Manager extends Base {
+	/**
+	 * Reset the registry between tests so a stub provider added in one
+	 * case doesn't bleed into the next case's `get_active()` resolution.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		$instance = Manager::get_instance();
+		Utility::set_and_get_hidden_property( $instance, 'providers', array() );
+		$instance->register_core_providers();
+
+		delete_option( Settings::OPTION_NAME );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Coverage for setup_hooks — verifies the two-phase
+	 * `gatherpress_loaded` registration (priority 1 for core providers,
+	 * priority 5 for the companion-plugin action).
+	 *
+	 * @covers ::__construct
+	 * @covers ::setup_hooks
+	 *
+	 * @return void
+	 */
+	public function test_setup_hooks(): void {
+		$instance = Manager::get_instance();
+		$hooks    = array(
+			array(
+				'type'     => 'action',
+				'name'     => 'gatherpress_loaded',
+				'priority' => 1,
+				'callback' => array( $instance, 'register_core_providers' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'gatherpress_loaded',
+				'priority' => 5,
+				'callback' => array( $instance, 'do_register_action' ),
+			),
+		);
+
+		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * `register()` stores the provider keyed by slug, and `is_registered()`
+	 * + `get()` see it afterwards.
+	 *
+	 * @covers ::register
+	 * @covers ::is_registered
+	 * @covers ::get
+	 *
+	 * @return void
+	 */
+	public function test_register_stores_provider(): void {
+		$instance = Manager::get_instance();
+		$provider = $this->make_stub_provider( 'fake' );
+
+		$instance->register( $provider );
+
+		$this->assertTrue( $instance->is_registered( 'fake' ) );
+		$this->assertSame( $provider, $instance->get( 'fake' ) );
+	}
+
+	/**
+	 * Re-registering the same slug must not replace the original instance —
+	 * companion-plugin double-load shouldn't silently swap providers.
+	 *
+	 * @covers ::register
+	 *
+	 * @return void
+	 */
+	public function test_register_is_idempotent(): void {
+		$instance = Manager::get_instance();
+		$first    = $this->make_stub_provider( 'twice' );
+		$second   = $this->make_stub_provider( 'twice' );
+
+		$instance->register( $first );
+		$instance->register( $second );
+
+		$this->assertSame( $first, $instance->get( 'twice' ) );
+	}
+
+	/**
+	 * A provider with an empty slug is silently dropped — registry keys
+	 * must be addressable.
+	 *
+	 * @covers ::register
+	 *
+	 * @return void
+	 */
+	public function test_register_skips_empty_slug(): void {
+		$instance = Manager::get_instance();
+		$provider = $this->make_stub_provider( '' );
+
+		$instance->register( $provider );
+
+		$this->assertFalse( $instance->is_registered( '' ) );
+	}
+
+	/**
+	 * `get()` returns null when the slug isn't registered.
+	 *
+	 * @covers ::get
+	 *
+	 * @return void
+	 */
+	public function test_get_returns_null_for_unknown_slug(): void {
+		$this->assertNull( Manager::get_instance()->get( 'nope' ) );
+	}
+
+	/**
+	 * `get_all()` returns the full registry keyed by slug.
+	 *
+	 * @covers ::get_all
+	 *
+	 * @return void
+	 */
+	public function test_get_all_returns_all_registered_providers(): void {
+		$instance = Manager::get_instance();
+		$instance->register( $this->make_stub_provider( 'alpha' ) );
+
+		$all = $instance->get_all();
+
+		$this->assertArrayHasKey( 'osm', $all );
+		$this->assertArrayHasKey( 'alpha', $all );
+	}
+
+	/**
+	 * `get_slugs()` returns just the keys, in registration order — OSM
+	 * registered first by `register_core_providers()`, then anything the
+	 * test added.
+	 *
+	 * @covers ::get_slugs
+	 *
+	 * @return void
+	 */
+	public function test_get_slugs_returns_keys_in_registration_order(): void {
+		$instance = Manager::get_instance();
+		$instance->register( $this->make_stub_provider( 'late' ) );
+
+		$this->assertSame( array( 'osm', 'late' ), $instance->get_slugs() );
+	}
+
+	/**
+	 * `register_core_providers()` always registers OSM — it is the
+	 * always-available fallback regardless of which platform the site picks.
+	 *
+	 * @covers ::register_core_providers
+	 *
+	 * @return void
+	 */
+	public function test_register_core_providers_registers_osm(): void {
+		$instance = Manager::get_instance();
+		$osm      = $instance->get( 'osm' );
+
+		$this->assertInstanceOf( OSM::class, $osm );
+	}
+
+	/**
+	 * `do_register_action()` fires `gatherpress_register_map_providers`
+	 * with the manager instance so companion plugins can register their
+	 * providers on top of the core ones.
+	 *
+	 * @covers ::do_register_action
+	 *
+	 * @return void
+	 */
+	public function test_do_register_action_fires_companion_action(): void {
+		$instance = Manager::get_instance();
+		$captured = null;
+
+		$callback = function ( $registry ) use ( &$captured ) {
+			$captured = $registry;
+		};
+
+		add_action( 'gatherpress_register_map_providers', $callback );
+
+		$instance->do_register_action();
+
+		remove_action( 'gatherpress_register_map_providers', $callback );
+
+		$this->assertSame( $instance, $captured );
+	}
+
+	/**
+	 * When `map_platform` points at a registered slug, `get_active()`
+	 * returns that provider.
+	 *
+	 * @covers ::get_active
+	 *
+	 * @return void
+	 */
+	public function test_get_active_returns_configured_provider(): void {
+		$instance = Manager::get_instance();
+		$custom   = $this->make_stub_provider( 'custom' );
+		$instance->register( $custom );
+
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'custom' ) );
+
+		$this->assertSame( $custom, $instance->get_active() );
+	}
+
+	/**
+	 * Empty `map_platform` setting falls through to OSM — site has never
+	 * touched the dropdown.
+	 *
+	 * @covers ::get_active
+	 *
+	 * @return void
+	 */
+	public function test_get_active_falls_back_to_osm_when_setting_empty(): void {
+		$instance = Manager::get_instance();
+
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => '' ) );
+
+		$this->assertInstanceOf( OSM::class, $instance->get_active() );
+	}
+
+	/**
+	 * A configured slug with no matching registered provider (e.g. `google`
+	 * before its provider class lands in #1528) triggers `_doing_it_wrong`
+	 * and falls back to OSM so the front end keeps rendering.
+	 *
+	 * @covers ::get_active
+	 *
+	 * @return void
+	 */
+	public function test_get_active_falls_back_to_osm_for_unknown_slug(): void {
+		$this->setExpectedIncorrectUsage( Manager::class . '::get_active' );
+
+		$instance = Manager::get_instance();
+
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'google' ) );
+
+		$this->assertInstanceOf( OSM::class, $instance->get_active() );
+	}
+
+	/**
+	 * When even OSM isn't registered yet (bootstrap hasn't run),
+	 * `get_active()` returns null rather than throwing.
+	 *
+	 * @covers ::get_active
+	 *
+	 * @return void
+	 */
+	public function test_get_active_returns_null_when_no_providers(): void {
+		$instance = Manager::get_instance();
+		Utility::set_and_get_hidden_property( $instance, 'providers', array() );
+
+		$this->assertNull( $instance->get_active() );
+	}
+
+	/**
+	 * `get_active_slug()` returns the active provider's slug, or empty
+	 * string when there's no active provider.
+	 *
+	 * @covers ::get_active_slug
+	 *
+	 * @return void
+	 */
+	public function test_get_active_slug_mirrors_get_active(): void {
+		$instance = Manager::get_instance();
+		$this->assertSame( 'osm', $instance->get_active_slug() );
+
+		Utility::set_and_get_hidden_property( $instance, 'providers', array() );
+		$this->assertSame( '', $instance->get_active_slug() );
+	}
+
+	/**
+	 * Build a minimal provider double — anonymous subclass of the abstract
+	 * Base with just enough plumbing to be registerable.
+	 *
+	 * @param string $slug Slug to advertise.
+	 * @return Map_Provider
+	 */
+	private function make_stub_provider( string $slug ): Map_Provider {
+		return new class( $slug ) extends Map_Provider {
+			/**
+			 * Slug to advertise.
+			 *
+			 * @var string
+			 */
+			private $slug;
+
+			/**
+			 * Capture the slug to return from `get_slug()`.
+			 *
+			 * @param string $slug Slug.
+			 */
+			public function __construct( string $slug ) {
+				$this->slug = $slug;
+			}
+
+			/**
+			 * Provider slug.
+			 *
+			 * @return string
+			 */
+			public function get_slug(): string {
+				return $this->slug;
+			}
+
+			/**
+			 * Provider label.
+			 *
+			 * @return string
+			 */
+			public function get_label(): string {
+				return 'Stub';
+			}
+
+			/**
+			 * No-op render — this stub is only used for registry assertions.
+			 *
+			 * @param float $latitude  Unused.
+			 * @param float $longitude Unused.
+			 * @param int   $zoom      Unused.
+			 * @param int   $width     Unused.
+			 * @param int   $height    Unused.
+			 * @param int   $density   Unused.
+			 * @return null
+			 */
+			public function render(
+				float $latitude,
+				float $longitude,
+				int $zoom,
+				int $width,
+				int $height,
+				int $density = 1
+			): ?\GdImage {
+				return null;
+			}
+		};
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
@@ -358,7 +358,7 @@ class Test_Manager extends Base {
 				int $width,
 				int $height,
 				int $density = 1
-			): ?\GdImage {
+			) {
 				return null;
 			}
 		};

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
@@ -38,9 +38,12 @@ class Test_Manager extends Base {
 	}
 
 	/**
-	 * Coverage for setup_hooks — verifies the two-phase
-	 * `gatherpress_loaded` registration (priority 1 for core providers,
-	 * priority 5 for the companion-plugin action).
+	 * Coverage for setup_hooks — verifies the companion-plugin
+	 * registration action is wired to `init` priority 0.
+	 *
+	 * Core providers register synchronously in the constructor and are
+	 * covered by `test_register_core_providers_registers_osm` rather
+	 * than as a hook here.
 	 *
 	 * @covers ::__construct
 	 * @covers ::setup_hooks
@@ -52,14 +55,8 @@ class Test_Manager extends Base {
 		$hooks    = array(
 			array(
 				'type'     => 'action',
-				'name'     => 'gatherpress_loaded',
-				'priority' => 1,
-				'callback' => array( $instance, 'register_core_providers' ),
-			),
-			array(
-				'type'     => 'action',
-				'name'     => 'gatherpress_loaded',
-				'priority' => 5,
+				'name'     => 'init',
+				'priority' => 0,
 				'callback' => array( $instance, 'do_register_action' ),
 			),
 		);

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
@@ -93,6 +93,11 @@ class Test_Manager extends Base {
 	 * @return void
 	 */
 	public function test_register_is_idempotent(): void {
+		// Second registration trips the slug-collision warning by design —
+		// surfaces the conflict in the debug log instead of silently
+		// overwriting.
+		$this->setExpectedIncorrectUsage( Manager::class . '::register' );
+
 		$instance = Manager::get_instance();
 		$first    = $this->make_stub_provider( 'twice' );
 		$second   = $this->make_stub_provider( 'twice' );

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
@@ -12,6 +12,8 @@
 
 namespace GatherPress\Tests\Core\Venue\Map;
 
+use GatherPress\Core\Settings;
+use GatherPress\Core\Venue\Map\Manager;
 use GatherPress\Core\Venue\Map\Map;
 use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue;
@@ -1445,24 +1447,24 @@ class Test_Map extends Base {
 		$too_high = static function () {
 			return 99;
 		};
-		add_filter( 'gatherpress_venue_map_zoom', $too_high );
+		add_filter( 'gatherpress_map_zoom', $too_high );
 		$this->assertSame(
 			Map::ZOOM_MAX,
 			Utility::invoke_hidden_method( $instance, 'get_zoom' ),
 			'Zoom beyond ZOOM_MAX must clamp down.'
 		);
-		remove_filter( 'gatherpress_venue_map_zoom', $too_high );
+		remove_filter( 'gatherpress_map_zoom', $too_high );
 
 		$too_low = static function () {
 			return 0;
 		};
-		add_filter( 'gatherpress_venue_map_zoom', $too_low );
+		add_filter( 'gatherpress_map_zoom', $too_low );
 		$this->assertSame(
 			Map::ZOOM_MIN,
 			Utility::invoke_hidden_method( $instance, 'get_zoom' ),
 			'Zoom below ZOOM_MIN must clamp up.'
 		);
-		remove_filter( 'gatherpress_venue_map_zoom', $too_low );
+		remove_filter( 'gatherpress_map_zoom', $too_low );
 	}
 
 	/**
@@ -1481,13 +1483,13 @@ class Test_Map extends Base {
 		$too_big = static function () {
 			return 9999;
 		};
-		add_filter( 'gatherpress_venue_map_height', $too_big );
+		add_filter( 'gatherpress_map_height', $too_big );
 		$this->assertSame(
 			Map::HEIGHT_MAX,
 			Utility::invoke_hidden_method( $instance, 'get_height' ),
 			'Height beyond HEIGHT_MAX must clamp down.'
 		);
-		remove_filter( 'gatherpress_venue_map_height', $too_big );
+		remove_filter( 'gatherpress_map_height', $too_big );
 	}
 
 	/**
@@ -2608,5 +2610,395 @@ class Test_Map extends Base {
 		add_post_meta( $post_id, 'gatherpress_longitude', '' );
 
 		$this->assertNull( $instance->get_descriptor_for_post( $post_id, Venue::POST_TYPE ) );
+	}
+
+	/**
+	 * `maybe_handle_settings_change()` is a no-op when `map_platform`
+	 * isn't actually changing — saving Settings without touching the
+	 * platform must not enqueue a fresh prewarm pass.
+	 *
+	 * @covers ::maybe_handle_settings_change
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_settings_change_skips_when_platform_unchanged(): void {
+		$instance = Map::get_instance();
+
+		$settings = array( 'map_platform' => 'osm' );
+
+		// Same platform on both sides → early return.
+		$instance->maybe_handle_settings_change( $settings, $settings );
+
+		$this->assertFalse(
+			(bool) wp_next_scheduled( \GatherPress\Core\Venue\Map\Prewarm::CRON_ACTION ),
+			'No warm jobs should be scheduled when the platform did not change.'
+		);
+	}
+
+	/**
+	 * `maybe_handle_settings_change()` reads the inner platform value and
+	 * tolerates non-array inputs on either side without warnings — both
+	 * code paths in the `is_array()` casts must be exercised.
+	 *
+	 * @covers ::maybe_handle_settings_change
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_settings_change_tolerates_non_array_inputs(): void {
+		$instance = Map::get_instance();
+
+		// Both non-array → both casts coerce to '' and the early-return
+		// path fires (empty === empty).
+		$instance->maybe_handle_settings_change( false, null );
+
+		$this->assertFalse(
+			(bool) wp_next_scheduled( \GatherPress\Core\Venue\Map\Prewarm::CRON_ACTION ),
+			'Non-array inputs must not schedule prewarm jobs.'
+		);
+	}
+
+	/**
+	 * Flipping `map_platform` triggers the same prewarm pass that runs on
+	 * theme switches — every venue's combos get re-enqueued so the new
+	 * provider's PNG files land in the background.
+	 *
+	 * @covers ::maybe_handle_settings_change
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_settings_change_schedules_prewarm_on_platform_change(): void {
+		$instance = Map::get_instance();
+
+		// At least one venue with usable coordinates so the prewarm pass
+		// has something to enqueue.
+		$venue_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+		add_post_meta( $venue_id, 'gatherpress_address', '1 Infinite Loop' );
+		add_post_meta( $venue_id, 'gatherpress_latitude', '37.3318' );
+		add_post_meta( $venue_id, 'gatherpress_longitude', '-122.0312' );
+
+		$old = array( 'map_platform' => 'osm' );
+		$new = array( 'map_platform' => 'google' );
+
+		$instance->maybe_handle_settings_change( $old, $new );
+
+		$this->assertTrue(
+			(bool) wp_next_scheduled( \GatherPress\Core\Venue\Map\Prewarm::CRON_ACTION, array( $venue_id ) ),
+			'Platform change must enqueue a warm job for each addressable venue.'
+		);
+
+		wp_clear_scheduled_hook( \GatherPress\Core\Venue\Map\Prewarm::CRON_ACTION );
+	}
+
+	/**
+	 * `get_descriptor_for_post()` walks other providers' stored entries
+	 * for the same combo when the active provider can't render. Lets a
+	 * site that just flipped from OSM to Google keep showing the OSM
+	 * PNG until the new provider's image lands.
+	 *
+	 * @covers ::get_descriptor_for_post
+	 *
+	 * @return void
+	 */
+	public function test_get_descriptor_for_post_falls_back_to_other_provider(): void {
+		$instance = Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
+		// No coords on purpose — that prevents the active provider from
+		// rendering, forcing the fallback walk below.
+		$key = sprintf( '%dx%dx%d', Map::DEFAULT_ZOOM, Map::DEFAULT_HEIGHT * 2, Map::DEFAULT_HEIGHT );
+		update_post_meta(
+			$post_id,
+			Map::META_KEY,
+			array(
+				'google' => array(
+					$key => array(
+						'url'    => 'https://example.test/google.png',
+						'url_2x' => '',
+						'hash'   => 'abc',
+						'zoom'   => Map::DEFAULT_ZOOM,
+						'width'  => Map::DEFAULT_HEIGHT * 2,
+						'height' => Map::DEFAULT_HEIGHT,
+					),
+				),
+			)
+		);
+
+		$descriptor = $instance->get_descriptor_for_post( $post_id, Venue::POST_TYPE );
+
+		$this->assertIsArray( $descriptor );
+		$this->assertSame( 'https://example.test/google.png', $descriptor['url'] );
+	}
+
+	/**
+	 * When neither the active provider nor any other provider has a
+	 * matching combo, `get_descriptor_for_post()` returns null.
+	 *
+	 * @covers ::get_descriptor_for_post
+	 *
+	 * @return void
+	 */
+	public function test_get_descriptor_for_post_returns_null_when_no_provider_has_combo(): void {
+		$instance = Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
+		// Stored combo doesn't match the requested combo, no coords to
+		// satisfy active-provider render either.
+		update_post_meta(
+			$post_id,
+			Map::META_KEY,
+			array(
+				'google' => array(
+					'5x100x100' => array(
+						'url'    => 'https://example.test/google.png',
+						'url_2x' => '',
+						'hash'   => 'abc',
+						'zoom'   => 5,
+						'width'  => 100,
+						'height' => 100,
+					),
+				),
+			)
+		);
+
+		$this->assertNull(
+			$instance->get_descriptor_for_post( $post_id, Venue::POST_TYPE )
+		);
+	}
+
+	/**
+	 * `get_all_descriptors()` skips entries whose top-level key is not a
+	 * non-empty string or whose value is not an array — defensive
+	 * cleanup for legacy meta written under the pre-provider-keyed
+	 * shape.
+	 *
+	 * @covers ::get_all_descriptors
+	 *
+	 * @return void
+	 */
+	public function test_get_all_descriptors_skips_malformed_provider_keys(): void {
+		$instance = Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		update_post_meta(
+			$post_id,
+			Map::META_KEY,
+			array(
+				'osm' => array(
+					'15x600x300' => array(
+						'url'    => 'https://example.test/a.png',
+						'hash'   => 'abc',
+						'zoom'   => 15,
+						'width'  => 600,
+						'height' => 300,
+					),
+				),
+				''    => array(
+					'15x600x300' => array(
+						'url'    => 'https://example.test/empty.png',
+						'hash'   => 'def',
+						'zoom'   => 15,
+						'width'  => 600,
+						'height' => 300,
+					),
+				),
+				'bad' => 'not-an-array',
+				42    => array(
+					'15x600x300' => array(
+						'url'    => 'https://example.test/int.png',
+						'hash'   => 'ghi',
+						'zoom'   => 15,
+						'width'  => 600,
+						'height' => 300,
+					),
+				),
+			)
+		);
+
+		$descriptors = $instance->get_all_descriptors( $post_id );
+
+		$this->assertSame(
+			array( 'osm' ),
+			array_keys( $descriptors ),
+			'Only the well-formed provider key should survive.'
+		);
+	}
+
+	/**
+	 * `get_cached_combos()` dedupes when two providers cached the same
+	 * `(zoom, width, height)`. The resulting list seeds the prewarm pass,
+	 * which would otherwise schedule duplicate jobs per combo.
+	 *
+	 * @covers ::get_cached_combos
+	 *
+	 * @return void
+	 */
+	public function test_get_cached_combos_dedupes_across_providers(): void {
+		$instance = Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		$entry = array(
+			'url'    => 'https://example.test/x.png',
+			'hash'   => 'abc',
+			'zoom'   => 15,
+			'width'  => 600,
+			'height' => 300,
+		);
+
+		update_post_meta(
+			$post_id,
+			Map::META_KEY,
+			array(
+				'osm'    => array( '15x600x300' => $entry ),
+				'google' => array( '15x600x300' => $entry ),
+			)
+		);
+
+		$combos = $instance->get_cached_combos( $post_id );
+
+		$this->assertCount(
+			1,
+			$combos,
+			'A combo cached under multiple providers must only seed one warm entry.'
+		);
+	}
+
+	/**
+	 * `ensure_descriptor_for_combo()` returns null when the manager has
+	 * no active provider (bootstrap hasn't run, or every provider was
+	 * unregistered by a misconfigured companion plugin).
+	 *
+	 * @covers ::ensure_descriptor_for_combo
+	 *
+	 * @return void
+	 */
+	public function test_ensure_descriptor_for_combo_returns_null_when_no_active_provider(): void {
+		$instance = Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
+		add_post_meta( $post_id, 'gatherpress_latitude', '37.3318' );
+		add_post_meta( $post_id, 'gatherpress_longitude', '-122.0312' );
+
+		// Wipe the registry so get_active() returns null.
+		$manager  = Manager::get_instance();
+		$original = Utility::set_and_get_hidden_property( $manager, 'providers', array() );
+
+		try {
+			$result = Utility::invoke_hidden_method(
+				$instance,
+				'ensure_descriptor_for_combo',
+				array(
+					$post_id,
+					array(
+						'address'   => '1 Infinite Loop',
+						'latitude'  => '37.3318',
+						'longitude' => '-122.0312',
+					),
+					Map::DEFAULT_ZOOM,
+					800,
+					400,
+				)
+			);
+		} finally {
+			Utility::set_and_get_hidden_property( $manager, 'providers', $original );
+			$manager->register_core_providers();
+		}
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * `ensure_descriptor_for_combo()` returns null when the active
+	 * provider's `render()` returns null — surfaces the failure to the
+	 * caller without persisting a half-baked descriptor.
+	 *
+	 * @covers ::ensure_descriptor_for_combo
+	 *
+	 * @return void
+	 */
+	public function test_ensure_descriptor_for_combo_returns_null_when_render_returns_null(): void {
+		$instance = Map::get_instance();
+		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
+
+		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
+		add_post_meta( $post_id, 'gatherpress_latitude', '37.3318' );
+		add_post_meta( $post_id, 'gatherpress_longitude', '-122.0312' );
+
+		// Anonymous provider whose render() always returns null. Wired
+		// into Manager and selected via `map_platform` so the orchestrator
+		// resolves to it.
+		$null_provider = new class() extends \GatherPress\Core\Venue\Map\Provider\Base {
+			/**
+			 * Provider slug.
+			 *
+			 * @return string
+			 */
+			public function get_slug(): string {
+				return 'always-null';
+			}
+
+			/**
+			 * Provider label.
+			 *
+			 * @return string
+			 */
+			public function get_label(): string {
+				return 'Null';
+			}
+
+			/**
+			 * Always-null render so the orchestrator's null-image branch fires.
+			 *
+			 * @param float $latitude  Unused.
+			 * @param float $longitude Unused.
+			 * @param int   $zoom      Unused.
+			 * @param int   $width     Unused.
+			 * @param int   $height    Unused.
+			 * @param int   $density   Unused.
+			 * @return null
+			 */
+			public function render(
+				float $latitude,
+				float $longitude,
+				int $zoom,
+				int $width,
+				int $height,
+				int $density = 1
+			) {
+				return null;
+			}
+		};
+
+		$manager = Manager::get_instance();
+		$manager->register( $null_provider );
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'always-null' ) );
+
+		try {
+			$result = Utility::invoke_hidden_method(
+				$instance,
+				'ensure_descriptor_for_combo',
+				array(
+					$post_id,
+					array(
+						'address'   => '1 Infinite Loop',
+						'latitude'  => '37.3318',
+						'longitude' => '-122.0312',
+					),
+					Map::DEFAULT_ZOOM,
+					800,
+					400,
+				)
+			);
+		} finally {
+			delete_option( Settings::OPTION_NAME );
+			$providers = Utility::set_and_get_hidden_property( $manager, 'providers', array() );
+			unset( $providers['always-null'] );
+			Utility::set_and_get_hidden_property( $manager, 'providers', $providers );
+			$manager->register_core_providers();
+		}
+
+		$this->assertNull( $result );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
@@ -144,6 +144,12 @@ class Test_Map extends Base {
 				'callback' => array( $instance, 'register_rest_routes' ),
 			),
 			array(
+				'type'     => 'action',
+				'name'     => 'update_option_gatherpress_settings',
+				'priority' => 10,
+				'callback' => array( $instance, 'maybe_handle_settings_change' ),
+			),
+			array(
 				'type'     => 'filter',
 				'name'     => 'block_type_metadata',
 				'priority' => 10,
@@ -367,11 +373,11 @@ class Test_Map extends Base {
 			'longitude' => '-122.0312',
 		);
 
-		$baseline = $instance->hash_for( $info, 15, 800, 400, Map::DEFAULT_TILE_URL );
+		$baseline = $instance->hash_for( $info, 15, 800, 400, 'osm' );
 
 		$this->assertSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 800, 400, Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 800, 400, 'osm' ),
 			'Hash should be stable when every input is identical.'
 		);
 
@@ -381,25 +387,25 @@ class Test_Map extends Base {
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $moved_info, 15, 800, 400, Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $moved_info, 15, 800, 400, 'osm' ),
 			'Hash should change when coordinates change.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 14, 800, 400, Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 14, 800, 400, 'osm' ),
 			'Hash should change when the zoom level changes.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 600, 400, Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 600, 400, 'osm' ),
 			'Hash should change when the width changes.'
 		);
 
 		$this->assertNotSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 800, 500, Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 800, 500, 'osm' ),
 			'Hash should change when the height changes.'
 		);
 
@@ -407,7 +413,7 @@ class Test_Map extends Base {
 		// filenames dedupe across venues at the same location.
 		$this->assertSame(
 			$baseline,
-			$instance->hash_for( $info, 15, 800, 400, Map::DEFAULT_TILE_URL ),
+			$instance->hash_for( $info, 15, 800, 400, 'osm' ),
 			'Hash is address-scoped, not post-scoped.'
 		);
 	}
@@ -416,10 +422,7 @@ class Test_Map extends Base {
 	 * Writes a PNG to the uploads subdir and stores its URL in post meta.
 	 *
 	 * @covers ::maybe_generate
-	 * @covers ::composite_image
 	 * @covers ::save_image
-	 * @covers ::stamp_marker
-	 * @covers ::fetch_tile
 	 * @covers ::get_stored_descriptor
 	 *
 	 * @return void
@@ -665,36 +668,39 @@ class Test_Map extends Base {
 			$post_id,
 			Map::META_KEY,
 			array(
-				'15x600x300'    => array(
-					'url'    => 'https://example.test/a.png',
-					'hash'   => 'abc',
-					'zoom'   => 15,
-					'width'  => 600,
-					'height' => 300,
+				'osm' => array(
+					'15x600x300'    => array(
+						'url'    => 'https://example.test/a.png',
+						'hash'   => 'abc',
+						'zoom'   => 15,
+						'width'  => 600,
+						'height' => 300,
+					),
+					'18x800x400'    => 'not-an-array',
+					'20x1000x500'   => array(
+						'url'    => 'https://example.test/b.png',
+						'zoom'   => 20,
+						'width'  => 1000,
+						'height' => 500,
+					), // Missing hash.
+					'missing-shape' => array(
+						'url'  => 'https://example.test/c.png',
+						'hash' => 'def',
+					), // Missing zoom/width/height.
 				),
-				'18x800x400'    => 'not-an-array',
-				'20x1000x500'   => array(
-					'url'    => 'https://example.test/b.png',
-					'zoom'   => 20,
-					'width'  => 1000,
-					'height' => 500,
-				), // Missing hash.
-				'missing-shape' => array(
-					'url'  => 'https://example.test/c.png',
-					'hash' => 'def',
-				), // Missing zoom/width/height.
 			)
 		);
 
 		$descriptors = $instance->get_all_descriptors( $post_id );
 
-		$this->assertArrayHasKey( '15x600x300', $descriptors );
-		$this->assertArrayNotHasKey( '18x800x400', $descriptors );
-		$this->assertArrayNotHasKey( '20x1000x500', $descriptors );
-		$this->assertArrayNotHasKey( 'missing-shape', $descriptors );
-		$this->assertSame( 15, $descriptors['15x600x300']['zoom'] );
-		$this->assertSame( 600, $descriptors['15x600x300']['width'] );
-		$this->assertSame( 300, $descriptors['15x600x300']['height'] );
+		$this->assertArrayHasKey( 'osm', $descriptors );
+		$this->assertArrayHasKey( '15x600x300', $descriptors['osm'] );
+		$this->assertArrayNotHasKey( '18x800x400', $descriptors['osm'] );
+		$this->assertArrayNotHasKey( '20x1000x500', $descriptors['osm'] );
+		$this->assertArrayNotHasKey( 'missing-shape', $descriptors['osm'] );
+		$this->assertSame( 15, $descriptors['osm']['15x600x300']['zoom'] );
+		$this->assertSame( 600, $descriptors['osm']['15x600x300']['width'] );
+		$this->assertSame( 300, $descriptors['osm']['15x600x300']['height'] );
 
 		// Read path must not mutate the meta — writing on every render would
 		// thrash the post-meta cache and churn the DB. Cleanup is deferred
@@ -702,7 +708,7 @@ class Test_Map extends Base {
 		$raw_after_read = get_post_meta( $post_id, Map::META_KEY, true );
 		$this->assertCount(
 			4,
-			$raw_after_read,
+			$raw_after_read['osm'],
 			'get_all_descriptors() must not rewrite meta on read.'
 		);
 	}
@@ -725,21 +731,31 @@ class Test_Map extends Base {
 			$post_id,
 			Map::META_KEY,
 			array(
-				'15x600x300' => array(
-					'url'    => 'https://example.test/a.png',
-					'hash'   => 'abc',
-					'zoom'   => 15,
-					'width'  => 600,
-					'height' => 300,
+				'osm' => array(
+					'15x600x300' => array(
+						'url'    => 'https://example.test/a.png',
+						'hash'   => 'abc',
+						'zoom'   => 15,
+						'width'  => 600,
+						'height' => 300,
+					),
 				),
 			)
 		);
 
 		$override = static function ( $descriptors, $filtered_post_id ) {
-			// Verify the filter receives both documented arguments.
-			foreach ( $descriptors as $key => $entry ) {
-				$descriptors[ $key ]['url']     = 'https://cdn.test/' . $filtered_post_id . '-' . $key . '.png';
-				$descriptors[ $key ]['post_id'] = $filtered_post_id;
+			// Verify the filter receives both documented arguments. With the
+			// provider-keyed shape we walk the inner map per provider.
+			foreach ( $descriptors as $slug => $combos ) {
+				foreach ( $combos as $key => $entry ) {
+					$descriptors[ $slug ][ $key ]['url']     = sprintf(
+						'https://cdn.test/%d-%s-%s.png',
+						$filtered_post_id,
+						$slug,
+						$key
+					);
+					$descriptors[ $slug ][ $key ]['post_id'] = $filtered_post_id;
+				}
 			}
 			return $descriptors;
 		};
@@ -750,13 +766,13 @@ class Test_Map extends Base {
 		remove_filter( 'gatherpress_venue_map_descriptors', $override, 10 );
 
 		$this->assertSame(
-			sprintf( 'https://cdn.test/%d-15x600x300.png', $post_id ),
-			$descriptors['15x600x300']['url'],
+			sprintf( 'https://cdn.test/%d-osm-15x600x300.png', $post_id ),
+			$descriptors['osm']['15x600x300']['url'],
 			'Filter can rewrite a URL.'
 		);
 		$this->assertSame(
 			$post_id,
-			$descriptors['15x600x300']['post_id'],
+			$descriptors['osm']['15x600x300']['post_id'],
 			'Filter receives the venue post ID as its second argument.'
 		);
 
@@ -793,16 +809,19 @@ class Test_Map extends Base {
 		add_post_meta( $post_id, 'gatherpress_latitude', '37.3318' );
 		add_post_meta( $post_id, 'gatherpress_longitude', '-122.0312' );
 
-		// Seed meta with a mix of good and malformed entries.
+		// Seed meta with a mix of good and malformed entries under the
+		// active provider key.
 		update_post_meta(
 			$post_id,
 			Map::META_KEY,
 			array(
-				'junk-row' => 'not-an-array',
-				'no-hash'  => array(
-					'url'    => 'https://example.test/b.png',
-					'zoom'   => 20,
-					'height' => 500,
+				'osm' => array(
+					'junk-row' => 'not-an-array',
+					'no-hash'  => array(
+						'url'    => 'https://example.test/b.png',
+						'zoom'   => 20,
+						'height' => 500,
+					),
 				),
 			)
 		);
@@ -812,8 +831,9 @@ class Test_Map extends Base {
 		$stored = get_post_meta( $post_id, Map::META_KEY, true );
 
 		$this->assertIsArray( $stored );
-		$this->assertArrayNotHasKey( 'junk-row', $stored );
-		$this->assertArrayNotHasKey( 'no-hash', $stored );
+		$this->assertArrayHasKey( 'osm', $stored );
+		$this->assertArrayNotHasKey( 'junk-row', $stored['osm'] );
+		$this->assertArrayNotHasKey( 'no-hash', $stored['osm'] );
 
 		$default_key = sprintf(
 			'%dx%dx%d',
@@ -821,7 +841,7 @@ class Test_Map extends Base {
 			Map::DEFAULT_HEIGHT * 2,
 			Map::DEFAULT_HEIGHT
 		);
-		$this->assertArrayHasKey( $default_key, $stored );
+		$this->assertArrayHasKey( $default_key, $stored['osm'] );
 	}
 
 	/**
@@ -853,10 +873,10 @@ class Test_Map extends Base {
 
 		$this->assertCount(
 			1,
-			$descriptors_before,
+			$descriptors_before['osm'],
 			'Initial save should seed only the default combo.'
 		);
-		$this->assertArrayHasKey( $default_key, $descriptors_before );
+		$this->assertArrayHasKey( $default_key, $descriptors_before['osm'] );
 
 		// Request a different zoom — simulates a block customized to zoom 14.
 		// Auto width at 2:1 ratio against DEFAULT_HEIGHT → DEFAULT_HEIGHT*2.
@@ -878,9 +898,9 @@ class Test_Map extends Base {
 
 		$descriptors_after = $instance->get_all_descriptors( $post_id );
 
-		$this->assertCount( 2, $descriptors_after, 'New combo should have been cached.' );
-		$this->assertArrayHasKey( $new_key, $descriptors_after );
-		$this->assertSame( $url, $descriptors_after[ $new_key ]['url'] );
+		$this->assertCount( 2, $descriptors_after['osm'], 'New combo should have been cached.' );
+		$this->assertArrayHasKey( $new_key, $descriptors_after['osm'] );
+		$this->assertSame( $url, $descriptors_after['osm'][ $new_key ]['url'] );
 	}
 
 	/**
@@ -916,9 +936,9 @@ class Test_Map extends Base {
 		$key = sprintf( '%dx1000x500', Map::DEFAULT_ZOOM );
 		$all = $instance->get_all_descriptors( $post_id );
 
-		$this->assertArrayHasKey( $key, $all, 'Tall-height combo should be cached under its own key.' );
-		$this->assertSame( 500, $all[ $key ]['height'] );
-		$this->assertSame( 1000, $all[ $key ]['width'] );
+		$this->assertArrayHasKey( $key, $all['osm'], 'Tall-height combo should be cached under its own key.' );
+		$this->assertSame( 500, $all['osm'][ $key ]['height'] );
+		$this->assertSame( 1000, $all['osm'][ $key ]['width'] );
 	}
 
 	/**
@@ -954,7 +974,7 @@ class Test_Map extends Base {
 
 		$before = $instance->get_all_descriptors( $post_id );
 
-		$this->assertCount( 2, $before );
+		$this->assertCount( 2, $before['osm'] );
 
 		// Change the address. maybe_generate should regenerate both combos.
 		update_post_meta( $post_id, 'gatherpress_address', '60 29th Street #343, San Francisco, CA 94110' );
@@ -964,15 +984,15 @@ class Test_Map extends Base {
 
 		$after = $instance->get_all_descriptors( $post_id );
 
-		$this->assertCount( 2, $after, 'Both combos should still be present after regeneration.' );
+		$this->assertCount( 2, $after['osm'], 'Both combos should still be present after regeneration.' );
 		$this->assertNotSame(
-			$before[ $default_key ]['hash'],
-			$after[ $default_key ]['hash'],
+			$before['osm'][ $default_key ]['hash'],
+			$after['osm'][ $default_key ]['hash'],
 			'Default-combo hash should change with new coordinates.'
 		);
 		$this->assertNotSame(
-			$before[ $second_key ]['hash'],
-			$after[ $second_key ]['hash'],
+			$before['osm'][ $second_key ]['hash'],
+			$after['osm'][ $second_key ]['hash'],
 			'Second-combo hash should change with new coordinates.'
 		);
 
@@ -980,14 +1000,14 @@ class Test_Map extends Base {
 		// deleted — with address-based naming they may be shared, and GC is
 		// deferred to a follow-up pass.
 		$this->assertFileExists(
-			(string) $this->path_for_url( $after[ $default_key ]['url'] )
+			(string) $this->path_for_url( $after['osm'][ $default_key ]['url'] )
 		);
 		$this->assertFileExists(
-			(string) $this->path_for_url( $after[ $second_key ]['url'] )
+			(string) $this->path_for_url( $after['osm'][ $second_key ]['url'] )
 		);
 		$this->assertNotSame(
-			$before[ $default_key ]['url'],
-			$after[ $default_key ]['url'],
+			$before['osm'][ $default_key ]['url'],
+			$after['osm'][ $default_key ]['url'],
 			'Address change produces a different URL via the slug.'
 		);
 	}
@@ -1239,7 +1259,7 @@ class Test_Map extends Base {
 		$this->assertSame( 15, $descriptor['zoom'] );
 		$this->assertSame( 800, $descriptor['width'] );
 		$this->assertSame( 400, $descriptor['height'] );
-		$this->assertStringEndsWith( '1-infinite-loop-15-800-400.png', $descriptor['url'] );
+		$this->assertStringEndsWith( '1-infinite-loop-osm-15-800-400.png', $descriptor['url'] );
 	}
 
 	/**
@@ -1278,18 +1298,18 @@ class Test_Map extends Base {
 		$instance = Map::get_instance();
 
 		// Empty string → fallback slug.
-		$empty = Utility::invoke_hidden_method( $instance, 'filename_for', array( '', 15, 800, 400 ) );
-		$this->assertSame( 'venue-15-800-400.png', $empty );
+		$empty = Utility::invoke_hidden_method( $instance, 'filename_for', array( '', 15, 800, 400, 'osm' ) );
+		$this->assertSame( 'venue-osm-15-800-400.png', $empty );
 
 		// All-special-char input sanitize_title strips to '' → fallback.
-		$weird = Utility::invoke_hidden_method( $instance, 'filename_for', array( '!!!', 15, 800, 400 ) );
-		$this->assertSame( 'venue-15-800-400.png', $weird );
+		$weird = Utility::invoke_hidden_method( $instance, 'filename_for', array( '!!!', 15, 800, 400, 'osm' ) );
+		$this->assertSame( 'venue-osm-15-800-400.png', $weird );
 
 		// Long slugs get truncated so the full filename stays under fs caps.
 		$long    = str_repeat( 'a', 300 );
-		$result  = Utility::invoke_hidden_method( $instance, 'filename_for', array( $long, 18, 600, 300 ) );
+		$result  = Utility::invoke_hidden_method( $instance, 'filename_for', array( $long, 18, 600, 300, 'osm' ) );
 		$matches = array();
-		preg_match( '/^([a-z]+)-18-600-300\.png$/', $result, $matches );
+		preg_match( '/^([a-z]+)-osm-18-600-300\.png$/', $result, $matches );
 		$this->assertNotEmpty( $matches, 'Truncated filename still matches the expected pattern.' );
 		$this->assertSame( 150, strlen( $matches[1] ), 'Slug is capped at 150 characters.' );
 	}
@@ -1333,130 +1353,9 @@ class Test_Map extends Base {
 	}
 
 	/**
-	 * Returns null from fetch_tile when the HTTP response is an error.
-	 *
-	 * @covers ::fetch_tile
-	 *
-	 * @return void
-	 */
-	public function test_fetch_tile_returns_null_on_http_error(): void {
-		$instance = Map::get_instance();
-
-		// Replace the success stub with a WP_Error short-circuit just for this test.
-		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
-		$fail = static function () {
-			return new \WP_Error( 'boom', 'tile fetch failed' );
-		};
-		add_filter( 'pre_http_request', $fail, 10 );
-
-		$this->assertNull(
-			$instance->fetch_tile( 15, 1, 1, Map::DEFAULT_TILE_URL )
-		);
-
-		remove_filter( 'pre_http_request', $fail, 10 );
-		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
-	}
-
-	/**
-	 * Returns null from fetch_tile when the HTTP response is not 200 OK.
-	 *
-	 * @covers ::fetch_tile
-	 *
-	 * @return void
-	 */
-	public function test_fetch_tile_returns_null_on_non_200_response(): void {
-		$instance = Map::get_instance();
-
-		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
-		$not_found = static function () {
-			return array(
-				'headers'  => array(),
-				'body'     => '',
-				'response' => array(
-					'code'    => 404,
-					'message' => 'Not Found',
-				),
-				'cookies'  => array(),
-				'filename' => null,
-			);
-		};
-		add_filter( 'pre_http_request', $not_found, 10 );
-
-		$this->assertNull(
-			$instance->fetch_tile( 15, 1, 1, Map::DEFAULT_TILE_URL )
-		);
-
-		remove_filter( 'pre_http_request', $not_found, 10 );
-		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
-	}
-
-	/**
-	 * Returns PNG bytes from fetch_tile when the request succeeds.
-	 *
-	 * @covers ::fetch_tile
-	 *
-	 * @return void
-	 */
-	public function test_fetch_tile_returns_png_bytes(): void {
-		$instance = Map::get_instance();
-
-		$this->assertSame(
-			$this->tile_png,
-			$instance->fetch_tile( 15, 1, 1, Map::DEFAULT_TILE_URL )
-		);
-	}
-
-	/**
-	 * Directly exercise composite_image so coverage credits the method entry.
-	 *
-	 * @covers ::composite_image
-	 *
-	 * @return void
-	 */
-	public function test_composite_image_returns_gd_image(): void {
-		$instance = Map::get_instance();
-
-		$image = $instance->composite_image(
-			37.3318,
-			-122.0312,
-			15,
-			512,
-			256,
-			Map::DEFAULT_TILE_URL
-		);
-
-		$this->assertInstanceOf( \GdImage::class, $image );
-		$this->assertSame( 512, imagesx( $image ) );
-		$this->assertSame( 256, imagesy( $image ) );
-
-		imagedestroy( $image );
-	}
-
-	/**
-	 * Draws a marker into the provided canvas.
-	 *
-	 * @covers ::stamp_marker
-	 *
-	 * @return void
-	 */
-	public function test_stamp_marker_draws_on_canvas(): void {
-		$instance = Map::get_instance();
-		$canvas   = imagecreatetruecolor( 40, 40 );
-		$instance->stamp_marker( $canvas, 20, 20 );
-
-		// The marker center should be white (inner dot).
-		$index = imagecolorat( $canvas, 20, 20 );
-		$rgb   = imagecolorsforindex( $canvas, $index );
-
-		$this->assertSame( 255, $rgb['red'] );
-		$this->assertSame( 255, $rgb['green'] );
-		$this->assertSame( 255, $rgb['blue'] );
-
-		imagedestroy( $canvas );
-	}
-
-	/**
 	 * Writes the PNG and returns a URL inside the plugin uploads subdir.
+	 * Provider slug is baked into the filename so two providers' files for
+	 * the same venue + dimensions can coexist on disk.
 	 *
 	 * @covers ::save_image
 	 *
@@ -1466,12 +1365,12 @@ class Test_Map extends Base {
 		$instance = Map::get_instance();
 		$canvas   = imagecreatetruecolor( 10, 10 );
 
-		$url = $instance->save_image( $canvas, '1 Infinite Loop', 15, 800, 400 );
+		$url = $instance->save_image( $canvas, '1 Infinite Loop', 15, 800, 400, 1, 'osm' );
 		imagedestroy( $canvas );
 
 		$this->assertNotNull( $url, 'save_image should return a URL on success.' );
 		$this->assertStringContainsString( Map::UPLOADS_SUBDIR, $url );
-		$this->assertStringEndsWith( '1-infinite-loop-15-800-400.png', $url );
+		$this->assertStringEndsWith( '1-infinite-loop-osm-15-800-400.png', $url );
 
 		$path = $this->path_for_url( $url );
 		$this->assertFileExists( $path );
@@ -1619,22 +1518,6 @@ class Test_Map extends Base {
 	}
 
 	/**
-	 * Coverage for the generator's tile URL getter.
-	 *
-	 * @covers ::get_tile_url_template
-	 *
-	 * @return void
-	 */
-	public function test_get_tile_url_template(): void {
-		$instance = Map::get_instance();
-
-		$this->assertSame(
-			Map::DEFAULT_TILE_URL,
-			Utility::invoke_hidden_method( $instance, 'get_tile_url_template' )
-		);
-	}
-
-	/**
 	 * Coverage for combo_key — formats `{zoom}x{width}x{height}`.
 	 *
 	 * @covers ::combo_key
@@ -1676,19 +1559,21 @@ class Test_Map extends Base {
 			$post_id,
 			Map::META_KEY,
 			array(
-				'15x600x300'  => array(
-					'url'    => 'https://example.test/a.png',
-					'hash'   => 'abc',
-					'zoom'   => 15,
-					'width'  => 600,
-					'height' => 300,
-				),
-				'18x1000x500' => array(
-					'url'    => 'https://example.test/b.png',
-					'hash'   => 'def',
-					'zoom'   => 18,
-					'width'  => 1000,
-					'height' => 500,
+				'osm' => array(
+					'15x600x300'  => array(
+						'url'    => 'https://example.test/a.png',
+						'hash'   => 'abc',
+						'zoom'   => 15,
+						'width'  => 600,
+						'height' => 300,
+					),
+					'18x1000x500' => array(
+						'url'    => 'https://example.test/b.png',
+						'hash'   => 'def',
+						'zoom'   => 18,
+						'width'  => 1000,
+						'height' => 500,
+					),
 				),
 			)
 		);
@@ -1715,153 +1600,6 @@ class Test_Map extends Base {
 	}
 
 	/**
-	 * When the composite time budget is exhausted, the inner loop breaks
-	 * out and the canvas is returned with the pre-painted gray background
-	 * intact — no tiles fetched. Filter-driven so we don't have to wait
-	 * COMPOSITE_TIME_BUDGET seconds to exercise the branch.
-	 *
-	 * @covers ::composite_image
-	 *
-	 * @return void
-	 */
-	public function test_composite_image_aborts_when_time_budget_exhausted(): void {
-		$instance = Map::get_instance();
-
-		$fetches = 0;
-		$counter = static function () use ( &$fetches ) {
-			++$fetches;
-			return array(
-				'headers'  => array(),
-				'body'     => '',
-				'response' => array(
-					'code'    => 200,
-					'message' => 'OK',
-				),
-				'cookies'  => array(),
-				'filename' => null,
-			);
-		};
-		$budget  = static function () {
-			// A negative budget makes the deadline sit in the past from
-			// the first iteration, forcing break 2 before any fetch runs.
-			return -1;
-		};
-
-		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
-		add_filter( 'pre_http_request', $counter, 10 );
-		add_filter( 'gatherpress_venue_map_composite_time_budget', $budget );
-
-		$image = $instance->composite_image(
-			37.3318,
-			-122.0312,
-			15,
-			512,
-			256,
-			Map::DEFAULT_TILE_URL
-		);
-
-		remove_filter( 'gatherpress_venue_map_composite_time_budget', $budget );
-		remove_filter( 'pre_http_request', $counter, 10 );
-		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
-
-		$this->assertInstanceOf(
-			\GdImage::class,
-			$image,
-			'Canvas should still be returned when the budget is exhausted.'
-		);
-		$this->assertSame( 0, $fetches, 'No tiles should be fetched when the deadline is already in the past.' );
-
-		// Center pixel should remain the neutral-gray background color since
-		// no tile was drawn.
-		$index = imagecolorat( $image, 128, 64 );
-		$rgb   = imagecolorsforindex( $image, $index );
-		$this->assertSame( 238, $rgb['red'] );
-		$this->assertSame( 238, $rgb['green'] );
-		$this->assertSame( 238, $rgb['blue'] );
-
-		imagedestroy( $image );
-	}
-
-	/**
-	 * Survives a tile that fails to fetch (falls through, blank area).
-	 *
-	 * @covers ::composite_image
-	 *
-	 * @return void
-	 */
-	public function test_composite_image_continues_past_failed_fetch(): void {
-		$instance = Map::get_instance();
-
-		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
-		$fail = static function () {
-			return new \WP_Error( 'boom', 'tile fetch failed' );
-		};
-		add_filter( 'pre_http_request', $fail, 10 );
-
-		$image = $instance->composite_image(
-			37.3318,
-			-122.0312,
-			15,
-			512,
-			256,
-			Map::DEFAULT_TILE_URL
-		);
-
-		remove_filter( 'pre_http_request', $fail, 10 );
-		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
-
-		$this->assertInstanceOf(
-			\GdImage::class,
-			$image,
-			'A failed tile fetch should leave the canvas intact rather than nulling the result.'
-		);
-
-		imagedestroy( $image );
-	}
-
-	/**
-	 * Survives a tile whose response body is not a valid PNG.
-	 *
-	 * @covers ::composite_image
-	 *
-	 * @return void
-	 */
-	public function test_composite_image_continues_past_invalid_png(): void {
-		$instance = Map::get_instance();
-
-		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
-		$garbage = static function () {
-			return array(
-				'headers'  => array(),
-				'body'     => 'not a png',
-				'response' => array(
-					'code'    => 200,
-					'message' => 'OK',
-				),
-				'cookies'  => array(),
-				'filename' => null,
-			);
-		};
-		add_filter( 'pre_http_request', $garbage, 10 );
-
-		$image = $instance->composite_image(
-			37.3318,
-			-122.0312,
-			15,
-			512,
-			256,
-			Map::DEFAULT_TILE_URL
-		);
-
-		remove_filter( 'pre_http_request', $garbage, 10 );
-		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
-
-		$this->assertInstanceOf( \GdImage::class, $image );
-
-		imagedestroy( $image );
-	}
-
-	/**
 	 * Returns null from save_image when wp_get_upload_dir reports an error.
 	 *
 	 * @covers ::save_image
@@ -1878,7 +1616,7 @@ class Test_Map extends Base {
 		};
 		add_filter( 'upload_dir', $force_error );
 
-		$url = $instance->save_image( $canvas, 'test address', 15, 800, 400 );
+		$url = $instance->save_image( $canvas, 'test address', 15, 800, 400, 1, 'osm' );
 
 		remove_filter( 'upload_dir', $force_error );
 		imagedestroy( $canvas );
@@ -1917,31 +1655,6 @@ class Test_Map extends Base {
 		$this->assertNull(
 			$instance->get_stored_descriptor( $post_id ),
 			'No descriptor should be stored when save_image fails.'
-		);
-	}
-
-	/**
-	 * Coverage for the lng/lat → world-pixel conversions.
-	 *
-	 * Verifies the canonical slippy-map invariants: `lng = 0, zoom = 0` sits
-	 * at the middle of the 256-pixel world, and `lat = 0` likewise.
-	 *
-	 * @covers ::lng_to_world_pixel
-	 * @covers ::lat_to_world_pixel
-	 *
-	 * @return void
-	 */
-	public function test_world_pixel_conversions(): void {
-		$instance = Map::get_instance();
-
-		$this->assertSame(
-			128.0,
-			Utility::invoke_hidden_method( $instance, 'lng_to_world_pixel', array( 0.0, 0 ) )
-		);
-		$this->assertEqualsWithDelta(
-			128.0,
-			Utility::invoke_hidden_method( $instance, 'lat_to_world_pixel', array( 0.0, 0 ) ),
-			0.000001
 		);
 	}
 
@@ -2096,14 +1809,14 @@ class Test_Map extends Base {
 		$instance->get_url_for_post( $post_id, Venue::POST_TYPE, 14, 0, 500, '' );
 
 		$before = $instance->get_all_descriptors( $post_id );
-		$this->assertCount( 2, $before );
+		$this->assertCount( 2, $before['osm'] );
 
 		// Mark the pre-regenerate files so we can detect rewrites below.
 		// When inputs are unchanged the hash (and therefore the filename)
 		// stays the same, so we can't rely on url comparison alone — mtime
 		// is the signal that the tile fetch + compositing ran again.
 		$pre_mtimes = array();
-		foreach ( $before as $combo_key => $descriptor ) {
+		foreach ( $before['osm'] as $combo_key => $descriptor ) {
 			$path                     = (string) $this->path_for_url( $descriptor['url'] );
 			$pre_mtimes[ $combo_key ] = filemtime( $path );
 		}
@@ -2113,13 +1826,13 @@ class Test_Map extends Base {
 
 		$this->assertCount(
 			2,
-			$result,
+			$result['osm'],
 			'regenerate() should return a descriptor for each previously cached combo.'
 		);
 
-		foreach ( $before as $combo_key => $old ) {
-			$this->assertArrayHasKey( $combo_key, $result );
-			$path = (string) $this->path_for_url( $result[ $combo_key ]['url'] );
+		foreach ( $before['osm'] as $combo_key => $old ) {
+			$this->assertArrayHasKey( $combo_key, $result['osm'] );
+			$path = (string) $this->path_for_url( $result['osm'][ $combo_key ]['url'] );
 			$this->assertFileExists(
 				$path,
 				sprintf( 'Post-regenerate PNG for %s should exist on disk.', $combo_key )
@@ -2158,12 +1871,12 @@ class Test_Map extends Base {
 		$expected_key = '8x590x295';
 		$this->assertArrayHasKey(
 			$expected_key,
-			$result,
+			$result['osm'],
 			'The caller-supplied combo must be included in the rebuild.'
 		);
-		$this->assertSame( 8, $result[ $expected_key ]['zoom'] );
-		$this->assertSame( 590, $result[ $expected_key ]['width'] );
-		$this->assertSame( 295, $result[ $expected_key ]['height'] );
+		$this->assertSame( 8, $result['osm'][ $expected_key ]['zoom'] );
+		$this->assertSame( 590, $result['osm'][ $expected_key ]['width'] );
+		$this->assertSame( 295, $result['osm'][ $expected_key ]['height'] );
 	}
 
 	/**
@@ -2193,7 +1906,7 @@ class Test_Map extends Base {
 
 		$this->assertCount(
 			1,
-			$result,
+			$result['osm'],
 			'Supplying the already-cached combo should not add a duplicate entry.'
 		);
 	}
@@ -2225,7 +1938,7 @@ class Test_Map extends Base {
 			Map::DEFAULT_HEIGHT * 2,
 			Map::DEFAULT_HEIGHT
 		);
-		$this->assertArrayHasKey( $default_key, $result );
+		$this->assertArrayHasKey( $default_key, $result['osm'] );
 	}
 
 	/**
@@ -2314,7 +2027,8 @@ class Test_Map extends Base {
 			Map::DEFAULT_HEIGHT * 2,
 			Map::DEFAULT_HEIGHT
 		);
-		$this->assertArrayHasKey( $default_key, (array) $data['descriptors'] );
+		$this->assertArrayHasKey( 'osm', (array) $data['descriptors'] );
+		$this->assertArrayHasKey( $default_key, (array) $data['descriptors']['osm'] );
 	}
 
 	/**
@@ -2544,147 +2258,18 @@ class Test_Map extends Base {
 		$one_x = Utility::invoke_hidden_method(
 			$instance,
 			'filename_for',
-			array( '1 Infinite Loop', 15, 800, 400, 1 )
+			array( '1 Infinite Loop', 15, 800, 400, 'osm', 1 )
 		);
 		$two_x = Utility::invoke_hidden_method(
 			$instance,
 			'filename_for',
-			array( '1 Infinite Loop', 15, 800, 400, 2 )
+			array( '1 Infinite Loop', 15, 800, 400, 'osm', 2 )
 		);
 
-		$this->assertSame( '1-infinite-loop-15-800-400.png', $one_x );
-		$this->assertSame( '1-infinite-loop-15-800-400@2x.png', $two_x );
+		$this->assertSame( '1-infinite-loop-osm-15-800-400.png', $one_x );
+		$this->assertSame( '1-infinite-loop-osm-15-800-400@2x.png', $two_x );
 	}
 
-	/**
-	 * Passing `density=2` doubles the canvas dimensions and pulls tiles
-	 * from `zoom+1` so the retina variant contains true 2× detail rather
-	 * than upscaled 1× pixels. The 1× default is unchanged.
-	 *
-	 * @covers ::composite_image
-	 *
-	 * @return void
-	 */
-	public function test_composite_image_density_two_doubles_canvas(): void {
-		$instance = Map::get_instance();
-
-		// `short_circuit_tile_requests` (installed in setUp) stubs every
-		// outbound tile request with the shared 1×1 PNG, so this call
-		// never touches CartoDB — we only care that the *canvas* GD hands
-		// back is sized correctly, not what it was composited from.
-		$image = $instance->composite_image(
-			37.3318,
-			-122.0312,
-			15,
-			400,
-			200,
-			Map::DEFAULT_TILE_URL,
-			2
-		);
-
-		$this->assertInstanceOf( \GdImage::class, $image );
-		$this->assertSame( 800, imagesx( $image ), 'Retina canvas width is 2× the 1× value.' );
-		$this->assertSame( 400, imagesy( $image ), 'Retina canvas height is 2× the 1× value.' );
-
-		imagedestroy( $image );
-	}
-
-	/**
-	 * Density=2 must fetch tiles at `zoom + 1`. If the compositor uses
-	 * zoom+1 coords against zoom-N tile URLs the server 404s every request
-	 * and the canvas renders as gray — the bug this test locks down.
-	 *
-	 * @covers ::composite_image
-	 *
-	 * @return void
-	 */
-	public function test_composite_image_density_two_fetches_zoom_plus_one_tiles(): void {
-		$instance = Map::get_instance();
-
-		$zooms_seen = array();
-		$spy        = function ( $preempt, $args, $url ) use ( &$zooms_seen ) {
-			unset( $args );
-			$path = (string) wp_parse_url( $url, PHP_URL_PATH );
-			// CartoDB template: /light_all/{z}/{x}/{y}.png — the `{z}`
-			// segment is what composite_image() is supposed to bump by 1
-			// when density > 1.
-			if ( preg_match( '#/light_all/(\d+)/\d+/\d+\.png$#', $path, $m ) ) {
-				$zooms_seen[] = (int) $m[1];
-			}
-
-			return array(
-				'headers'  => array(),
-				'body'     => $this->tile_png,
-				'response' => array(
-					'code'    => 200,
-					'message' => 'OK',
-				),
-				'cookies'  => array(),
-				'filename' => null,
-			);
-		};
-
-		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
-		add_filter( 'pre_http_request', $spy, 10, 3 );
-
-		$image = $instance->composite_image(
-			37.3318,
-			-122.0312,
-			15,
-			400,
-			200,
-			Map::DEFAULT_TILE_URL,
-			2
-		);
-
-		remove_filter( 'pre_http_request', $spy, 10 );
-		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
-
-		imagedestroy( $image );
-
-		$this->assertNotEmpty( $zooms_seen, 'Retina composite must attempt at least one tile fetch.' );
-		$this->assertSame(
-			array( 16 ),
-			array_values( array_unique( $zooms_seen ) ),
-			'All retina tile requests must go to zoom + 1.'
-		);
-	}
-
-	/**
-	 * `$scale > 1` proportionally grows the marker so a retina composite
-	 * doesn't shrink the pin to a pinprick. Checks the "outer white halo"
-	 * radius by sampling a pixel that is outside the 1× marker but inside
-	 * the 2× marker.
-	 *
-	 * @covers ::stamp_marker
-	 *
-	 * @return void
-	 */
-	public function test_stamp_marker_scales_radii(): void {
-		$instance = Map::get_instance();
-		$canvas   = imagecreatetruecolor( 80, 80 );
-
-		// Seed the canvas with a distinctive background so we can tell a
-		// stamped pixel from an untouched one.
-		$bg = imagecolorallocate( $canvas, 0, 0, 0 );
-		imagefilledrectangle( $canvas, 0, 0, 79, 79, $bg );
-
-		$instance->stamp_marker( $canvas, 40, 40, 2.0 );
-
-		// 15px from center: outside the 1× halo (radius ~10), inside the 2×
-		// halo (radius ~20). Any non-background pixel here proves the scale
-		// factor actually grew the marker.
-		$index = imagecolorat( $canvas, 40, 25 );
-		$rgb   = imagecolorsforindex( $canvas, $index );
-
-		$this->assertNotSame(
-			array( 0, 0, 0 ),
-			array( $rgb['red'], $rgb['green'], $rgb['blue'] ),
-			'A pixel 15px above the marker center is only painted when the marker is scaled.'
-		);
-
-		imagedestroy( $canvas );
-	}
 
 	/**
 	 * With the default (filter unchanged) the retina variant is generated
@@ -2777,12 +2362,14 @@ class Test_Map extends Base {
 			$post_id,
 			Map::META_KEY,
 			array(
-				'15x600x300' => array(
-					'url'    => 'https://example.test/legacy.png',
-					'hash'   => 'abc',
-					'zoom'   => 15,
-					'width'  => 600,
-					'height' => 300,
+				'osm' => array(
+					'15x600x300' => array(
+						'url'    => 'https://example.test/legacy.png',
+						'hash'   => 'abc',
+						'zoom'   => 15,
+						'width'  => 600,
+						'height' => 300,
+					),
 				),
 			)
 		);
@@ -2791,12 +2378,12 @@ class Test_Map extends Base {
 
 		$this->assertArrayHasKey(
 			'url_2x',
-			$descriptors['15x600x300'],
+			$descriptors['osm']['15x600x300'],
 			'Legacy descriptors still expose url_2x to callers.'
 		);
 		$this->assertSame(
 			'',
-			$descriptors['15x600x300']['url_2x'],
+			$descriptors['osm']['15x600x300']['url_2x'],
 			'Missing url_2x normalizes to empty string.'
 		);
 	}
@@ -2951,103 +2538,6 @@ class Test_Map extends Base {
 			$expected_2x_path,
 			'No @2x file must be written when the tile zoom would exceed the provider ceiling.'
 		);
-	}
-
-	/**
-	 * `composite_image()` clamps `tile_zoom` to `ZOOM_MAX` as
-	 * defense-in-depth. When a caller invokes it directly at the ceiling
-	 * the retina pass still returns a canvas — degraded (same zoom as 1×,
-	 * just larger) but not the broken all-gray PNG you'd get if we let
-	 * zoom+1 requests sail past the provider's max.
-	 *
-	 * @covers ::composite_image
-	 *
-	 * @return void
-	 */
-	public function test_composite_image_clamps_tile_zoom_to_ceiling(): void {
-		$instance = Map::get_instance();
-
-		$zooms_seen = array();
-		$spy        = function ( $preempt, $args, $url ) use ( &$zooms_seen ) {
-			unset( $args );
-			$path = (string) wp_parse_url( $url, PHP_URL_PATH );
-			if ( preg_match( '#/light_all/(\d+)/\d+/\d+\.png$#', $path, $m ) ) {
-				$zooms_seen[] = (int) $m[1];
-			}
-
-			return array(
-				'headers'  => array(),
-				'body'     => $this->tile_png,
-				'response' => array(
-					'code'    => 200,
-					'message' => 'OK',
-				),
-				'cookies'  => array(),
-				'filename' => null,
-			);
-		};
-
-		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
-		add_filter( 'pre_http_request', $spy, 10, 3 );
-
-		$image = $instance->composite_image(
-			37.3318,
-			-122.0312,
-			Map::ZOOM_MAX,
-			400,
-			200,
-			Map::DEFAULT_TILE_URL,
-			Map::RETINA_DENSITY
-		);
-
-		remove_filter( 'pre_http_request', $spy, 10 );
-		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
-
-		imagedestroy( $image );
-
-		$this->assertNotEmpty( $zooms_seen, 'Retina composite at the ceiling must still attempt tile fetches.' );
-		$this->assertSame(
-			array( Map::ZOOM_MAX ),
-			array_values( array_unique( $zooms_seen ) ),
-			'Tile fetches must clamp to ZOOM_MAX instead of overshooting to zoom+1 above the provider ceiling.'
-		);
-	}
-
-	/**
-	 * Densities outside the supported allow-list (1, 2) are coerced back
-	 * to 1. Without this `(int) log(3, 2) === 1` would produce a
-	 * canvas-tripled-but-only-zoom+1-tiles image — a cheap upscale that
-	 * wastes disk for no retina win.
-	 *
-	 * @covers ::composite_image
-	 *
-	 * @return void
-	 */
-	public function test_composite_image_coerces_unsupported_density_back_to_one(): void {
-		$instance = Map::get_instance();
-
-		$image = $instance->composite_image(
-			37.3318,
-			-122.0312,
-			15,
-			400,
-			200,
-			Map::DEFAULT_TILE_URL,
-			3
-		);
-
-		$this->assertSame(
-			400,
-			imagesx( $image ),
-			'Unsupported density must fall back to 1× canvas width.'
-		);
-		$this->assertSame(
-			200,
-			imagesy( $image ),
-			'Unsupported density must fall back to 1× canvas height.'
-		);
-
-		imagedestroy( $image );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
@@ -13,8 +13,8 @@
 namespace GatherPress\Tests\Core\Venue\Map;
 
 use GatherPress\Core\Settings;
+use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Manager;
-use GatherPress\Core\Venue\Map\Map;
 use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue;
 use GatherPress\Tests\Base;

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
@@ -1,18 +1,18 @@
 <?php
 /**
- * Unit tests for GatherPress\Core\Venue\Map.
+ * Unit tests for GatherPress\Core\Venue\Map\Map.
  *
- * These tests cover the generator's hash logic, the save/regenerate/cleanup
- * lifecycle, and the hook wiring. The tile fetcher is stubbed via an HTTP
- * short-circuit filter so tests never make a real network call.
+ * Covers the orchestrator's hash logic, the save/regenerate/cleanup
+ * lifecycle, and the hook wiring. Provider-specific compositing tests
+ * live in the OSM provider's own test class.
  *
- * @package GatherPress\Core\Venue
+ * @package GatherPress\Core\Venue\Map
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core\Venue;
+namespace GatherPress\Tests\Core\Venue\Map;
 
-use GatherPress\Core\Venue\Map;
+use GatherPress\Core\Venue\Map\Map;
 use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue;
 use GatherPress\Tests\Base;
@@ -22,7 +22,7 @@ use PMC\Unit_Test\Utility;
  * Class Test_Map.
  *
  * @group multisite
- * @coversDefaultClass \GatherPress\Core\Venue\Map
+ * @coversDefaultClass \GatherPress\Core\Venue\Map\Map
  */
 class Test_Map extends Base {
 	/**

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
@@ -2658,35 +2658,26 @@ class Test_Map extends Base {
 	}
 
 	/**
-	 * Flipping `map_platform` triggers the same prewarm pass that runs on
-	 * theme switches — every venue's combos get re-enqueued so the new
-	 * provider's PNG files land in the background.
+	 * Flipping `map_platform` falls through to the prewarm subsystem —
+	 * `Prewarm::on_theme_switched()` is invoked. Smoke test only; whether
+	 * cron jobs actually land depends on template content the test
+	 * environment can't seed, so we just exercise the branch.
 	 *
 	 * @covers ::maybe_handle_settings_change
 	 *
 	 * @return void
 	 */
-	public function test_maybe_handle_settings_change_schedules_prewarm_on_platform_change(): void {
+	public function test_maybe_handle_settings_change_invokes_prewarm_on_platform_change(): void {
 		$instance = Map::get_instance();
 
-		// At least one venue with usable coordinates so the prewarm pass
-		// has something to enqueue.
-		$venue_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
-		add_post_meta( $venue_id, 'gatherpress_address', '1 Infinite Loop' );
-		add_post_meta( $venue_id, 'gatherpress_latitude', '37.3318' );
-		add_post_meta( $venue_id, 'gatherpress_longitude', '-122.0312' );
-
-		$old = array( 'map_platform' => 'osm' );
-		$new = array( 'map_platform' => 'google' );
-
-		$instance->maybe_handle_settings_change( $old, $new );
-
-		$this->assertTrue(
-			(bool) wp_next_scheduled( \GatherPress\Core\Venue\Map\Prewarm::CRON_ACTION, array( $venue_id ) ),
-			'Platform change must enqueue a warm job for each addressable venue.'
+		$instance->maybe_handle_settings_change(
+			array( 'map_platform' => 'osm' ),
+			array( 'map_platform' => 'google' )
 		);
 
-		wp_clear_scheduled_hook( \GatherPress\Core\Venue\Map\Prewarm::CRON_ACTION );
+		// Reaching this line proves the platform-change branch executed
+		// without a fatal — that's what coverage of 336-337 needs.
+		$this->assertTrue( true );
 	}
 
 	/**
@@ -2704,8 +2695,12 @@ class Test_Map extends Base {
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
-		// No coords on purpose — that prevents the active provider from
-		// rendering, forcing the fallback walk below.
+		add_post_meta( $post_id, 'gatherpress_latitude', '37.3318' );
+		add_post_meta( $post_id, 'gatherpress_longitude', '-122.0312' );
+
+		// Seed a `google`-keyed descriptor for the combo the orchestrator
+		// will request. Active provider (the null-stub registered below)
+		// returns null, so the fallback chain must surface this entry.
 		$key = sprintf( '%dx%dx%d', Map::DEFAULT_ZOOM, Map::DEFAULT_HEIGHT * 2, Map::DEFAULT_HEIGHT );
 		update_post_meta(
 			$post_id,
@@ -2724,7 +2719,17 @@ class Test_Map extends Base {
 			)
 		);
 
-		$descriptor = $instance->get_descriptor_for_post( $post_id, Venue::POST_TYPE );
+		$null_provider = $this->make_null_provider( 'fallback-stub' );
+		$manager       = Manager::get_instance();
+		$manager->register( $null_provider );
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'fallback-stub' ) );
+
+		try {
+			$descriptor = $instance->get_descriptor_for_post( $post_id, Venue::POST_TYPE );
+		} finally {
+			$this->reset_manager_to_core_providers( $manager );
+			delete_option( Settings::OPTION_NAME );
+		}
 
 		$this->assertIsArray( $descriptor );
 		$this->assertSame( 'https://example.test/google.png', $descriptor['url'] );
@@ -2867,13 +2872,17 @@ class Test_Map extends Base {
 	/**
 	 * `ensure_descriptor_for_combo()` returns null when the manager has
 	 * no active provider (bootstrap hasn't run, or every provider was
-	 * unregistered by a misconfigured companion plugin).
+	 * unregistered by a misconfigured companion plugin). The persisted
+	 * `map_platform` default is `osm`, so emptying the registry trips
+	 * the misconfigured-slug warning on the way through — expected.
 	 *
 	 * @covers ::ensure_descriptor_for_combo
 	 *
 	 * @return void
 	 */
 	public function test_ensure_descriptor_for_combo_returns_null_when_no_active_provider(): void {
+		$this->setExpectedIncorrectUsage( Manager::class . '::get_active' );
+
 		$instance = Map::get_instance();
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
@@ -2881,9 +2890,8 @@ class Test_Map extends Base {
 		add_post_meta( $post_id, 'gatherpress_latitude', '37.3318' );
 		add_post_meta( $post_id, 'gatherpress_longitude', '-122.0312' );
 
-		// Wipe the registry so get_active() returns null.
-		$manager  = Manager::get_instance();
-		$original = Utility::set_and_get_hidden_property( $manager, 'providers', array() );
+		$manager = Manager::get_instance();
+		Utility::set_and_get_hidden_property( $manager, 'providers', array() );
 
 		try {
 			$result = Utility::invoke_hidden_method(
@@ -2902,8 +2910,7 @@ class Test_Map extends Base {
 				)
 			);
 		} finally {
-			Utility::set_and_get_hidden_property( $manager, 'providers', $original );
-			$manager->register_core_providers();
+			$this->reset_manager_to_core_providers( $manager );
 		}
 
 		$this->assertNull( $result );
@@ -2926,17 +2933,68 @@ class Test_Map extends Base {
 		add_post_meta( $post_id, 'gatherpress_latitude', '37.3318' );
 		add_post_meta( $post_id, 'gatherpress_longitude', '-122.0312' );
 
-		// Anonymous provider whose render() always returns null. Wired
-		// into Manager and selected via `map_platform` so the orchestrator
-		// resolves to it.
-		$null_provider = new class() extends \GatherPress\Core\Venue\Map\Provider\Base {
+		$null_provider = $this->make_null_provider( 'always-null' );
+		$manager       = Manager::get_instance();
+		$manager->register( $null_provider );
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'always-null' ) );
+
+		try {
+			$result = Utility::invoke_hidden_method(
+				$instance,
+				'ensure_descriptor_for_combo',
+				array(
+					$post_id,
+					array(
+						'address'   => '1 Infinite Loop',
+						'latitude'  => '37.3318',
+						'longitude' => '-122.0312',
+					),
+					Map::DEFAULT_ZOOM,
+					800,
+					400,
+				)
+			);
+		} finally {
+			delete_option( Settings::OPTION_NAME );
+			$this->reset_manager_to_core_providers( $manager );
+		}
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Build a Map\Provider\Base subclass whose `render()` always returns
+	 * null. Used by the fallback-chain and null-render coverage tests so
+	 * each can swap in a deterministic non-OSM active provider.
+	 *
+	 * @param string $slug Slug to advertise via `get_slug()`.
+	 * @return \GatherPress\Core\Venue\Map\Provider\Base
+	 */
+	private function make_null_provider( string $slug ): \GatherPress\Core\Venue\Map\Provider\Base {
+		return new class( $slug ) extends \GatherPress\Core\Venue\Map\Provider\Base {
+			/**
+			 * Slug captured from the constructor.
+			 *
+			 * @var string
+			 */
+			private $slug;
+
+			/**
+			 * Capture the slug to advertise.
+			 *
+			 * @param string $slug Slug.
+			 */
+			public function __construct( string $slug ) {
+				$this->slug = $slug;
+			}
+
 			/**
 			 * Provider slug.
 			 *
 			 * @return string
 			 */
 			public function get_slug(): string {
-				return 'always-null';
+				return $this->slug;
 			}
 
 			/**
@@ -2970,35 +3028,17 @@ class Test_Map extends Base {
 				return null;
 			}
 		};
+	}
 
-		$manager = Manager::get_instance();
-		$manager->register( $null_provider );
-		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'always-null' ) );
-
-		try {
-			$result = Utility::invoke_hidden_method(
-				$instance,
-				'ensure_descriptor_for_combo',
-				array(
-					$post_id,
-					array(
-						'address'   => '1 Infinite Loop',
-						'latitude'  => '37.3318',
-						'longitude' => '-122.0312',
-					),
-					Map::DEFAULT_ZOOM,
-					800,
-					400,
-				)
-			);
-		} finally {
-			delete_option( Settings::OPTION_NAME );
-			$providers = Utility::set_and_get_hidden_property( $manager, 'providers', array() );
-			unset( $providers['always-null'] );
-			Utility::set_and_get_hidden_property( $manager, 'providers', $providers );
-			$manager->register_core_providers();
-		}
-
-		$this->assertNull( $result );
+	/**
+	 * Wipe the registry and reinstantiate just the core providers. Lets a
+	 * test that mutates Manager state leave it in a clean baseline.
+	 *
+	 * @param Manager $manager Manager instance.
+	 * @return void
+	 */
+	private function reset_manager_to_core_providers( Manager $manager ): void {
+		Utility::set_and_get_hidden_property( $manager, 'providers', array() );
+		$manager->register_core_providers();
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
@@ -2658,16 +2658,17 @@ class Test_Map extends Base {
 	}
 
 	/**
-	 * Flipping `map_platform` falls through to the prewarm subsystem —
-	 * `Prewarm::on_theme_switched()` is invoked. Smoke test only; whether
-	 * cron jobs actually land depends on template content the test
-	 * environment can't seed, so we just exercise the branch.
+	 * Flipping `map_platform` schedules a single deferred cron sweep
+	 * via `Prewarm::schedule_full_sweep()` — the heavy template + venue
+	 * rescan runs on the next tick, not inline on the admin save.
 	 *
 	 * @covers ::maybe_handle_settings_change
 	 *
 	 * @return void
 	 */
-	public function test_maybe_handle_settings_change_invokes_prewarm_on_platform_change(): void {
+	public function test_maybe_handle_settings_change_schedules_deferred_sweep(): void {
+		wp_clear_scheduled_hook( \GatherPress\Core\Venue\Map\Prewarm::FULL_SWEEP_ACTION );
+
 		$instance = Map::get_instance();
 
 		$instance->maybe_handle_settings_change(
@@ -2675,9 +2676,12 @@ class Test_Map extends Base {
 			array( 'map_platform' => 'google' )
 		);
 
-		// Reaching this line proves the platform-change branch executed
-		// without a fatal — that's what coverage of 336-337 needs.
-		$this->assertTrue( true );
+		$this->assertNotFalse(
+			wp_next_scheduled( \GatherPress\Core\Venue\Map\Prewarm::FULL_SWEEP_ACTION ),
+			'Platform change must defer the rescan via the FULL_SWEEP_ACTION cron.'
+		);
+
+		wp_clear_scheduled_hook( \GatherPress\Core\Venue\Map\Prewarm::FULL_SWEEP_ACTION );
 	}
 
 	/**
@@ -2698,15 +2702,26 @@ class Test_Map extends Base {
 		add_post_meta( $post_id, 'gatherpress_latitude', '37.3318' );
 		add_post_meta( $post_id, 'gatherpress_longitude', '-122.0312' );
 
-		// Seed a `google`-keyed descriptor for the combo the orchestrator
-		// will request. Active provider (the null-stub registered below)
-		// returns null, so the fallback chain must surface this entry.
+		// Seed two providers: the active slug AND `google`. The active
+		// slug's entry is what proves the `continue` skip in the fallback
+		// walk fires; the google entry is what the walk should ultimately
+		// return.
 		$key = sprintf( '%dx%dx%d', Map::DEFAULT_ZOOM, Map::DEFAULT_HEIGHT * 2, Map::DEFAULT_HEIGHT );
 		update_post_meta(
 			$post_id,
 			Map::META_KEY,
 			array(
-				'google' => array(
+				'fallback-stub' => array(
+					$key => array(
+						'url'    => 'https://example.test/active-but-unusable.png',
+						'url_2x' => '',
+						'hash'   => 'xyz',
+						'zoom'   => Map::DEFAULT_ZOOM,
+						'width'  => Map::DEFAULT_HEIGHT * 2,
+						'height' => Map::DEFAULT_HEIGHT,
+					),
+				),
+				'google'        => array(
 					$key => array(
 						'url'    => 'https://example.test/google.png',
 						'url_2x' => '',
@@ -2736,8 +2751,9 @@ class Test_Map extends Base {
 	}
 
 	/**
-	 * When neither the active provider nor any other provider has a
-	 * matching combo, `get_descriptor_for_post()` returns null.
+	 * When the active provider can't render and no other provider has a
+	 * matching combo in storage, `get_descriptor_for_post()` falls
+	 * through the walk and returns null.
 	 *
 	 * @covers ::get_descriptor_for_post
 	 *
@@ -2748,8 +2764,11 @@ class Test_Map extends Base {
 		$post_id  = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 
 		add_post_meta( $post_id, 'gatherpress_address', '1 Infinite Loop' );
-		// Stored combo doesn't match the requested combo, no coords to
-		// satisfy active-provider render either.
+		add_post_meta( $post_id, 'gatherpress_latitude', '37.3318' );
+		add_post_meta( $post_id, 'gatherpress_longitude', '-122.0312' );
+
+		// Stored combo deliberately mismatches what the orchestrator
+		// will request, so the fallback walk completes without a match.
 		update_post_meta(
 			$post_id,
 			Map::META_KEY,
@@ -2767,9 +2786,22 @@ class Test_Map extends Base {
 			)
 		);
 
-		$this->assertNull(
-			$instance->get_descriptor_for_post( $post_id, Venue::POST_TYPE )
-		);
+		// Null-active provider so the active branch of
+		// `ensure_descriptor_for_combo` returns null, exercising the
+		// fallback walk in `get_descriptor_for_post`.
+		$null_provider = $this->make_null_provider( 'no-combo-active' );
+		$manager       = Manager::get_instance();
+		$manager->register( $null_provider );
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'no-combo-active' ) );
+
+		try {
+			$result = $instance->get_descriptor_for_post( $post_id, Venue::POST_TYPE );
+		} finally {
+			$this->reset_manager_to_core_providers( $manager );
+			delete_option( Settings::OPTION_NAME );
+		}
+
+		$this->assertNull( $result );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
@@ -1,26 +1,26 @@
 <?php
 /**
- * Unit tests for GatherPress\Core\Venue\Map_Prewarm.
+ * Unit tests for GatherPress\Core\Venue\Map\Prewarm.
  *
- * @package GatherPress\Core\Venue
+ * @package GatherPress\Core\Venue\Map
  * @since 1.0.0
  */
 
-namespace GatherPress\Tests\Core\Venue;
+namespace GatherPress\Tests\Core\Venue\Map;
 
-use GatherPress\Core\Venue\Map;
-use GatherPress\Core\Venue\Map_Prewarm;
+use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map\Prewarm;
 use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 
 /**
- * Class Test_Map_Prewarm.
+ * Class Test_Prewarm.
  *
- * @coversDefaultClass \GatherPress\Core\Venue\Map_Prewarm
+ * @coversDefaultClass \GatherPress\Core\Venue\Map\Prewarm
  */
-class Test_Map_Prewarm extends Base {
+class Test_Prewarm extends Base {
 	/**
 	 * Clear scheduled warm events between tests — wp_next_scheduled lookups
 	 * otherwise leak across cases and skew dedup assertions.
@@ -30,7 +30,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function tear_down(): void {
-		wp_clear_scheduled_hook( Map_Prewarm::CRON_ACTION );
+		wp_clear_scheduled_hook( Prewarm::CRON_ACTION );
 		parent::tear_down();
 	}
 
@@ -44,11 +44,11 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_setup_hooks(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 		$hooks    = array(
 			array(
 				'type'     => 'action',
-				'name'     => Map_Prewarm::CRON_ACTION,
+				'name'     => Prewarm::CRON_ACTION,
 				'priority' => 10,
 				'callback' => array( $instance, 'process_warm_job' ),
 			),
@@ -77,7 +77,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_collect_combos_from_content_ignores_unrelated_markup(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$result = Utility::invoke_hidden_method(
 			$instance,
@@ -106,7 +106,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_collect_combos_from_content_extracts_single_block(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 		$content  = '<!-- wp:gatherpress/venue-map {"zoom":15,"width":0,"height":400,"aspectRatio":"16/9"} /-->';
 
 		$result = Utility::invoke_hidden_method(
@@ -135,7 +135,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_walk_blocks_for_combos_recurses_inner_blocks(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 		$content  = '<!-- wp:gatherpress/venue -->'
 			. '<div class="wp-block-gatherpress-venue">'
 			. '<!-- wp:gatherpress/venue-map {"zoom":10,"width":800,"height":400,"aspectRatio":"2/1"} /-->'
@@ -161,7 +161,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_extract_block_combo_uses_venue_map_defaults(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$result = Utility::invoke_hidden_method(
 			$instance,
@@ -183,7 +183,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_dedupe_combos_collapses_duplicates(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 		$combos   = array(
 			array(
 				'zoom'         => 15,
@@ -222,7 +222,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_warm_job_schedules_cron_event(): void {
-		$instance      = Map_Prewarm::get_instance();
+		$instance      = Prewarm::get_instance();
 		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$combo         = array(
 			'zoom'         => 15,
@@ -238,7 +238,7 @@ class Test_Map_Prewarm extends Base {
 		);
 
 		$scheduled = wp_next_scheduled(
-			Map_Prewarm::CRON_ACTION,
+			Prewarm::CRON_ACTION,
 			array( $venue_post_id, 15, 800, 400, '2/1' )
 		);
 		$this->assertNotFalse( $scheduled, 'Warm job is scheduled.' );
@@ -253,7 +253,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_warm_job_deduplicates_identical_args(): void {
-		$instance      = Map_Prewarm::get_instance();
+		$instance      = Prewarm::get_instance();
 		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$combo         = array(
 			'zoom'         => 15,
@@ -264,13 +264,13 @@ class Test_Map_Prewarm extends Base {
 
 		Utility::invoke_hidden_method( $instance, 'enqueue_warm_job', array( $venue_post_id, $combo ) );
 		$first_timestamp = wp_next_scheduled(
-			Map_Prewarm::CRON_ACTION,
+			Prewarm::CRON_ACTION,
 			array( $venue_post_id, 15, 800, 400, '2/1' )
 		);
 
 		Utility::invoke_hidden_method( $instance, 'enqueue_warm_job', array( $venue_post_id, $combo ) );
 		$second_timestamp = wp_next_scheduled(
-			Map_Prewarm::CRON_ACTION,
+			Prewarm::CRON_ACTION,
 			array( $venue_post_id, 15, 800, 400, '2/1' )
 		);
 
@@ -289,7 +289,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_warm_job_filter_short_circuits_wp_cron_path(): void {
-		$instance      = Map_Prewarm::get_instance();
+		$instance      = Prewarm::get_instance();
 		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$combo         = array(
 			'zoom'         => 15,
@@ -316,13 +316,13 @@ class Test_Map_Prewarm extends Base {
 
 		$this->assertFalse(
 			wp_next_scheduled(
-				Map_Prewarm::CRON_ACTION,
+				Prewarm::CRON_ACTION,
 				array( $venue_post_id, 15, 800, 400, '2/1' )
 			),
 			'Default WP-Cron path must be suppressed when the filter returns non-null.'
 		);
 		$this->assertCount( 1, $seen, 'Filter is invoked exactly once per enqueue call.' );
-		$this->assertSame( Map_Prewarm::CRON_ACTION, $seen[0]['hook'] );
+		$this->assertSame( Prewarm::CRON_ACTION, $seen[0]['hook'] );
 		$this->assertSame(
 			array( $venue_post_id, 15, 800, 400, '2/1' ),
 			$seen[0]['args'],
@@ -343,7 +343,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_warm_job_filter_falsy_non_null_values_still_short_circuit(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		foreach ( array( false, 0, '' ) as $index => $falsy_return ) {
 			$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
@@ -366,7 +366,7 @@ class Test_Map_Prewarm extends Base {
 
 			$this->assertFalse(
 				wp_next_scheduled(
-					Map_Prewarm::CRON_ACTION,
+					Prewarm::CRON_ACTION,
 					array( $venue_post_id, 15, 800 + $index, 400, '2/1' )
 				),
 				sprintf(
@@ -387,7 +387,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_warm_job_filter_returning_null_preserves_default_path(): void {
-		$instance      = Map_Prewarm::get_instance();
+		$instance      = Prewarm::get_instance();
 		$venue_post_id = $this->factory->post->create( array( 'post_type' => Venue::POST_TYPE ) );
 		$combo         = array(
 			'zoom'         => 15,
@@ -407,7 +407,7 @@ class Test_Map_Prewarm extends Base {
 
 		$this->assertNotFalse(
 			wp_next_scheduled(
-				Map_Prewarm::CRON_ACTION,
+				Prewarm::CRON_ACTION,
 				array( $venue_post_id, 15, 800, 400, '2/1' )
 			),
 			'Null return from the filter must fall through to wp_schedule_single_event().'
@@ -425,7 +425,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_enqueues_for_venue(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		// Create a venue so get_venue_post_ids has at least one result when
 		// the template save would fan out; the test itself doesn't care
@@ -443,7 +443,7 @@ class Test_Map_Prewarm extends Base {
 		$instance->on_post_saved( $venue_post_id, $post );
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Prewarm::CRON_ACTION ),
 			'No combos means no scheduled warm jobs.'
 		);
 	}
@@ -457,7 +457,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_ignores_revisions(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$venue_post_id = $this->factory->post->create(
 			array(
@@ -475,7 +475,7 @@ class Test_Map_Prewarm extends Base {
 		$instance->on_post_saved( $revision_id, $revision );
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Prewarm::CRON_ACTION ),
 			'Revisions do not enqueue warm jobs.'
 		);
 	}
@@ -490,7 +490,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_skips_non_published_posts(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		foreach ( array( 'draft', 'auto-draft', 'trash' ) as $status ) {
 			$venue_post_id = $this->factory->post->create(
@@ -504,7 +504,7 @@ class Test_Map_Prewarm extends Base {
 		}
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Prewarm::CRON_ACTION ),
 			'Non-published saves enqueue nothing.'
 		);
 	}
@@ -519,7 +519,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_process_warm_job_is_safe_for_missing_venue(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		// No exception: warm() returns null for non-existent post IDs, and
 		// the cron handler is expected to swallow that outcome silently.
@@ -537,7 +537,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_fan_outs_template_save_to_all_venues(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$venue_a = $this->factory->post->create(
 			array(
@@ -565,14 +565,14 @@ class Test_Map_Prewarm extends Base {
 
 		$this->assertNotFalse(
 			wp_next_scheduled(
-				Map_Prewarm::CRON_ACTION,
+				Prewarm::CRON_ACTION,
 				array( $venue_a, 15, 800, 400, '2/1' )
 			),
 			'Venue A received a warm job for the template combo.'
 		);
 		$this->assertNotFalse(
 			wp_next_scheduled(
-				Map_Prewarm::CRON_ACTION,
+				Prewarm::CRON_ACTION,
 				array( $venue_b, 15, 800, 400, '2/1' )
 			),
 			'Venue B received a warm job for the template combo.'
@@ -589,7 +589,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_skips_template_without_venue_map(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$this->factory->post->create(
 			array(
@@ -609,7 +609,7 @@ class Test_Map_Prewarm extends Base {
 		$instance->on_post_saved( $template_id, get_post( $template_id ) );
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Prewarm::CRON_ACTION ),
 			'Templates without venue-map blocks enqueue nothing.'
 		);
 	}
@@ -625,7 +625,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_theme_switched_runs_without_error(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$this->factory->post->create(
 			array(
@@ -650,7 +650,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_get_venue_post_ids_returns_published_venues(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$published = $this->factory->post->create(
 			array(
@@ -681,7 +681,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_event_enqueues_via_linked_venue(): void {
-		$instance    = Map_Prewarm::get_instance();
+		$instance    = Prewarm::get_instance();
 		$venue_setup = Setup::get_instance();
 
 		$venue_post_id = $this->factory->post->create(
@@ -709,7 +709,7 @@ class Test_Map_Prewarm extends Base {
 
 		$this->assertNotFalse(
 			wp_next_scheduled(
-				Map_Prewarm::CRON_ACTION,
+				Prewarm::CRON_ACTION,
 				array( $venue_post_id, 12, 600, 300, '2/1' )
 			),
 			'Event save enqueues a warm job against the linked venue.'
@@ -725,7 +725,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_event_skips_when_no_venue_term(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$event_post_id = $this->factory->post->create(
 			array(
@@ -739,7 +739,7 @@ class Test_Map_Prewarm extends Base {
 		$instance->on_post_saved( $event_post_id, get_post( $event_post_id ) );
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Prewarm::CRON_ACTION ),
 			'Event with no venue term enqueues nothing.'
 		);
 	}
@@ -755,7 +755,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_collect_all_template_combos_paginates_event_content(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$this->factory->post->create(
 			array(
@@ -810,10 +810,10 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_get_content_scan_batch_size_applies_filter_and_clamps(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$this->assertSame(
-			Map_Prewarm::CONTENT_SCAN_BATCH_SIZE,
+			Prewarm::CONTENT_SCAN_BATCH_SIZE,
 			Utility::invoke_hidden_method( $instance, 'get_content_scan_batch_size' ),
 			'Default matches the CONTENT_SCAN_BATCH_SIZE constant.'
 		);
@@ -867,10 +867,10 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_get_scan_batch_size_applies_filter_and_clamps(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$this->assertSame(
-			Map_Prewarm::SCAN_BATCH_SIZE,
+			Prewarm::SCAN_BATCH_SIZE,
 			Utility::invoke_hidden_method( $instance, 'get_scan_batch_size' ),
 			'Default matches the SCAN_BATCH_SIZE constant.'
 		);
@@ -912,7 +912,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_for_all_venues_paginates(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$venue_ids = array(
 			$this->factory->post->create(
@@ -956,7 +956,7 @@ class Test_Map_Prewarm extends Base {
 		foreach ( $venue_ids as $venue_post_id ) {
 			$this->assertNotFalse(
 				wp_next_scheduled(
-					Map_Prewarm::CRON_ACTION,
+					Prewarm::CRON_ACTION,
 					array( $venue_post_id, 11, 500, 250, '2/1' )
 				),
 				sprintf( 'Venue %d received a warm job through the paginated loop.', $venue_post_id )
@@ -974,7 +974,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_collect_and_get_ids_paginate(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$this->factory->post->create(
 			array(
@@ -1033,7 +1033,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_enqueue_for_venue_schedules_jobs_for_each_combo(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$venue_post_id = $this->factory->post->create(
 			array(
@@ -1061,7 +1061,7 @@ class Test_Map_Prewarm extends Base {
 
 		$this->assertNotFalse(
 			wp_next_scheduled(
-				Map_Prewarm::CRON_ACTION,
+				Prewarm::CRON_ACTION,
 				array( $venue_post_id, 13, 700, 350, '2/1' )
 			),
 			'Venue received a warm job for the combo surfaced via enqueue_for_venue.'
@@ -1080,7 +1080,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_scans_short_circuit_without_venue_types(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		// Temporarily unregister the venue-information support so the
 		// gatherpress-venue-information feature has no matching post types.
@@ -1113,7 +1113,7 @@ class Test_Map_Prewarm extends Base {
 		}
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Prewarm::CRON_ACTION ),
 			'No venue types means no scheduled warm jobs.'
 		);
 		$this->assertSame( array(), $ids, 'get_venue_post_ids returns [] when no venue types are registered.' );
@@ -1135,7 +1135,7 @@ class Test_Map_Prewarm extends Base {
 			$this->markTestSkipped( 'WP_Block_Template not available in this environment.' );
 		}
 
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$template          = new \WP_Block_Template();
 		$template->content = '<!-- wp:gatherpress/venue-map '
@@ -1187,7 +1187,7 @@ class Test_Map_Prewarm extends Base {
 	 * @return void
 	 */
 	public function test_on_post_saved_event_skips_when_no_combos(): void {
-		$instance = Map_Prewarm::get_instance();
+		$instance = Prewarm::get_instance();
 
 		$event_post_id = $this->factory->post->create(
 			array(
@@ -1200,7 +1200,7 @@ class Test_Map_Prewarm extends Base {
 		$instance->on_post_saved( $event_post_id, get_post( $event_post_id ) );
 
 		$this->assertFalse(
-			(bool) wp_next_scheduled( Map_Prewarm::CRON_ACTION ),
+			(bool) wp_next_scheduled( Prewarm::CRON_ACTION ),
 			'No combos in event content means no cron jobs.'
 		);
 	}

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
@@ -8,7 +8,7 @@
 
 namespace GatherPress\Tests\Core\Venue\Map;
 
-use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Prewarm;
 use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue;

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
@@ -31,6 +31,7 @@ class Test_Prewarm extends Base {
 	 */
 	public function tear_down(): void {
 		wp_clear_scheduled_hook( Prewarm::CRON_ACTION );
+		wp_clear_scheduled_hook( Prewarm::FULL_SWEEP_ACTION );
 		parent::tear_down();
 	}
 
@@ -54,6 +55,12 @@ class Test_Prewarm extends Base {
 			),
 			array(
 				'type'     => 'action',
+				'name'     => Prewarm::FULL_SWEEP_ACTION,
+				'priority' => 10,
+				'callback' => array( $instance, 'on_theme_switched' ),
+			),
+			array(
+				'type'     => 'action',
 				'name'     => 'wp_after_insert_post',
 				'priority' => 12,
 				'callback' => array( $instance, 'on_post_saved' ),
@@ -67,6 +74,34 @@ class Test_Prewarm extends Base {
 		);
 
 		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * `schedule_full_sweep()` queues a single one-shot cron event for
+	 * the FULL_SWEEP_ACTION. Repeat calls coalesce — only one event
+	 * sits in the queue at a time so a burst of platform-saves
+	 * doesn't pile up duplicate sweeps.
+	 *
+	 * @covers ::schedule_full_sweep
+	 *
+	 * @return void
+	 */
+	public function test_schedule_full_sweep_is_idempotent(): void {
+		wp_clear_scheduled_hook( Prewarm::FULL_SWEEP_ACTION );
+
+		$instance = Prewarm::get_instance();
+
+		$instance->schedule_full_sweep();
+		$first = wp_next_scheduled( Prewarm::FULL_SWEEP_ACTION );
+
+		$this->assertNotFalse( $first, 'A one-shot sweep must be queued.' );
+
+		$instance->schedule_full_sweep();
+		$second = wp_next_scheduled( Prewarm::FULL_SWEEP_ACTION );
+
+		$this->assertSame( $first, $second, 'Repeat calls must not queue a second event.' );
+
+		wp_clear_scheduled_hook( Prewarm::FULL_SWEEP_ACTION );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-setup.php
@@ -64,4 +64,26 @@ class Test_Setup extends Base {
 			);
 		}
 	}
+
+	/**
+	 * Construction of the singleton runs `instantiate_classes()` so the
+	 * subsystem boots in one line from `Venue\Setup`. The plugin
+	 * bootstrap creates the instance long before this test class loads,
+	 * so reset the cached static `$instance` to force a fresh
+	 * construction and credit the `__construct()` body to coverage.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_runs_instantiate_classes(): void {
+		$reflection = new \ReflectionClass( Setup::class );
+		$property   = $reflection->getProperty( 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+
+		$instance = Setup::get_instance();
+
+		$this->assertInstanceOf( Setup::class, $instance );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-setup.php
@@ -8,8 +8,8 @@
 
 namespace GatherPress\Tests\Core\Venue\Map;
 
+use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Manager;
-use GatherPress\Core\Venue\Map\Map;
 use GatherPress\Core\Venue\Map\Prewarm;
 use GatherPress\Core\Venue\Map\Setup;
 use GatherPress\Tests\Base;

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-setup.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Unit tests for GatherPress\Core\Venue\Map\Setup.
+ *
+ * @package GatherPress\Core\Venue\Map
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Core\Venue\Map;
+
+use GatherPress\Core\Venue\Map\Manager;
+use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map\Prewarm;
+use GatherPress\Core\Venue\Map\Setup;
+use GatherPress\Tests\Base;
+use PMC\Unit_Test\Utility;
+
+/**
+ * Class Test_Setup.
+ *
+ * @coversDefaultClass \GatherPress\Core\Venue\Map\Setup
+ */
+class Test_Setup extends Base {
+	/**
+	 * Map\Setup is the hub for the venue map subsystem — its
+	 * `instantiate_classes()` is what wires Manager / Map / Prewarm so
+	 * `Venue\Setup` can hand off in one line. Per-sibling
+	 * proof-of-construction via each one's distinctive
+	 * `setup_hooks()`-registered callback. Catches the case where a
+	 * sibling silently drops out of `instantiate_classes()`.
+	 *
+	 * @covers ::__construct
+	 * @covers ::instantiate_classes
+	 *
+	 * @return void
+	 */
+	public function test_instantiate_classes_registers_siblings(): void {
+		Utility::invoke_hidden_method( Setup::get_instance(), 'instantiate_classes' );
+
+		$expected_hooks = array(
+			Manager::class => array(
+				'gatherpress_loaded',
+				array( Manager::get_instance(), 'register_core_providers' ),
+				1,
+			),
+			Map::class     => array(
+				'rest_api_init',
+				array( Map::get_instance(), 'register_rest_routes' ),
+				10,
+			),
+			Prewarm::class => array(
+				'switch_theme',
+				array( Prewarm::get_instance(), 'on_theme_switched' ),
+				10,
+			),
+		);
+
+		foreach ( $expected_hooks as $class_name => $expected ) {
+			list( $hook, $callback, $priority ) = $expected;
+			$this->assertSame(
+				$priority,
+				has_action( $hook, $callback ),
+				sprintf( '%s must be instantiated so its %s hook registers.', $class_name, $hook )
+			);
+		}
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-setup.php
@@ -39,9 +39,9 @@ class Test_Setup extends Base {
 
 		$expected_hooks = array(
 			Manager::class => array(
-				'gatherpress_loaded',
-				array( Manager::get_instance(), 'register_core_providers' ),
-				1,
+				'init',
+				array( Manager::get_instance(), 'do_register_action' ),
+				0,
 			),
 			Map::class     => array(
 				'rest_api_init',

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-base.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-base.php
@@ -115,7 +115,7 @@ class Test_Base extends GatherPress_Test_Base {
 				int $width,
 				int $height,
 				int $density = 1
-			): ?\GdImage {
+			) {
 				return null;
 			}
 
@@ -177,7 +177,7 @@ class Test_Base extends GatherPress_Test_Base {
 				int $width,
 				int $height,
 				int $density = 1
-			): ?\GdImage {
+			) {
 				return null;
 			}
 		};

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-base.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-base.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Unit tests for GatherPress\Core\Venue\Map\Provider\Base.
+ *
+ * Covers the abstract provider's default `attribution_html`,
+ * `supports_map_type`, and `supported_map_types` implementations — the
+ * three methods that subclasses can lean on without overriding.
+ *
+ * @package GatherPress\Core\Venue\Map\Provider
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Core\Venue\Map\Provider;
+
+use GatherPress\Core\Venue\Map\Provider\Base;
+use GatherPress\Tests\Base as GatherPress_Test_Base;
+
+/**
+ * Class Test_Base.
+ *
+ * @coversDefaultClass \GatherPress\Core\Venue\Map\Provider\Base
+ */
+class Test_Base extends GatherPress_Test_Base {
+	/**
+	 * Default `attribution_html()` returns an empty string — providers that
+	 * bake attribution into the rendered PNG (Google) inherit this; OSM
+	 * overrides it.
+	 *
+	 * @covers ::attribution_html
+	 *
+	 * @return void
+	 */
+	public function test_attribution_html_default_is_empty(): void {
+		$provider = $this->make_minimal_provider();
+
+		$this->assertSame( '', $provider->attribution_html() );
+	}
+
+	/**
+	 * Default `supported_map_types()` returns just `['roadmap']` —
+	 * a minimal provider only ships the basemap. Subclasses that ship
+	 * satellite/hybrid/terrain override this.
+	 *
+	 * @covers ::supported_map_types
+	 *
+	 * @return void
+	 */
+	public function test_supported_map_types_default(): void {
+		$provider = $this->make_minimal_provider();
+
+		$this->assertSame( array( 'roadmap' ), $provider->supported_map_types() );
+	}
+
+	/**
+	 * `supports_map_type()` returns true only for types declared by
+	 * `supported_map_types()`.
+	 *
+	 * @covers ::supports_map_type
+	 *
+	 * @return void
+	 */
+	public function test_supports_map_type_matches_supported_list(): void {
+		$provider = $this->make_minimal_provider();
+
+		$this->assertTrue( $provider->supports_map_type( 'roadmap' ) );
+		$this->assertFalse( $provider->supports_map_type( 'satellite' ) );
+		$this->assertFalse( $provider->supports_map_type( 'hybrid' ) );
+		$this->assertFalse( $provider->supports_map_type( 'terrain' ) );
+	}
+
+	/**
+	 * Subclasses that override `supported_map_types()` flow through
+	 * `supports_map_type()` automatically — the default impl uses
+	 * `in_array()` against whatever the subclass returns.
+	 *
+	 * @covers ::supports_map_type
+	 *
+	 * @return void
+	 */
+	public function test_supports_map_type_honors_subclass_override(): void {
+		$provider = new class() extends Base {
+			/**
+			 * Slug.
+			 *
+			 * @return string
+			 */
+			public function get_slug(): string {
+				return 'multi';
+			}
+
+			/**
+			 * Label.
+			 *
+			 * @return string
+			 */
+			public function get_label(): string {
+				return 'Multi';
+			}
+
+			/**
+			 * No-op render — this stub is only used for type-list assertions.
+			 *
+			 * @param float $latitude  Unused.
+			 * @param float $longitude Unused.
+			 * @param int   $zoom      Unused.
+			 * @param int   $width     Unused.
+			 * @param int   $height    Unused.
+			 * @param int   $density   Unused.
+			 * @return null
+			 */
+			public function render(
+				float $latitude,
+				float $longitude,
+				int $zoom,
+				int $width,
+				int $height,
+				int $density = 1
+			): ?\GdImage {
+				return null;
+			}
+
+			/**
+			 * Override the default to expose extra map types.
+			 *
+			 * @return string[]
+			 */
+			public function supported_map_types(): array {
+				return array( 'roadmap', 'satellite' );
+			}
+		};
+
+		$this->assertTrue( $provider->supports_map_type( 'satellite' ) );
+		$this->assertFalse( $provider->supports_map_type( 'terrain' ) );
+	}
+
+	/**
+	 * Build a minimal anonymous Base subclass — the smallest legal
+	 * provider that exercises only the default method bodies.
+	 *
+	 * @return Base
+	 */
+	private function make_minimal_provider(): Base {
+		return new class() extends Base {
+			/**
+			 * Slug.
+			 *
+			 * @return string
+			 */
+			public function get_slug(): string {
+				return 'minimal';
+			}
+
+			/**
+			 * Label.
+			 *
+			 * @return string
+			 */
+			public function get_label(): string {
+				return 'Minimal';
+			}
+
+			/**
+			 * No-op render — this stub never produces a PNG.
+			 *
+			 * @param float $latitude  Unused.
+			 * @param float $longitude Unused.
+			 * @param int   $zoom      Unused.
+			 * @param int   $width     Unused.
+			 * @param int   $height    Unused.
+			 * @param int   $density   Unused.
+			 * @return null
+			 */
+			public function render(
+				float $latitude,
+				float $longitude,
+				int $zoom,
+				int $width,
+				int $height,
+				int $density = 1
+			): ?\GdImage {
+				return null;
+			}
+		};
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -12,7 +12,7 @@
 
 namespace GatherPress\Tests\Core\Venue\Map\Provider;
 
-use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Provider\OSM;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
@@ -492,5 +492,51 @@ class Test_OSM extends Base {
 		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
 
 		$this->assertInstanceOf( GdImage::class, $canvas );
+	}
+
+	/**
+	 * `imagecreatefromstring()` can emit a PHP warning (which the test
+	 * runner converts to an exception via `convertWarningsToExceptions`)
+	 * when bytes start with a recognizable image-format magic but are
+	 * corrupt downstream — e.g. a truncated PNG. The try/catch around
+	 * the decode swallows the throw and falls through to "skip this
+	 * tile" so the whole composite doesn't fatal.
+	 *
+	 * @covers ::render
+	 *
+	 * @return void
+	 */
+	public function test_render_swallows_imagecreatefromstring_throw(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension is not available.' );
+		}
+
+		// PNG signature followed by garbage — PHP recognizes the magic
+		// bytes, attempts to read the IHDR chunk, fails, emits a warning.
+		$truncated_png = "\x89PNG\r\n\x1a\n" . str_repeat( "\x00", 50 );
+
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		$broken = static function () use ( $truncated_png ) {
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'body'     => $truncated_png,
+				'headers'  => array(),
+			);
+		};
+		add_filter( 'pre_http_request', $broken, 10 );
+
+		$canvas = ( new OSM() )->render( 37.3318, -122.0312, 15, 512, 256 );
+
+		remove_filter( 'pre_http_request', $broken, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+
+		$this->assertInstanceOf(
+			GdImage::class,
+			$canvas,
+			'A throw from imagecreatefromstring() must be caught and the composite must complete.'
+		);
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -495,48 +495,53 @@ class Test_OSM extends Base {
 	}
 
 	/**
-	 * `imagecreatefromstring()` can emit a PHP warning (which the test
-	 * runner converts to an exception via `convertWarningsToExceptions`)
-	 * when bytes start with a recognizable image-format magic but are
-	 * corrupt downstream — e.g. a truncated PNG. The try/catch around
-	 * the decode swallows the throw and falls through to "skip this
-	 * tile" so the whole composite doesn't fatal.
+	 * `decode_tile()` returns a GdImage when the bytes parse cleanly —
+	 * happy path. Use `fetch_tile`'s short-circuit stub to source real
+	 * PNG bytes so this isn't a tautology against a hand-crafted blob.
 	 *
-	 * @covers ::render
+	 * @covers ::decode_tile
 	 *
 	 * @return void
 	 */
-	public function test_render_swallows_imagecreatefromstring_throw(): void {
+	public function test_decode_tile_returns_image_for_valid_bytes(): void {
 		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
 			$this->markTestSkipped( 'GD extension is not available.' );
 		}
 
-		// PNG signature followed by garbage — PHP recognizes the magic
-		// bytes, attempts to read the IHDR chunk, fails, emits a warning.
-		$truncated_png = "\x89PNG\r\n\x1a\n" . str_repeat( "\x00", 50 );
-
-		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
-		$broken = static function () use ( $truncated_png ) {
-			return array(
-				'response' => array(
-					'code'    => 200,
-					'message' => 'OK',
-				),
-				'body'     => $truncated_png,
-				'headers'  => array(),
-			);
-		};
-		add_filter( 'pre_http_request', $broken, 10 );
-
-		$canvas = ( new OSM() )->render( 37.3318, -122.0312, 15, 512, 256 );
-
-		remove_filter( 'pre_http_request', $broken, 10 );
-		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
-
-		$this->assertInstanceOf(
-			GdImage::class,
-			$canvas,
-			'A throw from imagecreatefromstring() must be caught and the composite must complete.'
+		$image = Utility::invoke_hidden_method(
+			new OSM(),
+			'decode_tile',
+			array( $this->tile_png )
 		);
+
+		$this->assertInstanceOf( GdImage::class, $image );
+		imagedestroy( $image );
+	}
+
+	/**
+	 * `decode_tile()` returns `false` when `imagecreatefromstring()`
+	 * throws — exercises the catch branch. Empty input throws on every
+	 * supported PHP version under PHPUnit:
+	 *
+	 * - PHP 8.0+: native `ValueError` for empty input.
+	 * - PHP 7.4 under PHPUnit: `E_WARNING` converted to a `Throwable`
+	 *   by `convertWarningsToExceptions=true` in `phpunit.xml.dist`.
+	 *
+	 * @covers ::decode_tile
+	 *
+	 * @return void
+	 */
+	public function test_decode_tile_returns_false_when_bytes_throw(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension is not available.' );
+		}
+
+		$result = Utility::invoke_hidden_method(
+			new OSM(),
+			'decode_tile',
+			array( '' )
+		);
+
+		$this->assertFalse( $result );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -1,0 +1,384 @@
+<?php
+/**
+ * Unit tests for GatherPress\Core\Venue\Map\Provider\OSM.
+ *
+ * Covers the OSM-specific compositing pipeline: tile fetching,
+ * render-time tile-budget short-circuiting, marker stamping, the Web
+ * Mercator pixel projection, and the filterable tile URL template.
+ *
+ * @package GatherPress\Core\Venue\Map\Provider
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Core\Venue\Map\Provider;
+
+use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map\Provider\OSM;
+use GatherPress\Tests\Base;
+use PMC\Unit_Test\Utility;
+use GdImage;
+
+/**
+ * Class Test_OSM.
+ *
+ * @coversDefaultClass \GatherPress\Core\Venue\Map\Provider\OSM
+ */
+class Test_OSM extends Base {
+	/**
+	 * Minimal valid 1×1 PNG used as a stand-in for every tile fetch.
+	 * Keeping the payload tiny means tests stay fast and any code path
+	 * that accidentally hits the real network shows up as a timeout.
+	 *
+	 * @var string
+	 */
+	private $tile_png;
+
+	/**
+	 * Installs the HTTP short-circuit on every test so no network is touched.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$png  = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42m';
+		$png .= 'NkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Fixed, trusted PNG payload for the tile-fetch stub.
+		$this->tile_png = base64_decode( $png );
+
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+	}
+
+	/**
+	 * Removes the filter on tear-down.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Short-circuit every HTTP request by returning the canned tile response.
+	 *
+	 * @param mixed  $preempt Default false.
+	 * @param array  $args    HTTP args (unused).
+	 * @param string $url     Request URL (unused).
+	 * @return array
+	 */
+	public function short_circuit_tile_requests( $preempt, $args, $url ): array {
+		unset( $args, $url );
+
+		return array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => $this->tile_png,
+			'headers'  => array(),
+		);
+	}
+
+	/**
+	 * Slug must be `osm` — it's the value persisted in `map_platform`,
+	 * filename slugs, and post-meta keys, so changing it would silently
+	 * orphan every existing PNG and stored descriptor on every site.
+	 *
+	 * @covers ::get_slug
+	 *
+	 * @return void
+	 */
+	public function test_get_slug_returns_osm(): void {
+		$this->assertSame( 'osm', ( new OSM() )->get_slug() );
+	}
+
+	/**
+	 * Label is human-facing, lives in the Settings dropdown.
+	 *
+	 * @covers ::get_label
+	 *
+	 * @return void
+	 */
+	public function test_get_label_returns_translatable_string(): void {
+		$this->assertSame( 'OpenStreetMap', ( new OSM() )->get_label() );
+	}
+
+	/**
+	 * OSM must surface the CartoDB + OpenStreetMap attribution — the
+	 * tile licenses require it, and the front end pulls this string into
+	 * the static-map markup. Verifying both providers appear catches
+	 * accidental partial-rewrite regressions.
+	 *
+	 * @covers ::attribution_html
+	 *
+	 * @return void
+	 */
+	public function test_attribution_html_includes_required_providers(): void {
+		$html = ( new OSM() )->attribution_html();
+
+		$this->assertStringContainsString( 'OpenStreetMap', $html );
+		$this->assertStringContainsString( 'CARTO', $html );
+		$this->assertStringContainsString( 'openstreetmap.org/copyright', $html );
+	}
+
+	/**
+	 * `fetch_tile()` substitutes `{z}/{x}/{y}` and returns the response
+	 * body on a 200.
+	 *
+	 * @covers ::fetch_tile
+	 *
+	 * @return void
+	 */
+	public function test_fetch_tile_returns_body_on_success(): void {
+		$bytes = ( new OSM() )->fetch_tile( 12, 34, 56, 'https://example.test/{z}/{x}/{y}.png' );
+
+		$this->assertSame( $this->tile_png, $bytes );
+	}
+
+	/**
+	 * `fetch_tile()` returns null when the response code is non-200 — a
+	 * blank patch in the composite is preferable to aborting the whole
+	 * render.
+	 *
+	 * @covers ::fetch_tile
+	 *
+	 * @return void
+	 */
+	public function test_fetch_tile_returns_null_for_non_200(): void {
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+
+		$callback = function () {
+			return array(
+				'response' => array(
+					'code'    => 404,
+					'message' => 'Not Found',
+				),
+				'body'     => '',
+				'headers'  => array(),
+			);
+		};
+
+		add_filter( 'pre_http_request', $callback );
+
+		$bytes = ( new OSM() )->fetch_tile( 1, 2, 3, 'https://example.test/{z}/{x}/{y}.png' );
+
+		remove_filter( 'pre_http_request', $callback );
+
+		$this->assertNull( $bytes );
+	}
+
+	/**
+	 * `fetch_tile()` returns null when the HTTP layer surfaces a WP_Error
+	 * (DNS failure, timeout, etc.).
+	 *
+	 * @covers ::fetch_tile
+	 *
+	 * @return void
+	 */
+	public function test_fetch_tile_returns_null_on_wp_error(): void {
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+
+		$callback = function () {
+			return new \WP_Error( 'http_request_failed', 'boom' );
+		};
+
+		add_filter( 'pre_http_request', $callback );
+
+		$bytes = ( new OSM() )->fetch_tile( 1, 2, 3, 'https://example.test/{z}/{x}/{y}.png' );
+
+		remove_filter( 'pre_http_request', $callback );
+
+		$this->assertNull( $bytes );
+	}
+
+	/**
+	 * `fetch_tile()` returns null when a 200 response has an empty body —
+	 * the caller treats both shapes the same (skip the tile).
+	 *
+	 * @covers ::fetch_tile
+	 *
+	 * @return void
+	 */
+	public function test_fetch_tile_returns_null_for_empty_body(): void {
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+
+		$callback = function () {
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'body'     => '',
+				'headers'  => array(),
+			);
+		};
+
+		add_filter( 'pre_http_request', $callback );
+
+		$bytes = ( new OSM() )->fetch_tile( 1, 2, 3, 'https://example.test/{z}/{x}/{y}.png' );
+
+		remove_filter( 'pre_http_request', $callback );
+
+		$this->assertNull( $bytes );
+	}
+
+	/**
+	 * `stamp_marker()` must paint pixels at the given coordinates —
+	 * sampling the canvas before/after proves the marker actually got
+	 * drawn rather than silently no-op'ing.
+	 *
+	 * @covers ::stamp_marker
+	 *
+	 * @return void
+	 */
+	public function test_stamp_marker_draws_at_coordinates(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension is not available.' );
+		}
+
+		$canvas = imagecreatetruecolor( 64, 64 );
+		$bg     = imagecolorallocate( $canvas, 238, 238, 238 );
+		imagefilledrectangle( $canvas, 0, 0, 63, 63, $bg );
+
+		$before = imagecolorat( $canvas, 32, 32 );
+
+		( new OSM() )->stamp_marker( $canvas, 32, 32, 1.0 );
+
+		$after = imagecolorat( $canvas, 32, 32 );
+
+		$this->assertNotSame( $before, $after );
+	}
+
+	/**
+	 * Web Mercator projection: longitude 0 maps to the equator-meridian
+	 * intersection, which sits exactly at the canvas mid-point at any
+	 * zoom. zoom=2 → 4 tiles wide → 512 world pixels at TILE_SIZE 256.
+	 *
+	 * @covers ::lng_to_world_pixel
+	 *
+	 * @return void
+	 */
+	public function test_lng_to_world_pixel_matches_mercator(): void {
+		$pixel = Utility::invoke_hidden_method( new OSM(), 'lng_to_world_pixel', array( 0.0, 2 ) );
+
+		$this->assertEqualsWithDelta( 512.0, $pixel, 0.0001 );
+	}
+
+	/**
+	 * Latitude 0 sits at the equator — half-way down the world raster on
+	 * any zoom. zoom=2 → 1024 world pixels tall → equator at 512.
+	 *
+	 * @covers ::lat_to_world_pixel
+	 *
+	 * @return void
+	 */
+	public function test_lat_to_world_pixel_matches_mercator(): void {
+		$pixel = Utility::invoke_hidden_method( new OSM(), 'lat_to_world_pixel', array( 0.0, 2 ) );
+
+		$this->assertEqualsWithDelta( 512.0, $pixel, 0.0001 );
+	}
+
+	/**
+	 * `gatherpress_venue_map_tile_url` is the public hook for repointing
+	 * at a different XYZ provider; verifying the value flows through the
+	 * filter is what makes that hook a real contract.
+	 *
+	 * @covers ::get_tile_url_template
+	 *
+	 * @return void
+	 */
+	public function test_get_tile_url_template_is_filterable(): void {
+		$override = 'https://tiles.example.test/{z}/{x}/{y}.png';
+
+		add_filter(
+			'gatherpress_venue_map_tile_url',
+			function () use ( $override ) {
+				return $override;
+			}
+		);
+
+		$template = Utility::invoke_hidden_method( new OSM(), 'get_tile_url_template' );
+
+		remove_all_filters( 'gatherpress_venue_map_tile_url' );
+
+		$this->assertSame( $override, $template );
+	}
+
+	/**
+	 * `render()` returns a finished, correctly-sized GdImage when the
+	 * tile fetch succeeds. End-to-end smoke for the public contract.
+	 *
+	 * @covers ::render
+	 *
+	 * @return void
+	 */
+	public function test_render_returns_canvas_at_requested_dimensions(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension is not available.' );
+		}
+
+		$canvas = ( new OSM() )->render( 40.7128, -74.0060, 12, 320, 240 );
+
+		$this->assertInstanceOf( GdImage::class, $canvas );
+		$this->assertSame( 320, imagesx( $canvas ) );
+		$this->assertSame( 240, imagesy( $canvas ) );
+	}
+
+	/**
+	 * `render()` for retina (density 2) doubles the canvas pixels —
+	 * 320×240 logical = 640×480 actual.
+	 *
+	 * @covers ::render
+	 *
+	 * @return void
+	 */
+	public function test_render_returns_doubled_canvas_for_retina_density(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension is not available.' );
+		}
+
+		$canvas = ( new OSM() )->render( 40.7128, -74.0060, 10, 320, 240, 2 );
+
+		$this->assertInstanceOf( GdImage::class, $canvas );
+		$this->assertSame( 640, imagesx( $canvas ) );
+		$this->assertSame( 480, imagesy( $canvas ) );
+	}
+
+	/**
+	 * Unsupported density values coerce back to 1× — `density=3` would
+	 * paint at 3× canvas using only 2× tiles, which is just a wasteful
+	 * upscale. Keep the canvas at 1× instead.
+	 *
+	 * @covers ::render
+	 *
+	 * @return void
+	 */
+	public function test_render_coerces_unsupported_density_to_one(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension is not available.' );
+		}
+
+		$canvas = ( new OSM() )->render( 40.7128, -74.0060, 10, 320, 240, 3 );
+
+		$this->assertInstanceOf( GdImage::class, $canvas );
+		$this->assertSame( 320, imagesx( $canvas ) );
+		$this->assertSame( 240, imagesy( $canvas ) );
+	}
+
+	/**
+	 * When the requested zoom plus retina bump exceeds Map::ZOOM_MAX, the
+	 * render is skipped (returns null) — orchestrator treats that as
+	 * "no retina at this combo" without erroring.
+	 *
+	 * @covers ::render
+	 *
+	 * @return void
+	 */
+	public function test_render_returns_null_when_retina_zoom_exceeds_max(): void {
+		$canvas = ( new OSM() )->render( 40.7128, -74.0060, Map::ZOOM_MAX, 320, 240, 2 );
+
+		$this->assertNull( $canvas );
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -381,4 +381,116 @@ class Test_OSM extends Base {
 
 		$this->assertNull( $canvas );
 	}
+
+	/**
+	 * When the wall-clock budget is exhausted between iterations, the
+	 * render loop breaks out and the canvas comes back with the
+	 * pre-painted gray background — no tiles fetched. Filter-driven so
+	 * we don't have to wait COMPOSITE_TIME_BUDGET seconds.
+	 *
+	 * @covers ::render
+	 *
+	 * @return void
+	 */
+	public function test_render_aborts_when_time_budget_exhausted(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension is not available.' );
+		}
+
+		$fetches = 0;
+		$counter = function () use ( &$fetches ) {
+			++$fetches;
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'body'     => $this->tile_png,
+				'headers'  => array(),
+			);
+		};
+		// Negative budget puts the deadline in the past from the first
+		// iteration, forcing `break 2` before any fetch runs.
+		$budget = static fn() => -1;
+
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		add_filter( 'pre_http_request', $counter, 10 );
+		add_filter( 'gatherpress_venue_map_composite_time_budget', $budget );
+
+		$canvas = ( new OSM() )->render( 37.3318, -122.0312, 15, 512, 256 );
+
+		remove_filter( 'gatherpress_venue_map_composite_time_budget', $budget );
+		remove_filter( 'pre_http_request', $counter, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+
+		$this->assertInstanceOf( GdImage::class, $canvas );
+		$this->assertSame( 0, $fetches, 'No tiles should be fetched when the deadline is already in the past.' );
+	}
+
+	/**
+	 * A failed tile fetch (HTTP error → fetch_tile returns null) is
+	 * skipped and the loop continues — the canvas still comes back, just
+	 * with a gray patch where the tile would have gone.
+	 *
+	 * @covers ::render
+	 *
+	 * @return void
+	 */
+	public function test_render_continues_past_failed_tile_fetch(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension is not available.' );
+		}
+
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		$fail = static function () {
+			return new \WP_Error( 'boom', 'tile fetch failed' );
+		};
+		add_filter( 'pre_http_request', $fail, 10 );
+
+		$canvas = ( new OSM() )->render( 37.3318, -122.0312, 15, 512, 256 );
+
+		remove_filter( 'pre_http_request', $fail, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+
+		$this->assertInstanceOf(
+			GdImage::class,
+			$canvas,
+			'Failed fetch should leave the canvas intact rather than nulling the result.'
+		);
+	}
+
+	/**
+	 * A response body that isn't a valid PNG is skipped — `imagecreate-
+	 * fromstring()` returns false and the loop moves on without aborting
+	 * the whole composite.
+	 *
+	 * @covers ::render
+	 *
+	 * @return void
+	 */
+	public function test_render_continues_past_invalid_png_body(): void {
+		if ( ! function_exists( 'imagecreatetruecolor' ) ) {
+			$this->markTestSkipped( 'GD extension is not available.' );
+		}
+
+		remove_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10 );
+		$garbage = static function () {
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'body'     => 'not a png',
+				'headers'  => array(),
+			);
+		};
+		add_filter( 'pre_http_request', $garbage, 10 );
+
+		$canvas = ( new OSM() )->render( 37.3318, -122.0312, 15, 512, 256 );
+
+		remove_filter( 'pre_http_request', $garbage, 10 );
+		add_filter( 'pre_http_request', array( $this, 'short_circuit_tile_requests' ), 10, 3 );
+
+		$this->assertInstanceOf( GdImage::class, $canvas );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -12,11 +12,12 @@
 
 namespace GatherPress\Tests\Core\Venue\Map\Provider;
 
+use ErrorException;
 use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Provider\OSM;
 use GatherPress\Tests\Base;
-use PMC\Unit_Test\Utility;
 use GdImage;
+use PMC\Unit_Test\Utility;
 
 /**
  * Class Test_OSM.
@@ -519,13 +520,17 @@ class Test_OSM extends Base {
 	}
 
 	/**
-	 * `decode_tile()` returns `false` when `imagecreatefromstring()`
-	 * throws — exercises the catch branch. Empty input throws on every
-	 * supported PHP version under PHPUnit:
+	 * `decode_tile()` returns `false` when the decode throws.
 	 *
-	 * - PHP 8.0+: native `ValueError` for empty input.
-	 * - PHP 7.4 under PHPUnit: `E_WARNING` converted to a `Throwable`
-	 *   by `convertWarningsToExceptions=true` in `phpunit.xml.dist`.
+	 * `imagecreatefromstring()` itself only emits an E_WARNING for
+	 * malformed bytes on most PHP builds, not a throw — and PHPUnit's
+	 * `convertWarningsToExceptions` setting isn't reliably active in the
+	 * wp-env test runner. To exercise the catch branch deterministically
+	 * we install our own error handler for the duration of the call,
+	 * which rethrows any warning as an `ErrorException` (a `Throwable`).
+	 * That's exactly the shape `decode_tile()` defends against in
+	 * production when WordPress core or another plugin sets up an
+	 * equivalent handler.
 	 *
 	 * @covers ::decode_tile
 	 *
@@ -536,11 +541,23 @@ class Test_OSM extends Base {
 			$this->markTestSkipped( 'GD extension is not available.' );
 		}
 
-		$result = Utility::invoke_hidden_method(
-			new OSM(),
-			'decode_tile',
-			array( '' )
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Test setup, restored in finally below.
+		set_error_handler(
+			static function ( int $errno, string $errstr ): bool {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Test-only handler; the exception is caught immediately by decode_tile().
+				throw new ErrorException( $errstr, 0, $errno );
+			}
 		);
+
+		try {
+			$result = Utility::invoke_hidden_method(
+				new OSM(),
+				'decode_tile',
+				array( '' )
+			);
+		} finally {
+			restore_error_handler();
+		}
 
 		$this->assertFalse( $result );
 	}


### PR DESCRIPTION
### Description of the Change

Refactors the venue static-map pipeline into a swappable provider strategy so adding a new map source (Google Static Maps in #1528, MapBox/MapTiler in companion plugins) is a single class rather than a fork of `Map`.

**What moved:**
- `includes/core/classes/venue/class-map.php` → `includes/core/classes/venue/map/class-map.php` (with a `GatherPress\Core\Venue\Map` → `Map\Map` class alias for back-compat).
- `includes/core/classes/venue/class-map-prewarm.php` → `includes/core/classes/venue/map/class-prewarm.php` (renamed `Map_Prewarm` → `Prewarm`; no alias since the class is alpha and has no external consumers yet).

**What's new:**
- `Map\Provider\Base` — abstract contract: `get_slug()`, `get_label()`, `render()` are required; `attribution_html()` / `supports_map_type()` / `supported_map_types()` have sensible defaults so a minimal provider compiles in three method bodies.
- `Map\Provider\OSM` — all CartoDB tile-composite logic (`fetch_tile`, `stamp_marker`, `lng_to_world_pixel`, `lat_to_world_pixel`, `get_tile_url_template`, the `COMPOSITE_TIME_BUDGET`) extracted out of the orchestrator. `render()` returns a finished, marker-stamped GdImage.
- `Map\Manager` — singleton registry. `register_core_providers()` registers OSM at `gatherpress_loaded` priority 1; `do_register_action()` fires `gatherpress_register_map_providers` at priority 5 so companion plugins can register on top. `get_active()` reads the `map_platform` setting, falls back to OSM when the configured slug isn't registered, and surfaces a `_doing_it_wrong` so site owners notice the misconfiguration in their debug log.
- `Map\Setup` — sibling-singleton hub. `Venue\Setup::instantiate_classes()` hands the whole map subsystem off in one line, matching the shape of `Event\Setup` / `Rsvp\Setup`.

**Orchestrator changes in `Map\Map`:**
- Post-meta descriptor is now provider-keyed: `[provider_slug => [combo_key => entry]]` instead of `[combo_key => entry]`. Filenames include the provider slug (`venue-osm-…png`).
- `get_descriptor_for_post()` has a render-time fallback chain — if the active provider can't produce a PNG for this combo (network error, missing API key, GD missing), walk other providers' stored entries for the same combo. So a site that switches OSM → Google before re-prewarming still shows the OSM PNG until the Google PNG lands.
- `maybe_handle_settings_change()` listens on `update_option_gatherpress_settings`; flipping `map_platform` schedules a fresh prewarm so the new provider's PNGs land in the background.
- Hash signature changed from `(info, zoom, width, height, tiles)` to `(info, zoom, width, height, provider)` — a provider switch invalidates cached PNGs even if the rendered URL would otherwise be identical.

**Out of scope (deferred to #1528):**
- The Google provider itself. The `map_platform` setting still lists Google in the dropdown; selecting it now triggers the OSM-fallback path with a logged `_doing_it_wrong`. Decisions that affect the Google implementation (slug contract, attribution defaults, density coercion, zoom pre-clamping, registration via the action) are documented in the comment thread on #1528 so the implementer doesn't have to re-derive them.

Closes #1527

### How to test the Change

1. `npm run lint:phpstan` — passes clean.
2. `npm run test:unit:php` — Map / Prewarm / Setup / Manager / Provider\Base / Provider\OSM test classes all pass; multisite group passes.
3. Activate the plugin on a fresh site, save a venue with a real address, confirm a `venue-osm-…png` lands in `wp-content/uploads/gatherpress/static-maps/` and the front-end venue-map block shows it.
4. Settings → Venues → Maps, change Mapping Platform to Google. Reload the venue page — same OSM PNG should still render (fallback chain), and `wp-debug.log` should contain a `_doing_it_wrong` notice from `Manager::get_active()` saying no provider is registered for `google`.
5. Flip back to OpenStreetMap, save a venue, confirm a fresh prewarm cycle runs (check the `gatherpress_warm_venue_map` cron schedule).
6. Add a `gatherpress_venue_map_tile_url` filter pointing at a different XYZ tile server — confirm the next render uses it.

### Changelog Entry

> Changed - Refactor venue Map into a swappable provider strategy with a provider-keyed cache and render-time fallback so switching providers keeps existing PNGs visible until new ones land.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.