### PR TITLE
Add pattern picker to Venue block

### DIFF
--- a/docs/developer/blocks/pattern-pickers.md
+++ b/docs/developer/blocks/pattern-pickers.md
@@ -49,7 +49,7 @@ addFilter(
 );
 ```
 
-### Auto-loaded instances
+### Auto-loaded RSVP Response instances
 
 The RSVP Response block instance auto-loaded into a new event post (via the
 `gatherpress_event` post type's `template` arg) carries
@@ -122,6 +122,64 @@ Parallel to `gatherpress.rsvpResponseDefaultTemplate` — filters the template
 seeded into auto-loaded RSVP Form blocks (currently a no-op since the block
 isn't auto-included by the event post type's `template` arg, but kept for
 parity in case future patterns add it).
+
+## Venue — `gatherpress.venuePatterns`
+
+Same shape as RSVP Response and RSVP Form. Filters the array of starter
+patterns shown in the Venue block's picker. Each entry is
+`{ name, title, description, template }`.
+
+Two patterns ship by default, both always available in the chooser:
+
+- **Venue Details with Title** — prepends a `core/post-title` to the
+  address + phone + website + map. Default for event posts (the title
+  names the event hosting the venue).
+- **Venue Details** — the same address + phone + website + map without a
+  title. Default for venue posts (the host post itself names the venue).
+
+Authors can pick either regardless of host post type — the auto-load just
+picks the context-appropriate one when the picker is suppressed.
+
+```js
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+addFilter(
+    'gatherpress.venuePatterns',
+    'my-plugin/extra-venue-pattern',
+    ( patterns ) => [
+        ...patterns,
+        {
+            name: 'my-plugin/map-only',
+            title: __( 'Map only', 'my-plugin' ),
+            description: __(
+                'Just the embedded venue map, no contact details.',
+                'my-plugin'
+            ),
+            template: [ [ 'gatherpress/venue-map' ] ],
+        },
+    ]
+);
+```
+
+### Auto-loaded venue instances
+
+Two paths seed the picker as already-picked:
+
+- The `gatherpress_event` post type's `template` arg includes
+  `gatherpress/venue` with `patternPicked: true` — new event posts come
+  pre-populated with the with-title venue layout.
+- The `gatherpress/venue-template` hook anchor pattern's content is
+  `<!-- wp:gatherpress/venue {"patternPicked":true} /-->` — new venue posts
+  come pre-populated with the without-title layout.
+
+Manual venue inserts on other post types still hit the picker.
+
+### Swapping the venue auto-loaded template — `gatherpress.venueDefaultTemplate`
+
+Parallel to the RSVP Response/Form variants. Filters the template seeded
+into auto-loaded Venue blocks. Receives the context-resolved template
+(with-title or without-title).
 
 ## Adding a picker to a new block
 

--- a/includes/core/classes/blocks/class-setup.php
+++ b/includes/core/classes/blocks/class-setup.php
@@ -161,7 +161,12 @@ class Setup {
 				array(
 					'title'       => __( 'Venue Post Default Content', 'gatherpress' ),
 					'description' => $hook_anchor_description,
-					'content'     => '<!-- wp:gatherpress/venue /-->',
+					// `patternPicked: true` skips the venue block's pattern-picker
+					// UI and seeds the default layout directly — this is the
+					// canonical content for new venue posts, not a fresh manual
+					// insert. The block toolbar's "Choose pattern" action stays
+					// available for authors who want a different layout.
+					'content'     => '<!-- wp:gatherpress/venue {"patternPicked":true} /-->',
 					'inserter'    => false,
 					'source'      => 'plugin',
 				),

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -173,7 +173,16 @@ class Setup {
 				'template'      => array(
 					array( 'gatherpress/event-date' ),
 					array( 'gatherpress/add-to-calendar' ),
-					array( 'gatherpress/venue' ),
+					array(
+						'gatherpress/venue',
+						// Marking the attribute pre-picked tells the block to
+						// skip the pattern-picker UI and seed the default
+						// layout directly — this is the canonical auto-loaded
+						// instance, not a fresh manual insert. Users who want
+						// a different layout can still trigger the picker via
+						// the block toolbar's "Choose pattern" button.
+						array( 'patternPicked' => true ),
+					),
 					array( 'gatherpress/online-event' ),
 					array( 'gatherpress/rsvp' ),
 					array(

--- a/src/blocks/venue/block.json
+++ b/src/blocks/venue/block.json
@@ -15,6 +15,10 @@
 		},
 		"selectedPostType": {
 			"type": "string"
+		},
+		"patternPicked": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -3,13 +3,23 @@
  */
 import {
 	BlockContextProvider,
+	BlockControls,
 	InnerBlocks,
 	InspectorControls,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { PanelBody, PanelRow } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
+import {
+	PanelBody,
+	PanelRow,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,10 +28,87 @@ import { getCurrentContextualPostId, hasValidBlockContext, isInFSETemplate } fro
 import { usePostTypeSupports, findEventPostById, DISABLED_FIELD_OPACITY } from '../../helpers/event';
 import { GetVenuePostFromTermId, GetVenuePostFromEventId, findVenuePostById, getVenuePostType, getVenueTaxonomy, useVenueTaxonomyIds } from '../../helpers/venue';
 import VenueNavigator from '../../components/VenueNavigator';
-import { TEMPLATE_WITH_TITLE, TEMPLATE_WITHOUT_TITLE } from './template';
+import PatternPicker, { PatternChooserModal } from '../../components/PatternPicker';
+import { TEMPLATE_WITH_TITLE, TEMPLATE_WITHOUT_TITLE } from './templates/venue-details';
+
+/**
+ * Recursively turn an InnerBlocks-shape `[ name, attrs, inner ]` template
+ * tuple tree into instantiated block objects, ready for `replaceInnerBlocks`.
+ *
+ * @param {Array} template Tuples in `[ blockName, attributes, innerBlocks ]` form.
+ * @return {Array} Created block instances.
+ */
+function templateToBlocks( template ) {
+	return template.map( ( [ name, attributes, innerBlocks ] ) =>
+		createBlock(
+			name,
+			attributes,
+			templateToBlocks( innerBlocks || [] )
+		)
+	);
+}
+
+/**
+ * Starter patterns offered by the Venue block's pattern picker.
+ *
+ * Two layouts that share the address + phone + website + map base — one
+ * prepends a `core/post-title` (intended for event posts where the title
+ * names the event hosting the venue), the other omits it (intended for
+ * venue posts where the post itself is the venue and the page title
+ * already names it). Both are always available regardless of host post
+ * type — the picker lists both and `<defaultTemplate>` (computed from
+ * host context) decides which auto-loads when `patternPicked` is true.
+ *
+ * Filterable via `gatherpress.venuePatterns` so other plugins or themes
+ * can register their own venue layouts. Each entry is shaped
+ * `{ name, title, description, template }` — `template` is an `InnerBlocks`
+ * tuple tree (`[ blockName, attributes, innerBlocks ]`).
+ *
+ * @since 1.0.0
+ *
+ * @param {Array} patterns Default array containing the bundled
+ *                         "Venue Details with Title" and "Venue Details"
+ *                         patterns.
+ * @return {Array} Patterns shown in the picker modal, in display order.
+ *
+ * @example
+ *   addFilter(
+ *     'gatherpress.venuePatterns',
+ *     'my-plugin/extra-venue-pattern',
+ *     ( patterns ) => [ ...patterns, {
+ *       name: 'my-plugin/map-only',
+ *       title: __( 'Map only', 'my-plugin' ),
+ *       description: __( '...', 'my-plugin' ),
+ *       template: [ [ 'gatherpress/venue-map' ] ],
+ *     } ]
+ *   );
+ */
+const PATTERNS = applyFilters( 'gatherpress.venuePatterns', [
+	{
+		name: 'gatherpress/venue-details-with-title',
+		title: __( 'Venue Details with Title', 'gatherpress' ),
+		description: __(
+			'Post title above the venue address, phone, website, and map. Default for event posts.',
+			'gatherpress'
+		),
+		template: TEMPLATE_WITH_TITLE,
+	},
+	{
+		name: 'gatherpress/venue-details',
+		title: __( 'Venue Details', 'gatherpress' ),
+		description: __(
+			'Address, phone, website, and an embedded map (no post title). Default for venue posts.',
+			'gatherpress'
+		),
+		template: TEMPLATE_WITHOUT_TITLE,
+	},
+] );
 
 const Edit = ( props ) => {
-	const { attributes, context } = props;
+	const { attributes, setAttributes, clientId, context } = props;
+	const [ isToolbarChooserOpen, setIsToolbarChooserOpen ] = useState( false );
+	const { patternPicked } = attributes;
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 
 	const isDescendentOfQueryLoop = Number.isFinite( context?.queryId );
 	// Reactive supports checks so the block re-renders once the post-type
@@ -169,31 +256,115 @@ const Edit = ( props ) => {
 	// Check if we have a physical venue selected.
 	const hasVenue = 0 < venuePostId;
 
-	// Dim the block when no venue is selected or no valid context.
+	// Auto-load default template — picks the with-title variant on event
+	// hosts, the without-title variant elsewhere (including venue posts).
+	// Both patterns remain available in the picker modal regardless of
+	// context, so authors can manually pick the other variant if they want.
+	//
+	/**
+	 * Default template seeded into auto-loaded Venue blocks.
+	 *
+	 * Fires only when the picker is suppressed (the canonical instance on
+	 * a new event or venue post — `patternPicked: true` set in the post type
+	 * `template` arg / venue-template pattern). Lets a plugin or theme swap
+	 * the layout that appears without the user clicking through the picker.
+	 * Receives the context-resolved template (with-title in event hosts,
+	 * without-title elsewhere). The picker itself is filterable separately
+	 * via `gatherpress.venuePatterns`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param {Array} defaultTemplate Default `InnerBlocks` tuple tree
+	 *                                resolved from `TEMPLATE_WITH_TITLE` /
+	 *                                `TEMPLATE_WITHOUT_TITLE` based on
+	 *                                whether the host post supports events.
+	 * @return {Array} Tuple tree handed to `<InnerBlocks template={ ... } />`.
+	 */
+	const defaultTemplate = applyFilters(
+		'gatherpress.venueDefaultTemplate',
+		isEventContext ? TEMPLATE_WITH_TITLE : TEMPLATE_WITHOUT_TITLE
+	);
+
+	const innerBlockCount = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlocks( clientId ).length,
+		[ clientId ]
+	);
+	const showPatternPicker =
+		! patternPicked && 0 === innerBlockCount;
+
+	const handlePatternPick = ( pattern ) => {
+		replaceInnerBlocks(
+			clientId,
+			templateToBlocks( pattern.template )
+		);
+		setAttributes( { patternPicked: true } );
+	};
+
+	// Dim the block when no venue is selected or no valid context. The
+	// pattern-picker placeholder always renders at full opacity — dimming
+	// the picker would obscure the actionable Choose button.
 	const blockProps = useBlockProps( {
 		style: {
-			opacity: hasValidBlockContext( {
-				isDescendentOfQueryLoop,
-				hasSupport: isEventContext,
-				hasData: hasVenue,
-			} )
-				? 1
-				: DISABLED_FIELD_OPACITY,
+			opacity:
+				showPatternPicker ||
+				hasValidBlockContext( {
+					isDescendentOfQueryLoop,
+					hasSupport: isEventContext,
+					hasData: hasVenue,
+				} )
+					? 1
+					: DISABLED_FIELD_OPACITY,
 		},
 	} );
 
-	// Get the template based on context.
-	const template = isEventContext ? TEMPLATE_WITH_TITLE : TEMPLATE_WITHOUT_TITLE;
-
 	return (
 		<div { ...blockProps }>
+			{ ! showPatternPicker && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton
+							text={ __( 'Choose pattern', 'gatherpress' ) }
+							onClick={ () => setIsToolbarChooserOpen( true ) }
+						/>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
+			{ isToolbarChooserOpen && (
+				<PatternChooserModal
+					patterns={ PATTERNS }
+					onPick={ handlePatternPick }
+					onClose={ () => setIsToolbarChooserOpen( false ) }
+				/>
+			) }
 			<BlockContextProvider
 				value={ {
 					postId: venuePostId,
 					postType: venuePostType,
 				} }
 			>
-				<InnerBlocks template={ template } templateLock={ false } />
+				{ showPatternPicker && (
+					<PatternPicker
+						label={ __( 'Venue', 'gatherpress' ) }
+						icon="location"
+						instructions={ __(
+							'Choose a pattern for the venue.',
+							'gatherpress'
+						) }
+						patterns={ PATTERNS }
+						showStartBlank={ false }
+						onPick={ handlePatternPick }
+					/>
+				) }
+				{ ! showPatternPicker &&
+					( patternPicked && 0 === innerBlockCount ? (
+						<InnerBlocks
+							template={ defaultTemplate }
+							templateLock={ false }
+						/>
+					) : (
+						<InnerBlocks templateLock={ false } />
+					) ) }
 			</BlockContextProvider>
 			<InspectorControls>
 				{ ! isDescendentOfQueryLoop && ! isInFSETemplate() && isEventContext && (

--- a/src/blocks/venue/templates/venue-details.js
+++ b/src/blocks/venue/templates/venue-details.js
@@ -121,11 +121,10 @@ const VENUE_DETAILS = [
 	[ 'gatherpress/venue-map' ],
 ];
 
-// Template with post-title (for events).
+// Template variants for the Venue Details with Map pattern. Both share the
+// same address + phone + website + map block tree; the with-title variant
+// prepends a post title (used in event posts) while the without-title variant
+// drops it (used in venue posts where the host's title already names the
+// venue).
 export const TEMPLATE_WITH_TITLE = [ POST_TITLE, ...VENUE_DETAILS ];
-
-// Template without post-title (for venues).
 export const TEMPLATE_WITHOUT_TITLE = VENUE_DETAILS;
-
-// Default export is with title for backward compatibility.
-export default TEMPLATE_WITH_TITLE;


### PR DESCRIPTION
### Description of the Change

Ports the reusable `<PatternPicker>` from #1572 to the Venue block as the third consumer.

- Two starter patterns ship by default — both always available in the chooser regardless of host post type:
    - **Venue Details with Title** — POST_TITLE + address + phone + website + map (default for event posts)
    - **Venue Details** — same minus the title (default for venue posts where the host title already names the venue)
- Auto-load picks the context-appropriate one when `patternPicked` is true:
    - The `gatherpress_event` post type's `template` arg now passes `patternPicked: true` for the auto-included `gatherpress/venue` block — new event posts seed _Venue Details with Title_ silently.
    - The `gatherpress/venue-template` hook anchor pattern's content is updated to `<!-- wp:gatherpress/venue {"patternPicked":true} /-->` — new venue posts seed _Venue Details_ silently.
- A `gatherpress.venuePatterns` JS filter wraps the patterns array, and a `gatherpress.venueDefaultTemplate` filter swaps the auto-loaded template. Documented at `docs/developer/blocks/pattern-pickers.md`.

`templateLock={ false }` is preserved on the InnerBlocks render branches so existing inner-block edit behavior continues to work.

Closes #1574

### How to test the Change

1. **Auto-loaded on event**: create a new event (`/wp-admin/post-new.php?post_type=gatherpress_event`). The Venue block should appear pre-populated with title + address + phone + website + map — no picker.
2. **Auto-loaded on venue**: create a new venue (`/wp-admin/post-new.php?post_type=gatherpress_venue`). The Venue block should appear pre-populated with address + phone + website + map (no title) — no picker.
3. **Manual insert**: on any post type, insert the Venue block. The placeholder should show "Venue" + **Choose** button.
4. Click **Choose** → modal opens with two cards: "Venue Details with Title" and "Venue Details".
5. Click either → modal closes, that layout is seeded.
6. Block toolbar should now show **Choose pattern**. Clicking it reopens the same two-card modal.
7. **Regression**: open an existing post that already has a Venue block — picker should NOT appear.

### Changelog Entry

> Added - Pattern picker on the Venue block with two bundled patterns ("Venue Details with Title" + "Venue Details") and `gatherpress.venuePatterns` / `gatherpress.venueDefaultTemplate` JS filters for third-party patterns.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.