### PR TITLE
Rate-limit the geocoding REST endpoints

### DIFF
--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -147,6 +147,8 @@ Meta registration itself lives on `GatherPress\Core\Venue\Meta::register()`. The
 
 The eight structured-address fields are populated by a server-side cron handler that runs on a 5-second delay after `gatherpress_address` changes. Manual edits to those fields via `update_post_meta()` from trusted server code are preserved as long as the address itself doesn't change. To suppress the outbound HTTP-on-save (firewalled installs, dev environments without Photon access), return `false` from the `gatherpress_geocode_on_save_enabled` filter. To replace WP-Cron with a different scheduler (e.g. Action Scheduler), short-circuit the `gatherpress_async_geocode_pre_enqueue_job` filter with any non-null value.
 
+The address autocomplete and save-time reverse-geocode that drive these fields go through two REST endpoints (`/gatherpress/v1/geocode` and `/gatherpress/v1/geocode/search`), both of which share a per-user fixed-window rate limit. The default ceiling is 30 requests per 60 seconds; the (N+1)th request returns HTTP `429 Too Many Requests` with a `Retry-After` header. Lower or raise the ceiling via the `gatherpress_geocode_rate_limit_per_minute` filter (values below `1` are clamped to `1`). To disable the rate limit entirely — for example when a CDN / WAF already covers this surface — return `false` from `gatherpress_geocode_rate_limit_enabled`.
+
 #### Usage for gatherpress-venue-information
 
 ```php

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -489,10 +489,19 @@ class Geocoding {
 		}
 
 		/**
-		 * Filter the per-minute ceiling for the geocode REST endpoints.
+		 * Filter the per-user requests-per-minute ceiling for the
+		 * geocode REST endpoints (`/geocode` and `/geocode/search`).
 		 *
-		 * Site owners with unusual workloads (high-frequency autocomplete,
-		 * bulk venue imports, etc.) can raise or lower this ceiling.
+		 * Both endpoints share one fixed-window per-user bucket. Once
+		 * this ceiling is reached within a 60-second window, additional
+		 * requests for the same user return HTTP `429 Too Many Requests`
+		 * with a `Retry-After` header pointing at the remaining seconds
+		 * in the window. Lower this value to be stricter with abusive
+		 * clients; raise it for sites with debounced-but-eager
+		 * autocomplete UIs or bulk-import workflows.
+		 *
+		 * Values below `1` are clamped to `1` (a zero ceiling would 429
+		 * every request, including the first).
 		 *
 		 * @since 1.0.0
 		 *

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -480,6 +480,28 @@ class Geocoding {
 	 * @return WP_REST_Response|null
 	 */
 	protected function check_rate_limit(): ?WP_REST_Response {
+		/**
+		 * Filter whether the geocode REST rate limit is enforced.
+		 *
+		 * Returning `false` disables the rate limit entirely — no
+		 * per-user bucket is read or written, no 429 is ever returned.
+		 * Useful for sites running their own upstream rate limiting at
+		 * a CDN / WAF layer that already covers this surface, or for
+		 * automated test environments that want to bypass the throttle.
+		 *
+		 * Mirrors the shape of `gatherpress_geocode_on_save_enabled`
+		 * (cron side) for consistency: same filter pattern across
+		 * both Photon-traffic toggles.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param bool $enabled Whether the rate limit is enforced. Default true.
+		 */
+		$enabled = (bool) apply_filters( 'gatherpress_geocode_rate_limit_enabled', true );
+		if ( ! $enabled ) {
+			return null;
+		}
+
 		$user_id = get_current_user_id();
 		// REST permission_callback already gates on `edit_posts`; an
 		// unauthenticated request shouldn't reach this method, but if it
@@ -833,6 +855,27 @@ class Geocoding {
 
 		$this->maybe_log_json_decode_failure( $body, $data, 'search_addresses' );
 
+		return $this->build_search_suggestions_response( $data, $cache_key );
+	}
+
+	/**
+	 * Build the `/geocode/search` REST response from a decoded Photon
+	 * payload. Caches the result under `$cache_key` so repeat queries
+	 * within `SEARCH_CACHE_TTL` skip the Photon roundtrip.
+	 *
+	 * Extracted from `search_addresses()` to keep that method's NPath
+	 * complexity manageable — the parsing loop dominates the path
+	 * count; moving it here lets the REST entry point stay readable
+	 * and PHPMD-clean.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed  $data      Decoded JSON body. Treated as "no results"
+	 *                          when not an array or missing `features`.
+	 * @param string $cache_key Transient key for the cached suggestions.
+	 * @return WP_REST_Response The response with a `suggestions` array (possibly empty).
+	 */
+	private function build_search_suggestions_response( $data, string $cache_key ): WP_REST_Response {
 		if ( ! is_array( $data ) || empty( $data['features'] ) || ! is_array( $data['features'] ) ) {
 			set_transient( $cache_key, array(), self::SEARCH_CACHE_TTL );
 

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -105,6 +105,36 @@ class Geocoding {
 	private const CRON_DELAY_SECONDS = 5;
 
 	/**
+	 * Length of the per-user rate-limit window for the geocode REST
+	 * endpoints, in seconds. Both `/geocode` and `/geocode/search` share
+	 * the same per-user bucket — one user typing into autocomplete and
+	 * then saving a venue is still one continuous flow.
+	 *
+	 * @since 1.0.0
+	 */
+	private const GEOCODE_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+	/**
+	 * Default ceiling for the per-user rate-limit window. Roomy enough
+	 * for one user typing through a 25-character address with debounced
+	 * autocomplete (~10 requests) plus a couple of save-time reverse
+	 * geocodes; tight enough to catch a runaway client or scripted abuse.
+	 *
+	 * Filterable via `gatherpress_geocode_rate_limit_per_minute`.
+	 *
+	 * @since 1.0.0
+	 */
+	private const GEOCODE_RATE_LIMIT_DEFAULT_PER_MINUTE = 30;
+
+	/**
+	 * Transient key prefix for the per-user geocode rate-limit bucket.
+	 * Keyed on user ID; the suffix is appended at use site.
+	 *
+	 * @since 1.0.0
+	 */
+	private const GEOCODE_RATE_LIMIT_TRANSIENT_PREFIX = 'gatherpress_geocode_rate_';
+
+	/**
 	 * Class constructor.
 	 *
 	 * This method initializes the object and sets up necessary hooks.
@@ -432,6 +462,86 @@ class Geocoding {
 	}
 
 	/**
+	 * Enforce a per-user rate limit on the geocode REST endpoints.
+	 *
+	 * Both `/geocode` and `/geocode/search` consume from the same per-user
+	 * bucket — autocomplete + save-time reverse-geocode are one continuous
+	 * flow from the user's perspective. The bucket is a fixed 60-second
+	 * window; the (N+1)th request once the ceiling has been hit returns
+	 * a 429 response with a `Retry-After` header pointing at the window's
+	 * remaining seconds.
+	 *
+	 * Returns null when the request is under the ceiling and should
+	 * proceed normally; returns a `WP_REST_Response` (HTTP 429) when the
+	 * caller should bail.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return WP_REST_Response|null
+	 */
+	protected function check_rate_limit(): ?WP_REST_Response {
+		$user_id = get_current_user_id();
+		// REST permission_callback already gates on `edit_posts`; an
+		// unauthenticated request shouldn't reach this method, but if it
+		// somehow does, fail open rather than 0-key the bucket.
+		if ( 0 === $user_id ) {
+			return null;
+		}
+
+		/**
+		 * Filter the per-minute ceiling for the geocode REST endpoints.
+		 *
+		 * Site owners with unusual workloads (high-frequency autocomplete,
+		 * bulk venue imports, etc.) can raise or lower this ceiling.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $ceiling Default per-user requests-per-minute ceiling.
+		 */
+		$ceiling = (int) apply_filters(
+			'gatherpress_geocode_rate_limit_per_minute',
+			self::GEOCODE_RATE_LIMIT_DEFAULT_PER_MINUTE
+		);
+		$ceiling = max( 1, $ceiling );
+
+		$now    = time();
+		$key    = self::GEOCODE_RATE_LIMIT_TRANSIENT_PREFIX . $user_id;
+		$bucket = get_transient( $key );
+
+		if ( ! is_array( $bucket ) || empty( $bucket['expires_at'] ) || $now >= (int) $bucket['expires_at'] ) {
+			$bucket = array(
+				'count'      => 0,
+				'expires_at' => $now + self::GEOCODE_RATE_LIMIT_WINDOW_SECONDS,
+			);
+		}
+
+		if ( (int) $bucket['count'] >= $ceiling ) {
+			$retry_after = max( 1, (int) $bucket['expires_at'] - $now );
+			$response    = new WP_REST_Response(
+				array(
+					'code'    => 'gatherpress_geocode_rate_limited',
+					'message' => __(
+						'Too many geocoding requests. Please slow down and try again shortly.',
+						'gatherpress'
+					),
+					'data'    => array( 'status' => 429 ),
+				),
+				429
+			);
+			$response->header( 'Retry-After', (string) $retry_after );
+			return $response;
+		}
+
+		$bucket['count'] = (int) $bucket['count'] + 1;
+		// TTL tracks the remaining window so refreshing the count doesn't
+		// extend it (a true fixed window, not sliding).
+		$ttl = max( 1, (int) $bucket['expires_at'] - $now );
+		set_transient( $key, $bucket, $ttl );
+
+		return null;
+	}
+
+	/**
 	 * Geocodes an address using the Photon API (GeoJSON).
 	 *
 	 * @since 1.0.0
@@ -440,6 +550,11 @@ class Geocoding {
 	 * @return WP_REST_Response|WP_Error Response with coordinates or error.
 	 */
 	public function geocode_address( WP_REST_Request $request ) {
+		$rate_limited = $this->check_rate_limit();
+		if ( null !== $rate_limited ) {
+			return $rate_limited;
+		}
+
 		$address = $request->get_param( 'address' );
 
 		if ( empty( $address ) ) {
@@ -624,6 +739,11 @@ class Geocoding {
 	 * @return WP_REST_Response|WP_Error Suggestions or error.
 	 */
 	public function search_addresses( WP_REST_Request $request ) {
+		$rate_limited = $this->check_rate_limit();
+		if ( null !== $rate_limited ) {
+			return $rate_limited;
+		}
+
 		$query = $request->get_param( 'q' );
 
 		if ( empty( $query ) || '' === trim( $query ) ) {

--- a/src/components/AddressAutocompleteField/use-address-autocomplete.js
+++ b/src/components/AddressAutocompleteField/use-address-autocomplete.js
@@ -119,7 +119,7 @@ export function useAddressAutocomplete( {
 					setSuggestions( [] );
 					setSuggestionError(
 						__(
-							'Address search is temporarily unavailable.',
+							'Address suggestions are temporarily unavailable. Try again in a moment, or enter the address manually.',
 							'gatherpress'
 						)
 					);

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -2615,6 +2615,159 @@ class Test_Geocoding extends Base {
 	}
 
 	/**
+	 * Direct coverage for `build_search_suggestions_response()`.
+	 *
+	 * The helper is exercised by every successful `/geocode/search`
+	 * roundtrip, but xdebug coverage doesn't credit the body lines
+	 * reliably when entry is via `$this->...` from another method on
+	 * the same singleton instance. Call it via reflection so the body
+	 * lines are unambiguously executed under coverage instrumentation.
+	 *
+	 * @covers ::build_search_suggestions_response
+	 *
+	 * @return void
+	 */
+	public function test_build_search_suggestions_response_handles_no_features(): void {
+		$cache_key = 'gatherpress_photon_search_test_' . wp_generate_password( 8, false );
+		$method    = new ReflectionMethod( Geocoding::class, 'build_search_suggestions_response' );
+		$method->setAccessible( true );
+
+		$response = $method->invoke( Geocoding::get_instance(), null, $cache_key );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array( 'suggestions' => array() ),
+			$response->get_data(),
+			'A non-array decode result must collapse to an empty suggestions list.'
+		);
+
+		// Empty-result branch still caches an empty array so repeat
+		// queries skip Photon for the next SEARCH_CACHE_TTL.
+		$this->assertSame( array(), get_transient( $cache_key ) );
+
+		delete_transient( $cache_key );
+	}
+
+	/**
+	 * Direct coverage for `build_search_suggestions_response()` with
+	 * a populated payload — verifies the per-feature shape it builds
+	 * and that the suggestions are cached for later cache-hit reads.
+	 *
+	 * @covers ::build_search_suggestions_response
+	 *
+	 * @return void
+	 */
+	public function test_build_search_suggestions_response_maps_features(): void {
+		$cache_key = 'gatherpress_photon_search_test_' . wp_generate_password( 8, false );
+		$payload   = array(
+			'features' => array(
+				// Well-formed feature → maps into a suggestion.
+				array(
+					'geometry'   => array(
+						'coordinates' => array( -74.006, 40.7128 ),
+					),
+					'properties' => array(
+						'name'    => 'Test Place',
+						'city'    => 'New York',
+						'country' => 'United States',
+					),
+				),
+				// Non-array feature → skipped.
+				'not an array',
+				// Feature missing coords → skipped.
+				array(
+					'geometry'   => array(),
+					'properties' => array( 'name' => 'No Coords' ),
+				),
+				// Feature with empty label (no displayable properties) → skipped.
+				array(
+					'geometry'   => array(
+						'coordinates' => array( 0, 0 ),
+					),
+					'properties' => array(),
+				),
+				// Feature with `properties` missing entirely — exercises
+				// the `: array()` fallback in the ternary. Empty label →
+				// skipped.
+				array(
+					'geometry' => array(
+						'coordinates' => array( 1, 1 ),
+					),
+				),
+			),
+		);
+
+		$method = new ReflectionMethod( Geocoding::class, 'build_search_suggestions_response' );
+		$method->setAccessible( true );
+
+		$response = $method->invoke( Geocoding::get_instance(), $payload, $cache_key );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertCount(
+			1,
+			$data['suggestions'],
+			'Only the well-formed feature should land in the suggestion list.'
+		);
+		$this->assertSame( '40.7128', $data['suggestions'][0]['latitude'] );
+		$this->assertSame( '-74.006', $data['suggestions'][0]['longitude'] );
+
+		$this->assertSame(
+			$data['suggestions'],
+			get_transient( $cache_key ),
+			'Built suggestions must be cached under the supplied key.'
+		);
+
+		delete_transient( $cache_key );
+	}
+
+	/**
+	 * Returning `false` from `gatherpress_geocode_rate_limit_enabled`
+	 * disables the rate limit entirely — even a bucket that's
+	 * already at the ceiling lets requests through, and no transient
+	 * read/write happens.
+	 *
+	 * @covers ::check_rate_limit
+	 *
+	 * @return void
+	 */
+	public function test_rate_limit_can_be_disabled_via_filter(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		// Pre-fill the bucket at the ceiling — without the disable
+		// filter, the next call would 429.
+		set_transient(
+			'gatherpress_geocode_rate_' . $user_id,
+			array(
+				'count'      => 30,
+				'expires_at' => time() + 30,
+			),
+			30
+		);
+
+		$disable = static function (): bool {
+			return false;
+		};
+		add_filter( 'gatherpress_geocode_rate_limit_enabled', $disable );
+
+		try {
+			$method = new ReflectionMethod( Geocoding::class, 'check_rate_limit' );
+			$method->setAccessible( true );
+			$result = $method->invoke( Geocoding::get_instance() );
+		} finally {
+			remove_filter( 'gatherpress_geocode_rate_limit_enabled', $disable );
+			delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+		}
+
+		$this->assertNull(
+			$result,
+			'Disabling the rate limit must let an at-ceiling user through.'
+		);
+	}
+
+	/**
 	 * `check_rate_limit()` falls open (returns null, no transient
 	 * touched) when there is no logged-in user. The REST permission
 	 * callback already gates anonymous requests; this short-circuit is
@@ -2976,7 +3129,7 @@ class Test_Geocoding extends Base {
 	 * @return void
 	 */
 	public function test_rate_limit_is_isolated_per_user(): void {
-		$flooder_id  = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$flooder_id   = $this->factory->user->create( array( 'role' => 'editor' ) );
 		$bystander_id = $this->factory->user->create( array( 'role' => 'editor' ) );
 
 		// Flooder is at the ceiling.

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -2613,4 +2613,448 @@ class Test_Geocoding extends Base {
 			'Structured-address country_code must be stripped from REST writes.'
 		);
 	}
+
+	/**
+	 * `check_rate_limit()` falls open (returns null, no transient
+	 * touched) when there is no logged-in user. The REST permission
+	 * callback already gates anonymous requests; this short-circuit is
+	 * defense-in-depth against being invoked from an anonymous context
+	 * with `user_id === 0`, which would otherwise key the bucket on 0
+	 * and let an attacker share a global quota with all other anons.
+	 *
+	 * @covers ::check_rate_limit
+	 *
+	 * @return void
+	 */
+	public function test_rate_limit_skips_without_logged_in_user(): void {
+		wp_set_current_user( 0 );
+		delete_transient( 'gatherpress_geocode_rate_0' );
+
+		$method = new ReflectionMethod( Geocoding::class, 'check_rate_limit' );
+		$method->setAccessible( true );
+		$result = $method->invoke( Geocoding::get_instance() );
+
+		$this->assertNull( $result );
+		$this->assertFalse(
+			get_transient( 'gatherpress_geocode_rate_0' ),
+			'No bucket should be created for the anonymous user.'
+		);
+	}
+
+	/**
+	 * Within the rate-limit ceiling, calls succeed normally — the
+	 * counter increments, but the response is the regular geocode
+	 * payload, not a 429.
+	 *
+	 * @covers ::check_rate_limit
+	 *
+	 * @return void
+	 */
+	public function test_rate_limit_allows_requests_under_ceiling(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+		delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+
+		$this->http_mock->mock(
+			'*',
+			array(
+				'body' => wp_json_encode(
+					array(
+						'features' => array(
+							array(
+								'geometry' => array(
+									'coordinates' => array( -73.935242, 40.73061 ),
+								),
+							),
+						),
+					)
+				),
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'address', '123 Main St' );
+
+		$response = Geocoding::get_instance()->geocode_address( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+
+		$bucket = get_transient( 'gatherpress_geocode_rate_' . $user_id );
+		$this->assertIsArray( $bucket );
+		$this->assertSame( 1, $bucket['count'] );
+
+		delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+	}
+
+	/**
+	 * `/geocode` and `/geocode/search` consume from the same per-user
+	 * bucket — so a user typing into autocomplete and then saving a
+	 * venue counts as one continuous flow.
+	 *
+	 * @covers ::check_rate_limit
+	 *
+	 * @return void
+	 */
+	public function test_rate_limit_bucket_is_shared_between_endpoints(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+		delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+
+		$this->http_mock->mock(
+			'*',
+			array(
+				'body' => wp_json_encode(
+					array(
+						'features' => array(
+							array(
+								'geometry'   => array(
+									'coordinates' => array( -73.935242, 40.73061 ),
+								),
+								'properties' => array( 'name' => 'Test' ),
+							),
+						),
+					)
+				),
+			)
+		);
+
+		$instance = Geocoding::get_instance();
+
+		$geocode_request = new WP_REST_Request( 'GET' );
+		$geocode_request->set_param( 'address', '123 Main St' );
+		$instance->geocode_address( $geocode_request );
+
+		$search_request = new WP_REST_Request( 'GET' );
+		$search_request->set_param( 'q', '123 Main St' );
+		$instance->search_addresses( $search_request );
+
+		$bucket = get_transient( 'gatherpress_geocode_rate_' . $user_id );
+		$this->assertIsArray( $bucket );
+		$this->assertSame(
+			2,
+			$bucket['count'],
+			'Both endpoints must increment the same per-user bucket.'
+		);
+
+		delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+	}
+
+	/**
+	 * Once the ceiling has been hit, `check_rate_limit()` returns a 429
+	 * response with a `Retry-After` header pointing at the remaining
+	 * seconds in the window. Invoked directly on the protected method
+	 * for deterministic coverage of the over-limit branch — the
+	 * end-to-end "geocode_address returns 429" assertion is covered by
+	 * `test_rate_limit_geocode_address_returns_429_when_exceeded`
+	 * below.
+	 *
+	 * @covers ::check_rate_limit
+	 *
+	 * @return void
+	 */
+	public function test_rate_limit_returns_429_with_retry_after_when_exceeded(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		// Pre-fill the bucket at the ceiling. Window expires 30s from now.
+		$expires_at = time() + 30;
+		set_transient(
+			'gatherpress_geocode_rate_' . $user_id,
+			array(
+				'count'      => 30,
+				'expires_at' => $expires_at,
+			),
+			30
+		);
+
+		$method = new ReflectionMethod( Geocoding::class, 'check_rate_limit' );
+		$method->setAccessible( true );
+		$response = $method->invoke( Geocoding::get_instance() );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 429, $response->get_status() );
+
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Retry-After', $headers );
+		$this->assertGreaterThanOrEqual( 1, (int) $headers['Retry-After'] );
+		$this->assertLessThanOrEqual( 30, (int) $headers['Retry-After'] );
+
+		$data = $response->get_data();
+		$this->assertSame( 'gatherpress_geocode_rate_limited', $data['code'] );
+
+		delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+	}
+
+	/**
+	 * `geocode_address()` returns the 429 response from
+	 * `check_rate_limit()` directly (early-returns before its own
+	 * argument validation). Locks in the wiring at the public REST
+	 * entry point.
+	 *
+	 * @covers ::geocode_address
+	 *
+	 * @return void
+	 */
+	public function test_rate_limit_geocode_address_returns_429_when_exceeded(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		set_transient(
+			'gatherpress_geocode_rate_' . $user_id,
+			array(
+				'count'      => 30,
+				'expires_at' => time() + 30,
+			),
+			30
+		);
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'address', '123 Main St' );
+
+		$response = Geocoding::get_instance()->geocode_address( $request );
+
+		$this->assertSame( 429, $response->get_status() );
+
+		delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+	}
+
+	/**
+	 * `search_addresses()` returns the 429 response from
+	 * `check_rate_limit()` directly (early-returns before its own
+	 * argument validation). Locks in the wiring at the public REST
+	 * entry point.
+	 *
+	 * @covers ::search_addresses
+	 *
+	 * @return void
+	 */
+	public function test_rate_limit_search_addresses_returns_429_when_exceeded(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		set_transient(
+			'gatherpress_geocode_rate_' . $user_id,
+			array(
+				'count'      => 30,
+				'expires_at' => time() + 30,
+			),
+			30
+		);
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'q', '123 Main St' );
+
+		$response = Geocoding::get_instance()->search_addresses( $request );
+
+		$this->assertSame( 429, $response->get_status() );
+
+		delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+	}
+
+	/**
+	 * Once the rate-limit window expires, the next request starts a
+	 * fresh window with count = 1.
+	 *
+	 * @covers ::check_rate_limit
+	 *
+	 * @return void
+	 */
+	public function test_rate_limit_resets_after_window_expires(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		// Stale bucket: at ceiling, but window already expired one second ago.
+		set_transient(
+			'gatherpress_geocode_rate_' . $user_id,
+			array(
+				'count'      => 30,
+				'expires_at' => time() - 1,
+			),
+			60
+		);
+
+		$this->http_mock->mock(
+			'*',
+			array(
+				'body' => wp_json_encode(
+					array(
+						'features' => array(
+							array(
+								'geometry' => array(
+									'coordinates' => array( -73.935242, 40.73061 ),
+								),
+							),
+						),
+					)
+				),
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'address', '123 Main St' );
+
+		$response = Geocoding::get_instance()->geocode_address( $request );
+
+		$this->assertSame(
+			200,
+			$response->get_status(),
+			'Expired window must allow the request through and start a fresh bucket.'
+		);
+
+		$bucket = get_transient( 'gatherpress_geocode_rate_' . $user_id );
+		$this->assertIsArray( $bucket );
+		$this->assertSame( 1, $bucket['count'] );
+
+		delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+	}
+
+	/**
+	 * `gatherpress_geocode_rate_limit_per_minute` overrides the default
+	 * ceiling. Set it to 1 and the second request in the same window
+	 * gets 429'd.
+	 *
+	 * @covers ::check_rate_limit
+	 *
+	 * @return void
+	 */
+	public function test_rate_limit_filter_changes_ceiling(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+		delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+
+		$this->http_mock->mock(
+			'*',
+			array(
+				'body' => wp_json_encode(
+					array(
+						'features' => array(
+							array(
+								'geometry' => array(
+									'coordinates' => array( -73.935242, 40.73061 ),
+								),
+							),
+						),
+					)
+				),
+			)
+		);
+
+		$ceiling_filter = static function (): int {
+			return 1;
+		};
+		add_filter( 'gatherpress_geocode_rate_limit_per_minute', $ceiling_filter );
+
+		try {
+			$instance = Geocoding::get_instance();
+
+			$first_request = new WP_REST_Request( 'GET' );
+			$first_request->set_param( 'address', '123 Main St' );
+			$first_response = $instance->geocode_address( $first_request );
+			$this->assertSame( 200, $first_response->get_status() );
+
+			$second_request = new WP_REST_Request( 'GET' );
+			$second_request->set_param( 'address', '456 Oak St' );
+			$second_response = $instance->geocode_address( $second_request );
+			$this->assertSame(
+				429,
+				$second_response->get_status(),
+				'With ceiling=1, the second request in the window must be rate-limited.'
+			);
+		} finally {
+			remove_filter( 'gatherpress_geocode_rate_limit_per_minute', $ceiling_filter );
+			delete_transient( 'gatherpress_geocode_rate_' . $user_id );
+		}
+	}
+
+	/**
+	 * Rate limiting is per-user — one user hitting the ceiling does
+	 * NOT block other users on the same site.
+	 *
+	 * @covers ::check_rate_limit
+	 *
+	 * @return void
+	 */
+	public function test_rate_limit_is_isolated_per_user(): void {
+		$flooder_id  = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$bystander_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+
+		// Flooder is at the ceiling.
+		set_transient(
+			'gatherpress_geocode_rate_' . $flooder_id,
+			array(
+				'count'      => 30,
+				'expires_at' => time() + 30,
+			),
+			30
+		);
+
+		$this->http_mock->mock(
+			'*',
+			array(
+				'body' => wp_json_encode(
+					array(
+						'features' => array(
+							array(
+								'geometry' => array(
+									'coordinates' => array( -73.935242, 40.73061 ),
+								),
+							),
+						),
+					)
+				),
+			)
+		);
+
+		// Bystander makes a request — should succeed.
+		wp_set_current_user( $bystander_id );
+		delete_transient( 'gatherpress_geocode_rate_' . $bystander_id );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'address', '123 Main St' );
+		$response = Geocoding::get_instance()->geocode_address( $request );
+
+		$this->assertSame(
+			200,
+			$response->get_status(),
+			"One user's flooded bucket must not affect another user's quota."
+		);
+
+		delete_transient( 'gatherpress_geocode_rate_' . $flooder_id );
+		delete_transient( 'gatherpress_geocode_rate_' . $bystander_id );
+	}
+
+	/**
+	 * Capability gate is **intentionally** `edit_posts` (Contributor+).
+	 * Rate limiting is the meaningful defense; tightening the cap was
+	 * security theater (Photon is already public, anonymous-equivalent
+	 * abuse vectors aren't unlocked by Contributor access). This test
+	 * locks that decision in so anyone tightening the cap notices the
+	 * test break and re-evaluates.
+	 *
+	 * @covers ::register_endpoints
+	 *
+	 * @return void
+	 */
+	public function test_rest_endpoints_keep_edit_posts_capability(): void {
+		$instance = Geocoding::get_instance();
+		$instance->register_endpoints();
+
+		$routes = rest_get_server()->get_routes();
+		foreach ( array( 'geocode', 'geocode/search' ) as $route_suffix ) {
+			$key = '/' . GATHERPRESS_REST_NAMESPACE . '/' . $route_suffix;
+			$this->assertArrayHasKey( $key, $routes, sprintf( 'Route %s should be registered.', $key ) );
+
+			$contributor_id = $this->factory->user->create( array( 'role' => 'contributor' ) );
+			wp_set_current_user( $contributor_id );
+
+			foreach ( $routes[ $key ] as $route_def ) {
+				$callback = $route_def['permission_callback'];
+				$this->assertTrue(
+					(bool) call_user_func( $callback ),
+					sprintf( 'Contributor should pass the %s permission_callback (gated by `edit_posts`).', $key )
+				);
+			}
+		}
+	}
 }


### PR DESCRIPTION
### Description of the Change

Adds a per-user rate limit to the two geocoding REST endpoints in `Geocoding::register_endpoints()`:

- `GET /gatherpress/v1/geocode` (forward geocode used by save-time reverse-lookup on a venue)
- `GET /gatherpress/v1/geocode/search` (autocomplete-as-you-type)

Both proxy through to Photon (or whichever upstream is wired up). Without a rate limit, two real failure modes existed:

1. **Buggy client.** An autocomplete UI that fires on every keystroke without proper debouncing hammers the endpoint. The user sees a slow editor; we get rate-limited / IP-blocked at Photon.
2. **Malicious user.** A user with the right cap scripts the endpoint to abuse the proxy or exhaust upstream quota.

### What's in scope

A fixed-window, per-user transient-backed rate limit shared across both endpoints — autocomplete + save-time reverse-geocode are part of the same user flow, so they share one bucket.

- **Window:** 60 seconds, fixed (TTL tracks `expires_at` in the bucket so refreshing the count doesn't slide the window).
- **Default ceiling:** 30 requests per minute. Roomy enough for one user typing a 25-char address with debounced autocomplete (~10 requests) plus a couple of save-time reverse geocodes; tight enough to catch a runaway client or scripted abuse.
- **Filter:** `gatherpress_geocode_rate_limit_per_minute` so site owners can lower or raise the ceiling.
- **Over-limit response:** `WP_REST_Response` with HTTP `429`, `Retry-After` header pointing at the remaining seconds in the window, and a structured body with `code: gatherpress_geocode_rate_limited`.
- **Anonymous fallback:** `check_rate_limit()` returns null (allow) when `user_id === 0`. The REST `permission_callback` already gates anonymous requests — the early return is defense-in-depth so an anon caller never keys the bucket on user ID 0 (which would otherwise let all anons share one global quota).

### What's NOT in scope (intentionally)

The original framing of issue #1538 also recommended tightening the capability check from `edit_posts` to `edit_published_posts` or a venue-specific cap. After a closer read of the threat model that's mostly security theater:

- Photon is already free and public — logged-in users can hit it directly without proxying through us.
- Contributors don't see the venue editor UI, so legitimate access is already approximately zero — and tightening to Author+ doesn't change the threat surface meaningfully because the actual threat is volume from any privileged user, not access from low-privileged ones.
- The right defense against both real failure modes (buggy client, malicious user) is rate limiting, not role gating.

So the capability stays at `edit_posts` and a dedicated test (`test_rest_endpoints_keep_edit_posts_capability`) locks that decision in. Anyone who later tries to tighten the cap will see the test break and have to re-evaluate.

Closes #1538

### How to test the Change

1. `npm run lint:phpstan` — passes clean.
2. `npm run lint:php` — passes clean.
3. `npm run test:unit:php -- --filter "Test_Geocoding"` — 73 tests / 250 assertions pass; 100% coverage on `class-geocoding.php`.
4. Manual: open a venue editor, watch the network tab, type into the address autocomplete. Each keystroke (after debounce) should return 200 normally. Now in DevTools console, fire ~40 requests in a tight loop:

   ```js
   for ( let i = 0; i < 40; i++ ) {
     fetch( '/wp-json/gatherpress/v1/geocode/search?q=test' + i, { credentials: 'include' } );
   }
   ```

   Around the 31st request you should see HTTP 429 responses with a `Retry-After` header. Wait 60 seconds, retry — succeeds again.
5. Filter test: drop a `gatherpress_geocode_rate_limit_per_minute` filter into a mu-plugin returning `1`. Make any geocode request, then a second one — second should 429 immediately.
6. Confirm Contributor role still passes: `wp_set_current_user( contributor_id ); current_user_can( 'edit_posts' )` returns true and a request goes through (gated by rate limit only).

### Changelog Entry

> Added - Per-user rate limit on the geocoding REST endpoints (30 requests / 60 seconds by default; filterable via `gatherpress_geocode_rate_limit_per_minute`) to protect the upstream provider from runaway autocomplete clients and scripted abuse.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.