### PR TITLE
Venue starter pattern chooser

### DIFF
--- a/docs/developer/blocks/hookable-patterns/README.md
+++ b/docs/developer/blocks/hookable-patterns/README.md
@@ -35,11 +35,24 @@ GatherPress adds the following blocks by default into a new created event:
 
 ### New Venue
 
-A new created venue will have the following blocks prepared by default:
+Creating a new venue opens WordPress's "Choose a pattern" starter modal —
+the same UX Twenty Twenty-Five uses on new pages. A single starter pattern
+ships by default:
 
-- A block-pattern named `gatherpress/venue-template`, which contains the following block by default:
+- `gatherpress/venue-with-map` — title "Venue with Map", scoped to
+  `core/post-content` and every post type declaring
+  `gatherpress-venue-information` support. Picks insert a single
+  `gatherpress/venue` block (address + phone + website + map).
 
-    - `gatherpress/venue`
+The chooser is gated by the **Pattern Chooser** setting under
+*GatherPress Settings → Venues → Editor* (on by default). When off, the
+pattern is not registered and new venues open with blank content.
+
+The `gatherpress/venue-template` pattern still exists — it is the
+Block Hooks anchor and the seed used by `Venue\Setup::maybe_apply_venue_template()`
+when venues are created programmatically (e.g., via REST without
+content). Picking "Venue with Map" in the modal inserts the same
+`gatherpress/venue` block that template carries.
 
 
 ### New Event Queries within any post

--- a/docs/developer/blocks/hookable-patterns/README.md
+++ b/docs/developer/blocks/hookable-patterns/README.md
@@ -44,9 +44,9 @@ ships by default:
   `gatherpress-venue-information` support. Picks insert a single
   `gatherpress/venue` block (address + phone + website + map).
 
-The chooser is gated by the **Pattern Chooser** setting under
-*GatherPress Settings → Venues → Editor* (on by default). When off, the
-pattern is not registered and new venues open with blank content.
+Per-user dismissal is handled by the modal's own *"Always show starter
+patterns for new pages"* toggle — that's a WordPress-core user
+preference, not a GatherPress setting.
 
 The `gatherpress/venue-template` pattern still exists — it is the
 Block Hooks anchor and the seed used by `Venue\Setup::maybe_apply_venue_template()`

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -77,31 +77,7 @@ class Venues extends Base {
 	 */
 	protected function get_sections(): array {
 		return array(
-			'editor' => array(
-				'name'        => __( 'Editor', 'gatherpress' ),
-				'description' => __(
-					'Configure the block editor experience for new venues.',
-					'gatherpress'
-				),
-				'options'     => array(
-					'venue_pattern_chooser' => array(
-						'labels' => array(
-							'name' => __( 'Pattern Chooser', 'gatherpress' ),
-						),
-						'field'  => array(
-							'label'   => __(
-								'Show a starter pattern chooser when creating a new venue.',
-								'gatherpress'
-							),
-							'type'    => 'checkbox',
-							'options' => array(
-								'default' => true,
-							),
-						),
-					),
-				),
-			),
-			'maps'   => array(
+			'maps' => array(
 				'name'        => __( 'Maps', 'gatherpress' ),
 				'description' => __(
 					'Configure the mapping platform and defaults applied to new venue map blocks.',

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -77,7 +77,31 @@ class Venues extends Base {
 	 */
 	protected function get_sections(): array {
 		return array(
-			'maps' => array(
+			'editor' => array(
+				'name'        => __( 'Editor', 'gatherpress' ),
+				'description' => __(
+					'Configure the block editor experience for new venues.',
+					'gatherpress'
+				),
+				'options'     => array(
+					'venue_pattern_chooser' => array(
+						'labels' => array(
+							'name' => __( 'Pattern Chooser', 'gatherpress' ),
+						),
+						'field'  => array(
+							'label'   => __(
+								'Show a starter pattern chooser when creating a new venue.',
+								'gatherpress'
+							),
+							'type'    => 'checkbox',
+							'options' => array(
+								'default' => true,
+							),
+						),
+					),
+				),
+			),
+			'maps'   => array(
 				'name'        => __( 'Maps', 'gatherpress' ),
 				'description' => __(
 					'Configure the mapping platform and defaults applied to new venue map blocks.',

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -98,6 +98,7 @@ class Setup {
 		add_action( 'registered_post_type', array( $this, 'maybe_link_shadow_source_support' ), 9 );
 		// Priority 11 so post types registered at default priority 10 are available for get_post_types_by_support().
 		add_action( 'init', array( $this, 'register_taxonomy' ), 11 );
+		add_action( 'init', array( $this, 'register_starter_pattern' ), 11 );
 		add_filter( 'block_editor_settings_all', array( $this, 'add_editor_settings' ) );
 	}
 
@@ -232,9 +233,6 @@ class Setup {
 					'gatherpress-shadow-source',
 				),
 				'menu_icon'    => 'dashicons-location',
-				'template'     => array(
-					array( 'core/pattern', array( 'slug' => 'gatherpress/venue-template' ) ),
-				),
 				'has_archive'  => true,
 				'rewrite'      => array(
 					'slug'       => $rewrite_slug,
@@ -268,6 +266,53 @@ class Setup {
 			$venue_post_type = $this->get_venue_post_type( $event_post_type );
 			register_taxonomy_for_object_type( $this->get_taxonomy( $venue_post_type ), $event_post_type );
 		}
+	}
+
+	/**
+	 * Register the user-facing "Venue with Map" starter pattern.
+	 *
+	 * Scopes to every post type declaring `gatherpress-venue-information`
+	 * support so the WordPress block editor's starter pattern modal —
+	 * the same UX Twenty Twenty-Five uses on new pages — surfaces this
+	 * pattern when authors create a new venue. Companion plugins that
+	 * declare the support on custom venue post types get the chooser
+	 * for free.
+	 *
+	 * Gated by the `venue_pattern_chooser` setting (default on). When
+	 * the setting is off the pattern is not registered and new venues
+	 * open with blank content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function register_starter_pattern(): void {
+		$settings = Settings::get_instance();
+
+		if ( ! (bool) $settings->get( 'venue_pattern_chooser' ) ) {
+			return;
+		}
+
+		$post_types = get_post_types_by_support( 'gatherpress-venue-information' );
+
+		if ( empty( $post_types ) ) {
+			return;
+		}
+
+		register_block_pattern(
+			'gatherpress/venue-with-map',
+			array(
+				'title'       => __( 'Venue with Map', 'gatherpress' ),
+				'description' => __(
+					'Address, contact details, and an embedded map.',
+					'gatherpress'
+				),
+				'content'     => '<!-- wp:gatherpress/venue {"patternPicked":true} /-->',
+				'blockTypes'  => array( 'core/post-content' ),
+				'postTypes'   => $post_types,
+				'source'      => 'plugin',
+			)
+		);
 	}
 
 	/**

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -279,21 +279,15 @@ class Setup {
 	 * declare the support on custom venue post types get the chooser
 	 * for free.
 	 *
-	 * Gated by the `venue_pattern_chooser` setting (default on). When
-	 * the setting is off the pattern is not registered and new venues
-	 * open with blank content.
+	 * Per-user dismissal is handled by the modal's own "Always show
+	 * starter patterns for new pages" toggle, so no site-wide setting
+	 * is needed here.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
 	public function register_starter_pattern(): void {
-		$settings = Settings::get_instance();
-
-		if ( ! (bool) $settings->get( 'venue_pattern_chooser' ) ) {
-			return;
-		}
-
 		$post_types = get_post_types_by_support( 'gatherpress-venue-information' );
 
 		if ( empty( $post_types ) ) {

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -98,6 +98,7 @@ class Setup {
 		add_action( 'registered_post_type', array( $this, 'maybe_link_shadow_source_support' ), 9 );
 		// Priority 11 so post types registered at default priority 10 are available for get_post_types_by_support().
 		add_action( 'init', array( $this, 'register_taxonomy' ), 11 );
+		// Priority 11 so post types registered at default priority 10 are available for get_post_types_by_support().
 		add_action( 'init', array( $this, 'register_starter_pattern' ), 11 );
 		add_filter( 'block_editor_settings_all', array( $this, 'add_editor_settings' ) );
 	}

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -9,7 +9,6 @@
 namespace GatherPress\Tests\Core\Venue;
 
 use GatherPress\Core\Event;
-use GatherPress\Core\Settings;
 use GatherPress\Core\Venue\Map\Setup as Map_Setup;
 use GatherPress\Core\Venue\Meta;
 use GatherPress\Core\Venue\Setup;
@@ -206,14 +205,15 @@ class Test_Setup extends Base {
 	}
 
 	/**
-	 * Registers the user-facing starter pattern with the right scope when
-	 * the `venue_pattern_chooser` setting is on (default).
+	 * Registers the user-facing starter pattern scoped to core/post-content
+	 * and every post type declaring `gatherpress-venue-information` so the
+	 * starter pattern modal surfaces it on new venues.
 	 *
 	 * @covers ::register_starter_pattern
 	 *
 	 * @return void
 	 */
-	public function test_register_starter_pattern_on(): void {
+	public function test_register_starter_pattern(): void {
 		$instance = Setup::get_instance();
 		$registry = WP_Block_Patterns_Registry::get_instance();
 
@@ -221,13 +221,11 @@ class Test_Setup extends Base {
 			$registry->unregister( 'gatherpress/venue-with-map' );
 		}
 
-		update_option( Settings::OPTION_NAME, array( 'venue_pattern_chooser' => true ) );
-
 		$instance->register_starter_pattern();
 
 		$this->assertTrue(
 			$registry->is_registered( 'gatherpress/venue-with-map' ),
-			'Starter pattern should be registered when the setting is on.'
+			'Starter pattern should be registered.'
 		);
 
 		$pattern = $registry->get_registered( 'gatherpress/venue-with-map' );
@@ -244,35 +242,6 @@ class Test_Setup extends Base {
 		);
 
 		$registry->unregister( 'gatherpress/venue-with-map' );
-		delete_option( Settings::OPTION_NAME );
-	}
-
-	/**
-	 * Skips registration entirely when the `venue_pattern_chooser` setting
-	 * is off so new venues open with blank content.
-	 *
-	 * @covers ::register_starter_pattern
-	 *
-	 * @return void
-	 */
-	public function test_register_starter_pattern_off(): void {
-		$instance = Setup::get_instance();
-		$registry = WP_Block_Patterns_Registry::get_instance();
-
-		if ( $registry->is_registered( 'gatherpress/venue-with-map' ) ) {
-			$registry->unregister( 'gatherpress/venue-with-map' );
-		}
-
-		update_option( Settings::OPTION_NAME, array( 'venue_pattern_chooser' => false ) );
-
-		$instance->register_starter_pattern();
-
-		$this->assertFalse(
-			$registry->is_registered( 'gatherpress/venue-with-map' ),
-			'Starter pattern should not be registered when the setting is off.'
-		);
-
-		delete_option( Settings::OPTION_NAME );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -9,6 +9,7 @@
 namespace GatherPress\Tests\Core\Venue;
 
 use GatherPress\Core\Event;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Venue\Map\Setup as Map_Setup;
 use GatherPress\Core\Venue\Meta;
 use GatherPress\Core\Venue\Setup;
@@ -87,6 +88,12 @@ class Test_Setup extends Base {
 				'name'     => 'init',
 				'priority' => 11,
 				'callback' => array( $instance, 'register_taxonomy' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'init',
+				'priority' => 11,
+				'callback' => array( $instance, 'register_starter_pattern' ),
 			),
 			array(
 				'type'     => 'filter',
@@ -196,6 +203,76 @@ class Test_Setup extends Base {
 			$taxonomy->show_ui,
 			'Taxonomy should remain hidden from admin UI as a shadow taxonomy.'
 		);
+	}
+
+	/**
+	 * Registers the user-facing starter pattern with the right scope when
+	 * the `venue_pattern_chooser` setting is on (default).
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_on(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'gatherpress/venue-with-map' ) ) {
+			$registry->unregister( 'gatherpress/venue-with-map' );
+		}
+
+		update_option( Settings::OPTION_NAME, array( 'venue_pattern_chooser' => true ) );
+
+		$instance->register_starter_pattern();
+
+		$this->assertTrue(
+			$registry->is_registered( 'gatherpress/venue-with-map' ),
+			'Starter pattern should be registered when the setting is on.'
+		);
+
+		$pattern = $registry->get_registered( 'gatherpress/venue-with-map' );
+
+		$this->assertContains(
+			'core/post-content',
+			$pattern['blockTypes'],
+			'Starter pattern must scope to core/post-content so the chooser modal surfaces it.'
+		);
+		$this->assertContains(
+			Venue::POST_TYPE,
+			$pattern['postTypes'],
+			'Starter pattern must scope to gatherpress_venue post type.'
+		);
+
+		$registry->unregister( 'gatherpress/venue-with-map' );
+		delete_option( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Skips registration entirely when the `venue_pattern_chooser` setting
+	 * is off so new venues open with blank content.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_off(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'gatherpress/venue-with-map' ) ) {
+			$registry->unregister( 'gatherpress/venue-with-map' );
+		}
+
+		update_option( Settings::OPTION_NAME, array( 'venue_pattern_chooser' => false ) );
+
+		$instance->register_starter_pattern();
+
+		$this->assertFalse(
+			$registry->is_registered( 'gatherpress/venue-with-map' ),
+			'Starter pattern should not be registered when the setting is off.'
+		);
+
+		delete_option( Settings::OPTION_NAME );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -205,6 +205,45 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * Bails before registering when no post type declares
+	 * `gatherpress-venue-information` support. Without the guard,
+	 * `register_block_pattern` would be called with an empty
+	 * `postTypes` array and the chooser modal would have no
+	 * post-type scope to match against.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_bails_without_supported_post_types(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'gatherpress/venue-with-map' ) ) {
+			$registry->unregister( 'gatherpress/venue-with-map' );
+		}
+
+		// Strip the support from every post type that currently declares
+		// it so `get_post_types_by_support()` returns an empty array.
+		$supported = get_post_types_by_support( 'gatherpress-venue-information' );
+		foreach ( $supported as $post_type ) {
+			remove_post_type_support( $post_type, 'gatherpress-venue-information' );
+		}
+
+		$instance->register_starter_pattern();
+
+		$this->assertFalse(
+			$registry->is_registered( 'gatherpress/venue-with-map' ),
+			'Starter pattern must not be registered when no post type declares the venue-information support.'
+		);
+
+		// Restore support.
+		foreach ( $supported as $post_type ) {
+			add_post_type_support( $post_type, 'gatherpress-venue-information' );
+		}
+	}
+
+	/**
 	 * Registers the user-facing starter pattern scoped to core/post-content
 	 * and every post type declaring `gatherpress-venue-information` so the
 	 * starter pattern modal surfaces it on new venues.


### PR DESCRIPTION
### Description of the Change

Replaces the always-on auto-loaded venue template with WordPress's
"Choose a pattern" starter modal — same UX Twenty Twenty-Five uses on
new pages. New venues now open the modal with a single **Venue with Map**
pattern (address, contact details, embedded map — same content as
today's auto-load); choosing the X closes it for a blank start.

The pattern is registered via `register_block_pattern` scoped to
`core/post-content` + `get_post_types_by_support( 'gatherpress-venue-information' )`,
hooked on `init` priority 11 so any post type declaring the support —
including custom venue post types from companion plugins — gets the
chooser for free.

A new **Pattern Chooser** checkbox under *Venues → Editor* (on by
default) gates the registration. When off, the pattern isn't registered
and new venues open with blank content. The `template` arg has been
removed from the venue post type registration; `gatherpress/venue-template`
remains as a Block Hooks anchor and the seed for programmatic creation
via `maybe_apply_venue_template`.

Closes #1577

### How to test the Change

1. Create a new venue (`/wp-admin/post-new.php?post_type=gatherpress_venue`)
   — modal appears with the "Venue with Map" preview. Click it and
   confirm the venue card (address + phone + website + map) is inserted.
2. Toggle **GatherPress Settings → Venues → Editor → Pattern Chooser**
   off, save, create another new venue — no modal, blank editor.
3. Toggle it back on — modal returns.

### Changelog Entry

> Added - "Choose a pattern" starter modal on new venues with a default "Venue with Map" pattern, gated by a new Pattern Chooser setting.

### Credits

Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.