### PR TITLE
Use WP-native taxonomy column for venues in the events admin list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,10 @@ When working with this codebase:
     - ❌ Bad: `new \GatherPress\Core\Event( $post_id )`
     - For functions: `use function GatherPress\Core\filter_input;` then `filter_input( $value )`
 - **Namespace resolution**: When moving code between namespaces, ensure proper imports are updated
+- **Cross-subsystem use aliases**: When importing a class from another subsystem that shares a name with a local one (every subsystem has its own `Setup`, for example), alias it. Keeps the bare token unambiguously referring to the local same-namespace class and makes the cross-subsystem import announce itself at every call site.
+    - ✅ Good (in `GatherPress\Core\Event\Admin_List`): `use GatherPress\Core\Venue\Setup as Venue_Setup;` → `Venue_Setup::get_instance()`
+    - ❌ Bad (silently shadows the local `Event\Setup`): `use GatherPress\Core\Venue\Setup;` → `Setup::get_instance()`
+    - Within one subsystem (e.g. `Event\Admin_List` referencing `Event\Query`), no alias needed.
 - **Method organization**: Place related methods in logically grouped classes (e.g., form-related methods in `Rsvp_Form`)
 - **Singleton pattern**: Many GatherPress classes use the Singleton trait - check if a class has `use Singleton;`
     - **Singleton classes** (Blocks, Settings, Setup classes): Use `ClassName::get_instance()`

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -20,7 +20,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp\Query as Rsvp_Query;
 use GatherPress\Core\Rsvp\Rsvp;
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue\Setup;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 use WP_Query;
 
 /**
@@ -70,7 +70,6 @@ class Admin_List {
 	protected function setup_hooks(): void {
 		add_action( 'load-edit.php', array( $this, 'default_sort' ) );
 		add_action( 'pre_get_posts', array( $this, 'handle_rsvp_sorting' ) );
-		add_action( 'pre_get_posts', array( $this, 'handle_venue_sorting' ) );
 		add_filter( 'query_vars', array( $this, 'query_vars' ) );
 		add_action( 'registered_post_type', array( $this, 'maybe_register_post_type_hooks' ) );
 	}
@@ -154,8 +153,6 @@ class Admin_List {
 	public function sortable_columns( array $columns ): array {
 		// Add 'datetime' as a sortable column.
 		$columns['datetime'] = 'datetime';
-		// Add 'venue' as a sortable column.
-		$columns['venue'] = 'venue';
 		// Add 'rsvps' as a sortable column.
 		$columns['rsvps'] = 'rsvps';
 
@@ -225,14 +222,31 @@ class Admin_List {
 					$view_links['all']
 				);
 			} elseif ( false === strpos( $view_links['all'], 'class="current"' ) ) {
-				// Add "current" class to "All" when no filter is active.
-				// default_sort() adds orderby/order to $_GET which prevents
-				// WordPress from detecting this as a base request.
-				$view_links['all'] = str_replace(
-					'<a ',
-					'<a class="current" aria-current="page" ',
-					$view_links['all']
-				);
+				// Add "current" to "All" only when no other view is current.
+				// `default_sort()` adds `orderby`/`order` to `$_GET`, which
+				// prevents WP from detecting the base request and marking
+				// "All" itself — so we restore that. But we must not stomp
+				// on a built-in status filter (Published / Draft / Trash):
+				// when the user clicks one of those, that link already has
+				// `class="current"` and "All" should stay un-marked.
+				$another_view_is_current = false;
+				foreach ( $view_links as $other_key => $other_link ) {
+					if ( 'all' === $other_key ) {
+						continue;
+					}
+					if ( false !== strpos( (string) $other_link, 'class="current"' ) ) {
+						$another_view_is_current = true;
+						break;
+					}
+				}
+
+				if ( ! $another_view_is_current ) {
+					$view_links['all'] = str_replace(
+						'<a ',
+						'<a class="current" aria-current="page" ',
+						$view_links['all']
+					);
+				}
 			}
 		}
 
@@ -354,30 +368,6 @@ class Admin_List {
 	}
 
 	/**
-	 * Handle venue sorting in the admin list table.
-	 *
-	 * This method modifies the query to sort events by venue name alphabetically.
-	 * Similar to how WordPress core handles taxonomy sorting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param WP_Query $query The WP_Query instance.
-	 * @return void
-	 */
-	public function handle_venue_sorting( $query ): void {
-		$this->handle_column_sorting(
-			$query,
-			'venue',
-			array(
-				'posts_join_paged' => array( $this, 'venue_sorting_join_paged' ),
-				'posts_groupby'    => array( $this, 'sorting_groupby_post_id' ),
-				'posts_orderby'    => array( $this, 'venue_sorting_orderby' ),
-			),
-			'venue_sort_order'
-		);
-	}
-
-	/**
 	 * Handle column sorting for the admin events list table.
 	 *
 	 * Shared logic for sorting by custom columns (RSVP count, venue name, etc.).
@@ -488,68 +478,6 @@ class Admin_List {
 	}
 
 	/**
-	 * Join term relationships and terms tables for venue sorting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $join The JOIN clause of the query.
-	 * @return string Modified JOIN clause.
-	 */
-	public function venue_sorting_join_paged( string $join ): string {
-		global $wpdb;
-
-		$screen         = get_current_screen();
-		$post_type      = $screen ? $screen->post_type : Event::POST_TYPE;
-		$venue_taxonomy = Setup::get_instance()->taxonomy_for_event_post_type( $post_type );
-
-		// Bail early if the derived taxonomy is not registered to avoid invalid SQL.
-		if ( ! taxonomy_exists( $venue_taxonomy ) ) {
-			return $join;
-		}
-
-		$join .= $wpdb->prepare(
-			' LEFT JOIN %i AS venue_tr ON %i.%i = venue_tr.object_id',
-			$wpdb->term_relationships,
-			$wpdb->posts,
-			'ID'
-		);
-		$join .= $wpdb->prepare(
-			' LEFT JOIN %i AS venue_tt'
-			. ' ON venue_tr.term_taxonomy_id = venue_tt.term_taxonomy_id'
-			. ' AND venue_tt.taxonomy = %s',
-			$wpdb->term_taxonomy,
-			$venue_taxonomy
-		);
-		$join .= $wpdb->prepare(
-			' LEFT JOIN %i AS venue_terms ON venue_tt.term_id = venue_terms.term_id',
-			$wpdb->terms
-		);
-
-		return $join;
-	}
-
-	/**
-	 * Modify the ORDER BY clause for venue sorting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string Modified ORDER BY clause.
-	 */
-	public function venue_sorting_orderby(): string {
-		global $wp_query;
-
-		$order = $wp_query->get( 'venue_sort_order', 'ASC' );
-
-		// Remove the filters to prevent them from affecting other queries.
-		remove_filter( 'posts_join_paged', array( $this, 'venue_sorting_join_paged' ) );
-		remove_filter( 'posts_groupby', array( $this, 'sorting_groupby_post_id' ) );
-		remove_filter( 'posts_orderby', array( $this, 'venue_sorting_orderby' ) );
-
-		// Sort by venue name, with NULL/empty values last.
-		return "CASE WHEN venue_terms.name IS NULL THEN 1 ELSE 0 END ASC, venue_terms.name {$order}";
-	}
-
-	/**
 	 * Populate custom columns for Event post type in the admin dashboard.
 	 *
 	 * Displays additional information, like event datetime and RSVP count, for Event post types.
@@ -566,25 +494,6 @@ class Admin_List {
 		if ( 'datetime' === $column ) {
 			$event = new Event( $post_id );
 			echo esc_html( $event->get_display_datetime() );
-		}
-
-		if ( 'venue' === $column ) {
-			$event             = new Event( $post_id );
-			$venue_information = $event->get_venue_information();
-			$venue_name        = $venue_information['name'];
-			$venue_taxonomy    = Setup::get_instance()->taxonomy_for_event_post_type(
-				(string) get_post_type( $post_id )
-			);
-
-			if ( has_term( 'online-event', $venue_taxonomy, $post_id ) ) {
-				echo '<span class="dashicons dashicons-video-alt3"></span> ';
-			}
-
-			if ( ! empty( $venue_name ) ) {
-				echo esc_html( $venue_name );
-			} else {
-				echo '—';
-			}
 		}
 
 		if ( 'rsvps' === $column ) {
@@ -675,12 +584,37 @@ class Admin_List {
 		// Remove the author column.
 		unset( $columns['author'] );
 
+		// Pull the auto-injected taxonomy columns out of their default
+		// trailing position so we can re-insert them alongside our custom
+		// columns. Venue taxonomy goes first (it's the more useful filter
+		// link in this context); other taxonomies (Topics, etc.) follow.
+		$venue_taxonomy_columns = array();
+		$other_taxonomy_columns = array();
+		$screen                 = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		$post_type              = ( $screen && '' !== (string) $screen->post_type )
+			? (string) $screen->post_type
+			: Event::POST_TYPE;
+		$venue_taxonomy_key     = 'taxonomy-' . Venue_Setup::get_instance()->taxonomy_for_event_post_type( $post_type );
+
+		foreach ( $columns as $key => $label ) {
+			if ( 0 !== strpos( $key, 'taxonomy-' ) ) {
+				continue;
+			}
+
+			if ( $key === $venue_taxonomy_key ) {
+				$venue_taxonomy_columns[ $key ] = $label;
+			} else {
+				$other_taxonomy_columns[ $key ] = $label;
+			}
+
+			unset( $columns[ $key ] );
+		}
+
 		$placement = 2;
 		$insert    = array(
 			'datetime' => __( 'Event date &amp; time', 'gatherpress' ),
-			'venue'    => __( 'Venue', 'gatherpress' ),
 			'rsvps'    => __( 'RSVPs', 'gatherpress' ),
-		);
+		) + $venue_taxonomy_columns + $other_taxonomy_columns;
 
 		return array_slice( $columns, 0, $placement, true ) + $insert + array_slice( $columns, $placement, null, true );
 	}

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -271,7 +271,7 @@ class Setup {
 			'hierarchical'       => false,
 			'public'             => true,
 			'show_ui'            => false,
-			'show_admin_column'  => false,
+			'show_admin_column'  => true,
 			'query_var'          => true,
 			'publicly_queryable' => true,
 			'rewrite'            => false,

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -1434,6 +1434,13 @@ class Test_Admin_List extends Base {
 	public function test_set_custom_columns(): void {
 		$instance = Admin_List::get_instance();
 
+		// Pin the screen to the event edit screen — production calls go
+		// through the `manage_<post_type>_posts_columns` filter, which only
+		// fires when that screen is active. Setting it here also exercises
+		// the screen-driven `$screen->post_type` branch in
+		// `set_custom_columns()`'s venue-taxonomy resolution.
+		set_current_screen( 'edit-' . Event::POST_TYPE );
+
 		// Mirror what WP core hands the filter on the events list screen:
 		// title + auto-injected taxonomy columns + author + date. Venue
 		// taxonomy goes first so the test asserts the venue-first order
@@ -1448,6 +1455,8 @@ class Test_Admin_List extends Base {
 		);
 
 		$result = $instance->set_custom_columns( $default_columns );
+
+		set_current_screen( 'front' );
 
 		// Author column is dropped.
 		$this->assertArrayNotHasKey( 'author', $result, 'Author column should be removed.' );
@@ -1472,6 +1481,48 @@ class Test_Admin_List extends Base {
 			),
 			array_keys( $result ),
 			'Sortable custom columns must precede taxonomy columns; venue taxonomy must come first.'
+		);
+	}
+
+	/**
+	 * Coverage for `set_custom_columns()`'s no-screen fallback.
+	 *
+	 * When `get_current_screen()` returns null (or its `post_type` is
+	 * empty) the venue taxonomy resolves through `Event::POST_TYPE`
+	 * rather than `$screen->post_type`. Exercises the falsy ternary leg
+	 * left uncovered when a screen is set.
+	 *
+	 * @covers ::set_custom_columns
+	 *
+	 * @return void
+	 */
+	public function test_set_custom_columns_falls_back_to_event_post_type_without_screen(): void {
+		$instance = Admin_List::get_instance();
+
+		// Ensure no screen is set so the production code falls through
+		// to the `Event::POST_TYPE` default.
+		unset( $GLOBALS['current_screen'] );
+
+		$default_columns = array(
+			'cb'                          => '<input type="checkbox" />',
+			'title'                       => 'Title',
+			'taxonomy-_gatherpress_venue' => 'Venues',
+			'date'                        => 'Date',
+		);
+
+		$result = $instance->set_custom_columns( $default_columns );
+
+		$this->assertSame(
+			array(
+				'cb',
+				'title',
+				'datetime',
+				'rsvps',
+				'taxonomy-_gatherpress_venue',
+				'date',
+			),
+			array_keys( $result ),
+			'Without a screen, the venue taxonomy still routes through Event::POST_TYPE and lands in the same slot.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -11,8 +11,6 @@ namespace GatherPress\Tests\Core\Event;
 use GatherPress\Core\Event;
 use GatherPress\Core\Event\Admin_List;
 use GatherPress\Core\Rsvp\Rsvp;
-use GatherPress\Core\Venue;
-use GatherPress\Core\Venue\Setup;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 use WP_Query;
@@ -45,12 +43,6 @@ class Test_Admin_List extends Base {
 				'name'     => 'pre_get_posts',
 				'priority' => 10,
 				'callback' => array( $instance, 'handle_rsvp_sorting' ),
-			),
-			array(
-				'type'     => 'action',
-				'name'     => 'pre_get_posts',
-				'priority' => 10,
-				'callback' => array( $instance, 'handle_venue_sorting' ),
 			),
 			array(
 				'type'     => 'filter',
@@ -269,7 +261,6 @@ class Test_Admin_List extends Base {
 		$expects  = array(
 			'unit'     => 'test',
 			'datetime' => 'datetime',
-			'venue'    => 'venue',
 			'rsvps'    => 'rsvps',
 		);
 
@@ -577,6 +568,47 @@ class Test_Admin_List extends Base {
 			'aria-current="page"',
 			$result['all'],
 			'All link should get aria-current when no filter is active.'
+		);
+
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * `views_edit()` must not stamp "current" on "All" when WordPress
+	 * core has already marked another built-in view (Published, Draft,
+	 * Trash) as current. Without the guard, both "All" and the actual
+	 * status filter would render bold simultaneously.
+	 *
+	 * @covers ::views_edit
+	 *
+	 * @return void
+	 */
+	public function test_views_edit_does_not_mark_all_when_status_filter_is_current(): void {
+		$instance = Admin_List::get_instance();
+
+		set_current_screen( 'edit-' . Event::POST_TYPE );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		unset( $_GET['gatherpress_event_query'] );
+
+		// Simulate WordPress's view-link output when the user is on the
+		// Published filter: "All" is plain, "publish" carries `current`.
+		$view_links = array(
+			'all'     => '<a href="#all">All</a>',
+			'publish' => '<a href="#publish" class="current" aria-current="page">Published</a>',
+		);
+
+		$result = $instance->views_edit( $view_links );
+
+		$this->assertStringNotContainsString(
+			'class="current"',
+			$result['all'],
+			'All link must stay un-marked when another status filter is current.'
+		);
+		$this->assertStringContainsString(
+			'class="current"',
+			$result['publish'],
+			'Published link should retain its current class.'
 		);
 
 		set_current_screen( 'front' );
@@ -1035,73 +1067,6 @@ class Test_Admin_List extends Base {
 	}
 
 	/**
-	 * Coverage for handle_venue_sorting method.
-	 *
-	 * @covers ::handle_venue_sorting
-	 *
-	 * @return void
-	 */
-	public function test_handle_venue_sorting(): void {
-		$instance = Admin_List::get_instance();
-
-		// Create a mock query.
-		$query = $this->createMock( \WP_Query::class );
-
-		// Test non-admin context (is_admin() returns false by default in tests).
-		$query->method( 'is_main_query' )->willReturn( true );
-		$query->method( 'get' )->willReturnMap(
-			array(
-				array( 'post_type', null, Event::POST_TYPE ),
-				array( 'orderby', null, 'venue' ),
-			)
-		);
-
-		// Should return early due to non-admin context.
-		$instance->handle_venue_sorting( $query );
-
-		// Test different post type - should return early.
-		$query = $this->createMock( \WP_Query::class );
-		$query->method( 'is_main_query' )->willReturn( true );
-		$query->method( 'get' )->willReturnMap(
-			array(
-				array( 'post_type', null, 'post' ),
-				array( 'orderby', null, 'venue' ),
-			)
-		);
-
-		$instance->handle_venue_sorting( $query );
-
-		// Test non-main query - should return early.
-		$query = $this->createMock( \WP_Query::class );
-		$query->method( 'is_main_query' )->willReturn( false );
-		$query->method( 'get' )->willReturnMap(
-			array(
-				array( 'post_type', null, Event::POST_TYPE ),
-				array( 'orderby', null, 'venue' ),
-			)
-		);
-
-		$instance->handle_venue_sorting( $query );
-
-		// Test different orderby - should return early.
-		$query = $this->createMock( \WP_Query::class );
-		$query->method( 'is_main_query' )->willReturn( true );
-		$query->method( 'get' )->willReturnMap(
-			array(
-				array( 'post_type', null, Event::POST_TYPE ),
-				array( 'orderby', null, 'title' ),
-			)
-		);
-
-		$instance->handle_venue_sorting( $query );
-
-		// Since the method primarily adds filters and sets query vars,
-		// and we can't easily test is_admin() in unit tests,
-		// we'll focus on testing the individual components.
-		$this->assertTrue( true ); // Method completed without errors.
-	}
-
-	/**
 	 * Coverage for rsvp_sorting_join_paged method.
 	 *
 	 * @covers ::rsvp_sorting_join_paged
@@ -1161,121 +1126,6 @@ class Test_Admin_List extends Base {
 
 		// Should contain the expected COUNT structure.
 		$this->assertStringContainsString( 'COUNT(rsvp_sort_comments.comment_ID)', $result );
-
-		// Should contain either ASC or DESC (defaults to ASC).
-		$this->assertTrue(
-			strpos( $result, 'ASC' ) !== false || strpos( $result, 'DESC' ) !== false,
-			'ORDER BY clause should contain ASC or DESC'
-		);
-
-		// Verify the method returns a string (basic type check).
-		$this->assertIsString( $result );
-		$this->assertNotEmpty( $result );
-	}
-
-	/**
-	 * Coverage for venue_sorting_join_paged method with a current screen set.
-	 *
-	 * Exercises the $screen->post_type branch, where the venue taxonomy is derived
-	 * from the currently active admin screen rather than falling back to the default.
-	 *
-	 * @covers ::venue_sorting_join_paged
-	 *
-	 * @return void
-	 */
-	public function test_venue_sorting_join_paged_with_screen(): void {
-		global $wpdb;
-		$instance = Admin_List::get_instance();
-
-		set_current_screen( 'edit-' . Event::POST_TYPE );
-
-		$original_join = "LEFT JOIN {$wpdb->posts} AS posts ON posts.ID = {$wpdb->posts}.ID";
-		$result        = $instance->venue_sorting_join_paged( $original_join );
-
-		set_current_screen( 'front' );
-
-		$this->assertStringContainsString( "'" . Venue::TAXONOMY . "'", $result );
-	}
-
-	/**
-	 * Coverage for venue_sorting_join_paged method.
-	 *
-	 * @covers ::venue_sorting_join_paged
-	 *
-	 * @return void
-	 */
-	public function test_venue_sorting_join_paged(): void {
-		global $wpdb;
-		$instance = Admin_List::get_instance();
-
-		// Ensure no screen is set so the method falls back to the default post type.
-		unset( $GLOBALS['current_screen'] );
-
-		$original_join = "LEFT JOIN {$wpdb->posts} AS posts ON posts.ID = {$wpdb->posts}.ID";
-		$result        = $instance->venue_sorting_join_paged( $original_join );
-
-		// Should contain the original join plus the venue joins.
-		$this->assertStringContainsString( $original_join, $result );
-		$this->assertStringContainsString( 'LEFT JOIN', $result );
-		$this->assertStringContainsString( $wpdb->term_relationships, $result );
-		$this->assertStringContainsString( 'venue_tr', $result );
-		$this->assertStringContainsString( $wpdb->term_taxonomy, $result );
-		$this->assertStringContainsString( 'venue_tt', $result );
-		$this->assertStringContainsString( $wpdb->terms, $result );
-		$this->assertStringContainsString( 'venue_terms', $result );
-		$this->assertStringContainsString( "'" . Venue::TAXONOMY . "'", $result );
-	}
-
-	/**
-	 * Coverage for venue_sorting_join_paged when the venue taxonomy is not registered.
-	 *
-	 * Verifies that the method returns the original $join string unchanged when
-	 * taxonomy_exists() returns false for the derived taxonomy slug, avoiding
-	 * invalid SQL from being appended.
-	 *
-	 * @covers ::venue_sorting_join_paged
-	 *
-	 * @return void
-	 */
-	public function test_venue_sorting_join_paged_unregistered_taxonomy(): void {
-		$instance      = Admin_List::get_instance();
-		$original_join = 'ORIGINAL_JOIN';
-
-		// Temporarily unregister the venue taxonomy so taxonomy_exists() returns false.
-		unregister_taxonomy( Venue::TAXONOMY );
-
-		$result = $instance->venue_sorting_join_paged( $original_join );
-
-		// Re-register the taxonomy so subsequent tests are not affected.
-		Setup::get_instance()->register_taxonomy();
-
-		$this->assertSame(
-			$original_join,
-			$result,
-			'Failed to assert that venue_sorting_join_paged returns the original join.'
-		);
-	}
-
-	/**
-	 * Coverage for venue_sorting_orderby method.
-	 *
-	 * Note: This method relies on the global $wp_query, so we test the method's structure
-	 * and ensure it returns a proper ORDER BY clause with expected patterns.
-	 *
-	 * @covers ::venue_sorting_orderby
-	 *
-	 * @return void
-	 */
-	public function test_venue_sorting_orderby(): void {
-		$instance = Admin_List::get_instance();
-
-		$result = $instance->venue_sorting_orderby( 'original_orderby' );
-
-		// Should contain the expected CASE structure for NULL handling.
-		$this->assertStringContainsString( 'CASE WHEN venue_terms.name IS NULL THEN 1 ELSE 0 END ASC', $result );
-
-		// Should contain venue_terms.name in the ORDER BY.
-		$this->assertStringContainsString( 'venue_terms.name', $result );
 
 		// Should contain either ASC or DESC (defaults to ASC).
 		$this->assertTrue(
@@ -1451,134 +1301,6 @@ class Test_Admin_List extends Base {
 		set_current_screen( 'front' );
 	}
 
-	/**
-	 * Tests handle_venue_sorting with venue orderby.
-	 *
-	 * Covers: Venue sorting logic.
-	 *
-	 * @covers ::handle_venue_sorting
-	 * @covers ::handle_column_sorting
-	 * @return void
-	 */
-	public function test_venue_sorting_with_venue_orderby(): void {
-		global $wp_the_query;
-
-		// Create a WP_Query for events with venue sorting.
-		$query = new WP_Query(
-			array(
-				'post_type' => Event::POST_TYPE,
-				'orderby'   => 'venue',
-				'order'     => 'DESC',
-			)
-		);
-
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Necessary for testing query modifications.
-		$wp_the_query = $query;
-
-		set_current_screen( 'edit-gatherpress_event' );
-
-		$instance = Admin_List::get_instance();
-		$instance->handle_venue_sorting( $query );
-
-		// Verify that sorting order was set.
-		$this->assertEquals( 'DESC', $query->get( 'venue_sort_order' ), 'Should set DESC order' );
-
-		// Verify filters were added.
-		$this->assertNotFalse(
-			has_filter( 'posts_join_paged', array( $instance, 'venue_sorting_join_paged' ) ),
-			'Should add posts_join_paged filter for venue sorting'
-		);
-		$this->assertNotFalse(
-			has_filter( 'posts_groupby', array( $instance, 'sorting_groupby_post_id' ) ),
-			'Should add posts_groupby filter for venue sorting'
-		);
-		$this->assertNotFalse(
-			has_filter( 'posts_orderby', array( $instance, 'venue_sorting_orderby' ) ),
-			'Should add posts_orderby filter for venue sorting'
-		);
-
-		// Clean up.
-		remove_filter( 'posts_join_paged', array( $instance, 'venue_sorting_join_paged' ) );
-		remove_filter( 'posts_groupby', array( $instance, 'sorting_groupby_post_id' ) );
-		remove_filter( 'posts_orderby', array( $instance, 'venue_sorting_orderby' ) );
-		set_current_screen( 'front' );
-	}
-
-	/**
-	 * Tests handle_venue_sorting with invalid order.
-	 *
-	 * Covers: Order validation in venue sorting.
-	 *
-	 * @covers ::handle_venue_sorting
-	 * @covers ::handle_column_sorting
-	 * @return void
-	 */
-	public function test_venue_sorting_with_invalid_order(): void {
-		global $wp_the_query;
-
-		// Create a WP_Query for venue sorting.
-		$query = new WP_Query(
-			array(
-				'post_type' => Event::POST_TYPE,
-				'orderby'   => 'venue',
-			)
-		);
-
-		// Manually set invalid order (bypasses WP_Query's sanitization).
-		$query->set( 'order', 'RANDOM' );
-
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Necessary for testing query modifications.
-		$wp_the_query = $query;
-
-		set_current_screen( 'edit-gatherpress_event' );
-
-		$instance = Admin_List::get_instance();
-		$instance->handle_venue_sorting( $query );
-
-		// Should default to ASC for invalid order.
-		$this->assertEquals( 'ASC', $query->get( 'venue_sort_order' ), 'Should default to ASC for invalid order' );
-
-		// Clean up.
-		remove_filter( 'posts_join_paged', array( $instance, 'venue_sorting_join_paged' ) );
-		remove_filter( 'posts_groupby', array( $instance, 'sorting_groupby_post_id' ) );
-		remove_filter( 'posts_orderby', array( $instance, 'venue_sorting_orderby' ) );
-		set_current_screen( 'front' );
-	}
-
-	/**
-	 * Tests handle_venue_sorting early return when orderby is not 'venue'.
-	 *
-	 * @covers ::handle_venue_sorting
-	 * @covers ::handle_column_sorting
-	 * @return void
-	 */
-	public function test_venue_sorting_early_return_wrong_orderby(): void {
-		global $wp_the_query;
-
-		// Create a WP_Query for non-venue sorting.
-		$query = new WP_Query(
-			array(
-				'post_type' => Event::POST_TYPE,
-				'orderby'   => 'title',
-			)
-		);
-
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Necessary for testing query modifications.
-		$wp_the_query = $query;
-
-		set_current_screen( 'edit-gatherpress_event' );
-
-		$instance = Admin_List::get_instance();
-		$instance->handle_venue_sorting( $query );
-
-		// Should not set venue_sort_order since orderby is not 'venue'.
-		$this->assertEmpty(
-			$query->get( 'venue_sort_order' ),
-			'Should not set venue_sort_order for non-venue orderby'
-		);
-
-		set_current_screen( 'front' );
-	}
 
 	/**
 	 * Coverage for custom_columns method with datetime column.
@@ -1610,74 +1332,6 @@ class Test_Admin_List extends Base {
 		$this->assertStringContainsString( 'June', $output, 'Datetime output should contain month name.' );
 	}
 
-	/**
-	 * Coverage for custom_columns method with venue column.
-	 *
-	 * @covers ::custom_columns
-	 *
-	 * @return void
-	 */
-	public function test_custom_columns_venue_with_name(): void {
-		$instance = Admin_List::get_instance();
-		$post_id  = $this->mock->post(
-			array( 'post_type' => Event::POST_TYPE )
-		)->get()->ID;
-
-		// Create a venue term and associate it with the event.
-		$venue_name = 'Test Venue';
-		$term       = wp_insert_term( $venue_name, Venue::TAXONOMY );
-		wp_set_post_terms( $post_id, array( $term['term_id'] ), Venue::TAXONOMY );
-
-		ob_start();
-		$instance->custom_columns( 'venue', $post_id );
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( $venue_name, $output, 'Venue column should contain venue name.' );
-	}
-
-	/**
-	 * Coverage for custom_columns method with venue column and no venue.
-	 *
-	 * @covers ::custom_columns
-	 *
-	 * @return void
-	 */
-	public function test_custom_columns_venue_no_venue(): void {
-		$instance = Admin_List::get_instance();
-		$post_id  = $this->mock->post(
-			array( 'post_type' => Event::POST_TYPE )
-		)->get()->ID;
-
-		ob_start();
-		$instance->custom_columns( 'venue', $post_id );
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( '—', $output, 'Venue column should show em dash when no venue.' );
-	}
-
-	/**
-	 * Coverage for custom_columns method with venue column and online event.
-	 *
-	 * @covers ::custom_columns
-	 *
-	 * @return void
-	 */
-	public function test_custom_columns_venue_online_event(): void {
-		$instance = Admin_List::get_instance();
-		$post_id  = $this->mock->post(
-			array( 'post_type' => Event::POST_TYPE )
-		)->get()->ID;
-
-		// Set online event link.
-		update_post_meta( $post_id, 'gatherpress_online_event_link', 'https://example.com/meeting' );
-
-		ob_start();
-		$instance->custom_columns( 'venue', $post_id );
-		$output = ob_get_clean();
-
-		// The method should execute without error for online events.
-		$this->assertNotEmpty( $output, 'Online event column should produce output.' );
-	}
 
 	/**
 	 * Coverage for custom_columns method with rsvps column (no RSVPs).
@@ -1780,28 +1434,45 @@ class Test_Admin_List extends Base {
 	public function test_set_custom_columns(): void {
 		$instance = Admin_List::get_instance();
 
+		// Mirror what WP core hands the filter on the events list screen:
+		// title + auto-injected taxonomy columns + author + date. Venue
+		// taxonomy goes first so the test asserts the venue-first order
+		// the production method enforces.
 		$default_columns = array(
-			'cb'     => '<input type="checkbox" />',
-			'title'  => 'Title',
-			'author' => 'Author',
-			'date'   => 'Date',
+			'cb'                          => '<input type="checkbox" />',
+			'title'                       => 'Title',
+			'taxonomy-_gatherpress_venue' => 'Venues',
+			'taxonomy-gatherpress_topic'  => 'Topics',
+			'author'                      => 'Author',
+			'date'                        => 'Date',
 		);
 
 		$result = $instance->set_custom_columns( $default_columns );
 
-		// Should not contain author column.
+		// Author column is dropped.
 		$this->assertArrayNotHasKey( 'author', $result, 'Author column should be removed.' );
 
-		// Should contain custom columns.
-		$this->assertArrayHasKey( 'datetime', $result, 'Should have datetime column.' );
-		$this->assertArrayHasKey( 'venue', $result, 'Should have venue column.' );
-		$this->assertArrayHasKey( 'rsvps', $result, 'Should have rsvps column.' );
+		// Custom columns + the auto-injected taxonomy columns survive.
+		$this->assertArrayHasKey( 'datetime', $result );
+		$this->assertArrayHasKey( 'rsvps', $result );
+		$this->assertArrayHasKey( 'taxonomy-_gatherpress_venue', $result );
+		$this->assertArrayHasKey( 'taxonomy-gatherpress_topic', $result );
 
-		// Verify order (custom columns should be inserted after title).
-		$keys = array_keys( $result );
-		$this->assertEquals( 'cb', $keys[0], 'First column should be cb.' );
-		$this->assertEquals( 'title', $keys[1], 'Second column should be title.' );
-		$this->assertEquals( 'datetime', $keys[2], 'Third column should be datetime.' );
+		// Order: cb, title, datetime, rsvps, venue taxonomy, other
+		// taxonomies, then trailing built-ins.
+		$this->assertSame(
+			array(
+				'cb',
+				'title',
+				'datetime',
+				'rsvps',
+				'taxonomy-_gatherpress_venue',
+				'taxonomy-gatherpress_topic',
+				'date',
+			),
+			array_keys( $result ),
+			'Sortable custom columns must precede taxonomy columns; venue taxonomy must come first.'
+		);
 	}
 
 	/**
@@ -1866,35 +1537,5 @@ class Test_Admin_List extends Base {
 			$result,
 			'Failed to assert that empty array remains unchanged.'
 		);
-	}
-
-	/**
-	 * Tests custom_columns with online event.
-	 *
-	 * Covers: online-event icon display.
-	 *
-	 * @covers ::custom_columns
-	 * @return void
-	 */
-	public function test_custom_columns_venue_with_online_event(): void {
-		$post_id = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
-
-		// Create 'online-event' venue term.
-		$term = wp_insert_term(
-			'Online Event',
-			'_gatherpress_venue',
-			array( 'slug' => 'online-event' )
-		);
-
-		// Assign the term to the event.
-		wp_set_object_terms( $post_id, $term['term_id'], '_gatherpress_venue' );
-
-		$instance = Admin_List::get_instance();
-
-		ob_start();
-		$instance->custom_columns( 'venue', $post_id );
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'dashicons-video-alt3', $output, 'Should display online event icon' );
 	}
 }


### PR DESCRIPTION
### Description of the Change

Replaces our custom-rendered "Venue" column on the Events admin list with the WordPress-native taxonomy admin column. WP core already renders taxonomy columns as comma-separated, filter-linked term names — exactly the UX [#1541](https://github.com/GatherPress/gatherpress/issues/1541) called for — so we let core do it instead of building it ourselves.

**The flip:**

- `_gatherpress_venue` taxonomy now declares `show_admin_column => true` ([class-setup.php](includes/core/classes/venue/class-setup.php)). That alone makes the column render with linked, comma-separated term names that filter the list when clicked.
- The column header reads "Venues" (from the taxonomy's `labels.name`) and is positioned after RSVPs alongside any other auto-injected taxonomy columns (e.g. Topics). `set_custom_columns()` pulls every `taxonomy-*` column out of its default trailing position, places the venue taxonomy column first (it's the more useful filter link in this context), and slots the rest after it. Order: `Title | Event date & time | RSVPs | Venues | Topics | Date`.

**Removed code (custom rendering + custom sorting are no longer needed):**

- `custom_columns()` — the `'venue' === $column` branch.
- `set_custom_columns()` — the `'venue' => __( 'Venue', 'gatherpress' )` insert.
- `sortable_columns()` — the `'venue' => 'venue'` entry.
- `setup_hooks()` — the `pre_get_posts → handle_venue_sorting` hook.
- Three sort-plumbing methods: `handle_venue_sorting()`, `venue_sorting_join_paged()`, `venue_sorting_orderby()`.
- The `Venue\Setup` import (now unused after the venue branch left).
- All corresponding tests.

**Why no replacement sort:** clicking a venue name now filters to that venue's events, which is more useful than alphabetizing all events by venue. "Show me only Acme Hall's events" beats "show all events grouped by venue alphabetically." If we miss it later we can wire `taxonomy-_gatherpress_venue` into `sortable_columns` separately.

**Bonus fix while in `views_edit()`:** clicking a built-in status filter (Published / Draft / Trash) used to render BOTH "All" and the status filter as bold/current. Our manual "re-add `current` to All" branch (needed because `default_sort()` adds `orderby`/`order` to `$_GET` and confuses WP's base-request detection) didn't account for status filters already being current. Added a check: only re-stamp `current` on "All" when no other view link already carries it.

Closes #1541

### How to test the Change

1. `npm run lint:phpstan` — passes clean.
2. `npm run lint:php` — passes clean.
3. `npm run test:unit:php` — full single-site suite (1267 tests) passes; `Test_Admin_List` at 100% coverage on the touched class.
4. wp-admin → Events:
   - Confirm the column order is **Title | Event date & time | RSVPs | Venues | Topics | Date**.
   - Confirm the Venues column shows comma-separated, filter-linked term names: `[Online Event], [Acme Hall]` for hybrid events; `[Acme Hall]` for physical-only; `[Online Event]` for online-only; `—` for unset.
   - Click a venue name → URL gets `?_gatherpress_venue=<slug>` and the list filters down.
   - Click "Published" → only Published renders bold; "All" stays un-marked.
   - Click "Upcoming" / "Past" → those views render as current.
5. Custom event post type (`gatherpress-event-date` support) declared via a companion plugin: confirm the matching venue taxonomy column appears in the same slot.

### Changelog Entry

> Changed - Replace the custom Venue column on the Events admin list with the WordPress-native taxonomy column (comma-separated filter-linked term names), and stop marking "All" as current when a built-in status filter is selected.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.