### PR TITLE
    Fix timezone parsing to prevent HTML attribute leakage in option values

### DIFF
--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -154,17 +154,26 @@ class Utility {
 		$group           = null;
 
 		foreach ( $timezones_raw as $timezone ) {
-			preg_match( '/<optgroup label="(.+)">/', $timezone, $matches );
-
-			if ( 2 === count( $matches ) ) {
+			// Anchor on the specific `label=` and `value=` attribute names
+			// (`\b` word boundary) and capture only their attribute contents
+			// via `[^"]+`. The previous greedy `.+` would swallow any
+			// additional attributes WordPress emits on the same tag — recent
+			// WP versions added `dir="auto"` on optgroup/option — and the
+			// resulting option values never matched the saved timezone, so
+			// the SelectControl always fell back to the first option.
+			if (
+				false !== strpos( $timezone, '<optgroup' ) &&
+				preg_match( '/\blabel="([^"]+)"/', $timezone, $matches )
+			) {
 				$group                     = $matches[1];
 				$timezones_clean[ $group ] = array();
 				continue;
 			}
 
-			preg_match( '/<option.*value="(.+)">(.+)<\/option>/', $timezone, $matches );
-
-			if ( ! empty( $group ) && 3 === count( $matches ) ) {
+			if (
+				! empty( $group ) &&
+				preg_match( '/\bvalue="([^"]+)"[^>]*>([^<]+)<\/option>/', $timezone, $matches )
+			) {
 				$timezones_clean[ $group ][ $matches[1] ] = $matches[2];
 			}
 		}

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -162,7 +162,7 @@ class Utility {
 			// resulting option values never matched the saved timezone, so
 			// the SelectControl always fell back to the first option.
 			if (
-				false !== strpos( $timezone, '<optgroup' ) &&
+				str_contains( $timezone, '<optgroup' ) &&
 				preg_match( '/\blabel="([^"]+)"/', $timezone, $matches )
 			) {
 				$group                     = $matches[1];

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -182,6 +182,105 @@ class Test_Utility extends Base {
 	}
 
 	/**
+	 * Regression: option values must be raw timezone identifiers, never markup.
+	 *
+	 * WordPress's `wp_timezone_choice()` markup has shifted across releases —
+	 * recent versions added a `dir="auto"` attribute on `<optgroup>` and
+	 * `<option>` tags. A greedy `.+` capture in the parser used to pull that
+	 * trailing attribute into the option value, so the saved timezone never
+	 * matched any option in the editor's select and the dropdown silently
+	 * fell back to the first item. This bug has shipped twice; lock it down
+	 * with assertions that catch any HTML markup leaking into either group
+	 * keys or option values, regardless of which WP version emitted them.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @covers ::timezone_choices
+	 *
+	 * @return void
+	 */
+	public function test_timezone_choices_keys_and_values_have_no_html_leakage(): void {
+		$timezones = Utility::timezone_choices();
+
+		$this->assertNotEmpty(
+			$timezones,
+			'timezone_choices() should return at least one group.'
+		);
+
+		// Tokens that should never appear in a group label or option value /
+		// label — any presence indicates HTML markup leaked through the
+		// parser. Mapped to a short noun phrase that completes the
+		// assertion failure message ("Group label \"...\" contains <reason>").
+		$forbidden = array(
+			'"'    => 'a quote',
+			'<'    => 'a tag character',
+			'>'    => 'a tag character',
+			'dir=' => 'a `dir=` attribute',
+		);
+
+		foreach ( $timezones as $group_label => $options ) {
+			foreach ( $forbidden as $needle => $reason ) {
+				$this->assertStringNotContainsString(
+					$needle,
+					$group_label,
+					sprintf( 'Group label "%s" contains %s.', $group_label, $reason )
+				);
+			}
+
+			$this->assertIsArray( $options );
+
+			foreach ( $options as $value => $label ) {
+				$value_string = (string) $value;
+				foreach ( $forbidden as $needle => $reason ) {
+					$this->assertStringNotContainsString(
+						$needle,
+						$value_string,
+						sprintf( 'Option value "%s" contains %s.', $value_string, $reason )
+					);
+				}
+
+				$label_string = (string) $label;
+				foreach ( array( '<', '>' ) as $needle ) {
+					$this->assertStringNotContainsString(
+						$needle,
+						$label_string,
+						sprintf( 'Option label "%s" contains a tag character.', $label_string )
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Regression: well-known timezone identifiers must round-trip as exact keys.
+	 *
+	 * If the parser corrupts option `value` attributes, common identifiers
+	 * like `America/New_York` or `UTC` will not appear as exact keys in their
+	 * groups — instead the keys carry trailing markup like
+	 * `America/New_York" dir="auto`. Asserting that a few canonical
+	 * identifiers exist as exact keys is a tight check that catches this
+	 * class of regression early.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @covers ::timezone_choices
+	 *
+	 * @return void
+	 */
+	public function test_timezone_choices_exposes_canonical_identifiers_as_exact_keys(): void {
+		$timezones = Utility::timezone_choices();
+
+		$this->assertArrayHasKey( 'America', $timezones );
+		$this->assertArrayHasKey( 'America/New_York', $timezones['America'] );
+
+		$this->assertArrayHasKey( 'Europe', $timezones );
+		$this->assertArrayHasKey( 'Europe/Berlin', $timezones['Europe'] );
+
+		$this->assertArrayHasKey( 'UTC', $timezones );
+		$this->assertArrayHasKey( 'UTC', $timezones['UTC'] );
+	}
+
+	/**
 	 * Data provider for maybe_convert_utc_offset test.
 	 *
 	 * @return array


### PR DESCRIPTION
### Description of the Change
Fixes a parsing bug in `Utility::timezone_choices()` where greedy regex patterns (`.+`) could capture unintended HTML attributes from WordPress-generated markup.

Recent versions of WordPress added attributes like `dir="auto"` to `<optgroup>` and `<option>` tags returned by `wp_timezone_choice()`. The previous regex would greedily capture beyond the intended `label` and `value` attributes, resulting in corrupted option values such as:
```
America/New_York” dir=“auto
```
Because of this, saved timezone values would not match any option in the select control, causing the UI to silently fall back to the first option.

This change:
- Replaces greedy regex patterns with targeted, attribute-specific matches:
  - `\blabel="([^"]+)"`
  - `\bvalue="([^"]+)"[^>]*>([^<]+)</option>`
- Adds a lightweight guard using `str_contains()` to detect `<optgroup>` lines before parsing
- Ensures only the intended attribute values are captured, regardless of additional attributes added by WordPress

### Benefits
- Prevents silent UI fallback due to mismatched timezone values
- Makes parsing resilient to future changes in WordPress markup
- Fixes a regression that has occurred multiple times

### Alternatives Considered
- Using DOM parsing instead of regex (more robust but heavier and unnecessary for this constrained input)
- Stripping attributes post-parse (less reliable than fixing the root cause)

### Verification Steps
- Confirm timezone dropdown correctly reflects saved values (e.g. `America/New_York`)
- Confirm no option values contain HTML or attributes
- Run unit tests to ensure coverage of regression scenarios

Closes #1557

---

### How to test the Change
1. Load a context where `Utility::timezone_choices()` is used (e.g. editor select control)
2. Set a known timezone (e.g. `America/New_York`)
3. Reload and confirm the correct value is selected (no fallback to first option)
4. Inspect generated options to confirm:
   - No `dir="auto"` or other attributes leak into values
   - Keys match exact timezone identifiers
5. Run test suite:
   - Ensure new regression tests pass
   - Ensure no existing tests fail

---

### Changelog Entry
> Fixed - Timezone parsing bug causing HTML attribute leakage into option values and incorrect select behavior

---

### Credits
Props @mauteri 

---

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.