### PR TITLE
Rename safeHTML to stripScriptsAndEventHandlers and document its narrow scope

### DIFF
--- a/src/blocks/online-event-link/view.js
+++ b/src/blocks/online-event-link/view.js
@@ -7,7 +7,7 @@ import { store, getElement, getContext } from '@wordpress/interactivity';
  * Internal dependencies.
  */
 import { initPostContext } from '../../helpers/interactivity';
-import { safeHTML } from '../../helpers/globals';
+import { stripScriptsAndEventHandlers } from '../../helpers/globals';
 
 const { state } = store( 'gatherpress', {
 	callbacks: {
@@ -52,8 +52,15 @@ const { state } = store( 'gatherpress', {
 			const onlineEventLink = state.posts[ postId ]?.onlineEventLink || '';
 			const hasLink = '' !== onlineEventLink;
 
-			// Preserve current inner HTML (including tooltip markup), sanitized for security.
-			const currentHTML = safeHTML( currentElement.innerHTML );
+			// Preserve the current inner HTML (including tooltip markup)
+			// when we swap the wrapper between <a> and <span>. The HTML
+			// originates from PHP `render.php`, which escapes properly,
+			// so this is defense-in-depth against any third-party script
+			// that may have mutated the DOM between server render and
+			// our handler — not a substitute for proper escaping.
+			const currentHTML = stripScriptsAndEventHandlers(
+				currentElement.innerHTML
+			);
 
 			if ( hasLink && ! isLink ) {
 				const linkElement = document.createElement( 'a' );

--- a/src/blocks/rsvp-template/view.js
+++ b/src/blocks/rsvp-template/view.js
@@ -6,7 +6,7 @@ import { store, getContext, getElement } from '@wordpress/interactivity';
 /**
  * Internal dependencies.
  */
-import { safeHTML } from '../../helpers/globals';
+import { stripScriptsAndEventHandlers } from '../../helpers/globals';
 
 const { state } = store( 'gatherpress', {
 	callbacks: {
@@ -105,9 +105,14 @@ const { state } = store( 'gatherpress', {
 							}
 						}
 
+						// `res.content` is HTML rendered by GatherPress's own
+						// `/rsvp-status-html` REST endpoint, which escapes
+						// at template time. The strip pass here is
+						// defense-in-depth — not a substitute for proper
+						// server-side escaping.
 						element.ref.insertAdjacentHTML(
 							'beforebegin',
-							safeHTML( res.content ),
+							stripScriptsAndEventHandlers( res.content ),
 						);
 					}
 				} )

--- a/src/helpers/globals.js
+++ b/src/helpers/globals.js
@@ -1,17 +1,33 @@
 /**
- * Strip <script> tags and "on*" attributes from HTML to sanitize it.
+ * Strip `<script>` elements and `on*` event-handler attributes from an
+ * HTML string. **Not a general-purpose HTML sanitizer.**
  *
- * This function removes <script> elements and any attributes starting with "on" (e.g., event handlers)
- * to mitigate potential XSS vulnerabilities. It is a similar implementation to WordPress Core's `safeHTML` function
- * in `dom.js`, tailored for use when the Core implementation is unavailable or unnecessary.
+ * What it removes:
+ *
+ * - Every `<script>` element.
+ * - Every attribute whose name starts with `on` (e.g. `onclick`,
+ *   `onload`, `onerror`).
+ *
+ * What it does **not** remove (every one of these is a real XSS vector):
+ *
+ * - `javascript:` URLs in `href` / `src` / `action` / etc.
+ * - `data:` URIs with executable payloads (e.g. `data:text/html,...`).
+ * - `<iframe>`, `<object>`, `<embed>`, `<form>`, `<style>` elements.
+ * - `srcdoc`, `formaction`, `xlink:href`, `style` attributes.
+ * - CSS `expression()` / `url(javascript:...)` in inline styles.
+ *
+ * Use this only as defense-in-depth on HTML that is already trusted
+ * (server-rendered with proper escaping, REST responses produced by
+ * GatherPress's own endpoints). Never feed raw user input through it
+ * and treat the result as safe — it isn't. For untrusted HTML reach
+ * for DOMPurify or equivalent.
  *
  * @since 1.0.0
  *
- * @param {string} html - The raw HTML string to sanitize.
- *
- * @return {string} The sanitized HTML string.
+ * @param {string} html Raw HTML string.
+ * @return {string} The HTML with `<script>` elements and `on*` attributes removed.
  */
-export function safeHTML( html ) {
+export function stripScriptsAndEventHandlers( html ) {
 	const { body } = document.implementation.createHTMLDocument( '' );
 	body.innerHTML = html;
 	const elements = body.getElementsByTagName( '*' );

--- a/test/unit/js/src/helpers/globals.test.js
+++ b/test/unit/js/src/helpers/globals.test.js
@@ -8,17 +8,23 @@ import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
  */
 import {
 	toCamelCase,
-	safeHTML,
+	stripScriptsAndEventHandlers,
 	getUrlParam,
 } from '@src/helpers/globals';
 
 /**
- * Coverage for safeHTML.
+ * Coverage for stripScriptsAndEventHandlers.
+ *
+ * The function is a narrow defense-in-depth helper, NOT a general HTML
+ * sanitizer. The "removes ..." cases below cover what it strips; the
+ * "does NOT strip ..." cases lock in the intentional gaps so a future
+ * contributor doesn't mistake this helper for safe-by-default HTML
+ * sanitization. Untrusted HTML still needs DOMPurify or equivalent.
  */
-describe( 'safeHTML', () => {
+describe( 'stripScriptsAndEventHandlers', () => {
 	it( 'removes script tags from HTML', () => {
 		const html = '<div>Safe content<script>alert("xss");</script></div>';
-		const sanitized = safeHTML( html );
+		const sanitized = stripScriptsAndEventHandlers( html );
 
 		expect( sanitized ).not.toContain( '<script>' );
 		expect( sanitized ).toContain( '<div>Safe content</div>' );
@@ -26,7 +32,7 @@ describe( 'safeHTML', () => {
 
 	it( 'removes onclick attributes from HTML elements', () => {
 		const html = '<button onclick="alert(\'xss\')">Click me</button>';
-		const sanitized = safeHTML( html );
+		const sanitized = stripScriptsAndEventHandlers( html );
 
 		expect( sanitized ).not.toContain( 'onclick' );
 		expect( sanitized ).toContain( '<button>Click me</button>' );
@@ -35,7 +41,7 @@ describe( 'safeHTML', () => {
 	it( 'removes multiple on* event handlers from HTML elements', () => {
 		const html =
 			'<div onmouseover="alert(1)" onload="alert(2)" onclick="alert(3)">Test</div>';
-		const sanitized = safeHTML( html );
+		const sanitized = stripScriptsAndEventHandlers( html );
 
 		expect( sanitized ).not.toContain( 'onmouseover' );
 		expect( sanitized ).not.toContain( 'onload' );
@@ -46,7 +52,7 @@ describe( 'safeHTML', () => {
 	it( 'handles nested elements with unsafe attributes', () => {
 		const html =
 			'<div><p onclick="bad()">Text</p><span onmouseover="evil()">More</span></div>';
-		const sanitized = safeHTML( html );
+		const sanitized = stripScriptsAndEventHandlers( html );
 
 		expect( sanitized ).not.toContain( 'onclick' );
 		expect( sanitized ).not.toContain( 'onmouseover' );
@@ -56,7 +62,7 @@ describe( 'safeHTML', () => {
 	it( 'handles nested script tags', () => {
 		const html =
 			'<div>Start<script>bad code</script>Middle<script>more bad</script>End</div>';
-		const sanitized = safeHTML( html );
+		const sanitized = stripScriptsAndEventHandlers( html );
 
 		expect( sanitized ).not.toContain( '<script>' );
 		expect( sanitized ).toContain( '<div>StartMiddleEnd</div>' );
@@ -65,7 +71,7 @@ describe( 'safeHTML', () => {
 	it( 'preserves safe HTML content and attributes', () => {
 		const html =
 			'<a href="https://example.com" target="_blank" class="link">Safe Link</a>';
-		const sanitized = safeHTML( html );
+		const sanitized = stripScriptsAndEventHandlers( html );
 
 		expect( sanitized ).toContain( 'href="https://example.com"' );
 		expect( sanitized ).toContain( 'target="_blank"' );
@@ -74,18 +80,18 @@ describe( 'safeHTML', () => {
 	} );
 
 	it( 'handles empty input', () => {
-		expect( safeHTML( '' ) ).toBe( '' );
+		expect( stripScriptsAndEventHandlers( '' ) ).toBe( '' );
 	} );
 
 	it( 'handles plain text without HTML', () => {
 		const text = 'Just some plain text without any HTML';
 
-		expect( safeHTML( text ) ).toBe( text );
+		expect( stripScriptsAndEventHandlers( text ) ).toBe( text );
 	} );
 
 	it( 'handles malformed HTML gracefully', () => {
 		const malformed = '<div>Unclosed div<script>alert("bad");</script>';
-		const sanitized = safeHTML( malformed );
+		const sanitized = stripScriptsAndEventHandlers( malformed );
 
 		expect( sanitized ).not.toContain( '<script>' );
 		expect( sanitized ).toContain( '<div>Unclosed div' );
@@ -129,7 +135,7 @@ describe( 'safeHTML', () => {
 		};
 
 		// This should not throw even with a detached script element.
-		const sanitized = safeHTML( html );
+		const sanitized = stripScriptsAndEventHandlers( html );
 
 		// Restore original implementation.
 		document.implementation.createHTMLDocument =
@@ -137,6 +143,54 @@ describe( 'safeHTML', () => {
 
 		expect( sanitized ).not.toContain( '<script>' );
 		expect( sanitized ).toContain( '<div' );
+	} );
+
+	// The following cases lock in what the helper is INTENTIONALLY NOT
+	// doing. If any of them flips to "stripped", that's a behavior change
+	// that needs deliberate review and a docblock update — not a quiet
+	// improvement.
+
+	it( 'does NOT strip javascript: URLs', () => {
+		const html = '<a href="javascript:alert(1)">click</a>';
+		const sanitized = stripScriptsAndEventHandlers( html );
+
+		expect( sanitized ).toContain( 'javascript:alert(1)' );
+	} );
+
+	it( 'does NOT strip data: URIs with executable payloads', () => {
+		const html =
+			'<iframe src="data:text/html,<script>alert(1)</script>"></iframe>';
+		const sanitized = stripScriptsAndEventHandlers( html );
+
+		expect( sanitized ).toContain( 'data:text/html' );
+	} );
+
+	it( 'does NOT strip iframe / object / embed elements', () => {
+		const html =
+			'<iframe src="https://evil.test"></iframe><object data="x"></object><embed src="y">';
+		const sanitized = stripScriptsAndEventHandlers( html );
+
+		expect( sanitized ).toContain( '<iframe' );
+		expect( sanitized ).toContain( '<object' );
+		expect( sanitized ).toContain( '<embed' );
+	} );
+
+	it( 'does NOT strip srcdoc / formaction attributes', () => {
+		const html =
+			'<iframe srcdoc="<script>alert(1)</script>"></iframe>' +
+			'<button formaction="javascript:alert(1)">x</button>';
+		const sanitized = stripScriptsAndEventHandlers( html );
+
+		expect( sanitized ).toContain( 'srcdoc' );
+		expect( sanitized ).toContain( 'formaction' );
+	} );
+
+	it( 'does NOT strip inline style attributes', () => {
+		const html =
+			'<div style="background:url(javascript:alert(1))">x</div>';
+		const sanitized = stripScriptsAndEventHandlers( html );
+
+		expect( sanitized ).toContain( 'style=' );
 	} );
 } );
 


### PR DESCRIPTION
### Description of the Change

The helper exported from `src/helpers/globals.js` was named `safeHTML` and its JSDoc compared it to WP Core's `safeHTML` in `dom.js`. Both implied general-purpose sanitization. The actual implementation is narrower than that — it strips `<script>` elements and any attribute starting with `on` (event handlers), and nothing else.

What it does NOT strip — every one of these is a real XSS vector:

- `javascript:` URLs in `href` / `src` / `action` / etc.
- `data:` URIs with executable payloads
- `<iframe>`, `<object>`, `<embed>`, `<form>`, `<style>` elements
- `srcdoc`, `formaction`, `xlink:href`, inline `style` attributes
- CSS `expression()` / `url(javascript:...)` in inline styles

Current usage is fine. Both call sites — [online-event-link/view.js](src/blocks/online-event-link/view.js) (re-reading server-rendered HTML after a wrapper swap) and [rsvp-template/view.js](src/blocks/rsvp-template/view.js) (injecting HTML from GatherPress's own `/rsvp-status-html` REST endpoint) — feed the helper HTML that was already escaped at template time. The helper is defense-in-depth, not the primary security boundary. No active vulnerability.

The risk is the **name**. A future contributor seeing `safeHTML()` and feeding user-supplied HTML through it would create one. This PR closes that gap by:

1. **Renaming** the function to `stripScriptsAndEventHandlers` — describes what it actually does, drops the false promise of "safe."
2. **Rewriting the JSDoc** to explicitly enumerate what it strips AND what it does NOT, with the directive: "Use only as defense-in-depth on HTML that is already trusted. Never feed raw user input through it. For untrusted HTML reach for DOMPurify or equivalent."
3. **Updating both call sites** with inline comments explaining the trust assumption (input is server-rendered, the strip pass is defense-in-depth against post-render DOM mutations / response-path tampering, not a substitute for proper escaping).
4. **Adding negative tests** that lock in the intentional gaps — javascript: URLs, data: URIs, iframe/object/embed, srcdoc, formaction, inline styles all pass through unchanged. If any of those flips to "stripped" in a future change, that's a deliberate behavior change requiring docblock + test update, not a quiet improvement.

Net diff: rename, expanded docblock, expanded tests, two inline comments. No runtime behavior change.

**Why not pull in DOMPurify?** Currently two call sites, both server-rendered. Adding a runtime dep for a defense-in-depth pass on already-escaped input is over-engineering. If a third call site lands that handles genuinely user-supplied HTML, that's the moment to switch — and the new name makes the requirement obvious.

Closes #1537

### How to test the Change

1. `npm run lint:js` — passes clean.
2. `npx jest test/unit/js/src/helpers/globals.test.js` — 31 tests pass; 100% statement / branch / function / line coverage on `globals.js`.
3. Inspect the new tests in `test/unit/js/src/helpers/globals.test.js` — five "does NOT strip ..." cases document the intentional limitations.
4. wp-admin smoke: load any event with the online-event-link block on the front end; toggle the link state in the editor and reload — the HTML swap still works (input is re-read from the DOM, run through the strip pass, applied to the new wrapper).
5. wp-admin smoke: open an event with the rsvp-template block, switch RSVP filters in the front-end view (Attending / Waiting / Not Attending) — the REST round-trip still injects the rendered template via `insertAdjacentHTML`.
6. Grep for `safeHTML` across the repo — should return zero hits in the runtime tree.

### Changelog Entry

> Changed - Rename `safeHTML` helper to `stripScriptsAndEventHandlers` and document its narrow scope honestly so future callers understand it is not a general HTML sanitizer.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.