### PR TITLE
Refuse activation when duplicate GatherPress folders are on disk

### DIFF
--- a/includes/core/classes/class-coexistence-guard.php
+++ b/includes/core/classes/class-coexistence-guard.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Coexistence activation guard for GatherPress and its companion plugins.
+ *
+ * Detects when more than one folder matching a plugin's slug pattern exists on
+ * disk (the artifact of WordPress's upload-replace flow when the new build's
+ * folder name doesn't match the existing one) and refuses activation while a
+ * sibling copy is already running, surfacing a `wp_die()` page that lists the
+ * duplicate folders.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Core;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Traits\Singleton;
+
+/**
+ * Class Coexistence_Guard.
+ *
+ * Centralizes the "two folders of the same plugin, only one should run" guard
+ * for GatherPress and any companion plugin that registers itself via the
+ * `gatherpress_register_coexistence_guards` action.
+ *
+ * @since 1.0.0
+ */
+class Coexistence_Guard {
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @since 1.0.0
+	 */
+	public function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Set up hooks.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks(): void {
+		add_action( 'plugins_loaded', array( $this, 'fire_registration_action' ) );
+	}
+
+	/**
+	 * Self-registers GatherPress and fires the public registration action so
+	 * companion plugins can wire up their own guards.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function fire_registration_action(): void {
+		$this->register( 'gatherpress', 'GatherPress', GATHERPRESS_CORE_FILE );
+
+		/**
+		 * Fires to allow GatherPress companion plugins to register coexistence
+		 * activation guards.
+		 *
+		 * Companion plugins should hook into this action and call
+		 * `gatherpress_register_coexistence_guard()` from inside the callback,
+		 * passing their plugin slug, display name, and `__FILE__`. The
+		 * `function_exists()` guard recommended in the helper's docblock makes
+		 * the registration a graceful no-op if GatherPress is removed in the
+		 * future.
+		 *
+		 * @since 1.0.0
+		 */
+		do_action( 'gatherpress_register_coexistence_guards' );
+	}
+
+	/**
+	 * Wire up the activation guard for one plugin.
+	 *
+	 * Registers the canonical plugin's activation hook AND, when running in
+	 * admin context, mirrors the same callback onto every sibling folder
+	 * already on disk so an older build that doesn't carry this code still
+	 * trips the guard when activated.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $slug      Folder slug, e.g. `gatherpress-alpha`. The companion
+	 *                          plugin's main file must be `<slug>.php` inside a
+	 *                          folder named `<slug>` (canonical) or `<slug>-*` (siblings).
+	 * @param string $name      Display name, e.g. `GatherPress Alpha`.
+	 * @param string $main_file Absolute path to the companion's main plugin file.
+	 * @return void
+	 */
+	public function register( string $slug, string $name, string $main_file ): void {
+		$callback = function () use ( $slug, $name ): void {
+			$this->refuse_on_duplicates( $slug, $name );
+		};
+
+		register_activation_hook( $main_file, $callback );
+
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		foreach ( $this->find_duplicates( $slug ) as $sibling ) {
+			add_action( 'activate_' . $sibling, $callback );
+		}
+	}
+
+	/**
+	 * Returns every installed plugin file matching `<slug>*\/<slug>.php`, sorted.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $slug Plugin folder slug.
+	 * @return string[] Plugin basenames matching the slug pattern.
+	 */
+	public function find_duplicates( string $slug ): array {
+		$plugins       = get_plugins();
+		$duplicates    = array();
+		$expected_file = $slug . '.php';
+		$folder_prefix = $slug . '-';
+
+		foreach ( array_keys( $plugins ) as $plugin_file ) {
+			if ( ! is_string( $plugin_file ) ) {
+				continue;
+			}
+
+			$parts = explode( '/', $plugin_file );
+
+			if ( 2 !== count( $parts ) ) {
+				continue;
+			}
+
+			list( $folder, $file ) = $parts;
+
+			if ( $expected_file !== $file ) {
+				continue;
+			}
+
+			if ( $slug !== $folder && 0 !== strpos( $folder, $folder_prefix ) ) {
+				continue;
+			}
+
+			$duplicates[] = $plugin_file;
+		}
+
+		sort( $duplicates );
+
+		return $duplicates;
+	}
+
+	/**
+	 * Refuses activation when more than one matching folder is on disk and a
+	 * sibling copy is already active.
+	 *
+	 * Removes the failure-redirect Location header that `activate_plugin()`
+	 * pre-sends, then `wp_die()`s with a list of duplicate folders. The
+	 * `update_option( 'active_plugins', ... )` call in WordPress core runs
+	 * after this hook, so `wp_die()` alone prevents the plugin from being
+	 * persisted as active.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $slug Plugin folder slug.
+	 * @param string $name Plugin display name.
+	 * @return void
+	 */
+	public function refuse_on_duplicates( string $slug, string $name ): void {
+		$duplicates = $this->find_duplicates( $slug );
+
+		if ( count( $duplicates ) <= 1 ) {
+			return;
+		}
+
+		$active_duplicates = array_values( array_filter( $duplicates, 'is_plugin_active' ) );
+
+		if ( empty( $active_duplicates ) ) {
+			return;
+		}
+
+		// `headers_sent()` is unreliable in the PHPUnit CLI test environment —
+		// the test runner prints progress output to stdout before this branch
+		// runs, so the guarded `header_remove()` call cannot be reached from a
+		// test. The branch is exercised in production during the activation
+		// request, where the failure-Location header is queued but no body has
+		// been emitted yet.
+		if ( ! headers_sent() ) {
+			header_remove( 'Location' ); // @codeCoverageIgnore
+		}
+
+		$folders = array_map(
+			static function ( string $plugin_file ): string {
+				return dirname( $plugin_file );
+			},
+			$duplicates
+		);
+
+		wp_die(
+			sprintf(
+				'<h1>%s</h1><p>%s</p><ul><li><code>%s</code></li></ul><p>%s</p>',
+				esc_html(
+					sprintf(
+						/* translators: %s: Plugin name. */
+						__( 'Another copy of %s is already active', 'gatherpress' ),
+						$name
+					)
+				),
+				esc_html(
+					sprintf(
+						/* translators: %s: Plugin name. */
+						__(
+							// phpcs:disable Generic.Files.LineLength.TooLong
+							'Only one version of %s can run at a time. WordPress installed a new copy in a separate folder instead of replacing the existing one — both folders are now on disk:',
+							// phpcs:enable Generic.Files.LineLength.TooLong
+							'gatherpress'
+						),
+						$name
+					)
+				),
+				implode( '</code></li><li><code>', array_map( 'esc_html', $folders ) ),
+				esc_html__(
+					// phpcs:ignore Generic.Files.LineLength.TooLong
+					'Deactivate the currently-active copy or remove the duplicate folder via SFTP, then return to the plugins screen and try again.',
+					'gatherpress'
+				)
+			),
+			esc_html(
+				sprintf(
+					/* translators: %s: Plugin name. */
+					__( '%s activation halted', 'gatherpress' ),
+					$name
+				)
+			),
+			array(
+				'response'  => 200,
+				'back_link' => true,
+			)
+		);
+	}
+}

--- a/includes/core/classes/class-coexistence-guard.php
+++ b/includes/core/classes/class-coexistence-guard.php
@@ -23,8 +23,8 @@ use GatherPress\Core\Traits\Singleton;
  * Class Coexistence_Guard.
  *
  * Centralizes the "two folders of the same plugin, only one should run" guard
- * for GatherPress and any companion plugin that registers itself via the
- * `gatherpress_register_coexistence_guards` action.
+ * for GatherPress and any companion plugin that announces itself via the
+ * `gatherpress_register_coexistence_guard` action.
  *
  * @since 1.0.0
  */
@@ -41,6 +41,7 @@ class Coexistence_Guard {
 	 */
 	public function __construct() {
 		$this->setup_hooks();
+		$this->register( 'gatherpress', 'GatherPress', GATHERPRESS_CORE_FILE );
 	}
 
 	/**
@@ -51,34 +52,7 @@ class Coexistence_Guard {
 	 * @return void
 	 */
 	protected function setup_hooks(): void {
-		add_action( 'plugins_loaded', array( $this, 'fire_registration_action' ) );
-	}
-
-	/**
-	 * Self-registers GatherPress and fires the public registration action so
-	 * companion plugins can wire up their own guards.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return void
-	 */
-	public function fire_registration_action(): void {
-		$this->register( 'gatherpress', 'GatherPress', GATHERPRESS_CORE_FILE );
-
-		/**
-		 * Fires to allow GatherPress companion plugins to register coexistence
-		 * activation guards.
-		 *
-		 * Companion plugins should hook into this action and call
-		 * `gatherpress_register_coexistence_guard()` from inside the callback,
-		 * passing their plugin slug, display name, and `__FILE__`. The
-		 * `function_exists()` guard recommended in the helper's docblock makes
-		 * the registration a graceful no-op if GatherPress is removed in the
-		 * future.
-		 *
-		 * @since 1.0.0
-		 */
-		do_action( 'gatherpress_register_coexistence_guards' );
+		add_action( 'gatherpress_register_coexistence_guard', array( $this, 'register' ), 10, 3 );
 	}
 
 	/**

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -59,6 +59,7 @@ class Setup {
 		Assets::get_instance();
 		Blocks\Setup::get_instance();
 		Cli::get_instance();
+		Coexistence_Guard::get_instance();
 		Event\Setup::get_instance();
 		Export::get_instance();
 		Feed::get_instance();

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -149,32 +149,64 @@ class Utility {
 	 * @return array An array of time zones with labels as keys and time zone choices as values.
 	 */
 	public static function timezone_choices(): array {
-		$timezones_raw   = explode( PHP_EOL, wp_timezone_choice( 'UTC', get_user_locale() ) );
+		// Parse `wp_timezone_choice()` output through WordPress's HTML tag
+		// processor — no regex, no string-stripping. A previous greedy-regex
+		// parser silently broke when WordPress added a `dir="auto"`
+		// attribute to optgroup/option tags: the captured value carried
+		// trailing markup and never matched the saved timezone, so the
+		// editor's timezone select always fell back to the first option.
+		// Walking tokens via `WP_HTML_Tag_Processor` insulates this code
+		// from any future markup changes WordPress makes to those tags.
+		$tags = new \WP_HTML_Tag_Processor(
+			wp_timezone_choice( 'UTC', get_user_locale() )
+		);
+
 		$timezones_clean = array();
 		$group           = null;
+		$pending_value   = null;
 
-		foreach ( $timezones_raw as $timezone ) {
-			// Anchor on the specific `label=` and `value=` attribute names
-			// (`\b` word boundary) and capture only their attribute contents
-			// via `[^"]+`. The previous greedy `.+` would swallow any
-			// additional attributes WordPress emits on the same tag — recent
-			// WP versions added `dir="auto"` on optgroup/option — and the
-			// resulting option values never matched the saved timezone, so
-			// the SelectControl always fell back to the first option.
-			if (
-				str_contains( $timezone, '<optgroup' ) &&
-				preg_match( '/\blabel="([^"]+)"/', $timezone, $matches )
-			) {
-				$group                     = $matches[1];
-				$timezones_clean[ $group ] = array();
+		while ( $tags->next_token() ) {
+			$token_type = $tags->get_token_type();
+
+			if ( '#tag' === $token_type ) {
+				if ( $tags->is_tag_closer() ) {
+					continue;
+				}
+
+				$tag_name = $tags->get_tag();
+
+				if ( 'OPTGROUP' === $tag_name ) {
+					$label = $tags->get_attribute( 'label' );
+
+					if ( is_string( $label ) && '' !== $label ) {
+						$group                     = $label;
+						$timezones_clean[ $group ] = array();
+					}
+
+					$pending_value = null;
+					continue;
+				}
+
+				if ( 'OPTION' === $tag_name && null !== $group ) {
+					$value         = $tags->get_attribute( 'value' );
+					$pending_value = ( is_string( $value ) && '' !== $value ) ? $value : null;
+				}
+
 				continue;
 			}
 
 			if (
-				! empty( $group ) &&
-				preg_match( '/\bvalue="([^"]+)"[^>]*>([^<]+)<\/option>/', $timezone, $matches )
+				'#text' === $token_type &&
+				null !== $group &&
+				null !== $pending_value
 			) {
-				$timezones_clean[ $group ][ $matches[1] ] = $matches[2];
+				$text = trim( $tags->get_modifiable_text() );
+
+				if ( '' !== $text ) {
+					$timezones_clean[ $group ][ $pending_value ] = $text;
+				}
+
+				$pending_value = null;
 			}
 		}
 

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -15,6 +15,8 @@ namespace GatherPress\Core;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use WP_HTML_Tag_Processor;
+
 /**
  * Class Utility.
  *
@@ -157,7 +159,7 @@ class Utility {
 		// editor's timezone select always fell back to the first option.
 		// Walking tokens via `WP_HTML_Tag_Processor` insulates this code
 		// from any future markup changes WordPress makes to those tags.
-		$tags = new \WP_HTML_Tag_Processor(
+		$tags = new WP_HTML_Tag_Processor(
 			wp_timezone_choice( 'UTC', get_user_locale() )
 		);
 

--- a/includes/core/duplicate-check.php
+++ b/includes/core/duplicate-check.php
@@ -2,15 +2,11 @@
 /**
  * Duplicate GatherPress Plugin Check.
  *
- * Detects whether another copy of GatherPress is already running and exposes
- * the public helper companion plugins call from inside the
- * `gatherpress_register_coexistence_guards` action.
+ * This file checks to determine if another version of GatherPress is already running.
  *
  * @package GatherPress\Core
  * @since 1.0.0
  */
-
-use GatherPress\Core\Coexistence_Guard;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
@@ -36,37 +32,6 @@ if ( defined( 'GATHERPRESS_VERSION' ) ) {
 	);
 
 	$gatherpress_activated = true;
-}
-
-if ( ! function_exists( 'gatherpress_register_coexistence_guard' ) ) {
-	/**
-	 * Registers a coexistence activation guard for a GatherPress companion plugin.
-	 *
-	 * Companion plugins should hook into the `gatherpress_register_coexistence_guards`
-	 * action and call this helper from inside the callback, passing their plugin
-	 * slug, display name, and `__FILE__`:
-	 *
-	 * ```
-	 * add_action( 'gatherpress_register_coexistence_guards', static function (): void {
-	 *     if ( function_exists( 'gatherpress_register_coexistence_guard' ) ) {
-	 *         gatherpress_register_coexistence_guard( 'my-plugin-slug', 'My Plugin', __FILE__ );
-	 *     }
-	 * } );
-	 * ```
-	 *
-	 * The `function_exists()` guard turns the call into a graceful no-op if the
-	 * helper is removed in a future version of GatherPress.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $slug      Plugin folder slug, e.g. `gatherpress-alpha`.
-	 * @param string $name      Plugin display name, e.g. `GatherPress Alpha`.
-	 * @param string $main_file Absolute path to the companion's main plugin file.
-	 * @return void
-	 */
-	function gatherpress_register_coexistence_guard( string $slug, string $name, string $main_file ): void {
-		Coexistence_Guard::get_instance()->register( $slug, $name, $main_file );
-	}
 }
 
 return $gatherpress_activated;

--- a/includes/core/duplicate-check.php
+++ b/includes/core/duplicate-check.php
@@ -2,11 +2,15 @@
 /**
  * Duplicate GatherPress Plugin Check.
  *
- * This file checks to determine if another version of GatherPress is already running.
+ * Detects whether another copy of GatherPress is already running and exposes
+ * the public helper companion plugins call from inside the
+ * `gatherpress_register_coexistence_guards` action.
  *
  * @package GatherPress\Core
  * @since 1.0.0
  */
+
+use GatherPress\Core\Coexistence_Guard;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
@@ -34,141 +38,34 @@ if ( defined( 'GATHERPRESS_VERSION' ) ) {
 	$gatherpress_activated = true;
 }
 
-if ( ! function_exists( 'gatherpress_find_duplicate_folders' ) ) {
+if ( ! function_exists( 'gatherpress_register_coexistence_guard' ) ) {
 	/**
-	 * Returns the installed plugin folders that look like duplicate copies of GatherPress.
+	 * Registers a coexistence activation guard for a GatherPress companion plugin.
 	 *
-	 * WordPress's upload-replace flow keys off the plugin folder slug, so a fresh
-	 * upload of a GatherPress build whose folder name doesn't match an existing
-	 * copy lands in a sibling folder (`gatherpress-1`, `gatherpress-build`, etc.)
-	 * and leaves the older copy in place. This helper scans `get_plugins()` for
-	 * any `gatherpress*\/gatherpress.php` entries so callers can refuse activation
-	 * when more than one is on disk.
+	 * Companion plugins should hook into the `gatherpress_register_coexistence_guards`
+	 * action and call this helper from inside the callback, passing their plugin
+	 * slug, display name, and `__FILE__`:
+	 *
+	 * ```
+	 * add_action( 'gatherpress_register_coexistence_guards', static function (): void {
+	 *     if ( function_exists( 'gatherpress_register_coexistence_guard' ) ) {
+	 *         gatherpress_register_coexistence_guard( 'my-plugin-slug', 'My Plugin', __FILE__ );
+	 *     }
+	 * } );
+	 * ```
+	 *
+	 * The `function_exists()` guard turns the call into a graceful no-op if the
+	 * helper is removed in a future version of GatherPress.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return string[] Plugin basenames of every GatherPress-shaped folder found, sorted.
-	 */
-	function gatherpress_find_duplicate_folders(): array {
-		$plugins    = get_plugins();
-		$duplicates = array();
-
-		foreach ( array_keys( $plugins ) as $plugin_file ) {
-			if ( ! is_string( $plugin_file ) ) {
-				continue;
-			}
-
-			$parts = explode( '/', $plugin_file );
-
-			if ( 2 !== count( $parts ) ) {
-				continue;
-			}
-
-			list( $folder, $file ) = $parts;
-
-			if ( 'gatherpress.php' !== $file ) {
-				continue;
-			}
-
-			if ( 'gatherpress' !== $folder && 0 !== strpos( $folder, 'gatherpress-' ) ) {
-				continue;
-			}
-
-			$duplicates[] = $plugin_file;
-		}
-
-		sort( $duplicates );
-
-		return $duplicates;
-	}
-}
-
-if ( ! function_exists( 'gatherpress_refuse_activation_on_duplicates' ) ) {
-	/**
-	 * Refuses activation when more than one GatherPress folder is on disk.
-	 *
-	 * Belt-and-suspenders against WordPress's upload-replace miss: if the user has
-	 * uploaded a newer build into a sibling folder rather than replacing the
-	 * existing one, both copies show up in `get_plugins()`. Activating either
-	 * while the other still exists creates two GatherPress plugin rows. This
-	 * deactivates the plugin and halts with `wp_die()` so the user has to clean
-	 * up the duplicate folders before activation can succeed.
-	 *
-	 * @since 1.0.0
-	 *
+	 * @param string $slug      Plugin folder slug, e.g. `gatherpress-alpha`.
+	 * @param string $name      Plugin display name, e.g. `GatherPress Alpha`.
+	 * @param string $main_file Absolute path to the companion's main plugin file.
 	 * @return void
 	 */
-	function gatherpress_refuse_activation_on_duplicates(): void {
-		$duplicates = gatherpress_find_duplicate_folders();
-
-		if ( count( $duplicates ) <= 1 ) {
-			return;
-		}
-
-		// Only refuse when another copy of GatherPress is already active. With
-		// two folders on disk and neither active, the user is allowed to activate
-		// one — the guard kicks in only on the second activation attempt while a
-		// sibling is already running.
-		$active_duplicates = array_values( array_filter( $duplicates, 'is_plugin_active' ) );
-
-		if ( empty( $active_duplicates ) ) {
-			return;
-		}
-
-		// `activate_plugin()` pre-sends a `Location:` redirect header to a failure
-		// URL before running the activation hook, so any output produced by
-		// `wp_die()` here would be discarded by the browser as it follows the
-		// redirect. Remove the pre-set redirect so the user actually sees this.
-		// `update_option( 'active_plugins', ... )` runs *after* this hook in
-		// `activate_plugin()`, so `wp_die()` alone is enough to prevent the plugin
-		// from being persisted as active — no manual deactivation needed.
-		if ( ! headers_sent() ) {
-			header_remove( 'Location' );
-		}
-
-		$folders = array_map(
-			static function ( string $plugin_file ): string {
-				return dirname( $plugin_file );
-			},
-			$duplicates
-		);
-
-		wp_die(
-			sprintf(
-				'<h1>%s</h1><p>%s</p><ul><li><code>%s</code></li></ul><p>%s</p>',
-				esc_html__( 'Another copy of GatherPress is already active', 'gatherpress' ),
-				esc_html__(
-					// phpcs:ignore Generic.Files.LineLength.TooLong
-					'Only one version of GatherPress can run at a time. WordPress installed a new copy in a separate folder instead of replacing the existing one — both folders are now on disk:',
-					'gatherpress'
-				),
-				implode( '</code></li><li><code>', array_map( 'esc_html', $folders ) ),
-				esc_html__(
-					// phpcs:ignore Generic.Files.LineLength.TooLong
-					'Deactivate the currently-active copy or remove the duplicate folder via SFTP, then return to the plugins screen and try again.',
-					'gatherpress'
-				)
-			),
-			esc_html__( 'GatherPress activation halted', 'gatherpress' ),
-			array(
-				'response'  => 200,
-				'back_link' => true,
-			)
-		);
-	}
-}
-
-register_activation_hook(
-	dirname( __DIR__, 2 ) . '/gatherpress.php',
-	'gatherpress_refuse_activation_on_duplicates'
-);
-
-// Also wire the activation guard to every other GatherPress-shaped folder so
-// activating an older copy that lacks this guard still triggers the check from
-// the active install. `get_plugins()` is only available in admin context.
-if ( is_admin() ) {
-	foreach ( gatherpress_find_duplicate_folders() as $gatherpress_sibling_plugin_file ) {
-		add_action( 'activate_' . $gatherpress_sibling_plugin_file, 'gatherpress_refuse_activation_on_duplicates' );
+	function gatherpress_register_coexistence_guard( string $slug, string $name, string $main_file ): void {
+		Coexistence_Guard::get_instance()->register( $slug, $name, $main_file );
 	}
 }
 

--- a/includes/core/duplicate-check.php
+++ b/includes/core/duplicate-check.php
@@ -105,12 +105,23 @@ if ( ! function_exists( 'gatherpress_refuse_activation_on_duplicates' ) ) {
 			return;
 		}
 
-		deactivate_plugins( plugin_basename( dirname( __DIR__, 2 ) . '/gatherpress.php' ) );
+		// Only refuse when another copy of GatherPress is already active. With
+		// two folders on disk and neither active, the user is allowed to activate
+		// one — the guard kicks in only on the second activation attempt while a
+		// sibling is already running.
+		$active_duplicates = array_values( array_filter( $duplicates, 'is_plugin_active' ) );
+
+		if ( empty( $active_duplicates ) ) {
+			return;
+		}
 
 		// `activate_plugin()` pre-sends a `Location:` redirect header to a failure
 		// URL before running the activation hook, so any output produced by
 		// `wp_die()` here would be discarded by the browser as it follows the
 		// redirect. Remove the pre-set redirect so the user actually sees this.
+		// `update_option( 'active_plugins', ... )` runs *after* this hook in
+		// `activate_plugin()`, so `wp_die()` alone is enough to prevent the plugin
+		// from being persisted as active — no manual deactivation needed.
 		if ( ! headers_sent() ) {
 			header_remove( 'Location' );
 		}
@@ -125,16 +136,16 @@ if ( ! function_exists( 'gatherpress_refuse_activation_on_duplicates' ) ) {
 		wp_die(
 			sprintf(
 				'<h1>%s</h1><p>%s</p><ul><li><code>%s</code></li></ul><p>%s</p>',
-				esc_html__( 'Multiple GatherPress folders detected', 'gatherpress' ),
+				esc_html__( 'Another copy of GatherPress is already active', 'gatherpress' ),
 				esc_html__(
 					// phpcs:ignore Generic.Files.LineLength.TooLong
-					'WordPress installed a new copy of GatherPress into a separate folder instead of replacing the existing one. Activating any of these copies while the others remain on disk causes confusing behavior on the plugins screen.',
+					'Only one version of GatherPress can run at a time. WordPress installed a new copy in a separate folder instead of replacing the existing one — both folders are now on disk:',
 					'gatherpress'
 				),
 				implode( '</code></li><li><code>', array_map( 'esc_html', $folders ) ),
 				esc_html__(
 					// phpcs:ignore Generic.Files.LineLength.TooLong
-					'Remove all but one of these folders via SFTP or your file manager, then return to the plugins screen and try activating again.',
+					'Deactivate the currently-active copy or remove the duplicate folder via SFTP, then return to the plugins screen and try again.',
 					'gatherpress'
 				)
 			),

--- a/includes/core/duplicate-check.php
+++ b/includes/core/duplicate-check.php
@@ -105,7 +105,7 @@ if ( ! function_exists( 'gatherpress_refuse_activation_on_duplicates' ) ) {
 			return;
 		}
 
-		deactivate_plugins( plugin_basename( dirname( __FILE__, 3 ) . '/gatherpress.php' ) );
+		deactivate_plugins( plugin_basename( dirname( __DIR__, 2 ) . '/gatherpress.php' ) );
 
 		// `activate_plugin()` pre-sends a `Location:` redirect header to a failure
 		// URL before running the activation hook, so any output produced by
@@ -148,7 +148,7 @@ if ( ! function_exists( 'gatherpress_refuse_activation_on_duplicates' ) ) {
 }
 
 register_activation_hook(
-	dirname( __FILE__, 3 ) . '/gatherpress.php',
+	dirname( __DIR__, 2 ) . '/gatherpress.php',
 	'gatherpress_refuse_activation_on_duplicates'
 );
 

--- a/includes/core/duplicate-check.php
+++ b/includes/core/duplicate-check.php
@@ -34,4 +34,131 @@ if ( defined( 'GATHERPRESS_VERSION' ) ) {
 	$gatherpress_activated = true;
 }
 
+if ( ! function_exists( 'gatherpress_find_duplicate_folders' ) ) {
+	/**
+	 * Returns the installed plugin folders that look like duplicate copies of GatherPress.
+	 *
+	 * WordPress's upload-replace flow keys off the plugin folder slug, so a fresh
+	 * upload of a GatherPress build whose folder name doesn't match an existing
+	 * copy lands in a sibling folder (`gatherpress-1`, `gatherpress-build`, etc.)
+	 * and leaves the older copy in place. This helper scans `get_plugins()` for
+	 * any `gatherpress*\/gatherpress.php` entries so callers can refuse activation
+	 * when more than one is on disk.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string[] Plugin basenames of every GatherPress-shaped folder found, sorted.
+	 */
+	function gatherpress_find_duplicate_folders(): array {
+		$plugins    = get_plugins();
+		$duplicates = array();
+
+		foreach ( array_keys( $plugins ) as $plugin_file ) {
+			if ( ! is_string( $plugin_file ) ) {
+				continue;
+			}
+
+			$parts = explode( '/', $plugin_file );
+
+			if ( 2 !== count( $parts ) ) {
+				continue;
+			}
+
+			list( $folder, $file ) = $parts;
+
+			if ( 'gatherpress.php' !== $file ) {
+				continue;
+			}
+
+			if ( 'gatherpress' !== $folder && 0 !== strpos( $folder, 'gatherpress-' ) ) {
+				continue;
+			}
+
+			$duplicates[] = $plugin_file;
+		}
+
+		sort( $duplicates );
+
+		return $duplicates;
+	}
+}
+
+if ( ! function_exists( 'gatherpress_refuse_activation_on_duplicates' ) ) {
+	/**
+	 * Refuses activation when more than one GatherPress folder is on disk.
+	 *
+	 * Belt-and-suspenders against WordPress's upload-replace miss: if the user has
+	 * uploaded a newer build into a sibling folder rather than replacing the
+	 * existing one, both copies show up in `get_plugins()`. Activating either
+	 * while the other still exists creates two GatherPress plugin rows. This
+	 * deactivates the plugin and halts with `wp_die()` so the user has to clean
+	 * up the duplicate folders before activation can succeed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	function gatherpress_refuse_activation_on_duplicates(): void {
+		$duplicates = gatherpress_find_duplicate_folders();
+
+		if ( count( $duplicates ) <= 1 ) {
+			return;
+		}
+
+		deactivate_plugins( plugin_basename( dirname( __FILE__, 3 ) . '/gatherpress.php' ) );
+
+		// `activate_plugin()` pre-sends a `Location:` redirect header to a failure
+		// URL before running the activation hook, so any output produced by
+		// `wp_die()` here would be discarded by the browser as it follows the
+		// redirect. Remove the pre-set redirect so the user actually sees this.
+		if ( ! headers_sent() ) {
+			header_remove( 'Location' );
+		}
+
+		$folders = array_map(
+			static function ( string $plugin_file ): string {
+				return dirname( $plugin_file );
+			},
+			$duplicates
+		);
+
+		wp_die(
+			sprintf(
+				'<h1>%s</h1><p>%s</p><ul><li><code>%s</code></li></ul><p>%s</p>',
+				esc_html__( 'Multiple GatherPress folders detected', 'gatherpress' ),
+				esc_html__(
+					// phpcs:ignore Generic.Files.LineLength.TooLong
+					'WordPress installed a new copy of GatherPress into a separate folder instead of replacing the existing one. Activating any of these copies while the others remain on disk causes confusing behavior on the plugins screen.',
+					'gatherpress'
+				),
+				implode( '</code></li><li><code>', array_map( 'esc_html', $folders ) ),
+				esc_html__(
+					// phpcs:ignore Generic.Files.LineLength.TooLong
+					'Remove all but one of these folders via SFTP or your file manager, then return to the plugins screen and try activating again.',
+					'gatherpress'
+				)
+			),
+			esc_html__( 'GatherPress activation halted', 'gatherpress' ),
+			array(
+				'response'  => 200,
+				'back_link' => true,
+			)
+		);
+	}
+}
+
+register_activation_hook(
+	dirname( __FILE__, 3 ) . '/gatherpress.php',
+	'gatherpress_refuse_activation_on_duplicates'
+);
+
+// Also wire the activation guard to every other GatherPress-shaped folder so
+// activating an older copy that lacks this guard still triggers the check from
+// the active install. `get_plugins()` is only available in admin context.
+if ( is_admin() ) {
+	foreach ( gatherpress_find_duplicate_folders() as $gatherpress_sibling_plugin_file ) {
+		add_action( 'activate_' . $gatherpress_sibling_plugin_file, 'gatherpress_refuse_activation_on_duplicates' );
+	}
+}
+
 return $gatherpress_activated;

--- a/test/unit/php/includes/tests/core/classes/class-test-coexistence-guard.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-coexistence-guard.php
@@ -27,7 +27,7 @@ class Test_Coexistence_Guard extends Base {
 		wp_cache_delete( 'plugins', 'plugins' );
 		delete_option( 'active_plugins' );
 
-		// Clean up any activation hooks registered during the test for our
+		// Clean up activation hooks registered during the test for our
 		// synthetic test slugs so they don't leak into other tests.
 		global $wp_filter;
 		foreach ( array_keys( $wp_filter ) as $tag ) {
@@ -35,8 +35,6 @@ class Test_Coexistence_Guard extends Base {
 				unset( $wp_filter[ $tag ] );
 			}
 		}
-
-		remove_all_actions( 'gatherpress_register_coexistence_guards' );
 
 		parent::tearDown();
 	}
@@ -53,7 +51,8 @@ class Test_Coexistence_Guard extends Base {
 	}
 
 	/**
-	 * Coverage for __construct and setup_hooks.
+	 * Coverage for __construct and setup_hooks. Self-registration of the
+	 * GatherPress slug also runs through the constructor.
 	 *
 	 * @covers ::__construct
 	 * @covers ::setup_hooks
@@ -65,43 +64,17 @@ class Test_Coexistence_Guard extends Base {
 		$hooks    = array(
 			array(
 				'type'     => 'action',
-				'name'     => 'plugins_loaded',
+				'name'     => 'gatherpress_register_coexistence_guard',
 				'priority' => 10,
-				'callback' => array( $instance, 'fire_registration_action' ),
+				'callback' => array( $instance, 'register' ),
 			),
 		);
 
 		$this->assert_hooks( $hooks, $instance );
-	}
 
-	/**
-	 * Self-registers GatherPress and fires the public registration action.
-	 *
-	 * @covers ::fire_registration_action
-	 *
-	 * @return void
-	 */
-	public function test_fire_registration_action_self_registers_and_fires_action(): void {
-		$this->seed_plugins_cache(
-			array(
-				'gatherpress/gatherpress.php' => array( 'Name' => 'GatherPress' ),
-			)
-		);
-
-		$action_fired = false;
-		add_action(
-			'gatherpress_register_coexistence_guards',
-			static function () use ( &$action_fired ): void {
-				$action_fired = true;
-			}
-		);
-
-		Coexistence_Guard::get_instance()->fire_registration_action();
-
-		$this->assertTrue( $action_fired, 'gatherpress_register_coexistence_guards action should fire.' );
 		$this->assertNotFalse(
-			has_action( 'activate_gatherpress/gatherpress.php' ),
-			'GatherPress should self-register its activation hook.'
+			has_action( 'activate_' . plugin_basename( GATHERPRESS_CORE_FILE ) ),
+			'GatherPress should self-register its activation hook in the constructor.'
 		);
 	}
 
@@ -323,6 +296,11 @@ class Test_Coexistence_Guard extends Base {
 
 		$this->expectException( \WPDieException::class );
 
+		// WordPress's `activate_{plugin_file}` hook name shape carries the plugin
+		// basename verbatim, including the slash and dashes — that's the action
+		// name `register_activation_hook()` derives. Suppress the PHPCS naming
+		// sniffs since this is firing WP core's own hook, not a project hook.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound,WordPress.NamingConventions.ValidHookName.UseUnderscores
 		do_action( 'activate_test-coexistence-callback-build/test-coexistence-callback.php' );
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-coexistence-guard.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-coexistence-guard.php
@@ -1,0 +1,355 @@
+<?php
+/**
+ * Class handles unit tests for GatherPress\Core\Coexistence_Guard.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Core;
+
+use GatherPress\Core\Coexistence_Guard;
+use GatherPress\Tests\Base;
+
+/**
+ * Class Test_Coexistence_Guard.
+ *
+ * @coversDefaultClass \GatherPress\Core\Coexistence_Guard
+ */
+class Test_Coexistence_Guard extends Base {
+	/**
+	 * Reset cached plugin list and the active-plugins option after each test so
+	 * later tests start from a clean slate.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		wp_cache_delete( 'plugins', 'plugins' );
+		delete_option( 'active_plugins' );
+
+		// Clean up any activation hooks registered during the test for our
+		// synthetic test slugs so they don't leak into other tests.
+		global $wp_filter;
+		foreach ( array_keys( $wp_filter ) as $tag ) {
+			if ( 0 === strpos( $tag, 'activate_test-coexistence' ) ) {
+				unset( $wp_filter[ $tag ] );
+			}
+		}
+
+		remove_all_actions( 'gatherpress_register_coexistence_guards' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Seed `get_plugins()`'s cache so callers see a controlled fixture without
+	 * touching the real plugins directory.
+	 *
+	 * @param array<string, array<string, mixed>> $plugins Mapping of plugin basename to header data.
+	 * @return void
+	 */
+	private function seed_plugins_cache( array $plugins ): void {
+		wp_cache_set( 'plugins', array( '' => $plugins ), 'plugins' );
+	}
+
+	/**
+	 * Coverage for __construct and setup_hooks.
+	 *
+	 * @covers ::__construct
+	 * @covers ::setup_hooks
+	 *
+	 * @return void
+	 */
+	public function test_setup_hooks(): void {
+		$instance = Coexistence_Guard::get_instance();
+		$hooks    = array(
+			array(
+				'type'     => 'action',
+				'name'     => 'plugins_loaded',
+				'priority' => 10,
+				'callback' => array( $instance, 'fire_registration_action' ),
+			),
+		);
+
+		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * Self-registers GatherPress and fires the public registration action.
+	 *
+	 * @covers ::fire_registration_action
+	 *
+	 * @return void
+	 */
+	public function test_fire_registration_action_self_registers_and_fires_action(): void {
+		$this->seed_plugins_cache(
+			array(
+				'gatherpress/gatherpress.php' => array( 'Name' => 'GatherPress' ),
+			)
+		);
+
+		$action_fired = false;
+		add_action(
+			'gatherpress_register_coexistence_guards',
+			static function () use ( &$action_fired ): void {
+				$action_fired = true;
+			}
+		);
+
+		Coexistence_Guard::get_instance()->fire_registration_action();
+
+		$this->assertTrue( $action_fired, 'gatherpress_register_coexistence_guards action should fire.' );
+		$this->assertNotFalse(
+			has_action( 'activate_gatherpress/gatherpress.php' ),
+			'GatherPress should self-register its activation hook.'
+		);
+	}
+
+	/**
+	 * Registers the canonical activation hook regardless of admin context.
+	 *
+	 * @covers ::register
+	 *
+	 * @return void
+	 */
+	public function test_register_registers_canonical_activation_hook(): void {
+		$this->seed_plugins_cache( array() );
+
+		$main_file = WP_PLUGIN_DIR . '/test-coexistence-canonical/test-coexistence-canonical.php';
+
+		Coexistence_Guard::get_instance()->register(
+			'test-coexistence-canonical',
+			'Test Coexistence Canonical',
+			$main_file
+		);
+
+		$this->assertNotFalse(
+			has_action( 'activate_' . plugin_basename( $main_file ) ),
+			'Canonical activation hook should be registered.'
+		);
+	}
+
+	/**
+	 * Mirrors the activation hook onto sibling folders when running in admin.
+	 *
+	 * @covers ::register
+	 *
+	 * @return void
+	 */
+	public function test_register_mirrors_activation_hooks_onto_siblings_in_admin(): void {
+		$this->seed_plugins_cache(
+			array(
+				'test-coexistence-siblings/test-coexistence-siblings.php'       => array(),
+				'test-coexistence-siblings-build/test-coexistence-siblings.php' => array(),
+			)
+		);
+
+		set_current_screen( 'plugins' );
+
+		Coexistence_Guard::get_instance()->register(
+			'test-coexistence-siblings',
+			'Test Coexistence Siblings',
+			WP_PLUGIN_DIR . '/test-coexistence-siblings/test-coexistence-siblings.php'
+		);
+
+		$this->assertNotFalse(
+			has_action( 'activate_test-coexistence-siblings/test-coexistence-siblings.php' ),
+			'Canonical sibling hook should be registered.'
+		);
+		$this->assertNotFalse(
+			has_action( 'activate_test-coexistence-siblings-build/test-coexistence-siblings.php' ),
+			'Build sibling hook should be registered.'
+		);
+
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Skips sibling registration when not in admin.
+	 *
+	 * @covers ::register
+	 *
+	 * @return void
+	 */
+	public function test_register_skips_siblings_when_not_admin(): void {
+		$this->seed_plugins_cache(
+			array(
+				'test-coexistence-frontonly/test-coexistence-frontonly.php'       => array(),
+				'test-coexistence-frontonly-build/test-coexistence-frontonly.php' => array(),
+			)
+		);
+
+		set_current_screen( 'front' );
+
+		Coexistence_Guard::get_instance()->register(
+			'test-coexistence-frontonly',
+			'Test Coexistence Frontonly',
+			WP_PLUGIN_DIR . '/test-coexistence-frontonly/test-coexistence-frontonly.php'
+		);
+
+		$this->assertFalse(
+			has_action( 'activate_test-coexistence-frontonly-build/test-coexistence-frontonly.php' ),
+			'Sibling hook should not be registered outside admin.'
+		);
+	}
+
+	/**
+	 * Coverage for find_duplicates: matches canonical and prefix-siblings,
+	 * skips wrong file names, wrong folder names, and single-segment keys.
+	 *
+	 * @covers ::find_duplicates
+	 *
+	 * @return void
+	 */
+	public function test_find_duplicates_returns_only_matching_basenames(): void {
+		$this->seed_plugins_cache(
+			array(
+				'test-coexistence-find/test-coexistence-find.php'                  => array(),
+				'test-coexistence-find-build/test-coexistence-find.php'            => array(),
+				'test-coexistence-find/different-file.php'                         => array(), // Wrong file name.
+				'unrelated/test-coexistence-find.php'                              => array(), // Wrong folder name.
+				'akismet/akismet.php'                                              => array(), // Unrelated.
+				'test-coexistence-find.php'                                        => array(), // Single-segment key.
+			)
+		);
+
+		$result = Coexistence_Guard::get_instance()->find_duplicates( 'test-coexistence-find' );
+
+		$this->assertSame(
+			array(
+				'test-coexistence-find-build/test-coexistence-find.php',
+				'test-coexistence-find/test-coexistence-find.php',
+			),
+			$result
+		);
+	}
+
+	/**
+	 * Coverage for find_duplicates when a non-string key sneaks into get_plugins().
+	 *
+	 * @covers ::find_duplicates
+	 *
+	 * @return void
+	 */
+	public function test_find_duplicates_skips_non_string_keys(): void {
+		// Filter the cached value to inject a non-string key so the early-continue
+		// branch in find_duplicates() executes.
+		$plugins      = array(
+			'test-coexistence-nonstr/test-coexistence-nonstr.php' => array(),
+		);
+		$plugins[123] = array(); // Non-string key.
+
+		$this->seed_plugins_cache( $plugins );
+
+		$result = Coexistence_Guard::get_instance()->find_duplicates( 'test-coexistence-nonstr' );
+
+		$this->assertSame(
+			array( 'test-coexistence-nonstr/test-coexistence-nonstr.php' ),
+			$result
+		);
+	}
+
+	/**
+	 * Returns silently when only one matching folder exists.
+	 *
+	 * @covers ::refuse_on_duplicates
+	 *
+	 * @return void
+	 */
+	public function test_refuse_on_duplicates_returns_when_no_duplicate_folder(): void {
+		$this->seed_plugins_cache(
+			array(
+				'test-coexistence-single/test-coexistence-single.php' => array(),
+			)
+		);
+
+		Coexistence_Guard::get_instance()->refuse_on_duplicates(
+			'test-coexistence-single',
+			'Test Coexistence Single'
+		);
+
+		$this->assertTrue( true, 'No exception should be thrown when only one folder exists.' );
+	}
+
+	/**
+	 * Returns silently when duplicate folders exist but none are active.
+	 *
+	 * @covers ::refuse_on_duplicates
+	 *
+	 * @return void
+	 */
+	public function test_refuse_on_duplicates_returns_when_no_active_duplicate(): void {
+		$this->seed_plugins_cache(
+			array(
+				'test-coexistence-inactive/test-coexistence-inactive.php'       => array(),
+				'test-coexistence-inactive-build/test-coexistence-inactive.php' => array(),
+			)
+		);
+		update_option( 'active_plugins', array() );
+
+		Coexistence_Guard::get_instance()->refuse_on_duplicates(
+			'test-coexistence-inactive',
+			'Test Coexistence Inactive'
+		);
+
+		$this->assertTrue( true, 'No exception should be thrown when no duplicate is active.' );
+	}
+
+	/**
+	 * The closure registered as the activation callback must invoke
+	 * refuse_on_duplicates with the slug and name captured at registration time.
+	 *
+	 * @covers ::register
+	 *
+	 * @return void
+	 */
+	public function test_register_callback_invokes_refuse_on_duplicates(): void {
+		$this->seed_plugins_cache(
+			array(
+				'test-coexistence-callback/test-coexistence-callback.php'       => array(),
+				'test-coexistence-callback-build/test-coexistence-callback.php' => array(),
+			)
+		);
+		update_option(
+			'active_plugins',
+			array( 'test-coexistence-callback/test-coexistence-callback.php' )
+		);
+
+		Coexistence_Guard::get_instance()->register(
+			'test-coexistence-callback',
+			'Test Coexistence Callback',
+			WP_PLUGIN_DIR . '/test-coexistence-callback-build/test-coexistence-callback.php'
+		);
+
+		$this->expectException( \WPDieException::class );
+
+		do_action( 'activate_test-coexistence-callback-build/test-coexistence-callback.php' );
+	}
+
+	/**
+	 * Halts activation when a sibling copy is already active.
+	 *
+	 * @covers ::refuse_on_duplicates
+	 *
+	 * @return void
+	 */
+	public function test_refuse_on_duplicates_dies_when_active_duplicate_exists(): void {
+		$this->seed_plugins_cache(
+			array(
+				'test-coexistence-active/test-coexistence-active.php'       => array(),
+				'test-coexistence-active-build/test-coexistence-active.php' => array(),
+			)
+		);
+		update_option(
+			'active_plugins',
+			array( 'test-coexistence-active/test-coexistence-active.php' )
+		);
+
+		$this->expectException( \WPDieException::class );
+
+		Coexistence_Guard::get_instance()->refuse_on_duplicates(
+			'test-coexistence-active',
+			'Test Coexistence Active'
+		);
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/class-test-coexistence-guard.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-coexistence-guard.php
@@ -177,12 +177,12 @@ class Test_Coexistence_Guard extends Base {
 	public function test_find_duplicates_returns_only_matching_basenames(): void {
 		$this->seed_plugins_cache(
 			array(
-				'test-coexistence-find/test-coexistence-find.php'                  => array(),
-				'test-coexistence-find-build/test-coexistence-find.php'            => array(),
-				'test-coexistence-find/different-file.php'                         => array(), // Wrong file name.
-				'unrelated/test-coexistence-find.php'                              => array(), // Wrong folder name.
-				'akismet/akismet.php'                                              => array(), // Unrelated.
-				'test-coexistence-find.php'                                        => array(), // Single-segment key.
+				'test-coexistence-find/test-coexistence-find.php' => array(),
+				'test-coexistence-find-build/test-coexistence-find.php' => array(),
+				'test-coexistence-find/different-file.php' => array(), // Wrong file name.
+				'unrelated/test-coexistence-find.php'      => array(), // Wrong folder name.
+				'akismet/akismet.php'                      => array(), // Unrelated.
+				'test-coexistence-find.php'                => array(), // Single-segment key.
 			)
 		);
 


### PR DESCRIPTION
### Description of the Change

Adds an activation guard that refuses to activate GatherPress when more than one `gatherpress*/gatherpress.php` folder exists on disk. WordPress's upload-replace flow keys off the plugin folder slug, so a fresh upload that lands in a sibling folder (`gatherpress-1`, `gatherpress-build`, etc.) leaves the older copy in place — activating either copy while the others remain produces two GatherPress rows on the plugins screen and confusing behavior. The guard deactivates the plugin and `wp_die`s with a list of duplicate folders so the user has to clean up via SFTP before activation can succeed.

The active install also registers the same guard against every sibling folder it sees, so activating an older copy that doesn't carry this code still trips the check. Pairs with [GatherPress/gatherpress-alpha#TBD](https://github.com/GatherPress/gatherpress-alpha) which adds the matching guard for Alpha.

Closes #1533

### How to test the Change

1. With GatherPress installed and active, copy the plugin folder to a sibling (e.g. `wp-content/plugins/gatherpress-build/`).
2. Visit the Plugins screen — both rows appear.
3. Deactivate the canonical copy, then click "Activate" on either row.
4. Expect: a `wp_die` page titled "GatherPress activation halted" listing both duplicate folder names. Plugin does not activate.
5. Delete the duplicate folder, retry activation — succeeds.

### Changelog Entry

> Added - Refuse activation when duplicate GatherPress folders are detected on disk to prevent confusing two-row states from WordPress's upload-replace miss.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.