### PR TITLE
Add pattern picker to RSVP Form block

### DIFF
--- a/docs/developer/blocks/pattern-pickers.md
+++ b/docs/developer/blocks/pattern-pickers.md
@@ -84,6 +84,45 @@ addFilter(
 This only affects the auto-loaded path. Manual inserts still go through the
 picker, which is filtered separately via `gatherpress.rsvpResponsePatterns`.
 
+## RSVP Form — `gatherpress.rsvpFormPatterns`
+
+Same shape as RSVP Response. Filters the array of starter patterns shown in
+the RSVP Form block's picker. Each entry is `{ name, title, description, template }`.
+
+The bundled default (_Standard RSVP Form_) is the only entry registered out
+of the box. Add your own:
+
+```js
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+addFilter(
+    'gatherpress.rsvpFormPatterns',
+    'my-plugin/extra-rsvp-form',
+    ( patterns ) => [
+        ...patterns,
+        {
+            name: 'my-plugin/minimal',
+            title: __( 'Minimal', 'my-plugin' ),
+            description: __(
+                'Name + email + submit only.',
+                'my-plugin'
+            ),
+            template: [
+                /* ...InnerBlocks tuples... */
+            ],
+        },
+    ]
+);
+```
+
+### Swapping the RSVP Form auto-loaded template — `gatherpress.rsvpFormDefaultTemplate`
+
+Parallel to `gatherpress.rsvpResponseDefaultTemplate` — filters the template
+seeded into auto-loaded RSVP Form blocks (currently a no-op since the block
+isn't auto-included by the event post type's `template` arg, but kept for
+parity in case future patterns add it).
+
 ## Adding a picker to a new block
 
 The picker component lives at [`src/components/PatternPicker/`](../../../src/components/PatternPicker/)

--- a/src/blocks/rsvp-form/block.json
+++ b/src/blocks/rsvp-form/block.json
@@ -9,6 +9,12 @@
 	"example": {},
 	"description": "Allows visitors to RSVP to an event without requiring a site account.",
 	"usesContext": [ "postId", "queryId" ],
+	"attributes": {
+		"patternPicked": {
+			"type": "boolean",
+			"default": false
+		}
+	},
 	"supports": {
 		"gatherpress": {
 			"postIdOverride": true

--- a/src/blocks/rsvp-form/edit.js
+++ b/src/blocks/rsvp-form/edit.js
@@ -56,7 +56,7 @@ function templateToBlocks( template ) {
  * through the picker. The picker itself is filterable separately via
  * `gatherpress.rsvpFormPatterns`.
  *
- * @since 0.34.0
+ * @since 1.0.0
  *
  * @param {Array} template Default `InnerBlocks` tuple tree —
  *                         `[ blockName, attributes, innerBlocks ]` — that
@@ -76,7 +76,7 @@ const DEFAULT_TEMPLATE = applyFilters(
  * `{ name, title, description, template }` — `template` is an `InnerBlocks`
  * tuple tree (`[ blockName, attributes, innerBlocks ]`).
  *
- * @since 0.34.0
+ * @since 1.0.0
  *
  * @param {Array} patterns Default array containing the bundled
  *                         "Standard RSVP Form" pattern.

--- a/src/blocks/rsvp-form/edit.js
+++ b/src/blocks/rsvp-form/edit.js
@@ -2,27 +2,115 @@
  * WordPress dependencies.
  */
 import {
+	BlockControls,
 	useBlockProps,
 	InnerBlocks,
 	InspectorControls,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import {
+	PanelBody,
+	SelectControl,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import { useState, useEffect, useCallback } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
-import { getBlockTypes } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createBlock, getBlockTypes } from '@wordpress/blocks';
 
 /**
  * Internal dependencies.
  */
-import TEMPLATE from './template';
+import STANDARD_RSVP_FORM_TEMPLATE from './templates/standard-rsvp-form';
+import PatternPicker, { PatternChooserModal } from '../../components/PatternPicker';
 import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, isRsvpEnabledForEvent, isOpenRsvpEnabled } from '../../helpers/event';
 import { isInFSETemplate, getEditorDocument } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
 import { shouldHideBlock } from './visibility';
 
-const Edit = ( { attributes, clientId, context } ) => {
+/**
+ * Recursively turn an InnerBlocks-shape `[ name, attrs, inner ]` template
+ * tuple tree into instantiated block objects, ready for `replaceInnerBlocks`.
+ *
+ * @param {Array} template Tuples in `[ blockName, attributes, innerBlocks ]` form.
+ * @return {Array} Created block instances.
+ */
+function templateToBlocks( template ) {
+	return template.map( ( [ name, attributes, innerBlocks ] ) =>
+		createBlock(
+			name,
+			attributes,
+			templateToBlocks( innerBlocks || [] )
+		)
+	);
+}
+
+/**
+ * Default template seeded into auto-loaded RSVP Form blocks.
+ *
+ * Fires only when the picker is suppressed (`patternPicked` already true on
+ * insert — e.g. a future post type template seeding the block). Lets a
+ * plugin or theme swap the layout that appears without the user clicking
+ * through the picker. The picker itself is filterable separately via
+ * `gatherpress.rsvpFormPatterns`.
+ *
+ * @since 0.34.0
+ *
+ * @param {Array} template Default `InnerBlocks` tuple tree —
+ *                         `[ blockName, attributes, innerBlocks ]` — that
+ *                         matches the bundled "Standard RSVP Form" pattern.
+ * @return {Array} Tuple tree handed to `<InnerBlocks template={ ... } />`.
+ */
+const DEFAULT_TEMPLATE = applyFilters(
+	'gatherpress.rsvpFormDefaultTemplate',
+	STANDARD_RSVP_FORM_TEMPLATE
+);
+
+/**
+ * Starter patterns offered by the RSVP Form block's pattern picker.
+ *
+ * Lets other plugins or themes register their own RSVP Form layouts without
+ * forking the block. Each entry is shaped
+ * `{ name, title, description, template }` — `template` is an `InnerBlocks`
+ * tuple tree (`[ blockName, attributes, innerBlocks ]`).
+ *
+ * @since 0.34.0
+ *
+ * @param {Array} patterns Default array containing the bundled
+ *                         "Standard RSVP Form" pattern.
+ * @return {Array} Patterns shown in the picker modal, in display order.
+ *
+ * @example
+ *   addFilter(
+ *     'gatherpress.rsvpFormPatterns',
+ *     'my-plugin/extra-rsvp-form',
+ *     ( patterns ) => [ ...patterns, {
+ *       name: 'my-plugin/minimal',
+ *       title: __( 'Minimal', 'my-plugin' ),
+ *       description: __( '...', 'my-plugin' ),
+ *       template: [ ... ],
+ *     } ]
+ *   );
+ */
+const PATTERNS = applyFilters( 'gatherpress.rsvpFormPatterns', [
+	{
+		name: 'gatherpress/standard-rsvp-form',
+		title: __( 'Standard RSVP Form', 'gatherpress' ),
+		description: __(
+			'Name + email + guest count + anonymous opt-in + email-updates opt-in, plus success and past-event message groups.',
+			'gatherpress'
+		),
+		template: STANDARD_RSVP_FORM_TEMPLATE,
+	},
+] );
+
+const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 	const [ formState, setFormState ] = useState( 'default' );
+	const [ isToolbarChooserOpen, setIsToolbarChooserOpen ] = useState( false );
+	const { patternPicked } = attributes;
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 	// Normalize empty strings to null so fallback to context.postId works correctly.
 	const postId = ( attributes?.postId || null ) ?? context?.postId ?? null;
 
@@ -57,6 +145,18 @@ const Edit = ( { attributes, clientId, context } ) => {
 		const block = getBlock( clientId );
 		return block?.innerBlocks || [];
 	}, [ clientId ] );
+
+	// Show the pattern picker on a brand-new block. Once the user picks a
+	// pattern (`patternPicked` flips true) or the block already carries inner
+	// blocks from a prior session, fall through to the normal `<InnerBlocks />`
+	// flow. Reading inner-block count keeps existing posts (which never had
+	// `patternPicked` set) from suddenly seeing the picker.
+	const showPatternPicker = ! patternPicked && 0 === innerBlocks.length;
+
+	const handlePatternPick = ( pattern ) => {
+		replaceInnerBlocks( clientId, templateToBlocks( pattern.template ) );
+		setAttributes( { patternPicked: true } );
+	};
 
 	/**
 	 * Apply conditional visibility class to form fields based on event settings.
@@ -194,6 +294,7 @@ const Edit = ( { attributes, clientId, context } ) => {
 	const blockProps = useBlockProps( {
 		style: {
 			opacity:
+				showPatternPicker ||
 				isInFSETemplate() ||
 				( isValidEvent &&
 					isRsvpEnabledForEvent( rsvpMode, enableRsvp ) &&
@@ -233,11 +334,46 @@ const Edit = ( { attributes, clientId, context } ) => {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div { ...blockProps }>
-				<InnerBlocks
-					template={ TEMPLATE }
-					allowedBlocks={ allowedBlocks }
+			{ ! showPatternPicker && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton
+							text={ __( 'Choose pattern', 'gatherpress' ) }
+							onClick={ () => setIsToolbarChooserOpen( true ) }
+						/>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
+			{ isToolbarChooserOpen && (
+				<PatternChooserModal
+					patterns={ PATTERNS }
+					onPick={ handlePatternPick }
+					onClose={ () => setIsToolbarChooserOpen( false ) }
 				/>
+			) }
+			<div { ...blockProps }>
+				{ showPatternPicker && (
+					<PatternPicker
+						label={ __( 'RSVP Form', 'gatherpress' ) }
+						icon="forms"
+						instructions={ __(
+							'Choose a pattern for the RSVP form.',
+							'gatherpress'
+						) }
+						patterns={ PATTERNS }
+						showStartBlank={ false }
+						onPick={ handlePatternPick }
+					/>
+				) }
+				{ ! showPatternPicker &&
+					( patternPicked && 0 === innerBlocks.length ? (
+						<InnerBlocks
+							template={ DEFAULT_TEMPLATE }
+							allowedBlocks={ allowedBlocks }
+						/>
+					) : (
+						<InnerBlocks allowedBlocks={ allowedBlocks } />
+					) ) }
 			</div>
 		</>
 	);

--- a/src/blocks/rsvp-form/templates/standard-rsvp-form.js
+++ b/src/blocks/rsvp-form/templates/standard-rsvp-form.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const TEMPLATE = [
+const STANDARD_RSVP_FORM_TEMPLATE = [
 	[
 		'core/group',
 		{
@@ -204,4 +204,4 @@ const TEMPLATE = [
 	],
 ];
 
-export default TEMPLATE;
+export default STANDARD_RSVP_FORM_TEMPLATE;

--- a/src/blocks/rsvp-response/edit.js
+++ b/src/blocks/rsvp-response/edit.js
@@ -61,7 +61,7 @@ function templateToBlocks( template ) {
  * `{ name, title, description, template }` — `template` is an `InnerBlocks`
  * tuple tree (`[ blockName, attributes, innerBlocks ]`).
  *
- * @since 0.34.0
+ * @since 1.0.0
  *
  * @param {Array} patterns Default array containing the bundled
  *                         "Attendee Grid with Filter" pattern.
@@ -88,7 +88,7 @@ function templateToBlocks( template ) {
  * user having to click through the picker. The picker itself is filterable
  * separately via `gatherpress.rsvpResponsePatterns`.
  *
- * @since 0.34.0
+ * @since 1.0.0
  *
  * @param {Array} template Default `InnerBlocks` tuple tree —
  *                         `[ blockName, attributes, innerBlocks ]` — that


### PR DESCRIPTION
### Description of the Change

Ports the reusable `<PatternPicker>` from #1572 to the RSVP Form block as the second consumer.

- On insert, the block opens the picker placeholder ("Choose a pattern for the RSVP form.") with a single **Standard RSVP Form** entry — the layout that previously seeded automatically (success message + past-event message + Name/Email/Guests/Anonymous/Email-updates fields + Submit). The block toolbar gains a **Choose pattern** action that re-opens the same modal so users can swap layouts later.
- A `gatherpress.rsvpFormPatterns` JS filter wraps the patterns array so other plugins/themes can register their own RSVP Form layouts without forking the block. A parallel `gatherpress.rsvpFormDefaultTemplate` filter swaps the auto-loaded layout (no-op today since the block isn't auto-included by the event post type's `template` arg, kept for parity).
- Documented at `docs/developer/blocks/pattern-pickers.md`.

`allowedBlocks` is preserved on both render branches (picker-suppressed and post-pick) so existing field-restriction behavior continues to apply.

Closes #1573

### How to test the Change

1. **Manual insert**: on any post or event, insert the RSVP Form block. The placeholder should show "RSVP Form" + **Choose** button (no Start blank).
2. Click **Choose** → modal opens with one card titled "Standard RSVP Form".
3. Click the card → modal closes, the full form (success message group, past-event message group, Name + Email + Guests + Anonymous + Email-updates + Submit) is seeded.
4. Block toolbar should now show **Choose pattern**. Click it → same modal reopens; picking again replaces the inner blocks.
5. **Regression**: open an existing post that already has an RSVP Form block — the picker should NOT appear (existing inner blocks bypass the picker).
6. **Filter**: in a companion plugin/theme, add a pattern via `addFilter( 'gatherpress.rsvpFormPatterns', ... )` and verify it appears as a second card in the modal.

### Changelog Entry

> Added - Pattern picker on the RSVP Form block with a "Standard RSVP Form" default and `gatherpress.rsvpFormPatterns` / `gatherpress.rsvpFormDefaultTemplate` JS filters for third-party patterns.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.