### PR TITLE
Hide venue filter toggle and gate Event Query Settings panel by context

### DIFF
--- a/docs/user/blocks/event-query.md
+++ b/docs/user/blocks/event-query.md
@@ -20,4 +20,5 @@ GatherPress includes a block-variation of the `core/query` block, called _Event 
    - last modified date
 8. ... in either ASC or DESC `ORDER`
 9. Allows to filter the queried events by Author, Keyword, Topic or Venue (and any other additionally registered taxonomies).
-10. The variation is automatically loaded, when an editor chooses the „Event“ post type in a regular `core/query` block.
+10. **Filter by current venue** toggle — when placed on a venue page, the query is automatically scoped to that venue's events. The toggle is hidden on regular posts where there's no venue context to use. In templates or template parts, the toggle is shown with a note that the filter only takes effect when the template renders on a venue page.
+11. The variation is automatically loaded, when an editor chooses the „Event“ post type in a regular `core/query` block.

--- a/src/variations/core/query/components.js
+++ b/src/variations/core/query/components.js
@@ -18,7 +18,8 @@ import { __, _x, sprintf } from '@wordpress/i18n';
  */
 import GatherPressQueryControls from './slots/query-controls';
 import GatherPressInheritedQueryControls from './slots/inherited-query-controls';
-import { isEventPostType } from '../../../helpers/event';
+import { isEventPostType, usePostTypeSupports } from '../../../helpers/event';
+import { isInFSETemplate } from '../../../helpers/editor';
 
 /**
  * EventCountControls component
@@ -222,23 +223,40 @@ export const EventListTypeControls = ( { attributes, setAttributes } ) => {
  * events associated with that venue are shown. When not on a
  * venue page, the filter is gracefully ignored.
  *
+ * In a template/template-part context, the editor has no
+ * current venue to bind to — the toggle is still relevant
+ * because the template will be applied to venue posts at
+ * render time, but the help copy reflects the deferred binding.
+ *
  * @param {Object}   props
- * @param {Object}   props.attributes    Block attributes.
- * @param {Function} props.setAttributes Function to update block attributes.
- * @return {Element}                     ToggleControl for venue filtering.
+ * @param {Object}   props.attributes        Block attributes.
+ * @param {Function} props.setAttributes     Function to update block attributes.
+ * @param {boolean}  props.inTemplateContext Whether the host editor is a template or template part.
+ * @return {Element}                          ToggleControl for venue filtering.
  */
-export const VenueFilterControls = ( { attributes, setAttributes } ) => {
+export const VenueFilterControls = ( {
+	attributes,
+	setAttributes,
+	inTemplateContext = false,
+} ) => {
 	const {
 		query: { venue_filter: venueFilter } = {},
 	} = attributes;
 
+	const helpText = inTemplateContext
+		? __(
+			'The filter only takes effect when this template renders on a venue page.',
+			'gatherpress'
+		)
+		: __(
+			'When placed on a venue page, only shows events at that venue.',
+			'gatherpress'
+		);
+
 	return (
 		<ToggleControl
 			label={ __( 'Filter by current venue', 'gatherpress' ) }
-			help={ __(
-				'When placed on a venue page, only shows events at that venue.',
-				'gatherpress'
-			) }
+			help={ helpText }
 			checked={ !! venueFilter }
 			onChange={ ( value ) => {
 				setAttributes( {
@@ -370,6 +388,18 @@ export const EventOrderControls = ( { attributes, setAttributes } ) => {
 export const GatherPressQueryControlsSlotFill = () => {
 	// If the is the correct variation, add the custom controls.
 	const isEventContext = isEventPostType();
+
+	// Reactive gate against the host editor's post type. Templates and template
+	// parts have no concrete venue context to bind to, but they may render on a
+	// venue page later, so we keep the toggle visible there with adjusted copy.
+	// On any non-venue, non-template host the toggle can never apply, so we hide
+	// it to remove the mental load of an option that does nothing.
+	const isVenueContext = usePostTypeSupports(
+		'gatherpress-venue-information'
+	);
+	const inTemplateContext = isInFSETemplate();
+	const showVenueFilter = isVenueContext || inTemplateContext;
+
 	return (
 		<GatherPressQueryControls>
 			{ ( props ) => (
@@ -378,7 +408,12 @@ export const GatherPressQueryControlsSlotFill = () => {
 					<EventIncludeUnfinishedControls { ...props } />
 
 					{ isEventContext && <EventExcludeControls { ...props } /> }
-					<VenueFilterControls { ...props } />
+					{ showVenueFilter && (
+						<VenueFilterControls
+							{ ...props }
+							inTemplateContext={ inTemplateContext }
+						/>
+					) }
 					<EventCountControls { ...props } />
 					<EventOffsetControls { ...props } />
 					<EventOrderControls { ...props } />

--- a/src/variations/core/query/components.js
+++ b/src/variations/core/query/components.js
@@ -16,8 +16,8 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import GatherPressQueryControls from './slots/query-controls';
-import GatherPressInheritedQueryControls from './slots/inherited-query-controls';
+import EventQueryControls from './slots/query-controls';
+import EventInheritedQueryControls from './slots/inherited-query-controls';
 import { isEventPostType, usePostTypeSupports } from '../../../helpers/event';
 import { isInFSETemplate } from '../../../helpers/editor';
 
@@ -377,7 +377,7 @@ export const EventOrderControls = ( { attributes, setAttributes } ) => {
 };
 
 /**
- * GatherPressQueryControlsSlotFill component
+ * EventQueryControlsSlotFill component
  *
  * Provides the main container for all GatherPress event query controls.
  * Renders all controls depending on the current context (such as post type),
@@ -385,7 +385,7 @@ export const EventOrderControls = ( { attributes, setAttributes } ) => {
  *
  * @return {Element} SlotFill with all event query controls for GatherPress.
  */
-export const GatherPressQueryControlsSlotFill = () => {
+export const EventQueryControlsSlotFill = () => {
 	// If the is the correct variation, add the custom controls.
 	const isEventContext = isEventPostType();
 
@@ -401,7 +401,7 @@ export const GatherPressQueryControlsSlotFill = () => {
 	const showVenueFilter = isVenueContext || inTemplateContext;
 
 	return (
-		<GatherPressQueryControls>
+		<EventQueryControls>
 			{ ( props ) => (
 				<>
 					<EventListTypeControls { ...props } />
@@ -419,12 +419,12 @@ export const GatherPressQueryControlsSlotFill = () => {
 					<EventOrderControls { ...props } />
 				</>
 			) }
-		</GatherPressQueryControls>
+		</EventQueryControls>
 	);
 };
 
 /**
- * GatherPressInheritedQueryControlsSlotFill component
+ * EventInheritedQueryControlsSlotFill component
  *
  * Provides a condensed container for controls used when
  * a query is "inherited" (such as for nested queries), omitting
@@ -432,9 +432,9 @@ export const GatherPressQueryControlsSlotFill = () => {
  *
  * @return {Element} SlotFill with inherited event query controls for GatherPress.
  */
-export const GatherPressInheritedQueryControlsSlotFill = () => {
+export const EventInheritedQueryControlsSlotFill = () => {
 	return (
-		<GatherPressInheritedQueryControls>
+		<EventInheritedQueryControls>
 			{ ( props ) => (
 				<>
 					<EventListTypeControls { ...props } />
@@ -442,6 +442,6 @@ export const GatherPressInheritedQueryControlsSlotFill = () => {
 					<EventOrderControls { ...props } />
 				</>
 			) }
-		</GatherPressInheritedQueryControls>
+		</EventInheritedQueryControls>
 	);
 };

--- a/src/variations/core/query/controls.js
+++ b/src/variations/core/query/controls.js
@@ -12,11 +12,11 @@ import { registerPlugin } from '@wordpress/plugins';
  *  Internal dependencies
  */
 import { NAME } from '.';
-import GatherPressQueryControls from './slots/query-controls';
-import GatherPressInheritedQueryControls from './slots/inherited-query-controls';
+import EventQueryControls from './slots/query-controls';
+import EventInheritedQueryControls from './slots/inherited-query-controls';
 import {
-	GatherPressQueryControlsSlotFill,
-	GatherPressInheritedQueryControlsSlotFill,
+	EventQueryControlsSlotFill,
+	EventInheritedQueryControlsSlotFill,
 } from './components';
 import { usePostTypeSupports } from '../../../helpers/event';
 
@@ -27,7 +27,7 @@ import { usePostTypeSupports } from '../../../helpers/event';
  * @param {Object} props.attributes - Block attributes.
  * @return {boolean} True if the block's namespace matches 'gatherpress-event-query', otherwise false.
  */
-const isGatherPressQueryLoop = ( props ) => {
+const isEventQueryLoop = ( props ) => {
 	const {
 		attributes: { namespace },
 	} = props;
@@ -102,11 +102,11 @@ export const EventQueryControlsPanel = ( props ) => {
 		<InspectorControls>
 			<PanelBody title={ __( 'Event Query Settings', 'gatherpress' ) }>
 				{ false === props.attributes.query.inherit ? (
-					<GatherPressQueryControls.Slot
+					<EventQueryControls.Slot
 						fillProps={ { ...props } }
 					/>
 				) : (
-					<GatherPressInheritedQueryControls.Slot
+					<EventInheritedQueryControls.Slot
 						fillProps={ { ...props } }
 					/>
 				) }
@@ -125,13 +125,13 @@ export const EventQueryControlsPanel = ( props ) => {
  * @param {Function} BlockEdit - The Query block's BlockEdit component.
  * @return {Function} Enhanced BlockEdit component.
  */
-const withGatherPressQueryControls = ( BlockEdit ) => ( props ) => {
+const withEventQueryControls = ( BlockEdit ) => ( props ) => {
 	// Early return if block is not a query or not a supported variation.
-	if ( ! isGatherPressQueryLoop( props ) && 'core/query' !== props.name ) {
+	if ( ! isEventQueryLoop( props ) && 'core/query' !== props.name ) {
 		return <BlockEdit { ...props } />;
 	}
 	/// If it's a generic core/query, observe for transformation to GatherPress event query.
-	if ( ! isGatherPressQueryLoop( props ) ) {
+	if ( ! isEventQueryLoop( props ) ) {
 		return (
 			<>
 				<QueryPosttypeObserver { ...props } />
@@ -149,18 +149,18 @@ const withGatherPressQueryControls = ( BlockEdit ) => ( props ) => {
 };
 
 /**
- * Registers the withGatherPressQueryControls HOC as a filter to extend core/query blocks
+ * Registers the withEventQueryControls HOC as a filter to extend core/query blocks
  * with custom InspectorControls for GatherPress event queries.
  */
-addFilter( 'editor.BlockEdit', 'core/query', withGatherPressQueryControls );
+addFilter( 'editor.BlockEdit', 'core/query', withEventQueryControls );
 
 /**
  * Registers the Query Controls SlotFills for the plugin interface, allowing
  * the relevant GatherPress query controls and inherited controls to be displayed.
  */
 registerPlugin( 'gatherpress-query-controls-slotfill', {
-	render: GatherPressQueryControlsSlotFill,
+	render: EventQueryControlsSlotFill,
 } );
 registerPlugin( 'gatherpress-inherited-query-controls-slotfill', {
-	render: GatherPressInheritedQueryControlsSlotFill,
+	render: EventInheritedQueryControlsSlotFill,
 } );

--- a/src/variations/core/query/controls.js
+++ b/src/variations/core/query/controls.js
@@ -18,6 +18,7 @@ import {
 	GatherPressQueryControlsSlotFill,
 	GatherPressInheritedQueryControlsSlotFill,
 } from './components';
+import { usePostTypeSupports } from '../../../helpers/event';
 
 /**
  * Determines if the current block instance is the GatherPress event query variation.
@@ -71,6 +72,50 @@ const QueryPosttypeObserver = ( { attributes, setAttributes } ) => {
 };
 
 /**
+ * Renders the "Event Query Settings" panel for a GatherPress event query block.
+ *
+ * Extracted into its own component so the `usePostTypeSupports` hook can be
+ * called unconditionally at the top of a render (Rules of Hooks) — the HOC
+ * has early-return paths for non-query blocks where we don't want to read
+ * supports at all.
+ *
+ * Hides itself when the queried post type doesn't support
+ * `gatherpress-event-date`, so changing a loop's post type away from events
+ * (without removing the variation) collapses the now-irrelevant panel
+ * instead of leaving stale event-only controls visible.
+ *
+ * @param {Object} props - Block props passed through from the HOC.
+ * @return {Element|null} The InspectorControls panel, or null when not applicable.
+ */
+export const EventQueryControlsPanel = ( props ) => {
+	const queryPostType = props.attributes?.query?.postType;
+	const queryPostTypeSupportsEvents = usePostTypeSupports(
+		'gatherpress-event-date',
+		queryPostType
+	);
+
+	if ( ! queryPostTypeSupportsEvents ) {
+		return null;
+	}
+
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Event Query Settings', 'gatherpress' ) }>
+				{ false === props.attributes.query.inherit ? (
+					<GatherPressQueryControls.Slot
+						fillProps={ { ...props } }
+					/>
+				) : (
+					<GatherPressInheritedQueryControls.Slot
+						fillProps={ { ...props } }
+					/>
+				) }
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+/**
  * Higher Order Component (HOC) to inject GatherPress-specific controls into core/query blocks.
  *
  * - If the block is not the designated event query or a query block, returns the block unchanged.
@@ -94,23 +139,11 @@ const withGatherPressQueryControls = ( BlockEdit ) => ( props ) => {
 			</>
 		);
 	}
-	// For a GatherPress event query, inject controls panel (will show full or inherited controls).
+	// For a GatherPress event query, inject the controls panel (full or inherited controls).
 	return (
 		<>
 			<BlockEdit { ...props } />
-			<InspectorControls>
-				<PanelBody title={ __( 'Event Query Settings', 'gatherpress' ) }>
-					{ false === props.attributes.query.inherit ? (
-						<GatherPressQueryControls.Slot
-							fillProps={ { ...props } }
-						/>
-					) : (
-						<GatherPressInheritedQueryControls.Slot
-							fillProps={ { ...props } }
-						/>
-					) }
-				</PanelBody>
-			</InspectorControls>
+			<EventQueryControlsPanel { ...props } />
 		</>
 	);
 };

--- a/src/variations/core/query/slots/inherited-query-controls.js
+++ b/src/variations/core/query/slots/inherited-query-controls.js
@@ -6,16 +6,16 @@ import { createSlotFill } from '@wordpress/components';
 /**
  * Create our Slot and Fill components
  */
-const { Fill, Slot } = createSlotFill( 'GatherPressInheritedQueryControls' );
+const { Fill, Slot } = createSlotFill( 'EventInheritedQueryControls' );
 
-const GatherPressInheritedQueryControls = ( { children } ) => (
+const EventInheritedQueryControls = ( { children } ) => (
 	<Fill>{ children }</Fill>
 );
 
-GatherPressInheritedQueryControls.Slot = ( { fillProps } ) => (
+EventInheritedQueryControls.Slot = ( { fillProps } ) => (
 	<Slot fillProps={ fillProps }>
 		{ ( fills ) => ( fills.length ? fills : null ) }
 	</Slot>
 );
 
-export default GatherPressInheritedQueryControls;
+export default EventInheritedQueryControls;

--- a/src/variations/core/query/slots/query-controls.js
+++ b/src/variations/core/query/slots/query-controls.js
@@ -6,14 +6,14 @@ import { createSlotFill } from '@wordpress/components';
 /**
  * Create our Slot and Fill components
  */
-const { Fill, Slot } = createSlotFill( 'GatherPressQueryControls' );
+const { Fill, Slot } = createSlotFill( 'EventQueryControls' );
 
-const GatherPressQueryControls = ( { children } ) => <Fill>{ children }</Fill>;
+const EventQueryControls = ( { children } ) => <Fill>{ children }</Fill>;
 
-GatherPressQueryControls.Slot = ( { fillProps } ) => (
+EventQueryControls.Slot = ( { fillProps } ) => (
 	<Slot fillProps={ fillProps }>
 		{ ( fills ) => ( fills.length ? fills : null ) }
 	</Slot>
 );
 
-export default GatherPressQueryControls;
+export default EventQueryControls;

--- a/test/unit/js/src/variations/core/query/components.test.js
+++ b/test/unit/js/src/variations/core/query/components.test.js
@@ -88,7 +88,7 @@ import { isInFSETemplate } from '@src/helpers/editor';
 /**
  * Internal dependencies.
  */
-import { GatherPressQueryControlsSlotFill } from '@src/variations/core/query/components';
+import { EventQueryControlsSlotFill } from '@src/variations/core/query/components';
 
 const venueToggleLabel = 'Filter by current venue';
 const excludeToggleLabel = 'Exclude Current Event';
@@ -97,7 +97,7 @@ const venueHelp =
 const templateHelp =
 	'The filter only takes effect when this template renders on a venue page.';
 
-describe( 'GatherPressQueryControlsSlotFill', () => {
+describe( 'EventQueryControlsSlotFill', () => {
 	beforeEach( () => {
 		isEventPostType.mockReset();
 		usePostTypeSupports.mockReset();
@@ -109,7 +109,7 @@ describe( 'GatherPressQueryControlsSlotFill', () => {
 		usePostTypeSupports.mockReturnValue( false );
 		isInFSETemplate.mockReturnValue( false );
 
-		render( <GatherPressQueryControlsSlotFill /> );
+		render( <EventQueryControlsSlotFill /> );
 
 		expect(
 			screen.queryByText( venueToggleLabel )
@@ -124,7 +124,7 @@ describe( 'GatherPressQueryControlsSlotFill', () => {
 		usePostTypeSupports.mockReturnValue( true );
 		isInFSETemplate.mockReturnValue( false );
 
-		render( <GatherPressQueryControlsSlotFill /> );
+		render( <EventQueryControlsSlotFill /> );
 
 		expect( screen.getByText( venueToggleLabel ) ).toBeInTheDocument();
 		expect( screen.getByText( venueHelp ) ).toBeInTheDocument();
@@ -136,7 +136,7 @@ describe( 'GatherPressQueryControlsSlotFill', () => {
 		usePostTypeSupports.mockReturnValue( false );
 		isInFSETemplate.mockReturnValue( true );
 
-		render( <GatherPressQueryControlsSlotFill /> );
+		render( <EventQueryControlsSlotFill /> );
 
 		expect( screen.getByText( venueToggleLabel ) ).toBeInTheDocument();
 		expect( screen.getByText( templateHelp ) ).toBeInTheDocument();
@@ -148,7 +148,7 @@ describe( 'GatherPressQueryControlsSlotFill', () => {
 		usePostTypeSupports.mockReturnValue( true );
 		isInFSETemplate.mockReturnValue( false );
 
-		render( <GatherPressQueryControlsSlotFill /> );
+		render( <EventQueryControlsSlotFill /> );
 
 		expect(
 			screen.queryByText( excludeToggleLabel )
@@ -160,7 +160,7 @@ describe( 'GatherPressQueryControlsSlotFill', () => {
 		usePostTypeSupports.mockReturnValue( true );
 		isInFSETemplate.mockReturnValue( false );
 
-		render( <GatherPressQueryControlsSlotFill /> );
+		render( <EventQueryControlsSlotFill /> );
 
 		expect( screen.getByText( excludeToggleLabel ) ).toBeInTheDocument();
 	} );

--- a/test/unit/js/src/variations/core/query/components.test.js
+++ b/test/unit/js/src/variations/core/query/components.test.js
@@ -1,0 +1,167 @@
+/**
+ * External dependencies.
+ */
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock( '@wordpress/components', () => ( {
+	RangeControl: ( { label } ) => (
+		<div data-testid="range-control">{ label }</div>
+	),
+	SelectControl: ( { label } ) => (
+		<div data-testid="select-control">{ label }</div>
+	),
+	ToggleControl: ( { label, help } ) => (
+		<div data-testid="toggle-control">
+			<span>{ label }</span>
+			{ help && <span data-testid="toggle-help">{ help }</span> }
+		</div>
+	),
+	__experimentalToggleGroupControl: ( { label, children } ) => (
+		<div data-testid="toggle-group-control">
+			{ label }
+			{ children }
+		</div>
+	),
+	__experimentalToggleGroupControlOption: ( { label } ) => (
+		<div data-testid="toggle-group-option">{ label }</div>
+	),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn( () => ( { id: 1 } ) ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+	_x: ( text ) => text,
+	sprintf: ( fmt, ...args ) => args.reduce( ( s, a ) => s.replace( '%s', a ), fmt ),
+} ) );
+
+// The slot wrapper invokes its render-prop child immediately so we can assert
+// on what the fill renders without setting up a real Slot consumer.
+jest.mock( '@src/variations/core/query/slots/query-controls', () => ( {
+	__esModule: true,
+	default: ( { children } ) => (
+		<div data-testid="query-controls-fill">
+			{ children( {
+				attributes: {
+					query: {
+						postType: 'gatherpress_event',
+						inherit: false,
+					},
+				},
+				setAttributes: jest.fn(),
+			} ) }
+		</div>
+	),
+} ) );
+
+jest.mock( '@src/variations/core/query/slots/inherited-query-controls', () => ( {
+	__esModule: true,
+	default: ( { children } ) => (
+		<div data-testid="inherited-fill">
+			{ children( {
+				attributes: { query: { inherit: true } },
+				setAttributes: jest.fn(),
+			} ) }
+		</div>
+	),
+} ) );
+
+jest.mock( '@src/helpers/event', () => ( {
+	isEventPostType: jest.fn(),
+	usePostTypeSupports: jest.fn(),
+} ) );
+
+jest.mock( '@src/helpers/editor', () => ( {
+	isInFSETemplate: jest.fn(),
+} ) );
+
+/**
+ * WordPress dependencies.
+ */
+import { isEventPostType, usePostTypeSupports } from '@src/helpers/event';
+import { isInFSETemplate } from '@src/helpers/editor';
+
+/**
+ * Internal dependencies.
+ */
+import { GatherPressQueryControlsSlotFill } from '@src/variations/core/query/components';
+
+const venueToggleLabel = 'Filter by current venue';
+const excludeToggleLabel = 'Exclude Current Event';
+const venueHelp =
+	'When placed on a venue page, only shows events at that venue.';
+const templateHelp =
+	'The filter only takes effect when this template renders on a venue page.';
+
+describe( 'GatherPressQueryControlsSlotFill', () => {
+	beforeEach( () => {
+		isEventPostType.mockReset();
+		usePostTypeSupports.mockReset();
+		isInFSETemplate.mockReset();
+	} );
+
+	it( 'hides the venue filter toggle on a regular non-venue, non-template host', () => {
+		isEventPostType.mockReturnValue( true );
+		usePostTypeSupports.mockReturnValue( false );
+		isInFSETemplate.mockReturnValue( false );
+
+		render( <GatherPressQueryControlsSlotFill /> );
+
+		expect(
+			screen.queryByText( venueToggleLabel )
+		).not.toBeInTheDocument();
+		expect( usePostTypeSupports ).toHaveBeenCalledWith(
+			'gatherpress-venue-information'
+		);
+	} );
+
+	it( 'shows the venue filter toggle with venue copy when host is a venue post', () => {
+		isEventPostType.mockReturnValue( false );
+		usePostTypeSupports.mockReturnValue( true );
+		isInFSETemplate.mockReturnValue( false );
+
+		render( <GatherPressQueryControlsSlotFill /> );
+
+		expect( screen.getByText( venueToggleLabel ) ).toBeInTheDocument();
+		expect( screen.getByText( venueHelp ) ).toBeInTheDocument();
+		expect( screen.queryByText( templateHelp ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the venue filter toggle with template copy on a template / template part', () => {
+		isEventPostType.mockReturnValue( false );
+		usePostTypeSupports.mockReturnValue( false );
+		isInFSETemplate.mockReturnValue( true );
+
+		render( <GatherPressQueryControlsSlotFill /> );
+
+		expect( screen.getByText( venueToggleLabel ) ).toBeInTheDocument();
+		expect( screen.getByText( templateHelp ) ).toBeInTheDocument();
+		expect( screen.queryByText( venueHelp ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'still gates the exclude-current-event toggle on the existing isEventPostType check', () => {
+		isEventPostType.mockReturnValue( false );
+		usePostTypeSupports.mockReturnValue( true );
+		isInFSETemplate.mockReturnValue( false );
+
+		render( <GatherPressQueryControlsSlotFill /> );
+
+		expect(
+			screen.queryByText( excludeToggleLabel )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the exclude-current-event toggle when the host is an event post type', () => {
+		isEventPostType.mockReturnValue( true );
+		usePostTypeSupports.mockReturnValue( true );
+		isInFSETemplate.mockReturnValue( false );
+
+		render( <GatherPressQueryControlsSlotFill /> );
+
+		expect( screen.getByText( excludeToggleLabel ) ).toBeInTheDocument();
+	} );
+} );

--- a/test/unit/js/src/variations/core/query/controls.test.js
+++ b/test/unit/js/src/variations/core/query/controls.test.js
@@ -56,8 +56,8 @@ jest.mock( '@src/variations/core/query/slots/inherited-query-controls', () => {
 } );
 
 jest.mock( '@src/variations/core/query/components', () => ( {
-	GatherPressQueryControlsSlotFill: () => null,
-	GatherPressInheritedQueryControlsSlotFill: () => null,
+	EventQueryControlsSlotFill: () => null,
+	EventInheritedQueryControlsSlotFill: () => null,
 } ) );
 
 jest.mock( '@src/helpers/event', () => ( {

--- a/test/unit/js/src/variations/core/query/controls.test.js
+++ b/test/unit/js/src/variations/core/query/controls.test.js
@@ -1,0 +1,164 @@
+/**
+ * External dependencies.
+ */
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock( '@wordpress/hooks', () => ( {
+	addFilter: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/element', () => {
+	const actual = jest.requireActual( '@wordpress/element' );
+	return { ...actual, useEffect: jest.fn() };
+} );
+
+jest.mock( '@wordpress/plugins', () => ( {
+	registerPlugin: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: ( { children } ) => (
+		<div data-testid="inspector-controls">{ children }</div>
+	),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { children, title } ) => (
+		<div data-testid="panel-body" data-title={ title }>
+			{ children }
+		</div>
+	),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+
+jest.mock( '@src/variations/core/query/slots/query-controls', () => {
+	const Slot = ( { fillProps } ) => (
+		<div
+			data-testid="query-controls-slot"
+			data-post-type={ fillProps?.attributes?.query?.postType }
+		/>
+	);
+	const Fill = ( { children } ) => <>{ children }</>;
+	Fill.Slot = Slot;
+	return { __esModule: true, default: Fill };
+} );
+
+jest.mock( '@src/variations/core/query/slots/inherited-query-controls', () => {
+	const Slot = () => <div data-testid="inherited-query-controls-slot" />;
+	const Fill = ( { children } ) => <>{ children }</>;
+	Fill.Slot = Slot;
+	return { __esModule: true, default: Fill };
+} );
+
+jest.mock( '@src/variations/core/query/components', () => ( {
+	GatherPressQueryControlsSlotFill: () => null,
+	GatherPressInheritedQueryControlsSlotFill: () => null,
+} ) );
+
+jest.mock( '@src/helpers/event', () => ( {
+	usePostTypeSupports: jest.fn(),
+} ) );
+
+/**
+ * WordPress dependencies.
+ */
+import { usePostTypeSupports } from '@src/helpers/event';
+
+/**
+ * Internal dependencies.
+ */
+import { EventQueryControlsPanel } from '@src/variations/core/query/controls';
+
+describe( 'EventQueryControlsPanel', () => {
+	const baseProps = ( { postType = 'gatherpress_event', inherit = false } = {} ) => ( {
+		attributes: {
+			query: {
+				postType,
+				inherit,
+			},
+		},
+	} );
+
+	beforeEach( () => {
+		usePostTypeSupports.mockReset();
+	} );
+
+	it( 'returns null when the queried post type does not support gatherpress-event-date', () => {
+		usePostTypeSupports.mockReturnValue( false );
+
+		const { container } = render(
+			<EventQueryControlsPanel { ...baseProps( { postType: 'post' } ) } />
+		);
+
+		expect( container.firstChild ).toBeNull();
+		expect( usePostTypeSupports ).toHaveBeenCalledWith(
+			'gatherpress-event-date',
+			'post'
+		);
+	} );
+
+	it( 'renders the panel when the queried post type supports gatherpress-event-date', () => {
+		usePostTypeSupports.mockReturnValue( true );
+
+		render( <EventQueryControlsPanel { ...baseProps() } /> );
+
+		expect( screen.getByTestId( 'inspector-controls' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'panel-body' ) ).toHaveAttribute(
+			'data-title',
+			'Event Query Settings'
+		);
+		expect( usePostTypeSupports ).toHaveBeenCalledWith(
+			'gatherpress-event-date',
+			'gatherpress_event'
+		);
+	} );
+
+	it( 'renders the standard query slot when inherit is false', () => {
+		usePostTypeSupports.mockReturnValue( true );
+
+		render(
+			<EventQueryControlsPanel { ...baseProps( { inherit: false } ) } />
+		);
+
+		expect(
+			screen.getByTestId( 'query-controls-slot' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'inherited-query-controls-slot' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the inherited slot when inherit is true', () => {
+		usePostTypeSupports.mockReturnValue( true );
+
+		render(
+			<EventQueryControlsPanel { ...baseProps( { inherit: true } ) } />
+		);
+
+		expect(
+			screen.getByTestId( 'inherited-query-controls-slot' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'query-controls-slot' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'gracefully handles a missing query.postType (treats it as unsupported)', () => {
+		usePostTypeSupports.mockReturnValue( false );
+
+		const { container } = render(
+			<EventQueryControlsPanel attributes={ { query: {} } } />
+		);
+
+		expect( container.firstChild ).toBeNull();
+		expect( usePostTypeSupports ).toHaveBeenCalledWith(
+			'gatherpress-event-date',
+			undefined
+		);
+	} );
+} );


### PR DESCRIPTION
### Description of the Change

Two related fixes to the Event Query Loop's sidebar:

- **Venue filter toggle**: previously rendered on every host post type. Now hidden unless the host post type supports `gatherpress-venue-information` or the host is a template / template part. In template contexts the toggle's help copy is swapped to reflect the deferred binding.
- **Event Query Settings panel**: previously gated only on the variation's namespace, so changing the loop's `postType` to a non-event type left a stale event-only panel visible. Now also gated on the queried `query.postType` supporting `gatherpress-event-date`.

Closes #1563

### How to test the Change

1. Edit a regular post → insert Event Query block → "Filter by current venue" is hidden.
2. Edit a venue post → toggle is visible with "When placed on a venue page…" help.
3. Site Editor → any template or template part → toggle is visible with "The filter only takes effect when this template renders on a venue page." help.
4. Insert Event Query block → switch its post type away from event-supporting types → the entire "Event Query Settings" panel disappears. Switch back → panel returns.

### Changelog Entry

> Fixed - Event Query Loop sidebar now hides the venue filter toggle outside venue and template contexts, and the Event Query Settings panel only appears when the loop is querying an event-supporting post type.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.