### PR TITLE
Stop dimming GatherPress blocks inside Query Loops with valid event context (#1547)

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: NPM install
         if: steps.node_modules-cache.outputs.cache-hit != 'true'
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       # Creating a short lived node_modules cache
       - uses: actions/cache/save@v4
@@ -144,7 +144,7 @@ jobs:
 
       - name: NPM install
         if: steps.node_modules-cache.outputs.cache-hit != 'true'
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       # Creating a short lived node_modules cache
       - uses: actions/cache/save@v4

--- a/.github/workflows/general-linting.yml
+++ b/.github/workflows/general-linting.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: NPM install
         if: steps.node_modules-cache.outputs.cache-hit != 'true'
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       # Creating a short lived node_modules cache
       - uses: actions/cache/save@v4
@@ -101,7 +101,7 @@ jobs:
 
       - name: NPM install
         if: steps.node_modules-cache.outputs.cache-hit != 'true'
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       # Creating a short lived node_modules cache
       - uses: actions/cache/save@v4

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: NPM install
         if: steps.node_modules-cache.outputs.cache-hit != 'true'
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       # Creating a short lived node_modules cache
       - uses: actions/cache/save@v4

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: NPM install
         if: steps.node_modules-cache.outputs.cache-hit != 'true'
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       # Creating a short lived node_modules cache
       - uses: actions/cache/save@v4

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: NPM install
         if: steps.node_modules-cache.outputs.cache-hit != 'true'
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       # Creating a short lived node_modules cache
       - uses: actions/cache/save@v4

--- a/.github/workflows/wordpress-org-screenshots.yml
+++ b/.github/workflows/wordpress-org-screenshots.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: NPM install
       if: steps.node_modules-cache.outputs.cache-hit != 'true'
-      run: npm ci --legacy-peer-deps
+      run: npm ci
 
     # Creating a short lived node_modules cache
     - uses: actions/cache/save@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ GatherPress uses custom `post_type_supports` to decouple features from specific 
 - PHP checks use `post_type_supports( $post_type, 'gatherpress-event-date' )` instead of `Event::POST_TYPE === $post_type`
 - PHP checks use `post_type_supports( $post_type, 'gatherpress-venue-information' )` instead of `Venue::POST_TYPE === $post_type`
 - Queries use `get_post_types_by_support( 'gatherpress-event-date' )` or `get_post_types_by_support( 'gatherpress-venue-information' )` instead of hardcoded post type slugs
-- JS checks use `select('core').getPostType(slug)?.supports?.['gatherpress-event-date']` via the WordPress data store
+- JS checks go through helpers in `src/helpers/event.js`: `isPostTypeSupporting( support, postType )` for imperative use, `usePostTypeSupports( support, postType )` (a `useSelect`-backed hook) when the result drives rendering. The non-reactive variant misses the post-type registry's first-render cache miss and leaves dim-gated blocks permanently dimmed in Query Loops — always reach for `usePostTypeSupports` inside React components
 - JS venue post type resolution uses `select('core/editor').getEditorSettings()?.gatherpress?.config?.venuePostTypes` (exposed via `block_editor_settings_all` filter)
 - Post-type-specific hooks are registered inside `register_post_meta()` or similar `init` callbacks that loop over supported post types at priority 11
 
@@ -154,7 +154,7 @@ add_filter( 'gatherpress_venue_post_type', function( $post_type, $event_post_typ
 4. Replace `Venue::POST_TYPE === get_post_type()` checks with `post_type_supports( ..., 'gatherpress-venue-information' )`
 5. Replace `'post_type' => Event::POST_TYPE` in queries with `get_post_types_by_support( 'gatherpress-event-date' )`
 6. Register post-type-specific hooks inside `register_post_meta()` or similar `init` callbacks at priority 11 that loop over supported post types
-7. Update JS helpers to check supports via `select('core').getPostType(slug)?.supports`
+7. Update JS helpers to check supports via `isPostTypeSupporting` (imperative) or `usePostTypeSupports` (reactive — required when the check drives render output, including dim/opacity gates)
 8. Update corresponding unit tests (PHP and JS mocks)
 
 ### Database Schema

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -230,15 +230,41 @@ $args = array( 'post_type' => get_post_types_by_support( 'gatherpress-event-date
 $args = array( 'post_type' => get_post_types_by_support( 'gatherpress-venue-information' ) );
 ```
 
-In JavaScript, support checks use the WordPress data store:
+In JavaScript, support checks go through one of two helpers in `src/helpers/event.js`:
 
 ```js
-// Check if current post type is an event.
-select( 'core' ).getPostType( postType )?.supports?.[ 'gatherpress-event-date' ];
+import {
+	isPostTypeSupporting,
+	usePostTypeSupports,
+} from '../../helpers/event';
 
-// Check if current post type is a venue.
-select( 'core' ).getPostType( postType )?.supports?.[ 'gatherpress-venue-information' ];
+// Outside React: imperative check that reads the post-type registry once.
+isPostTypeSupporting( 'gatherpress-event-date', postType );
+
+// Inside a React component: reactive check via useSelect, so the component
+// re-renders the moment the post-type definition resolves.
+const isEvent = usePostTypeSupports( 'gatherpress-event-date', postType );
 ```
+
+**Always reach for `usePostTypeSupports` when the result drives rendering** — opacity, visibility, conditional inspector controls, etc. The non-reactive `isPostTypeSupporting` reads `select('core').getPostType(...)` directly, and the post-type registry usually isn't cached on first render. If a dim gate is wired through the non-reactive helper, the gate resolves to `false` on the first paint and the component never re-renders once supports load — leaving the block permanently dimmed in Query Loops.
+
+For blocks that gate dimming on both context support and data presence, `hasValidBlockContext` in `src/helpers/editor.js` accepts a pre-computed `hasSupport` boolean — pass the result of `usePostTypeSupports`:
+
+```js
+const hasSupport = usePostTypeSupports( 'gatherpress-venue', context?.postType );
+
+const blockProps = useBlockProps( {
+	style: {
+		opacity: hasValidBlockContext( {
+			isDescendentOfQueryLoop,
+			hasSupport,
+			hasData: hasVenue,
+		} ) ? 1 : DISABLED_FIELD_OPACITY,
+	},
+} );
+```
+
+Reading the post type from block context (`context?.postType`) requires `postType` to be declared in the block's `block.json` `usesContext` array — otherwise `context.postType` will be `undefined` inside a Query Loop's Post Template even when the queried post type would carry the relevant supports.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,8 +58,9 @@
 				"playwright": "^1.58.2",
 				"prettier": "^3.8.1",
 				"rimraf": "^6.1.3",
-				"stylelint-config-recommended-scss": "^17.0.0",
-				"stylelint-config-standard": "^40.0.0",
+				"stylelint": "^16.26.1",
+				"stylelint-config-recommended-scss": "^16.0.0",
+				"stylelint-config-standard": "^39.0.0",
 				"uuid": "^14.0.0",
 				"webpack-remove-empty-scripts": "^1.1.1"
 			}
@@ -7662,20 +7663,6 @@
 				"url": "https://github.com/sindresorhus/is?sponsor=1"
 			}
 		},
-		"node_modules/@sindresorhus/merge-streams": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-			"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -12328,212 +12315,6 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"license": "Python-2.0"
-		},
-		"node_modules/@wordpress/scripts/node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/balanced-match": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/scripts/node_modules/cosmiconfig": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"env-paths": "^2.2.1",
-				"import-fresh": "^3.3.0",
-				"js-yaml": "^4.1.0",
-				"parse-json": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/d-fischer"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.9.5"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/scripts/node_modules/file-entry-cache": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
-			"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"flat-cache": "^6.1.20"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/flat-cache": {
-			"version": "6.1.21",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.21.tgz",
-			"integrity": "sha512-2u7cJfSf7Th7NxEk/VzQjnPoglok2YCsevS7TSbJjcDQWJPbqUUnSYtriHSvtnq+fRZHy1s0ugk4ApnQyhPGoQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cacheable": "^2.3.3",
-				"flatted": "^3.4.1",
-				"hookified": "^1.15.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/global-modules": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"global-prefix": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/global-prefix": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ini": "^1.3.5",
-				"kind-of": "^6.0.2",
-				"which": "^1.3.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/globby/node_modules/ignore": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/html-tags": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
-			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@wordpress/scripts/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/kind-of": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/mathml-tag-names": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
-			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/meow": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/prettier": {
 			"name": "wp-prettier",
 			"version": "3.0.3",
@@ -12549,85 +12330,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/stylelint": {
-			"version": "16.26.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
-			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/stylelint"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/stylelint"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
-				"@csstools/css-tokenizer": "^3.0.4",
-				"@csstools/media-query-list-parser": "^4.0.3",
-				"@csstools/selector-specificity": "^5.0.0",
-				"@dual-bundle/import-meta-resolve": "^4.2.1",
-				"balanced-match": "^2.0.0",
-				"colord": "^2.9.3",
-				"cosmiconfig": "^9.0.0",
-				"css-functions-list": "^3.2.3",
-				"css-tree": "^3.1.0",
-				"debug": "^4.4.3",
-				"fast-glob": "^3.3.3",
-				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^11.1.1",
-				"global-modules": "^2.0.0",
-				"globby": "^11.1.0",
-				"globjoin": "^0.1.4",
-				"html-tags": "^3.3.1",
-				"ignore": "^7.0.5",
-				"imurmurhash": "^0.1.4",
-				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.37.0",
-				"mathml-tag-names": "^2.1.3",
-				"meow": "^13.2.0",
-				"micromatch": "^4.0.8",
-				"normalize-path": "^3.0.0",
-				"picocolors": "^1.1.1",
-				"postcss": "^8.5.6",
-				"postcss-resolve-nested-selector": "^0.1.6",
-				"postcss-safe-parser": "^7.0.1",
-				"postcss-selector-parser": "^7.1.0",
-				"postcss-value-parser": "^4.2.0",
-				"resolve-from": "^5.0.0",
-				"string-width": "^4.2.3",
-				"supports-hyperlinks": "^3.2.0",
-				"svg-tags": "^1.0.0",
-				"table": "^6.9.0",
-				"write-file-atomic": "^5.0.1"
-			},
-			"bin": {
-				"stylelint": "bin/stylelint.mjs"
-			},
-			"engines": {
-				"node": ">=18.12.0"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/stylelint-config-recommended": {
@@ -12675,124 +12377,6 @@
 				"postcss": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/stylelint-scss": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.14.0.tgz",
-			"integrity": "sha512-ZKmHMZolxeuYsnB+PCYrTpFce0/QWX9i9gh0hPXzp73WjuIMqUpzdQaBCrKoLWh6XtCFSaNDErkMPqdjy1/8aA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"css-tree": "^3.0.1",
-				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.37.0",
-				"mdn-data": "^2.25.0",
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-resolve-nested-selector": "^0.1.6",
-				"postcss-selector-parser": "^7.1.1",
-				"postcss-value-parser": "^4.2.0"
-			},
-			"engines": {
-				"node": ">=18.12.0"
-			},
-			"peerDependencies": {
-				"stylelint": "^16.8.2"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/stylelint/node_modules/@csstools/selector-specificity": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"postcss-selector-parser": "^7.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/stylelint/node_modules/postcss-selector-parser": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/supports-hyperlinks": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"which": "bin/which"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/write-file-atomic": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@wordpress/server-side-render": {
@@ -15163,28 +14747,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/cliui/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/cliui/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/cliui/node_modules/wrap-ansi": {
@@ -19001,20 +18563,6 @@
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
-		"node_modules/get-east-asian-width": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/get-intrinsic": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -19844,14 +19392,13 @@
 			}
 		},
 		"node_modules/html-tags": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
-			"integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
-				"node": ">=20.10"
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -20224,18 +19771,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/import-meta-resolve": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/imurmurhash": {
@@ -25053,12 +24588,11 @@
 			}
 		},
 		"node_modules/mathml-tag-names": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
-			"integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
@@ -30520,21 +30054,18 @@
 			}
 		},
 		"node_modules/string-width": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-			"integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"get-east-asian-width": "^1.5.0",
-				"strip-ansi": "^7.1.2"
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
 			},
 			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
 		"node_modules/string-width-cjs": {
@@ -30560,36 +30091,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/string-width/node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+		"node_modules/string-width/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/string-width/node_modules/strip-ansi": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^6.2.2"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
+			"license": "MIT"
 		},
 		"node_modules/string.prototype.includes": {
 			"version": "2.0.1",
@@ -30875,9 +30382,9 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "17.5.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.5.0.tgz",
-			"integrity": "sha512-o/NS6zhsPZFmgUm5tXX4pVNg1XDOZSlucLdf2qow/lVn4JIyzZIQ5b3kad1ugqUj3GSIgr2u5lQw7X8rjqw33g==",
+			"version": "16.26.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
 			"dev": true,
 			"funding": [
 				{
@@ -30890,57 +30397,58 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@csstools/css-calc": "^3.1.1",
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-syntax-patches-for-csstree": "^1.0.29",
-				"@csstools/css-tokenizer": "^4.0.0",
-				"@csstools/media-query-list-parser": "^5.0.0",
-				"@csstools/selector-resolve-nested": "^4.0.0",
-				"@csstools/selector-specificity": "^6.0.0",
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
+				"@csstools/css-tokenizer": "^3.0.4",
+				"@csstools/media-query-list-parser": "^4.0.3",
+				"@csstools/selector-specificity": "^5.0.0",
+				"@dual-bundle/import-meta-resolve": "^4.2.1",
+				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
-				"cosmiconfig": "^9.0.1",
-				"css-functions-list": "^3.3.3",
-				"css-tree": "^3.2.1",
+				"cosmiconfig": "^9.0.0",
+				"css-functions-list": "^3.2.3",
+				"css-tree": "^3.1.0",
 				"debug": "^4.4.3",
 				"fast-glob": "^3.3.3",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^11.1.2",
+				"file-entry-cache": "^11.1.1",
 				"global-modules": "^2.0.0",
-				"globby": "^16.1.1",
+				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
-				"html-tags": "^5.1.0",
+				"html-tags": "^3.3.1",
 				"ignore": "^7.0.5",
-				"import-meta-resolve": "^4.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"mathml-tag-names": "^4.0.0",
-				"meow": "^14.1.0",
+				"known-css-properties": "^0.37.0",
+				"mathml-tag-names": "^2.1.3",
+				"meow": "^13.2.0",
 				"micromatch": "^4.0.8",
 				"normalize-path": "^3.0.0",
 				"picocolors": "^1.1.1",
-				"postcss": "^8.5.8",
+				"postcss": "^8.5.6",
+				"postcss-resolve-nested-selector": "^0.1.6",
 				"postcss-safe-parser": "^7.0.1",
-				"postcss-selector-parser": "^7.1.1",
+				"postcss-selector-parser": "^7.1.0",
 				"postcss-value-parser": "^4.2.0",
-				"string-width": "^8.2.0",
-				"supports-hyperlinks": "^4.4.0",
+				"resolve-from": "^5.0.0",
+				"string-width": "^4.2.3",
+				"supports-hyperlinks": "^3.2.0",
 				"svg-tags": "^1.0.0",
 				"table": "^6.9.0",
-				"write-file-atomic": "^7.0.0"
+				"write-file-atomic": "^5.0.1"
 			},
 			"bin": {
 				"stylelint": "bin/stylelint.mjs"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18.12.0"
 			}
 		},
 		"node_modules/stylelint-config-recommended": {
-			"version": "18.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
-			"integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-17.0.0.tgz",
+			"integrity": "sha512-WaMSdEiPfZTSFVoYmJbxorJfA610O0tlYuU2aEwY33UQhSPgFbClrVJYWvy3jGJx+XW37O+LyNLiZOEXhKhJmA==",
 			"dev": true,
 			"funding": [
 				{
@@ -30954,29 +30462,29 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^17.0.0"
+				"stylelint": "^16.23.0"
 			}
 		},
 		"node_modules/stylelint-config-recommended-scss": {
-			"version": "17.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-17.0.0.tgz",
-			"integrity": "sha512-VkVD9r7jfUT/dq3mA3/I1WXXk2U71rO5wvU2yIil9PW5o1g3UM7Xc82vHmuVJHV7Y8ok5K137fmW5u3HbhtTOA==",
+			"version": "16.0.2",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-16.0.2.tgz",
+			"integrity": "sha512-aUTHhPPWCvFyWaxtckJlCPaXTDFsp4pKO8evXNCsW9OwsaUWyMd6jvcUhSmfGWPrTddvzNqK4rS/UuSLcbVGdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-scss": "^4.0.9",
-				"stylelint-config-recommended": "^18.0.0",
-				"stylelint-scss": "^7.0.0"
+				"stylelint-config-recommended": "^17.0.0",
+				"stylelint-scss": "^6.12.1"
 			},
 			"engines": {
 				"node": ">=20"
 			},
 			"peerDependencies": {
 				"postcss": "^8.3.3",
-				"stylelint": "^17.0.0"
+				"stylelint": "^16.24.0"
 			},
 			"peerDependenciesMeta": {
 				"postcss": {
@@ -30985,9 +30493,9 @@
 			}
 		},
 		"node_modules/stylelint-config-standard": {
-			"version": "40.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
-			"integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
+			"version": "39.0.1",
+			"resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-39.0.1.tgz",
+			"integrity": "sha512-b7Fja59EYHRNOTa3aXiuWnhUWXFU2Nfg6h61bLfAb5GS5fX3LMUD0U5t4S8N/4tpHQg3Acs2UVPR9jy2l1g/3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -31001,19 +30509,19 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"stylelint-config-recommended": "^18.0.0"
+				"stylelint-config-recommended": "^17.0.0"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^17.0.0"
+				"stylelint": "^16.23.0"
 			}
 		},
 		"node_modules/stylelint-scss": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-7.0.0.tgz",
-			"integrity": "sha512-H88kCC+6Vtzj76NsC8rv6x/LW8slBzIbyeSjsKVlS+4qaEJoDrcJR4L+8JdrR2ORdTscrBzYWiiT2jq6leYR1Q==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.14.0.tgz",
+			"integrity": "sha512-ZKmHMZolxeuYsnB+PCYrTpFce0/QWX9i9gh0hPXzp73WjuIMqUpzdQaBCrKoLWh6XtCFSaNDErkMPqdjy1/8aA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -31027,10 +30535,10 @@
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^16.8.2 || ^17.0.0"
+				"stylelint": "^16.8.2"
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
@@ -31047,129 +30555,10 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/stylelint/node_modules/@csstools/css-calc": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
-			}
-		},
-		"node_modules/stylelint/node_modules/@csstools/css-parser-algorithms": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"peerDependencies": {
-				"@csstools/css-tokenizer": "^4.0.0"
-			}
-		},
-		"node_modules/stylelint/node_modules/@csstools/css-tokenizer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=20.19.0"
-			}
-		},
-		"node_modules/stylelint/node_modules/@csstools/media-query-list-parser": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
-			"integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
-			}
-		},
-		"node_modules/stylelint/node_modules/@csstools/selector-resolve-nested": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
-			"integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"peer": true,
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"peerDependencies": {
-				"postcss-selector-parser": "^7.1.1"
-			}
-		},
 		"node_modules/stylelint/node_modules/@csstools/selector-specificity": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
-			"integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
 			"dev": true,
 			"funding": [
 				{
@@ -31182,12 +30571,11 @@
 				}
 			],
 			"license": "MIT-0",
-			"peer": true,
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"postcss-selector-parser": "^7.1.1"
+				"postcss-selector-parser": "^7.0.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/argparse": {
@@ -31195,8 +30583,24 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
-			"license": "Python-2.0",
-			"peer": true
+			"license": "Python-2.0"
+		},
+		"node_modules/stylelint/node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/stylelint/node_modules/balanced-match": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/cosmiconfig": {
 			"version": "9.0.1",
@@ -31204,7 +30608,6 @@
 			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"env-paths": "^2.2.1",
 				"import-fresh": "^3.3.0",
@@ -31232,7 +30635,6 @@
 			"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"flat-cache": "^6.1.20"
 			}
@@ -31243,7 +30645,6 @@
 			"integrity": "sha512-2u7cJfSf7Th7NxEk/VzQjnPoglok2YCsevS7TSbJjcDQWJPbqUUnSYtriHSvtnq+fRZHy1s0ugk4ApnQyhPGoQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cacheable": "^2.3.3",
 				"flatted": "^3.4.1",
@@ -31256,7 +30657,6 @@
 			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"global-prefix": "^3.0.0"
 			},
@@ -31270,7 +30670,6 @@
 			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ini": "^1.3.5",
 				"kind-of": "^6.0.2",
@@ -31281,25 +30680,34 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/globby": {
-			"version": "16.1.1",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
-			"integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@sindresorhus/merge-streams": "^4.0.0",
-				"fast-glob": "^3.3.3",
-				"ignore": "^7.0.5",
-				"is-path-inside": "^4.0.0",
-				"slash": "^5.1.0",
-				"unicorn-magic": "^0.4.0"
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/stylelint/node_modules/globby/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/stylelint/node_modules/ini": {
@@ -31307,22 +30715,7 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/stylelint/node_modules/is-path-inside": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-			"integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
+			"license": "ISC"
 		},
 		"node_modules/stylelint/node_modules/js-yaml": {
 			"version": "4.1.1",
@@ -31330,7 +30723,6 @@
 			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -31344,20 +30736,18 @@
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/meow": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
-			"integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
-				"node": ">=20"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -31369,7 +30759,6 @@
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -31378,27 +30767,12 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/stylelint/node_modules/slash": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/stylelint/node_modules/which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -31407,17 +30781,17 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/write-file-atomic": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
-			"integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
+				"imurmurhash": "^0.1.4",
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/stylis": {
@@ -31441,49 +30815,20 @@
 			}
 		},
 		"node_modules/supports-hyperlinks": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
-			"integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"has-flag": "^5.0.1",
-				"supports-color": "^10.2.2"
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=14.18"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
-			}
-		},
-		"node_modules/supports-hyperlinks/node_modules/has-flag": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
-			"integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/supports-hyperlinks/node_modules/supports-color": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-			"integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -31614,28 +30959,6 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/table/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/table/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/tannin": {
@@ -32477,20 +31800,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/unicorn-magic": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
-			"integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/universal-github-app-jwt": {
@@ -33654,50 +32963,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/wrap-ansi/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -33894,28 +33159,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/yargs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/yargs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -66,8 +66,9 @@
 		"playwright": "^1.58.2",
 		"prettier": "^3.8.1",
 		"rimraf": "^6.1.3",
-		"stylelint-config-recommended-scss": "^17.0.0",
-		"stylelint-config-standard": "^40.0.0",
+		"stylelint": "^16.26.1",
+		"stylelint-config-recommended-scss": "^16.0.0",
+		"stylelint-config-standard": "^39.0.0",
 		"uuid": "^14.0.0",
 		"webpack-remove-empty-scripts": "^1.1.1"
 	},

--- a/src/blocks/add-to-calendar/block.json
+++ b/src/blocks/add-to-calendar/block.json
@@ -8,7 +8,7 @@
 	"icon": "calendar",
 	"example": {},
 	"description": "Allows a member to add an event to their preferred calendar.",
-	"usesContext": [ "postId", "queryId" ],
+	"usesContext": [ "postId", "postType", "queryId" ],
 	"supports": {
 		"gatherpress": {
 			"blockGuard": true,

--- a/src/blocks/add-to-calendar/edit.js
+++ b/src/blocks/add-to-calendar/edit.js
@@ -7,7 +7,7 @@ import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
  * Internal dependencies.
  */
 import TEMPLATE from './template';
-import { hasValidEventId, usePostTypeSupports } from '../../helpers/event';
+import { hasValidEventId, usePostTypeSupports, DISABLED_FIELD_OPACITY } from '../../helpers/event';
 import { isInFSETemplate } from '../../helpers/editor';
 
 const Edit = ( { attributes, context } ) => {
@@ -32,7 +32,7 @@ const Edit = ( { attributes, context } ) => {
 
 	const blockProps = useBlockProps( {
 		style: {
-			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : 0.3,
+			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : DISABLED_FIELD_OPACITY,
 		},
 	} );
 

--- a/src/blocks/add-to-calendar/edit.js
+++ b/src/blocks/add-to-calendar/edit.js
@@ -7,15 +7,28 @@ import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
  * Internal dependencies.
  */
 import TEMPLATE from './template';
-import { hasValidEventId } from '../../helpers/event';
+import { hasValidEventId, usePostTypeSupports } from '../../helpers/event';
 import { isInFSETemplate } from '../../helpers/editor';
 
 const Edit = ( { attributes, context } ) => {
-	// Normalize empty strings to null so fallback to context.postId works correctly.
-	const postId = ( attributes?.postId || null ) ?? context?.postId ?? null;
+	// Check if we're inside a query loop and if context is an event.
+	// `usePostTypeSupports` is reactive so the block re-renders the moment the
+	// post-type definition resolves; the non-reactive variant would miss it
+	// and leave the block permanently dimmed in Query Loops.
+	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
+	const isEventContext = usePostTypeSupports( 'gatherpress-event-date', context?.postType );
+
+	// Only use postId if context is an event or have an explicit override.
+	const postId =
+		( attributes?.postId || null ) ??
+		( ( isDescendentOfQueryLoop || isEventContext ) ? context?.postId : null ) ??
+		null;
 
 	// Check if block has a valid event connection.
-	const isValidEvent = hasValidEventId( postId );
+	// Only check if we're in an event context.
+	const isValidEvent =
+		( isDescendentOfQueryLoop || isEventContext ) &&
+		hasValidEventId( postId, context?.postType );
 
 	const blockProps = useBlockProps( {
 		style: {

--- a/src/blocks/event-date/block.json
+++ b/src/blocks/event-date/block.json
@@ -10,7 +10,7 @@
 		"viewportWidth": 350
 	},
 	"description": "Displays the date and time for an event.",
-	"usesContext": [ "postId", "queryId" ],
+	"usesContext": [ "postId", "postType", "queryId" ],
 	"attributes": {
 		"eventEnd": {
 			"type": "string"

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -38,7 +38,7 @@ import {
 } from '../../helpers/datetime';
 import DateTimeRange from '../../components/DateTimeRange';
 import { getFromSettings } from '../../helpers/editor-settings';
-import { isEventPostType, hasValidEventId } from '../../helpers/event';
+import { isEventPostType } from '../../helpers/event';
 import { isInFSETemplate } from '../../helpers/editor';
 
 /**
@@ -199,32 +199,33 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const timeFormat = getFromSettings( 'timeFormat' );
 	const defaultShowTimezone = getFromSettings( 'showTimezone' );
 
-	// Check if we're inside a query loop and if context is an event.
+	// Check if we're inside a query loop.
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
-	const isEventContext = isEventPostType( context?.postType );
 
 	// Only use postId if context is an event or have an explicit override.
+	// Defer the supports check to useSelect so it stays reactive.
 	const postId =
 		( attributes?.postId || null ) ??
-		( ( isDescendentOfQueryLoop || isEventContext ) ? context?.postId : null ) ??
+		( isDescendentOfQueryLoop ? context?.postId : null ) ??
+		context?.postId ??
 		null;
 
-	// Check if block has a valid event connection.
-	// Only check if we're in an event context.
-	const isValidEvent =
-		( isDescendentOfQueryLoop || isEventContext ) &&
-		hasValidEventId( postId, context?.postType );
-
-	const blockProps = useBlockProps( {
-		style: {
-			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : 0.3,
-		},
-	} );
-
-	const { dateTimeStart, dateTimeEnd, timezone, isLoading } = useSelect(
+	const { dateTimeStart, dateTimeEnd, timezone, isLoading, isValidEvent } = useSelect(
 		( select ) => {
+			// Resolve the post type from context or fall back to the editor's current post type.
+			// This ensures custom post types with gatherpress-event-date support work correctly
+			// in Query Loop blocks and postId override scenarios.
+			const postType =
+				context?.postType ||
+				select( 'core/editor' )?.getCurrentPostType();
+
+			// Reactive supports check — `getPostType` is read inside useSelect so the
+			// component re-renders once the post-type definition (and its supports) load.
+			const supportsEventDate = !! select( 'core' )
+				.getPostType( postType )?.supports?.[ 'gatherpress-event-date' ];
+
 			if ( ! postId ) {
-				return {};
+				return { isValidEvent: false };
 			}
 
 			// When editing an event directly, use the datetime store for live updates.
@@ -234,15 +235,9 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 					dateTimeStart: datetimeStore.getDateTimeStart(),
 					dateTimeEnd: datetimeStore.getDateTimeEnd(),
 					timezone: datetimeStore.getTimezone(),
+					isValidEvent: supportsEventDate,
 				};
 			}
-
-			// Resolve the post type from context or fall back to the editor's current post type.
-			// This ensures custom post types with gatherpress-event-date support work correctly
-			// in Query Loop blocks and postId override scenarios.
-			const postType =
-				context?.postType ||
-				select( 'core/editor' )?.getCurrentPostType();
 
 			// For Query Loop and override contexts, fetch from entity record.
 			const hasResolved = select( 'core' ).hasFinishedResolution(
@@ -251,23 +246,36 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 			);
 
 			if ( ! hasResolved ) {
-				return { isLoading: true };
+				return { isLoading: true, isValidEvent: false };
 			}
 
-			const meta = select( 'core' ).getEntityRecord(
-				'postType',
-				postType,
-				postId
-			)?.meta;
+			const post = supportsEventDate
+				? select( 'core' ).getEntityRecord(
+					'postType',
+					postType,
+					postId
+				)
+				: null;
+			const meta = post?.meta;
 
 			return {
 				dateTimeStart: meta?.gatherpress_datetime_start,
 				dateTimeEnd: meta?.gatherpress_datetime_end,
 				timezone: meta?.gatherpress_timezone,
+				isValidEvent:
+					supportsEventDate &&
+					!! post &&
+					'publish' === post?.status,
 			};
 		},
 		[ postId, context?.postType ]
 	);
+
+	const blockProps = useBlockProps( {
+		style: {
+			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : 0.3,
+		},
+	} );
 
 	// Show spinner only while loading, not on 404.
 	if ( isLoading ) {

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -199,16 +199,8 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const timeFormat = getFromSettings( 'timeFormat' );
 	const defaultShowTimezone = getFromSettings( 'showTimezone' );
 
-	// Check if we're inside a query loop.
-	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
-
-	// Only use postId if context is an event or have an explicit override.
 	// Defer the supports check to useSelect so it stays reactive.
-	const postId =
-		( attributes?.postId || null ) ??
-		( isDescendentOfQueryLoop ? context?.postId : null ) ??
-		context?.postId ??
-		null;
+	const postId = attributes?.postId ?? context?.postId ?? null;
 
 	const { dateTimeStart, dateTimeEnd, timezone, isLoading, isValidEvent } = useSelect(
 		( select ) => {
@@ -239,6 +231,14 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				};
 			}
 
+			// Short-circuit before checking resolution: if the context post type doesn't
+			// support event-date we never call `getEntityRecord`, so its resolver never
+			// fires and `hasFinishedResolution` would stay false forever — blocking the
+			// component on a spinner that never resolves.
+			if ( ! supportsEventDate ) {
+				return { isValidEvent: false };
+			}
+
 			// For Query Loop and override contexts, fetch from entity record.
 			const hasResolved = select( 'core' ).hasFinishedResolution(
 				'getEntityRecord',
@@ -249,23 +249,21 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 				return { isLoading: true, isValidEvent: false };
 			}
 
-			const post = supportsEventDate
-				? select( 'core' ).getEntityRecord(
-					'postType',
-					postType,
-					postId
-				)
-				: null;
+			const post = select( 'core' ).getEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
 			const meta = post?.meta;
 
+			// Match the original `hasValidEventId` semantics: only treat the block as
+			// "connected" when the referenced post is published. Drafts/scheduled posts
+			// referenced via Query Loop or postId override stay dim by design.
 			return {
 				dateTimeStart: meta?.gatherpress_datetime_start,
 				dateTimeEnd: meta?.gatherpress_datetime_end,
 				timezone: meta?.gatherpress_timezone,
-				isValidEvent:
-					supportsEventDate &&
-					!! post &&
-					'publish' === post?.status,
+				isValidEvent: !! post && 'publish' === post?.status,
 			};
 		},
 		[ postId, context?.postType ]

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -38,7 +38,7 @@ import {
 } from '../../helpers/datetime';
 import DateTimeRange from '../../components/DateTimeRange';
 import { getFromSettings } from '../../helpers/editor-settings';
-import { isEventPostType } from '../../helpers/event';
+import { isEventPostType, DISABLED_FIELD_OPACITY } from '../../helpers/event';
 import { isInFSETemplate } from '../../helpers/editor';
 
 /**
@@ -273,7 +273,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 
 	const blockProps = useBlockProps( {
 		style: {
-			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : 0.3,
+			opacity: ( isInFSETemplate() || isValidEvent ) ? 1 : DISABLED_FIELD_OPACITY,
 		},
 	} );
 

--- a/src/blocks/online-event-link/block.json
+++ b/src/blocks/online-event-link/block.json
@@ -8,7 +8,7 @@
 	"icon": "admin-links",
 	"description": "Display an editable link for online events. Link URL comes from event meta, text is customizable.",
 	"ancestor": ["gatherpress/online-event"],
-	"usesContext": ["postId", "queryId"],
+	"usesContext": ["postId", "postType", "queryId"],
 	"attributes": {
 		"linkText": {
 			"type": "string",

--- a/src/blocks/online-event/block.json
+++ b/src/blocks/online-event/block.json
@@ -7,7 +7,7 @@
 	"category": "gatherpress",
 	"icon": "video-alt2",
 	"description": "Container block for online event display with icon and link.",
-	"usesContext": ["postId", "queryId"],
+	"usesContext": ["postId", "postType", "queryId"],
 	"providesContext": {
 		"postId": "postId"
 	},

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -17,7 +17,7 @@ import { __ } from '@wordpress/i18n';
  */
 import TEMPLATE from './template';
 import { hasValidBlockContext, isInFSETemplate } from '../../helpers/editor';
-import { isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
+import { isPostTypeSupporting, usePostTypeSupports, DISABLED_FIELD_OPACITY } from '../../helpers/event';
 import { getVenuePostType, getVenueTaxonomy, useVenueTaxonomyIds } from '../../helpers/venue';
 
 /**
@@ -179,13 +179,19 @@ const Edit = ( { attributes, context } ) => {
 		[ eventId, onlineEventTerm, venueTaxonomy ]
 	);
 
+	// Reactive supports check — keeps the block from staying dimmed when the
+	// post-type definition isn't cached on first render.
+	const hasOnlineEventSupport = usePostTypeSupports(
+		'gatherpress-online-event',
+		context?.postType
+	);
+
 	// Dim the block when not an online event or no valid context.
 	const blockProps = useBlockProps( {
 		style: {
 			opacity: hasValidBlockContext( {
 				isDescendentOfQueryLoop,
-				postType: context?.postType,
-				support: 'gatherpress-online-event',
+				hasSupport: hasOnlineEventSupport,
 				hasData: isOnlineEvent,
 			} )
 				? 1

--- a/src/blocks/rsvp-count/edit.js
+++ b/src/blocks/rsvp-count/edit.js
@@ -11,7 +11,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies.
  */
-import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isPostTypeSupporting, isRsvpEnabledForEvent } from '../../helpers/event';
+import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, usePostTypeSupports, isRsvpEnabledForEvent } from '../../helpers/event';
 import { EVENT_REST_API } from '../../helpers/namespace';
 import { isInFSETemplate } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
@@ -51,7 +51,10 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
 
 	// Check if context post type supports RSVP.
-	const isEventContext = isPostTypeSupporting( 'gatherpress-rsvp', context?.postType );
+	// `usePostTypeSupports` is reactive so the block re-renders the moment the
+	// post-type definition resolves; the non-reactive variant would miss it
+	// and leave the block permanently dimmed in Query Loops.
+	const isEventContext = usePostTypeSupports( 'gatherpress-rsvp', context?.postType );
 
 	// Only use postId if context is an event or have an explicit override.
 	const postId =

--- a/src/blocks/rsvp-guest-count-display/block.json
+++ b/src/blocks/rsvp-guest-count-display/block.json
@@ -10,7 +10,7 @@
 	"icon": "yes",
 	"example": {},
 	"attributes": {},
-	"usesContext": [ "commentId", "postId", "postType", "queryId", "gatherpress/rsvpResponses" ],
+	"usesContext": [ "commentId", "postId", "postType", "gatherpress/rsvpResponses" ],
 	"supports": {
 		"align": [ "left", "center", "right" ],
 		"spacing": {

--- a/src/blocks/rsvp-guest-count-display/block.json
+++ b/src/blocks/rsvp-guest-count-display/block.json
@@ -10,7 +10,7 @@
 	"icon": "yes",
 	"example": {},
 	"attributes": {},
-	"usesContext": [ "commentId", "gatherpress/rsvpResponses" ],
+	"usesContext": [ "commentId", "postId", "postType", "queryId", "gatherpress/rsvpResponses" ],
 	"supports": {
 		"align": [ "left", "center", "right" ],
 		"spacing": {

--- a/src/blocks/rsvp-guest-count-display/edit.js
+++ b/src/blocks/rsvp-guest-count-display/edit.js
@@ -10,7 +10,7 @@ import { useEffect } from '@wordpress/element';
  * Internal dependencies.
  */
 import { getEditorDocument } from '../../helpers/editor';
-import { DISABLED_FIELD_OPACITY, isPostTypeSupporting, usePostTypeSupports } from '../../helpers/event';
+import { DISABLED_FIELD_OPACITY, usePostTypeSupports } from '../../helpers/event';
 
 /**
  * Edit function for the RSVP Guest Count Display Block.
@@ -86,10 +86,15 @@ const Edit = ( { context, clientId } ) => {
 				return post?.meta?.gatherpress_max_guest_limit || 0;
 			}
 
-			// Otherwise check current post.
+			// Otherwise check current post. Read supports through the `select`
+			// parameter so this branch re-runs once the post-type definition
+			// resolves — the imperative `isPostTypeSupporting` helper would
+			// race the post-type cache and freeze this branch at 0.
 			const currentPostType = select( 'core/editor' )?.getCurrentPostType();
+			const currentSupportsRsvp = !! select( 'core' )
+				.getPostType( currentPostType )?.supports?.[ 'gatherpress-rsvp' ];
 
-			if ( isPostTypeSupporting( 'gatherpress-rsvp', currentPostType ) ) {
+			if ( currentSupportsRsvp ) {
 				return select( 'core/editor' ).getEditedPostAttribute( 'meta' )
 					?.gatherpress_max_guest_limit || 0;
 			}

--- a/src/blocks/rsvp-guest-count-display/edit.js
+++ b/src/blocks/rsvp-guest-count-display/edit.js
@@ -10,7 +10,7 @@ import { useEffect } from '@wordpress/element';
  * Internal dependencies.
  */
 import { getEditorDocument } from '../../helpers/editor';
-import { DISABLED_FIELD_OPACITY, isPostTypeSupporting } from '../../helpers/event';
+import { DISABLED_FIELD_OPACITY, isPostTypeSupporting, usePostTypeSupports } from '../../helpers/event';
 
 /**
  * Edit function for the RSVP Guest Count Display Block.
@@ -32,7 +32,10 @@ const Edit = ( { context, clientId } ) => {
 	const rsvpResponses = context?.[ 'gatherpress/rsvpResponses' ] ?? null;
 
 	// Check if context post type supports RSVP.
-	const isEventContext = isPostTypeSupporting( 'gatherpress-rsvp', context?.postType );
+	// `usePostTypeSupports` is reactive so the block re-renders the moment the
+	// post-type definition resolves; the non-reactive variant would miss it
+	// and leave the block permanently dimmed in Query Loops.
+	const isEventContext = usePostTypeSupports( 'gatherpress-rsvp', context?.postType );
 
 	// Example guest count.
 	let guestCount = 1;

--- a/src/blocks/rsvp-response/block.json
+++ b/src/blocks/rsvp-response/block.json
@@ -8,7 +8,7 @@
 	"icon": "groups",
 	"example": {},
 	"description": "Displays a list of members who have confirmed their attendance for an event.",
-	"usesContext": [ "postId", "queryId" ],
+	"usesContext": [ "postId", "postType", "queryId" ],
 	"attributes": {
 		"rsvpLimitEnabled": {
 			"type": "boolean",

--- a/src/blocks/rsvp-response/edit.js
+++ b/src/blocks/rsvp-response/edit.js
@@ -27,7 +27,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import RsvpManager from './rsvp-manager';
 import TEMPLATE from './template';
-import { hasValidEventId, isPostTypeSupporting, DISABLED_FIELD_OPACITY, getEventMeta, isRsvpEnabledForEvent } from '../../helpers/event';
+import { hasValidEventId, isPostTypeSupporting, usePostTypeSupports, DISABLED_FIELD_OPACITY, getEventMeta, isRsvpEnabledForEvent } from '../../helpers/event';
 import { getEditorDocument, isInFSETemplate } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
 import { EVENT_REST_API } from '../../helpers/namespace';
@@ -68,8 +68,11 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const [ error, setError ] = useState( null );
 
 	// Check if we're inside a query loop and if context is an RSVP-enabled post type.
+	// `usePostTypeSupports` is reactive so the block re-renders the moment the
+	// post-type definition resolves; the non-reactive variant would miss it
+	// and leave the block permanently dimmed in Query Loops.
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
-	const isEventContext = isPostTypeSupporting( 'gatherpress-rsvp', context?.postType );
+	const isEventContext = usePostTypeSupports( 'gatherpress-rsvp', context?.postType );
 
 	// Only use postId if context is an event or have an explicit override.
 	const postId =

--- a/src/blocks/rsvp-response/edit.js
+++ b/src/blocks/rsvp-response/edit.js
@@ -27,7 +27,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import RsvpManager from './rsvp-manager';
 import TEMPLATE from './template';
-import { hasValidEventId, isPostTypeSupporting, usePostTypeSupports, DISABLED_FIELD_OPACITY, getEventMeta, isRsvpEnabledForEvent } from '../../helpers/event';
+import { hasValidEventId, usePostTypeSupports, DISABLED_FIELD_OPACITY, getEventMeta, isRsvpEnabledForEvent } from '../../helpers/event';
 import { getEditorDocument, isInFSETemplate } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
 import { EVENT_REST_API } from '../../helpers/namespace';
@@ -73,6 +73,10 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	// and leave the block permanently dimmed in Query Loops.
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
 	const isEventContext = usePostTypeSupports( 'gatherpress-rsvp', context?.postType );
+	// Editor-side check (no postType arg) for the inline edit toolbar — only
+	// surface it when editing an RSVP-supporting post directly. Reactive so
+	// the toolbar appears once supports load instead of staying hidden.
+	const isEditingRsvpPost = usePostTypeSupports( 'gatherpress-rsvp' );
 
 	// Only use postId if context is an event or have an explicit override.
 	const postId =
@@ -243,7 +247,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 						) }
 					</PanelBody>
 				</InspectorControls>
-				{ isPostTypeSupporting( 'gatherpress-rsvp' ) && (
+				{ isEditingRsvpPost && (
 					<BlockControls>
 						<ToolbarGroup>
 							<ToolbarButton

--- a/src/blocks/rsvp/block.json
+++ b/src/blocks/rsvp/block.json
@@ -8,7 +8,7 @@
 	"icon": "insert",
 	"example": {},
 	"description": "Enables members to easily confirm their attendance for an event.",
-	"usesContext": [ "postId", "queryId" ],
+	"usesContext": [ "postId", "postType", "queryId" ],
 	"attributes": {
 		"serializedInnerBlocks": {
 			"type": "string",

--- a/src/blocks/rsvp/edit.js
+++ b/src/blocks/rsvp/edit.js
@@ -17,7 +17,7 @@ import { createBlock, parse, serialize } from '@wordpress/blocks';
  * Internal dependencies.
  */
 import TEMPLATES from './templates';
-import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isPostTypeSupporting, isRsvpEnabledForEvent } from '../../helpers/event';
+import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, usePostTypeSupports, isRsvpEnabledForEvent } from '../../helpers/event';
 import { isInFSETemplate, getEditorDocument } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
 
@@ -55,8 +55,11 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 
 	// Check if we're inside a query loop and if context is an RSVP-enabled post type.
+	// `usePostTypeSupports` is reactive so the block re-renders the moment the
+	// post-type definition resolves — non-reactive checks miss this and leave
+	// the block permanently dimmed in Query Loops.
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
-	const isEventContext = isPostTypeSupporting( 'gatherpress-rsvp', context?.postType );
+	const isEventContext = usePostTypeSupports( 'gatherpress-rsvp', context?.postType );
 
 	// Only use postId if context is an event or have an explicit override.
 	const postId =

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -15,7 +15,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { getCurrentContextualPostId, hasValidBlockContext, isInFSETemplate } from '../../helpers/editor';
-import { isPostTypeSupporting, DISABLED_FIELD_OPACITY } from '../../helpers/event';
+import { usePostTypeSupports, DISABLED_FIELD_OPACITY } from '../../helpers/event';
 import { GetVenuePostFromTermId, GetVenuePostFromEventId, getVenuePostType, getVenueTaxonomy, useVenueTaxonomyIds } from '../../helpers/venue';
 import VenueNavigator from '../../components/VenueNavigator';
 import { TEMPLATE_WITH_TITLE, TEMPLATE_WITHOUT_TITLE } from './template';
@@ -24,8 +24,11 @@ const Edit = ( props ) => {
 	const { context } = props;
 
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
-	const isEventContext = isPostTypeSupporting( 'gatherpress-venue', context?.postType );
-	const isVenueContext = isPostTypeSupporting( 'gatherpress-venue-information', context?.postType );
+	// Reactive supports checks so the block re-renders once the post-type
+	// definition (and its supports) load — non-reactive `select()` calls miss
+	// that resolution and leave the block permanently dimmed in Query Loops.
+	const isEventContext = usePostTypeSupports( 'gatherpress-venue', context?.postType );
+	const isVenueContext = usePostTypeSupports( 'gatherpress-venue-information', context?.postType );
 
 	// Resolve the effective post type from context or the current editor post type.
 	const currentEditorPostType = useSelect(
@@ -107,8 +110,7 @@ const Edit = ( props ) => {
 		style: {
 			opacity: hasValidBlockContext( {
 				isDescendentOfQueryLoop,
-				postType: context?.postType,
-				support: 'gatherpress-venue',
+				hasSupport: isEventContext,
 				hasData: hasVenue,
 			} )
 				? 1

--- a/src/helpers/editor.js
+++ b/src/helpers/editor.js
@@ -84,20 +84,33 @@ export function isInFSETemplate() {
  * Use this helper to consistently apply dimming logic across GatherPress blocks.
  * A block is fully visible (not dimmed) when:
  * - It's in an FSE template (always visible for preview)
- * - It's in a Query Loop with valid post type context AND has data
+ * - It's in a Query Loop with valid post type support AND has data
  * - It's editing a post directly AND has data
+ *
+ * The supports check is intentionally a parameter (`hasSupport`) rather than
+ * computed inside the helper. Reading post-type supports via `select(...)` is
+ * non-reactive — the post-type definition often isn't cached on first render,
+ * so the gate would resolve to `false` and the block would never re-render
+ * once supports load. Callers should compute `hasSupport` reactively via the
+ * `usePostTypeSupports` hook so the block re-renders the moment supports become known.
+ *
+ * Backwards compatible: if `hasSupport` is omitted, falls back to a non-reactive
+ * `isPostTypeSupporting( support, postType )` check.
  *
  * @since 1.0.0
  *
  * @param {Object}  options                         Options for determining visibility.
  * @param {boolean} options.isDescendentOfQueryLoop Whether the block is inside a Query Loop.
- * @param {string}  options.postType                The post type from block context.
- * @param {string}  options.support                 The post type support to check (e.g. 'gatherpress-venue').
+ * @param {boolean} [options.hasSupport]            Whether the resolved post type has the required support.
+ *                                                  Pass the result of `usePostTypeSupports` for reactivity.
+ * @param {string}  [options.postType]              Legacy fallback when `hasSupport` is omitted.
+ * @param {string}  [options.support]               Legacy fallback when `hasSupport` is omitted.
  * @param {boolean} [options.hasData=false]         Whether the block has its specific data.
  * @return {boolean} True if the block should be fully visible, false if it should be dimmed.
  */
 export function hasValidBlockContext( {
 	isDescendentOfQueryLoop,
+	hasSupport,
 	postType,
 	support,
 	hasData = false,
@@ -109,7 +122,12 @@ export function hasValidBlockContext( {
 
 	// In Query Loop, require both valid post type support AND data.
 	if ( isDescendentOfQueryLoop ) {
-		return isPostTypeSupporting( support, postType ) && hasData;
+		const resolvedSupport =
+			undefined !== hasSupport
+				? hasSupport
+				: isPostTypeSupporting( support, postType );
+
+		return resolvedSupport && hasData;
 	}
 
 	// When editing directly, just check if we have data.

--- a/src/helpers/editor.js
+++ b/src/helpers/editor.js
@@ -103,8 +103,10 @@ export function isInFSETemplate() {
  * @param {boolean} options.isDescendentOfQueryLoop Whether the block is inside a Query Loop.
  * @param {boolean} [options.hasSupport]            Whether the resolved post type has the required support.
  *                                                  Pass the result of `usePostTypeSupports` for reactivity.
- * @param {string}  [options.postType]              Legacy fallback when `hasSupport` is omitted.
- * @param {string}  [options.support]               Legacy fallback when `hasSupport` is omitted.
+ * @param {string}  [options.postType]              Deprecated. Legacy fallback when `hasSupport` is omitted —
+ *                                                  prefer `hasSupport` so the supports gate stays reactive.
+ * @param {string}  [options.support]               Deprecated. Legacy fallback when `hasSupport` is omitted —
+ *                                                  prefer `hasSupport` so the supports gate stays reactive.
  * @param {boolean} [options.hasData=false]         Whether the block has its specific data.
  * @return {boolean} True if the block should be fully visible, false if it should be dimmed.
  */

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -6,7 +6,7 @@ import moment from 'moment';
 /**
  * WordPress dependencies.
  */
-import { dispatch, select } from '@wordpress/data';
+import { dispatch, select, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -51,6 +51,39 @@ export function isPostTypeSupporting( support, postType = null ) {
 	const postTypeObject = select( 'core' ).getPostType( typeToCheck );
 
 	return !! postTypeObject?.supports?.[ support ];
+}
+
+/**
+ * Reactive variant of `isPostTypeSupporting` for use in React components.
+ *
+ * `isPostTypeSupporting` reads `getPostType()` non-reactively, so when the
+ * post-type definition isn't yet cached at render time the support gate
+ * resolves to `false` and the component never re-renders once it loads.
+ * This hook subscribes via `useSelect` so the component re-renders the moment
+ * the supports become known — which is the difference between a permanently
+ * dimmed block in a Query Loop and one that lights up correctly.
+ *
+ * @since 1.0.0
+ *
+ * @param {string}      support  The post type support to check.
+ * @param {string|null} postType Optional post type to check. Falls back to the editor post type.
+ * @return {boolean} True if the resolved post type has the given support, false otherwise.
+ */
+export function usePostTypeSupports( support, postType = null ) {
+	return useSelect(
+		( wpSelect ) => {
+			const typeToCheck =
+				postType ?? wpSelect( 'core/editor' )?.getCurrentPostType();
+
+			if ( ! typeToCheck ) {
+				return false;
+			}
+
+			return !! wpSelect( 'core' ).getPostType( typeToCheck )
+				?.supports?.[ support ];
+		},
+		[ support, postType ]
+	);
 }
 
 /**

--- a/test/unit/js/src/helpers/editor.test.js
+++ b/test/unit/js/src/helpers/editor.test.js
@@ -475,5 +475,72 @@ describe( 'Editor helper functions', () => {
 
 			expect( result ).toBe( true );
 		} );
+
+		describe( 'with reactive hasSupport', () => {
+			beforeEach( () => {
+				// `hasSupport` is the canonical input. When provided, the helper
+				// must not fall back to the non-reactive `isPostTypeSupporting`
+				// path — otherwise blocks would still race the post-type cache.
+				select.mockReturnValue( {
+					getCurrentPostType: jest.fn().mockReturnValue( 'post' ),
+				} );
+			} );
+
+			it( 'returns true in Query Loop when hasSupport is true and hasData is true', () => {
+				const result = hasValidBlockContext( {
+					isDescendentOfQueryLoop: true,
+					hasSupport: true,
+					hasData: true,
+				} );
+
+				expect( result ).toBe( true );
+			} );
+
+			it( 'returns false in Query Loop when hasSupport is false', () => {
+				const result = hasValidBlockContext( {
+					isDescendentOfQueryLoop: true,
+					hasSupport: false,
+					hasData: true,
+				} );
+
+				expect( result ).toBe( false );
+			} );
+
+			it( 'returns false in Query Loop when hasSupport is true but no data', () => {
+				const result = hasValidBlockContext( {
+					isDescendentOfQueryLoop: true,
+					hasSupport: true,
+					hasData: false,
+				} );
+
+				expect( result ).toBe( false );
+			} );
+
+			it( 'prefers hasSupport over the legacy postType + support fallback', () => {
+				// If hasSupport is provided, `isPostTypeSupporting` must not be
+				// consulted — otherwise the non-reactive race re-emerges.
+				const getPostType = jest.fn();
+				select.mockImplementation( ( store ) => {
+					if ( 'core/editor' === store ) {
+						return { getCurrentPostType: jest.fn().mockReturnValue( 'post' ) };
+					}
+					if ( 'core' === store ) {
+						return { getPostType };
+					}
+					return {};
+				} );
+
+				const result = hasValidBlockContext( {
+					isDescendentOfQueryLoop: true,
+					hasSupport: true,
+					postType: 'gatherpress_event',
+					support: 'gatherpress-event-date',
+					hasData: true,
+				} );
+
+				expect( result ).toBe( true );
+				expect( getPostType ).not.toHaveBeenCalled();
+			} );
+		} );
 	} );
 } );

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -13,6 +13,7 @@ import { dispatch } from '@wordpress/data';
 // Mock WordPress modules before importing internal dependencies.
 jest.mock( '@wordpress/data', () => ( {
 	select: jest.fn(),
+	useSelect: jest.fn( ( cb ) => cb( jest.requireMock( '@wordpress/data' ).select ) ),
 	dispatch: jest.fn().mockReturnValue( {
 		removeNotice: jest.fn(),
 		createNotice: jest.fn(),
@@ -29,6 +30,7 @@ import {
 	hasEventPast,
 	hasEventPastNotice,
 	isPostTypeSupporting,
+	usePostTypeSupports,
 	isEventPostType,
 	hasValidEventId,
 	getEventMeta,
@@ -112,6 +114,80 @@ describe( 'isPostTypeSupporting', () => {
 		require( '@wordpress/data' ).select.mockReturnValue( undefined );
 
 		expect( isPostTypeSupporting( 'gatherpress-rsvp' ) ).toBe( false );
+	} );
+} );
+
+/**
+ * Coverage for usePostTypeSupports — the reactive variant of isPostTypeSupporting.
+ */
+describe( 'usePostTypeSupports', () => {
+	it( 'returns true when the resolved post type has the support', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
+		expect(
+			usePostTypeSupports( 'gatherpress-event-date', 'gatherpress_event' )
+		).toBe( true );
+	} );
+
+	it( 'returns false when the resolved post type lacks the support', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
+		expect(
+			usePostTypeSupports( 'gatherpress-event-date', 'post' )
+		).toBe( false );
+	} );
+
+	it( 'falls back to the editor post type when no postType is given', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'gatherpress_event' };
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
+		expect( usePostTypeSupports( 'gatherpress-rsvp' ) ).toBe( true );
+	} );
+
+	it( 'returns false when no post type can be resolved', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => undefined };
+			}
+			return {};
+		} );
+
+		expect( usePostTypeSupports( 'gatherpress-event-date' ) ).toBe( false );
+	} );
+
+	it( 'subscribes via useSelect so the support gate is reactive', () => {
+		// Confirms the hook delegates to useSelect — the whole reason the hook
+		// exists, since the non-reactive sibling leaves blocks dimmed when the
+		// post-type definition isn't cached on first render.
+		const { useSelect } = require( '@wordpress/data' );
+		useSelect.mockClear();
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		} );
+
+		usePostTypeSupports( 'gatherpress-event-date', 'gatherpress_event' );
+
+		expect( useSelect ).toHaveBeenCalledTimes( 1 );
 	} );
 } );
 

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -189,6 +189,38 @@ describe( 'usePostTypeSupports', () => {
 
 		expect( useSelect ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 're-evaluates when getPostType resolves later', () => {
+		// Simulates the actual race the hook is fixing: on first render the
+		// post-type definition isn't cached yet (returns undefined), then
+		// resolves on a subsequent invocation. The hook must reflect the new
+		// value rather than caching the false negative.
+		const { select } = require( '@wordpress/data' );
+		let resolved = false;
+		select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return {
+					getPostType: ( slug ) => {
+						if ( ! resolved ) {
+							return undefined;
+						}
+						return mockGetPostType( slug );
+					},
+				};
+			}
+			return {};
+		} );
+
+		expect(
+			usePostTypeSupports( 'gatherpress-event-date', 'gatherpress_event' )
+		).toBe( false );
+
+		resolved = true;
+
+		expect(
+			usePostTypeSupports( 'gatherpress-event-date', 'gatherpress_event' )
+		).toBe( true );
+	} );
 } );
 
 /**


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change

Two related fixes were needed to stop GatherPress blocks from rendering dimmed in the editor preview when placed inside a `core/query` Query Loop iterating over a post type that does carry the relevant `gatherpress-*` supports.

**1. Block context wiring.** Several blocks (`event-date`, `add-to-calendar`, `rsvp`, `rsvp-response`, `rsvp-guest-count-display`, `online-event`, `online-event-link`) were not declaring `postType` in their `block.json` `usesContext`, so `context.postType` was always `undefined` inside each Edit component — even when the surrounding Post Template was iterating over a post type that did carry the relevant supports. Added `postType` to `usesContext` on each so the iterated post type actually reaches the component.

**2. Non-reactive supports race.** Even with context flowing, blocks still rendered dim because the dim gate ultimately called `isPostTypeSupporting`, which reads `select('core').getPostType(...)` non-reactively. On first render the post-type definition is not cached, the gate resolves to `false`, and nothing subscribes to that data — so the block never re-renders once supports load. Forcing a re-render (selecting the block) flipped opacity from `0.3` to `1`, which confirmed the race.

The fix:
- Added a `usePostTypeSupports` hook in `src/helpers/event.js` that wraps the same logic in `useSelect`, so the component re-renders the moment the post-type definition resolves.
- Refactored `hasValidBlockContext` in `src/helpers/editor.js` to accept a pre-computed `hasSupport` boolean. The legacy `postType + support` shape is kept as a fallback for backwards compatibility.
- Switched dim-gating call sites in `event-date`, `add-to-calendar`, `rsvp`, `rsvp-count`, `rsvp-response`, `rsvp-guest-count-display`, `venue`, and `online-event` to read the supports flag through the new hook.

This mirrors the post-type-supports decoupling already documented in `docs/developer/post-type-supports/README.md` — the editor previews now ask "does the current post's post type _support_ what this block needs?" instead of "is the current post type literally `gatherpress_event`?".

Closes #1547

### How to test the Change

1. Edit any FSE template / template part / regular post or page.
2. Add a Query Loop block configured to query `gatherpress_event` (or any custom post type that declares `gatherpress-event-date` support).
3. Inside the Query Loop's Post Template, add the GatherPress blocks: `event-date`, `add-to-calendar`, `rsvp`, `online-event`, `online-event-link`, and `venue`.
4. **Before this PR:** every GatherPress block renders dimmed in the editor preview, even though they would render correctly on the front end.
5. **After this PR:** blocks for which the queried post type has the relevant support render at full opacity. Blocks without data (e.g. a `venue` block when the iterated event has no physical venue assigned) correctly stay dim, as do blocks dropped onto a canvas with no event context.
6. As a regression check, repeat with a Query Loop iterating over `core/page` (or any post type without the relevant supports). The blocks should still dim — that is correct behavior, telling the user the block won't render.

### Changelog Entry

> Fixed - GatherPress blocks (event-date, add-to-calendar, rsvp, rsvp-count, rsvp-response, online-event, online-event-link, venue) no longer render dimmed in the editor when placed inside a Query Loop iterating over a post type that carries the relevant `gatherpress-*` supports.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.