### PR TITLE
Block transform: core/post-date → gatherpress/event-date

### DIFF
--- a/src/blocks/event-date/index.js
+++ b/src/blocks/event-date/index.js
@@ -8,6 +8,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import edit from './edit';
 import metadata from './block.json';
+import transforms from './transforms';
 import './style.scss';
 
 /**
@@ -26,4 +27,5 @@ import './style.scss';
 registerBlockType( metadata, {
 	edit,
 	save: () => null,
+	transforms,
 } );

--- a/src/blocks/event-date/transforms.js
+++ b/src/blocks/event-date/transforms.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies.
+ */
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Block transforms for the GatherPress Event Date block.
+ *
+ * Allows a core/post-date block to be converted into a gatherpress/event-date
+ * block via the editor's "Transform to" menu, preserving the user's PHP date
+ * format and text alignment.
+ */
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/post-date' ],
+			transform: ( attributes ) => {
+				const { format, textAlign } = attributes;
+				const newAttributes = {
+					displayType: 'start',
+				};
+
+				if ( format ) {
+					newAttributes.startDateFormat = format;
+				}
+
+				if ( textAlign ) {
+					newAttributes.textAlign = textAlign;
+				}
+
+				return createBlock(
+					'gatherpress/event-date',
+					newAttributes
+				);
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/src/editor.js
+++ b/src/editor.js
@@ -12,6 +12,7 @@ import EmailNotificationManager from './components/EmailNotificationManager';
 import './stores';
 import './supports/post-id-override';
 import './supports/post-date-override';
+import './supports/post-date-convert';
 import './supports/block-guard';
 import './formats/tooltip';
 

--- a/src/supports/post-date-convert.js
+++ b/src/supports/post-date-convert.js
@@ -1,0 +1,92 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { InspectorControls } from '@wordpress/block-editor';
+import { Button, PanelBody } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { switchToBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import { usePostTypeSupports } from '../helpers/event';
+
+/**
+ * Adds a "Convert to Event Date" button to the core/post-date inspector
+ * sidebar when the current post type supports `gatherpress-event-date`.
+ *
+ * The button reuses the registered cross-block transform (see
+ * `src/blocks/event-date/transforms.js`), so the attribute mapping stays in
+ * one place. Clicking it replaces the selected post-date block with a
+ * gatherpress/event-date block carrying the same date format and alignment.
+ *
+ * Gated on the reactive `usePostTypeSupports` hook so the button only renders
+ * where the resulting block has somewhere meaningful to read its datetime
+ * from — on non-event post types the button stays hidden rather than letting
+ * the user create a permanently dim event-date block.
+ */
+const withPostDateConvertToEventDate = createHigherOrderComponent(
+	( BlockEdit ) => {
+		return ( props ) => {
+			const { name, clientId, attributes } = props;
+
+			const supportsEventDate = usePostTypeSupports(
+				'gatherpress-event-date'
+			);
+
+			const { replaceBlocks } = useDispatch( 'core/block-editor' );
+
+			if ( 'core/post-date' !== name || ! supportsEventDate ) {
+				return <BlockEdit { ...props } />;
+			}
+
+			const onConvert = () => {
+				const block = { name, attributes, innerBlocks: [] };
+				const newBlocks = switchToBlockType(
+					block,
+					'gatherpress/event-date'
+				);
+
+				if ( newBlocks ) {
+					replaceBlocks( clientId, newBlocks );
+				}
+			};
+
+			return (
+				<>
+					<BlockEdit { ...props } />
+					<InspectorControls>
+						<PanelBody>
+							<p className="gatherpress-convert-to-event-date__description">
+								{ __(
+									"Display an event's date and time.",
+									'gatherpress'
+								) }
+							</p>
+							<Button
+								className="gatherpress-convert-to-event-date"
+								variant="secondary"
+								onClick={ onConvert }
+							>
+								{ __(
+									'Convert to Event Date',
+									'gatherpress'
+								) }
+							</Button>
+						</PanelBody>
+					</InspectorControls>
+				</>
+			);
+		};
+	},
+	'withPostDateConvertToEventDate'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'gatherpress/post-date-convert-to-event-date',
+	withPostDateConvertToEventDate
+);

--- a/test/unit/js/src/blocks/event-date/transforms.test.js
+++ b/test/unit/js/src/blocks/event-date/transforms.test.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies.
+ */
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+
+// Mock @wordpress/blocks so createBlock returns a deterministic shape we can assert on.
+jest.mock( '@wordpress/blocks', () => ( {
+	createBlock: jest.fn( ( name, attributes ) => ( { name, attributes } ) ),
+} ) );
+
+/**
+ * WordPress dependencies.
+ */
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import transforms from '@src/blocks/event-date/transforms';
+
+describe( 'event-date transforms', () => {
+	beforeEach( () => {
+		createBlock.mockClear();
+	} );
+
+	it( 'exports a from array with a single core/post-date entry', () => {
+		expect( Array.isArray( transforms.from ) ).toBe( true );
+		expect( transforms.from ).toHaveLength( 1 );
+
+		const [ rule ] = transforms.from;
+		expect( rule.type ).toBe( 'block' );
+		expect( rule.blocks ).toEqual( [ 'core/post-date' ] );
+		expect( typeof rule.transform ).toBe( 'function' );
+	} );
+
+	it( 'maps core/post-date format and textAlign onto the new block', () => {
+		const result = transforms.from[ 0 ].transform( {
+			format: 'F j, Y',
+			textAlign: 'center',
+		} );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'gatherpress/event-date',
+			{
+				displayType: 'start',
+				startDateFormat: 'F j, Y',
+				textAlign: 'center',
+			}
+		);
+		expect( result ).toEqual( {
+			name: 'gatherpress/event-date',
+			attributes: {
+				displayType: 'start',
+				startDateFormat: 'F j, Y',
+				textAlign: 'center',
+			},
+		} );
+	} );
+
+	it( 'omits startDateFormat when format is empty so the block falls back to defaults', () => {
+		transforms.from[ 0 ].transform( { format: '' } );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'gatherpress/event-date',
+			{ displayType: 'start' }
+		);
+	} );
+
+	it( 'omits textAlign when not provided', () => {
+		transforms.from[ 0 ].transform( { format: 'Y-m-d' } );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'gatherpress/event-date',
+			{
+				displayType: 'start',
+				startDateFormat: 'Y-m-d',
+			}
+		);
+	} );
+
+	it( 'handles a bare core/post-date with no attributes', () => {
+		transforms.from[ 0 ].transform( {} );
+
+		expect( createBlock ).toHaveBeenCalledWith(
+			'gatherpress/event-date',
+			{ displayType: 'start' }
+		);
+	} );
+} );

--- a/test/unit/js/src/supports/post-date-convert.test.js
+++ b/test/unit/js/src/supports/post-date-convert.test.js
@@ -1,0 +1,207 @@
+/**
+ * External dependencies.
+ */
+import {
+	describe,
+	expect,
+	it,
+	beforeEach,
+	jest,
+} from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * WordPress dependencies.
+ */
+import { addFilter } from '@wordpress/hooks';
+import { switchToBlockType } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies.
+ */
+import { usePostTypeSupports } from '@src/helpers/event';
+
+jest.mock( '@wordpress/hooks', () => ( {
+	addFilter: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	switchToBlockType: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	createHigherOrderComponent: jest.fn( ( hoc ) => hoc ),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: ( { children } ) => (
+		<div data-testid="inspector-controls">{ children }</div>
+	),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, onClick } ) => (
+		<button data-testid="convert-button" onClick={ onClick }>
+			{ children }
+		</button>
+	),
+	PanelBody: ( { children } ) => (
+		<div data-testid="panel-body">{ children }</div>
+	),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+
+jest.mock( '@src/helpers/event', () => ( {
+	usePostTypeSupports: jest.fn(),
+} ) );
+
+// Importing for side effects: this triggers the addFilter call we capture below.
+require( '@src/supports/post-date-convert' );
+
+// Capture the registration call once at module load — `clearAllMocks` in
+// `beforeEach` would otherwise wipe the call history before tests can read it.
+const registrationCall = addFilter.mock.calls.find(
+	( [ , namespace ] ) =>
+		'gatherpress/post-date-convert-to-event-date' === namespace
+);
+const wrapBlockEdit = registrationCall[ 2 ];
+
+const getWrappedEdit = () => {
+	const BlockEditMock = ( props ) => (
+		<div data-testid="original-edit" data-name={ props.name } />
+	);
+	return wrapBlockEdit( BlockEditMock );
+};
+
+describe( 'post-date-convert support', () => {
+	const replaceBlocks = jest.fn();
+
+	beforeEach( () => {
+		usePostTypeSupports.mockReset();
+		switchToBlockType.mockReset();
+		replaceBlocks.mockReset();
+		useDispatch.mockReturnValue( { replaceBlocks } );
+	} );
+
+	it( 'registers the editor.BlockEdit filter under the gatherpress namespace', () => {
+		expect( registrationCall ).toBeDefined();
+		expect( registrationCall[ 0 ] ).toBe( 'editor.BlockEdit' );
+		expect( typeof registrationCall[ 2 ] ).toBe( 'function' );
+	} );
+
+	it( 'passes through unchanged for non-post-date blocks even when post type supports event-date', () => {
+		usePostTypeSupports.mockReturnValue( true );
+		const Wrapped = getWrappedEdit();
+
+		render(
+			<Wrapped
+				name="core/paragraph"
+				clientId="abc"
+				attributes={ {} }
+			/>
+		);
+
+		expect( screen.getByTestId( 'original-edit' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'convert-button' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'passes through unchanged when post type does not support event-date', () => {
+		usePostTypeSupports.mockReturnValue( false );
+		const Wrapped = getWrappedEdit();
+
+		render(
+			<Wrapped
+				name="core/post-date"
+				clientId="abc"
+				attributes={ {} }
+			/>
+		);
+
+		expect( screen.getByTestId( 'original-edit' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'convert-button' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the inspector button on core/post-date when post type supports event-date', () => {
+		usePostTypeSupports.mockReturnValue( true );
+		const Wrapped = getWrappedEdit();
+
+		render(
+			<Wrapped
+				name="core/post-date"
+				clientId="abc"
+				attributes={ {} }
+			/>
+		);
+
+		expect( screen.getByTestId( 'original-edit' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'inspector-controls' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'convert-button' ) ).toHaveTextContent(
+			'Convert to Event Date'
+		);
+		expect(
+			screen.getByText( "Display an event's date and time." )
+		).toBeInTheDocument();
+	} );
+
+	it( 'invokes switchToBlockType + replaceBlocks when the button is clicked', () => {
+		usePostTypeSupports.mockReturnValue( true );
+		switchToBlockType.mockReturnValue( [
+			{ name: 'gatherpress/event-date' },
+		] );
+		const Wrapped = getWrappedEdit();
+		const attributes = { format: 'F j, Y', textAlign: 'center' };
+
+		render(
+			<Wrapped
+				name="core/post-date"
+				clientId="block-id-1"
+				attributes={ attributes }
+			/>
+		);
+
+		fireEvent.click( screen.getByTestId( 'convert-button' ) );
+
+		expect( switchToBlockType ).toHaveBeenCalledWith(
+			{
+				name: 'core/post-date',
+				attributes,
+				innerBlocks: [],
+			},
+			'gatherpress/event-date'
+		);
+		expect( replaceBlocks ).toHaveBeenCalledWith( 'block-id-1', [
+			{ name: 'gatherpress/event-date' },
+		] );
+	} );
+
+	it( 'does not call replaceBlocks when switchToBlockType returns null', () => {
+		usePostTypeSupports.mockReturnValue( true );
+		switchToBlockType.mockReturnValue( null );
+		const Wrapped = getWrappedEdit();
+
+		render(
+			<Wrapped
+				name="core/post-date"
+				clientId="block-id-2"
+				attributes={ {} }
+			/>
+		);
+
+		fireEvent.click( screen.getByTestId( 'convert-button' ) );
+
+		expect( replaceBlocks ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
### Description of the Change

Adds a block transform from `core/post-date` to `gatherpress/event-date`. The transform is wired in two places:

- **Block toolbar** — appears in the standard "Transform to" menu (the leftmost block-type icon) on any `core/post-date` block.
- **Inspector sidebar** — a "Convert to Event Date" button with a short description, gated to post types that support `gatherpress-event-date` so it only surfaces where the resulting block has a datetime source.

Attribute mapping: `format` → `startDateFormat`, `textAlign` carries over, `displayType` defaults to `'start'` (post-date is single-date). The sidebar button reuses the registered transform via `switchToBlockType`, so the mapping lives in one place.

Closes #1562

### How to test the Change

1. Edit any event post.
2. Insert a Post Date block.
3. Toolbar path: click the block-type icon (leftmost in the toolbar) → "Transform to" → **Event Date**.
4. Sidebar path: with the post-date block selected, look in the right sidebar for the "Convert to Event Date" button.
5. Verify the resulting Event Date block carries the date format and text alignment from the original.
6. Insert a Post Date on a non-event post type — the sidebar button should not appear.

### Changelog Entry

> Added - Block transform from `core/post-date` to `gatherpress/event-date`, available in the toolbar's "Transform to" menu and as a "Convert to Event Date" button in the inspector sidebar.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.