### PR TITLE
Make postIdOverride work for event and venue blocks

### DIFF
--- a/docs/user/event-id-override.md
+++ b/docs/user/event-id-override.md
@@ -9,6 +9,7 @@ The following GatherPress blocks support an Event ID Override.
 - RSVP Response
 - RSVP Count
 - Online Event
+- Venue
 
 What this allows:
 
@@ -16,6 +17,8 @@ What this allows:
 - Place RSVP, attendance status, or related UI elements on other pages or posts.
 
 This is found when selecting a block that supports it, clicking "Advanced" and adding a valid event post ID to "Post ID Override". When an Event ID is provided, the block explicitly targets that event instead.
+
+The Venue block accepts either an event ID or a venue ID in the override field. When given an event ID, it resolves to that event's associated venue; when given a venue ID, it uses that venue directly.
 
 In the editor, the block dims while no override is set (or the ID is invalid) and lights up to full opacity once a valid published event ID is entered — a quick visual confirmation that the override is wired up correctly.
 

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -269,6 +269,17 @@ class Event_Query {
 	 * @return array Array of arguments for WP_Query.
 	 */
 	public function rest_query( array $args, WP_REST_Request $request ): array {
+		// When a request explicitly asks for specific events by ID (`include`),
+		// the upcoming/past date filter should not apply — ID-based lookups
+		// are explicit and the date filter is meant for browsing. Without
+		// this bypass, any block that resolves an event by ID via the
+		// collection endpoint (e.g. the postIdOverride resolver) silently
+		// gets an empty array for past events and the override looks broken.
+		$include = $request->get_param( 'include' );
+		if ( ! empty( $include ) ) {
+			return $args;
+		}
+
 		// Generate a new custom query will all potential query vars.
 		$custom_args = array();
 

--- a/src/blocks/add-to-calendar/edit.js
+++ b/src/blocks/add-to-calendar/edit.js
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies.
@@ -28,10 +29,20 @@ const Edit = ( { attributes, context } ) => {
 	// Check if block has a valid event connection. An explicit override
 	// (`attributes.postId`) is a third valid path alongside Query Loop and
 	// event-supporting host: it targets a specific event post regardless of
-	// the host's post type.
-	const isValidEvent =
-		( hasExplicitOverride || isDescendentOfQueryLoop || isEventContext ) &&
-		hasValidEventId( postId, context?.postType );
+	// the host's post type. Wrap in `useSelect` so the gate re-evaluates when
+	// the override target's entity record loads.
+	const isValidEvent = useSelect(
+		( select ) =>
+			( hasExplicitOverride || isDescendentOfQueryLoop || isEventContext ) &&
+			hasValidEventId( select, postId, context?.postType ),
+		[
+			postId,
+			context?.postType,
+			hasExplicitOverride,
+			isDescendentOfQueryLoop,
+			isEventContext,
+		]
+	);
 
 	const blockProps = useBlockProps( {
 		style: {

--- a/src/blocks/rsvp-count/edit.js
+++ b/src/blocks/rsvp-count/edit.js
@@ -80,10 +80,20 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	// Check if block has a valid event connection. An explicit override
 	// (`attributes.postId`) is a third valid path alongside Query Loop and
 	// event-supporting host: it targets a specific event post regardless of
-	// the host's post type.
-	const isValidEvent =
-		( hasExplicitOverride || isDescendentOfQueryLoop || isEventContext ) &&
-		hasValidEventId( postId, context?.postType );
+	// the host's post type. Wrap in `useSelect` so the gate re-evaluates when
+	// the override target's entity record loads.
+	const isValidEvent = useSelect(
+		( select ) =>
+			( hasExplicitOverride || isDescendentOfQueryLoop || isEventContext ) &&
+			hasValidEventId( select, postId, context?.postType ),
+		[
+			postId,
+			context?.postType,
+			hasExplicitOverride,
+			isDescendentOfQueryLoop,
+			isEventContext,
+		]
+	);
 
 	const rsvpMode = getFromSettings( 'rsvpMode' ) ?? 'all_on';
 

--- a/src/blocks/rsvp-form/edit.js
+++ b/src/blocks/rsvp-form/edit.js
@@ -44,8 +44,12 @@ const Edit = ( { attributes, clientId, context } ) => {
 		return rawValue === undefined || null === rawValue ? true : 0 !== rawValue;
 	}, [] );
 
-	// Check if block has a valid event connection.
-	const isValidEvent = hasValidEventId( postId );
+	// Check if block has a valid event connection. Wrap in `useSelect` so the
+	// gate re-evaluates when the override target's entity record loads.
+	const isValidEvent = useSelect(
+		( select ) => hasValidEventId( select, postId ),
+		[ postId ]
+	);
 
 	// Get all inner blocks.
 	const innerBlocks = useSelect( ( select ) => {

--- a/src/blocks/rsvp-response/edit.js
+++ b/src/blocks/rsvp-response/edit.js
@@ -89,10 +89,20 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	// Check if block has a valid event connection. An explicit override
 	// (`attributes.postId`) is a third valid path alongside Query Loop and
 	// event-supporting host: it targets a specific event post regardless of
-	// the host's post type.
-	const isValidEvent =
-		( hasExplicitOverride || isDescendentOfQueryLoop || isEventContext ) &&
-		hasValidEventId( postId, context?.postType );
+	// the host's post type. Wrap in `useSelect` so the gate re-evaluates when
+	// the override target's entity record loads.
+	const isValidEvent = useSelect(
+		( select ) =>
+			( hasExplicitOverride || isDescendentOfQueryLoop || isEventContext ) &&
+			hasValidEventId( select, postId, context?.postType ),
+		[
+			postId,
+			context?.postType,
+			hasExplicitOverride,
+			isDescendentOfQueryLoop,
+			isEventContext,
+		]
+	);
 
 	const { enableRsvp } = useSelect(
 		( select ) => getEventMeta( select, postId, attributes ),

--- a/src/blocks/rsvp/edit.js
+++ b/src/blocks/rsvp/edit.js
@@ -71,10 +71,22 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 	// Check if block has a valid event connection. An explicit override
 	// (`attributes.postId`) is a third valid path alongside Query Loop and
 	// event-supporting host: it targets a specific event post regardless of
-	// the host's post type.
-	const isValidEvent =
-		( hasExplicitOverride || isDescendentOfQueryLoop || isEventContext ) &&
-		hasValidEventId( postId, context?.postType );
+	// the host's post type. Wrap in `useSelect` so the gate re-evaluates when
+	// the override target's entity record loads — `hasValidEventId` reads
+	// `getEntityRecord` / `getEntityRecords`, which only emit subscription
+	// updates when called via the `useSelect` callback's `select`.
+	const isValidEvent = useSelect(
+		( select ) =>
+			( hasExplicitOverride || isDescendentOfQueryLoop || isEventContext ) &&
+			hasValidEventId( select, postId, context?.postType ),
+		[
+			postId,
+			context?.postType,
+			hasExplicitOverride,
+			isDescendentOfQueryLoop,
+			isEventContext,
+		]
+	);
 
 	// Get the current inner blocks
 	const innerBlocks = useSelect(

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -15,13 +15,13 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { getCurrentContextualPostId, hasValidBlockContext, isInFSETemplate } from '../../helpers/editor';
-import { usePostTypeSupports, DISABLED_FIELD_OPACITY } from '../../helpers/event';
-import { GetVenuePostFromTermId, GetVenuePostFromEventId, getVenuePostType, getVenueTaxonomy, useVenueTaxonomyIds } from '../../helpers/venue';
+import { usePostTypeSupports, findEventPostById, DISABLED_FIELD_OPACITY } from '../../helpers/event';
+import { GetVenuePostFromTermId, GetVenuePostFromEventId, findVenuePostById, getVenuePostType, getVenueTaxonomy, useVenueTaxonomyIds } from '../../helpers/venue';
 import VenueNavigator from '../../components/VenueNavigator';
 import { TEMPLATE_WITH_TITLE, TEMPLATE_WITHOUT_TITLE } from './template';
 
 const Edit = ( props ) => {
-	const { context } = props;
+	const { attributes, context } = props;
 
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
 	// Reactive supports checks so the block re-renders once the post-type
@@ -35,17 +35,76 @@ const Edit = ( props ) => {
 		( select ) => select( 'core/editor' )?.getCurrentPostType(),
 		[]
 	);
-	const effectivePostType = context?.postType || currentEditorPostType;
-	const venuePostType = getVenuePostType( effectivePostType );
 
-	const eventId = getCurrentContextualPostId( context?.postId );
+	// Resolve the postIdOverride target across event-supporting and venue-
+	// supporting post types so the block can light up on a non-event /
+	// non-venue host (e.g. a regular page). Event lookup wins on tie — the
+	// rest of the block's flow is event-centric, so an ID that resolves as
+	// an event is treated as one even if a venue with the same ID also
+	// exists. Returns null when the override is unset or resolves to
+	// neither bucket.
+	const overrideId = attributes?.postId || null;
+	const overrideResolution = useSelect(
+		( select ) => {
+			if ( ! overrideId ) {
+				return null;
+			}
+			const eventPost = findEventPostById( select, overrideId );
+			if ( eventPost ) {
+				return { kind: 'event', postType: eventPost.type };
+			}
+			const venuePost = findVenuePostById( select, overrideId );
+			if ( venuePost ) {
+				return { kind: 'venue', postType: venuePost.type };
+			}
+			return null;
+		},
+		[ overrideId ]
+	);
+
+	// When the override resolves to an event, use the override as the event
+	// being walked (so the venue taxonomy lookup uses the override's event
+	// post type, not the host's). When the override resolves to a venue,
+	// the post type comes from that venue directly.
+	const effectivePostType =
+		'event' === overrideResolution?.kind
+			? overrideResolution.postType
+			: context?.postType || currentEditorPostType;
+	const venuePostType =
+		'venue' === overrideResolution?.kind
+			? overrideResolution.postType
+			: getVenuePostType( effectivePostType );
+
+	// `eventId` is the post whose venue taxonomy we walk to find the venue.
+	// Only set it when we genuinely have an event in hand — otherwise the
+	// REST query below fires against the host page and 403s, since the
+	// `_gatherpress_venue` taxonomy isn't associated with non-event posts.
+	const isOverrideEvent = 'event' === overrideResolution?.kind;
+	const isOverrideVenue = 'venue' === overrideResolution?.kind;
+	const isOverrideActive = !! overrideId;
+
+	let eventId = null;
+	if ( isOverrideEvent ) {
+		eventId = overrideId;
+	} else if ( ! isOverrideActive && isEventContext ) {
+		eventId = getCurrentContextualPostId( context?.postId );
+	}
 	const venueTaxonomy = getVenueTaxonomy( venuePostType );
 
-	// Read venue taxonomy IDs without triggering context=edit REST requests.
+	// Skip the taxonomy walk when there's no event to walk against (no event
+	// host + no event override), when the host post IS the venue, when the
+	// override resolved to a venue directly (no walk needed), or when in a
+	// Query Loop (handled by GetVenuePostFromEventId below).
+	const skipVenueTaxonomyLookup =
+		null === eventId ||
+		isVenueContext ||
+		isDescendentOfQueryLoop ||
+		isOverrideVenue;
+
 	const venueTaxonomyIds = useVenueTaxonomyIds(
 		venueTaxonomy,
 		eventId,
-		isVenueContext || isDescendentOfQueryLoop
+		skipVenueTaxonomyLookup
 	);
 
 	const isEditableEventContext =
@@ -90,10 +149,15 @@ const Edit = ( props ) => {
 		? venuePostFromEvent
 		: venuePostFromTerm;
 
-	// When on a venue post, use the current post ID directly.
-	// Otherwise, resolve from the event's venue taxonomy.
+	// Resolution priority for the rendered venue:
+	// 1. postIdOverride that points at a venue post → use it directly.
+	// 2. Host post is a venue → use the current post.
+	// 3. Otherwise → walk the event's venue taxonomy (event may itself be
+	//    the override, see `eventId` resolution above).
 	let venuePostId = 0;
-	if ( isVenueContext ) {
+	if ( isOverrideVenue ) {
+		venuePostId = overrideId;
+	} else if ( isVenueContext && ! isOverrideActive ) {
 		venuePostId = getCurrentContextualPostId( context?.postId );
 	} else if (
 		venuePostArray?.[ 0 ]?.id &&

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -126,7 +126,13 @@ export function findEventPostById( selectFunc, postId ) {
 		return null;
 	}
 
-	const postTypes = selectFunc( 'core' ).getPostTypes?.( { per_page: -1 } );
+	// `context: 'edit'` is required because WP REST only exposes the
+	// `supports` field on post types in the edit context. Without it the
+	// loop below never matches any type and the override silently fails.
+	const postTypes = selectFunc( 'core' ).getPostTypes?.( {
+		per_page: -1,
+		context: 'edit',
+	} );
 	if ( ! Array.isArray( postTypes ) ) {
 		return null;
 	}
@@ -135,13 +141,27 @@ export function findEventPostById( selectFunc, postId ) {
 		if ( ! type?.supports?.[ 'gatherpress-event-date' ] ) {
 			continue;
 		}
-		const post = selectFunc( 'core' ).getEntityRecord(
+		// Query by `include` filter rather than `getEntityRecord( id )` so a
+		// miss returns an empty array (HTTP 200) instead of a 404. The 404s
+		// are technically accurate but they show up in browser devtools and
+		// look like a real bug to anyone reading the console. Edit context
+		// matches the default `getEntityRecord` uses inside the editor and
+		// guarantees full `meta` in the response — callers like the
+		// event-date block read `post.meta.gatherpress_datetime_start`.
+		//
+		// The `Event_Query` REST filter detects the `include` param and
+		// skips its upcoming/past date filter so this lookup catches past
+		// events too (see `Event_Query::rest_query`).
+		const records = selectFunc( 'core' ).getEntityRecords(
 			'postType',
 			type.slug,
-			postId
+			{ include: [ postId ], context: 'edit', per_page: 1 }
 		);
-		if ( post && 'publish' === post.status ) {
-			return post;
+		if ( Array.isArray( records ) && 0 < records.length ) {
+			const post = records[ 0 ];
+			if ( post && 'publish' === post.status ) {
+				return post;
+			}
 		}
 	}
 
@@ -154,29 +174,68 @@ export function findEventPostById( selectFunc, postId ) {
  * This function checks if the block is connected to a valid event, either by being
  * placed in an event post or having a postId attribute that points to a valid event.
  *
+ * Pass `useSelect`'s `select` callback as the first argument to subscribe the
+ * caller to the underlying entity-record reads — without this, the gate is
+ * computed once with whatever data was cached at first render and never
+ * re-evaluates when the override target loads, leaving the block dimmed even
+ * after the data arrives. The non-`useSelect` global `select` import is used
+ * as a default to keep older call sites working, but new callers should pass
+ * their `useSelect` callback's `select`.
+ *
  * @since 1.0.0
  *
- * @param {number|null} postId   Optional post ID override to check.
- * @param {string|null} postType Optional post type to verify before making API calls.
+ * @param {Function|number|null} selectFuncOrPostId Either a `useSelect` `select`
+ *                                                  callback (preferred) or, for
+ *                                                  back-compat, a postId number
+ *                                                  / null. When a function is
+ *                                                  provided, the next argument
+ *                                                  is treated as `postId`.
+ * @param {number|null}          maybePostId        Post ID override to check
+ *                                                  (when `selectFuncOrPostId`
+ *                                                  is a function).
+ * @param {string|null}          maybePostType      Optional post type to verify
+ *                                                  before making API calls.
  * @return {boolean} True if connected to a valid event, false otherwise.
  */
-export function hasValidEventId( postId = null, postType = null ) {
+export function hasValidEventId( selectFuncOrPostId = null, maybePostId = null, maybePostType = null ) {
+	// Back-compat shim: if the first argument isn't a function, assume the
+	// older `hasValidEventId( postId, postType )` shape and fall back to the
+	// non-reactive global `select`. Calls inside `useSelect` should pass that
+	// hook's `select` callback as the first argument so subscriptions track.
+	let selectFunc;
+	let postId;
+	let postType;
+	if ( 'function' === typeof selectFuncOrPostId ) {
+		selectFunc = selectFuncOrPostId;
+		postId = maybePostId;
+		postType = maybePostType;
+	} else {
+		selectFunc = select;
+		postId = selectFuncOrPostId;
+		postType = maybePostId;
+	}
+
 	// If postId is provided, verify it points to a valid, published event.
 	if ( postId ) {
 		// Check if this is the current post being edited in the editor.
 		const currentPostId =
-			select( 'core/editor' )?.getCurrentPostId();
+			selectFunc( 'core/editor' )?.getCurrentPostId();
 		const currentPostType =
-			select( 'core/editor' )?.getCurrentPostType();
+			selectFunc( 'core/editor' )?.getCurrentPostType();
 		const isCurrentPost =
 			currentPostId && currentPostId === postId;
 
+		const isEventSupporting = ( slug ) =>
+			!! selectFunc( 'core' ).getPostType( slug )?.supports?.[
+				'gatherpress-event-date'
+			];
+
 		// If this is the current post, check if it supports event_date.
 		if ( isCurrentPost ) {
-			if ( ! isEventPostType( currentPostType ) ) {
+			if ( ! isEventSupporting( currentPostType ) ) {
 				return false;
 			}
-			const post = select( 'core' ).getEntityRecord(
+			const post = selectFunc( 'core' ).getEntityRecord(
 				'postType',
 				currentPostType,
 				postId
@@ -188,14 +247,14 @@ export function hasValidEventId( postId = null, postType = null ) {
 		// explicit hint (if event-supporting) → current editor type (if
 		// event-supporting) → cross-type registry scan.
 		let lookupType = null;
-		if ( postType && isEventPostType( postType ) ) {
+		if ( postType && isEventSupporting( postType ) ) {
 			lookupType = postType;
-		} else if ( isEventPostType( currentPostType ) ) {
+		} else if ( isEventSupporting( currentPostType ) ) {
 			lookupType = currentPostType;
 		}
 
 		if ( lookupType ) {
-			const post = select( 'core' ).getEntityRecord(
+			const post = selectFunc( 'core' ).getEntityRecord(
 				'postType',
 				lookupType,
 				postId
@@ -206,11 +265,14 @@ export function hasValidEventId( postId = null, postType = null ) {
 		// Neither the hint nor the host is event-supporting. This is a
 		// postIdOverride flow on a non-event host (e.g. a regular page). Scan
 		// event-supporting post types so the block can still light up.
-		return null !== findEventPostById( select, postId );
+		return null !== findEventPostById( selectFunc, postId );
 	}
 
 	// Otherwise, check if current post supports event_date (no publish check needed).
-	return isEventPostType();
+	const editorPostType = selectFunc( 'core/editor' )?.getCurrentPostType();
+	return !! selectFunc( 'core' ).getPostType( editorPostType )?.supports?.[
+		'gatherpress-event-date'
+	];
 }
 
 /**

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -416,3 +416,67 @@ export function usePopularVenues( limit = 3, venuePostType = DEFAULT_VENUE_POST_
 
 	return popularVenues ?? [];
 }
+
+/**
+ * Look up a post by ID across all venue-supporting post types.
+ *
+ * Mirrors `findEventPostById()` but scans for `gatherpress-venue-information`
+ * support instead of `gatherpress-event-date`. Used by the venue block's
+ * `postIdOverride` resolver to detect when the override target is a venue
+ * post (so it can be used directly) vs. an event post (so the venue is
+ * derived from the event's venue taxonomy).
+ *
+ * Returns `null` when the post type registry has not finished loading. The
+ * caller's `useSelect` will re-run once it does, since `getPostTypes` is a
+ * subscribed read.
+ *
+ * @since 1.0.0
+ *
+ * @param {Function} selectFunc WordPress data `select` function.
+ * @param {number}   postId     Post ID to resolve.
+ * @return {Object|null} The post entity if found in any venue-supporting post
+ *                       type; null when the registry isn't loaded yet, when
+ *                       no venue-supporting type owns the ID, or when the
+ *                       found post isn't published.
+ */
+export function findVenuePostById( selectFunc, postId ) {
+	if ( ! postId ) {
+		return null;
+	}
+
+	// `context: 'edit'` is required because WP REST only exposes the
+	// `supports` field on post types in the edit context. Without it the
+	// loop below never matches any type and the override silently fails.
+	const postTypes = selectFunc( 'core' ).getPostTypes?.( {
+		per_page: -1,
+		context: 'edit',
+	} );
+	if ( ! Array.isArray( postTypes ) ) {
+		return null;
+	}
+
+	for ( const type of postTypes ) {
+		if ( ! type?.supports?.[ 'gatherpress-venue-information' ] ) {
+			continue;
+		}
+		// Query by `include` filter rather than `getEntityRecord( id )` so a
+		// miss returns an empty array (HTTP 200) instead of a 404. The 404s
+		// are technically accurate but they show up in browser devtools and
+		// look like a real bug to anyone reading the console. Edit context
+		// matches the default `getEntityRecord` uses inside the editor and
+		// keeps the response shape consistent with the event-side helper.
+		const records = selectFunc( 'core' ).getEntityRecords(
+			'postType',
+			type.slug,
+			{ include: [ postId ], context: 'edit', per_page: 1 }
+		);
+		if ( Array.isArray( records ) && 0 < records.length ) {
+			const post = records[ 0 ];
+			if ( post && 'publish' === post.status ) {
+				return post;
+			}
+		}
+	}
+
+	return null;
+}

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -738,6 +738,49 @@ describe( 'hasValidEventId', () => {
 
 		expect( hasValidEventId( postId, 'page' ) ).toBe( false );
 	} );
+
+	it( 'accepts a useSelect-style select callback as the first argument and uses it for reactive reads', () => {
+		const postId = 460;
+		// Custom select function that doesn't touch the global @wordpress/data
+		// mock — proves the back-compat shim picks up `selectFunc` from the
+		// first argument when it's callable.
+		const selectFunc = ( store ) => {
+			if ( 'core/editor' === store ) {
+				return {
+					getCurrentPostId: () => 999, // Not the override.
+					getCurrentPostType: () => 'gatherpress_event',
+				};
+			}
+			if ( 'core' === store ) {
+				return {
+					getPostType: mockGetPostType,
+					getEntityRecord: ( kind, postTypeName, id ) =>
+						'gatherpress_event' === postTypeName && postId === id
+							? { id: postId, status: 'publish' }
+							: null,
+				};
+			}
+			return {};
+		};
+
+		expect( hasValidEventId( selectFunc, postId, 'gatherpress_event' ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'returns event-supporting status of the editor host when called with a select callback and no postId', () => {
+		const selectFunc = ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'gatherpress_event' };
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostType };
+			}
+			return {};
+		};
+
+		expect( hasValidEventId( selectFunc ) ).toBe( true );
+	} );
 } );
 
 /**

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -691,14 +691,14 @@ describe( 'hasValidEventId', () => {
 						},
 						{ slug: 'page', supports: {} },
 					],
-					getEntityRecord: ( kind, postTypeName, id ) => {
+					getEntityRecords: ( kind, postTypeName, query ) => {
 						if (
 							'gatherpress_event' === postTypeName &&
-							postId === id
+							query?.include?.[ 0 ] === postId
 						) {
-							return { id: postId, status: 'publish' };
+							return [ { id: postId, status: 'publish' } ];
 						}
-						return null;
+						return [];
 					},
 				};
 			}
@@ -728,7 +728,9 @@ describe( 'hasValidEventId', () => {
 							supports: { 'gatherpress-event-date': true },
 						},
 					],
-					getEntityRecord: () => ( { id: postId, status: 'draft' } ),
+					getEntityRecords: () => [
+						{ id: postId, status: 'draft' },
+					],
 				};
 			}
 			return {};
@@ -783,10 +785,11 @@ describe( 'findEventPostById', () => {
 							supports: { 'gatherpress-event-date': true },
 						},
 					],
-					getEntityRecord: ( kind, postTypeName, id ) =>
-						'gatherpress_event' === postTypeName && postId === id
-							? { id: postId, status: 'publish' }
-							: null,
+					getEntityRecords: ( kind, postTypeName, query ) =>
+						'gatherpress_event' === postTypeName &&
+						query?.include?.[ 0 ] === postId
+							? [ { id: postId, status: 'publish' } ]
+							: [],
 				};
 			}
 			return {};
@@ -810,11 +813,11 @@ describe( 'findEventPostById', () => {
 							supports: { 'gatherpress-event-date': true },
 						},
 					],
-					getEntityRecord: ( kind, postTypeName, id ) => {
+					getEntityRecords: ( kind, postTypeName ) => {
 						calls.push( postTypeName );
 						return 'gatherpress_event' === postTypeName
-							? { id, status: 'publish' }
-							: null;
+							? [ { id: postId, status: 'publish' } ]
+							: [];
 					},
 				};
 			}
@@ -835,7 +838,7 @@ describe( 'findEventPostById', () => {
 							supports: { 'gatherpress-event-date': true },
 						},
 					],
-					getEntityRecord: () => null,
+					getEntityRecords: () => [],
 				};
 			}
 			return {};
@@ -855,13 +858,32 @@ describe( 'findEventPostById', () => {
 							supports: { 'gatherpress-event-date': true },
 						},
 					],
-					getEntityRecord: () => ( { id: postId, status: 'draft' } ),
+					getEntityRecords: () => [ { id: postId, status: 'draft' } ],
 				};
 			}
 			return {};
 		};
 
 		expect( findEventPostById( selectFunc, postId ) ).toBeNull();
+	} );
+
+	it( 'returns null when getEntityRecords is still loading (returns non-array)', () => {
+		const selectFunc = ( store ) => {
+			if ( 'core' === store ) {
+				return {
+					getPostTypes: () => [
+						{
+							slug: 'gatherpress_event',
+							supports: { 'gatherpress-event-date': true },
+						},
+					],
+					getEntityRecords: () => null,
+				};
+			}
+			return {};
+		};
+
+		expect( findEventPostById( selectFunc, 123 ) ).toBeNull();
 	} );
 } );
 

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -43,6 +43,7 @@ import {
 	useVenueOptions,
 	usePopularVenues,
 	useVenueTaxonomyIds,
+	findVenuePostById,
 } from '@src/helpers/venue';
 
 /**
@@ -1041,3 +1042,158 @@ describe( 'useVenueTaxonomyIds', () => {
 		expect( capturedQuery ).toMatchObject( { context: 'view', post: 42 } );
 	} );
 } );
+
+/**
+ * Coverage for findVenuePostById.
+ */
+describe( 'findVenuePostById', () => {
+	it( 'returns null when postId is falsy', () => {
+		const selectFunc = jest.fn();
+		expect( findVenuePostById( selectFunc, null ) ).toBeNull();
+		expect( findVenuePostById( selectFunc, 0 ) ).toBeNull();
+		expect( selectFunc ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns null when getPostTypes is not loaded yet', () => {
+		const selectFunc = ( store ) => {
+			if ( 'core' === store ) {
+				return { getPostTypes: () => undefined };
+			}
+			return {};
+		};
+
+		expect( findVenuePostById( selectFunc, 123 ) ).toBeNull();
+	} );
+
+	it( 'returns null when getPostTypes selector is missing entirely', () => {
+		const selectFunc = ( store ) => {
+			if ( 'core' === store ) {
+				return {};
+			}
+			return {};
+		};
+
+		expect( findVenuePostById( selectFunc, 123 ) ).toBeNull();
+	} );
+
+	it( 'returns the published venue from the first venue-supporting type that owns the ID', () => {
+		const postId = 300;
+		const selectFunc = ( store ) => {
+			if ( 'core' === store ) {
+				return {
+					getPostTypes: () => [
+						{ slug: 'page', supports: {} },
+						{
+							slug: 'gatherpress_venue',
+							supports: { 'gatherpress-venue-information': true },
+						},
+					],
+					getEntityRecords: ( kind, postTypeName, query ) =>
+						'gatherpress_venue' === postTypeName &&
+						query?.include?.[ 0 ] === postId
+							? [ { id: postId, status: 'publish' } ]
+							: [],
+				};
+			}
+			return {};
+		};
+
+		expect( findVenuePostById( selectFunc, postId ) ).toEqual( {
+			id: postId,
+			status: 'publish',
+		} );
+	} );
+
+	it( 'skips non-venue-supporting post types when scanning', () => {
+		const postId = 301;
+		const calls = [];
+		const selectFunc = ( store ) => {
+			if ( 'core' === store ) {
+				return {
+					getPostTypes: () => [
+						{ slug: 'page', supports: {} },
+						{
+							slug: 'gatherpress_event',
+							supports: { 'gatherpress-event-date': true },
+						},
+						{
+							slug: 'gatherpress_venue',
+							supports: { 'gatherpress-venue-information': true },
+						},
+					],
+					getEntityRecords: ( kind, postTypeName ) => {
+						calls.push( postTypeName );
+						return 'gatherpress_venue' === postTypeName
+							? [ { id: postId, status: 'publish' } ]
+							: [];
+					},
+				};
+			}
+			return {};
+		};
+
+		findVenuePostById( selectFunc, postId );
+		expect( calls ).toEqual( [ 'gatherpress_venue' ] );
+	} );
+
+	it( 'returns null when no venue-supporting type owns the ID', () => {
+		const selectFunc = ( store ) => {
+			if ( 'core' === store ) {
+				return {
+					getPostTypes: () => [
+						{
+							slug: 'gatherpress_venue',
+							supports: { 'gatherpress-venue-information': true },
+						},
+					],
+					getEntityRecords: () => [],
+				};
+			}
+			return {};
+		};
+
+		expect( findVenuePostById( selectFunc, 999 ) ).toBeNull();
+	} );
+
+	it( 'returns null when the found post is not published', () => {
+		const postId = 302;
+		const selectFunc = ( store ) => {
+			if ( 'core' === store ) {
+				return {
+					getPostTypes: () => [
+						{
+							slug: 'gatherpress_venue',
+							supports: { 'gatherpress-venue-information': true },
+						},
+					],
+					getEntityRecords: () => [
+						{ id: postId, status: 'draft' },
+					],
+				};
+			}
+			return {};
+		};
+
+		expect( findVenuePostById( selectFunc, postId ) ).toBeNull();
+	} );
+
+	it( 'returns null when getEntityRecords is still loading (returns non-array)', () => {
+		const selectFunc = ( store ) => {
+			if ( 'core' === store ) {
+				return {
+					getPostTypes: () => [
+						{
+							slug: 'gatherpress_venue',
+							supports: { 'gatherpress-venue-information': true },
+						},
+					],
+					getEntityRecords: () => null,
+				};
+			}
+			return {};
+		};
+
+		expect( findVenuePostById( selectFunc, 123 ) ).toBeNull();
+	} );
+} );
+

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -133,6 +133,7 @@ class Test_Event_Query extends Base {
 
 		// Set up parameter map for get_param calls.
 		$param_map = array(
+			array( 'include', null ),
 			array( 'gatherpress_event_query', 'past' ),
 			array( 'include_unfinished', 0 ), // Integer 0 - the critical test case.
 			array( 'exclude_current', null ),
@@ -140,7 +141,7 @@ class Test_Event_Query extends Base {
 			array( 'venue_filter', null ),
 		);
 
-		$request->expects( $this->exactly( 5 ) )
+		$request->expects( $this->exactly( 6 ) )
 			->method( 'get_param' )
 			->willReturnMap( $param_map );
 
@@ -502,6 +503,7 @@ class Test_Event_Query extends Base {
 		$request = $this->createMock( \WP_REST_Request::class );
 
 		$param_map = array(
+			array( 'include', null ),
 			array( 'gatherpress_event_query', 'upcoming' ),
 			array( 'exclude_current', 456 ),
 			array( 'include_unfinished', null ),
@@ -509,7 +511,7 @@ class Test_Event_Query extends Base {
 			array( 'venue_filter', null ),
 		);
 
-		$request->expects( $this->exactly( 5 ) )
+		$request->expects( $this->exactly( 6 ) )
 			->method( 'get_param' )
 			->willReturnMap( $param_map );
 
@@ -547,6 +549,7 @@ class Test_Event_Query extends Base {
 		$request = $this->createMock( \WP_REST_Request::class );
 
 		$param_map = array(
+			array( 'include', null ),
 			array( 'gatherpress_event_query', 'past' ),
 			array( 'exclude_current', null ),
 			array( 'include_unfinished', 1 ),
@@ -554,7 +557,7 @@ class Test_Event_Query extends Base {
 			array( 'venue_filter', null ),
 		);
 
-		$request->expects( $this->exactly( 5 ) )
+		$request->expects( $this->exactly( 6 ) )
 			->method( 'get_param' )
 			->willReturnMap( $param_map );
 
@@ -596,6 +599,7 @@ class Test_Event_Query extends Base {
 		$request = $this->createMock( \WP_REST_Request::class );
 
 		$param_map = array(
+			array( 'include', null ),
 			array( 'gatherpress_event_query', null ),
 			array( 'exclude_current', null ),
 			array( 'include_unfinished', null ),
@@ -603,7 +607,7 @@ class Test_Event_Query extends Base {
 			array( 'venue_filter', null ),
 		);
 
-		$request->expects( $this->exactly( 5 ) )
+		$request->expects( $this->exactly( 6 ) )
 			->method( 'get_param' )
 			->willReturnMap( $param_map );
 
@@ -779,6 +783,7 @@ class Test_Event_Query extends Base {
 		$request = $this->createMock( \WP_REST_Request::class );
 
 		$param_map = array(
+			array( 'include', null ),
 			array( 'gatherpress_event_query', '' ),
 			array( 'exclude_current', null ),
 			array( 'include_unfinished', null ),
@@ -786,7 +791,7 @@ class Test_Event_Query extends Base {
 			array( 'venue_filter', null ),
 		);
 
-		$request->expects( $this->exactly( 5 ) )
+		$request->expects( $this->exactly( 6 ) )
 			->method( 'get_param' )
 			->willReturnMap( $param_map );
 
@@ -845,6 +850,7 @@ class Test_Event_Query extends Base {
 		$request = $this->createMock( \WP_REST_Request::class );
 
 		$param_map = array(
+			array( 'include', null ),
 			array( 'gatherpress_event_query', 'upcoming' ),
 			array( 'exclude_current', null ),
 			array( 'include_unfinished', null ),
@@ -852,7 +858,7 @@ class Test_Event_Query extends Base {
 			array( 'venue_filter', 1 ),
 		);
 
-		$request->expects( $this->exactly( 5 ) )
+		$request->expects( $this->exactly( 6 ) )
 			->method( 'get_param' )
 			->willReturnMap( $param_map );
 
@@ -872,6 +878,48 @@ class Test_Event_Query extends Base {
 		$result = $instance->rest_query( $initial_args, $request );
 
 		$this->assertSame( 1, $result['venue_filter'], 'Should pass venue_filter through to custom args.' );
+	}
+
+	/**
+	 * Test rest_query short-circuits when `include` is in the request.
+	 *
+	 * ID-based REST lookups should bypass the upcoming/past date filter so
+	 * they can resolve past events too — without this, blocks that look up
+	 * an override target via the collection endpoint silently get an empty
+	 * array for past events and stay dimmed.
+	 *
+	 * @since 1.0.0
+	 * @covers ::rest_query
+	 *
+	 * @return void
+	 */
+	public function test_rest_query_bypasses_filter_when_include_param_is_set(): void {
+		$instance = Event_Query::get_instance();
+
+		$request = $this->createMock( \WP_REST_Request::class );
+
+		// Only `include` should be read — none of the date/orderby params
+		// because the bypass returns before reaching them.
+		$request->expects( $this->once() )
+			->method( 'get_param' )
+			->with( 'include' )
+			->willReturn( array( 42 ) );
+
+		$request->expects( $this->never() )
+			->method( 'get_params' );
+
+		$initial_args = array(
+			'post_type'      => Event::POST_TYPE,
+			'posts_per_page' => 1,
+		);
+
+		$result = $instance->rest_query( $initial_args, $request );
+
+		$this->assertSame(
+			$initial_args,
+			$result,
+			'Args should be returned unchanged when `include` is present.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Wires up `postIdOverride` on the venue block (it was declared but unused) and tightens the override behavior across the event blocks. Three connected fixes:

1. **Venue block override resolver** — reads `attributes.postId`, identifies whether the target is an event-supporting or venue-supporting post type (event wins on tie), and routes accordingly: an event override walks that event's venue taxonomy, a venue override is used directly. Updates `eventId` / `venuePostId` / `venuePostType` in the existing flow and skips the venue taxonomy REST query when there's no event to walk against (eliminates the 403 on non-event hosts).
2. **REST filter bypass for ID lookups** — `Event_Query::rest_query` defaults to upcoming-only and was filtering out past events from `?include[]=<id>` queries, so any ID-based lookup of a past event silently returned `[]`. The filter now skips when `include` is in the request — ID-based lookups are explicit and shouldn't be subject to the date filter.
3. **Reactive event dim gate** — `hasValidEventId` now accepts a `useSelect` callback's `select` so subscriptions actually track entity-record loads. Updates `add-to-calendar`, `rsvp`, `rsvp-count`, `rsvp-response`, and `rsvp-form` to wrap the gate in `useSelect`. Without this, `getEventMeta`'s `useSelect` returned a shallow-equal object before/after the override target loaded, so the component never re-rendered and the block stayed dimmed even after the data arrived.

Also: `findEventPostById` / `findVenuePostById` now query `getEntityRecords({ include: [id], context: 'edit' })` instead of `getEntityRecord(id)`. Misses return `[]` (HTTP 200) instead of 404, and edit context guarantees the `meta` field is populated. `getPostTypes()` is called with `context: 'edit'` so the `supports` field is exposed on the returned types.

User-facing docs at `docs/user/event-id-override.md` updated to add Venue to the supported list and explain the dual event-or-venue input behavior.

Closes #1553

### How to test the Change

1. `npm run lint:js`, `npm run lint:php`, `npm run lint:phpstan`, `npm run lint:md:docs` — all clean.
2. `npm run test:unit:js` — 740 passing.
3. `npm run test:unit:php` — 1281 passing.
4. In the editor, on a regular Page:
   - Add a Venue block, set Post ID Override to an event ID → block lights up + shows that event's venue.
   - Set the override to a venue ID instead → block lights up + shows that venue directly.
   - Add Event Date / RSVP / RSVP Count / RSVP Response / Add to Calendar blocks, set their Post ID Override to a valid event ID (try a **past** event too) → blocks light up and render the event's data.
   - Clear or set an invalid override → block stays dim, **no console 404s/403s**.

### Changelog Entry

> Fixed - `postIdOverride` now works on the venue block and reliably lights up event blocks once the override target loads, including for past events.

### Credits

Props @mauteri

### Checklist

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.