### PR TITLE
Event starter pattern chooser

### DIFF
--- a/docs/developer/blocks/hookable-patterns/README.md
+++ b/docs/developer/blocks/hookable-patterns/README.md
@@ -8,7 +8,7 @@ Patterns allow to be filtered by the (upgraded since WordPress 6.5) Block Hooks 
 - GatherPress provides central entry points for plugin developers to hook-in own blocks, to extend GatherPress
 - GatherPress' blocks will provide their hooking code themself, which keeps concerns separate and code clean
 
-For example, when you create a new event post, it gets pre-populated with a set of blocks, curated within a block-pattern named `gatherpress/event-template`.
+For example, the `gatherpress/event-template` pattern is the Block Hooks anchor that companion plugins extend; the user-facing "Event with RSVP" starter pattern surfaced in the new-event chooser modal seeds the same canonical block layout.
 
 ## Overview of hookable patterns
 

--- a/docs/developer/blocks/hookable-patterns/README.md
+++ b/docs/developer/blocks/hookable-patterns/README.md
@@ -21,16 +21,25 @@ GatherPress combines four of such block-patterns to curate the creation of:
 
 ### New Event
 
-GatherPress adds the following blocks by default into a new created event:
+Creating a new event opens WordPress's "Choose a pattern" starter modal —
+the same UX Twenty Twenty-Five uses on new pages. A single starter pattern
+ships by default:
 
-- A block-pattern named `gatherpress/event-template`, which contains the following blocks by default:
+- `gatherpress/event-with-rsvp` — title "Event with RSVP", scoped to
+  `core/post-content` and every post type declaring
+  `gatherpress-event-date` support. Picks insert event-date,
+  add-to-calendar, venue, online-event, RSVP, a description paragraph,
+  and rsvp-response — the canonical event layout. The venue, RSVP,
+  and rsvp-response blocks ship with `patternPicked: true` so their
+  in-block pattern pickers stay suppressed.
 
-    - `gatherpress/event-date`
-    - `gatherpress/add-to-calendar`
-    - `gatherpress/venue`
-    - `gatherpress/rsvp`
-    - `core/paragraph`
-    - `gatherpress/rsvp-response`
+Per-user dismissal is handled by the modal's own *"Always show starter
+patterns for new pages"* toggle — that's a WordPress-core user
+preference, not a GatherPress setting.
+
+The `gatherpress/event-template` pattern still exists as the Block Hooks
+anchor for companion plugins that hook blocks before/after the event-date
+block via `hooked_block_types`.
 
 
 ### New Venue

--- a/docs/developer/blocks/hookable-patterns/README.md
+++ b/docs/developer/blocks/hookable-patterns/README.md
@@ -22,16 +22,38 @@ GatherPress combines four of such block-patterns to curate the creation of:
 ### New Event
 
 Creating a new event opens WordPress's "Choose a pattern" starter modal —
-the same UX Twenty Twenty-Five uses on new pages. A single starter pattern
-ships by default:
+the same UX Twenty Twenty-Five uses on new pages. The bundled patterns
+live in `includes/core/templates/event/`; each file returns a
+`name/title/description/content` array and the loader registers it
+scoped to `core/post-content` plus every post type declaring
+`gatherpress-event-date` support. Adding a new pattern is just dropping
+a file into that directory.
 
-- `gatherpress/event-with-rsvp` — title "Event with RSVP", scoped to
-  `core/post-content` and every post type declaring
-  `gatherpress-event-date` support. Picks insert event-date,
-  add-to-calendar, venue, online-event, RSVP, a description paragraph,
-  and rsvp-response — the canonical event layout. The venue, RSVP,
-  and rsvp-response blocks ship with `patternPicked: true` so their
+The bundled default ships with the plugin:
+
+- `gatherpress/event-with-rsvp` (title *"Event with RSVP"*) seeds the
+  canonical event layout: event-date + add-to-calendar + venue +
+  online-event + RSVP + description paragraph + rsvp-response. Venue,
+  RSVP, and rsvp-response carry `patternPicked: true` so their
   in-block pattern pickers stay suppressed.
+
+Third parties can append their own without forking by hooking the
+`gatherpress_event_starter_patterns` filter:
+
+```php
+add_filter(
+    'gatherpress_event_starter_patterns',
+    function ( array $patterns ): array {
+        $patterns[] = array(
+            'name'        => 'my-plugin/minimal-event',
+            'title'       => __( 'Minimal Event', 'my-plugin' ),
+            'description' => __( 'Date + RSVP only.', 'my-plugin' ),
+            'content'     => '<!-- wp:gatherpress/event-date /--><!-- wp:gatherpress/rsvp {"patternPicked":true} --><div class="wp-block-gatherpress-rsvp"></div><!-- /wp:gatherpress/rsvp -->',
+        );
+        return $patterns;
+    }
+);
+```
 
 Per-user dismissal is handled by the modal's own *"Always show starter
 patterns for new pages"* toggle — that's a WordPress-core user
@@ -44,14 +66,21 @@ block via `hooked_block_types`.
 
 ### New Venue
 
-Creating a new venue opens WordPress's "Choose a pattern" starter modal —
-the same UX Twenty Twenty-Five uses on new pages. A single starter pattern
-ships by default:
+Same shape as the event flow. Bundled venue starter patterns live in
+`includes/core/templates/venue/`; each file returns a
+`name/title/description/content` array and the loader registers it
+scoped to `core/post-content` plus every post type declaring
+`gatherpress-venue-information` support.
 
-- `gatherpress/venue-with-map` — title "Venue with Map", scoped to
-  `core/post-content` and every post type declaring
-  `gatherpress-venue-information` support. Picks insert a single
-  `gatherpress/venue` block (address + phone + website + map).
+The bundled default:
+
+- `gatherpress/venue-with-map` (title *"Venue with Map"*) seeds a
+  single `gatherpress/venue` block with `patternPicked: true` so the
+  block's in-block picker stays suppressed.
+
+Third parties can append their own via the
+`gatherpress_venue_starter_patterns` filter — same shape as the event
+filter above.
 
 Per-user dismissal is handled by the modal's own *"Always show starter
 patterns for new pages"* toggle — that's a WordPress-core user
@@ -60,8 +89,7 @@ preference, not a GatherPress setting.
 The `gatherpress/venue-template` pattern still exists — it is the
 Block Hooks anchor and the seed used by `Venue\Setup::maybe_apply_venue_template()`
 when venues are created programmatically (e.g., via REST without
-content). Picking "Venue with Map" in the modal inserts the same
-`gatherpress/venue` block that template carries.
+content).
 
 
 ### New Event Queries within any post

--- a/docs/developer/blocks/pattern-pickers.md
+++ b/docs/developer/blocks/pattern-pickers.md
@@ -51,12 +51,12 @@ addFilter(
 
 ### Auto-loaded RSVP Response instances
 
-The RSVP Response block instance auto-loaded into a new event post (via the
-`gatherpress_event` post type's `template` arg) carries
-`patternPicked: true` so the picker is suppressed and the block seeds the
-default template directly. Authors can still swap layouts via the block
-toolbar's **Choose pattern** action — that opens the same modal your filter
-contributes to.
+The RSVP Response block seeded into a new event post (via the
+`gatherpress/event-with-rsvp` starter pattern surfaced in the new-event
+chooser modal) carries `patternPicked: true` so the picker is suppressed
+and the block seeds the default template directly. Authors can still swap
+layouts via the block toolbar's **Choose pattern** action — that opens
+the same modal your filter contributes to.
 
 ### Swapping the auto-loaded template — `gatherpress.rsvpResponseDefaultTemplate`
 
@@ -166,12 +166,13 @@ addFilter(
 
 Two paths seed the picker as already-picked:
 
-- The `gatherpress_event` post type's `template` arg includes
-  `gatherpress/venue` with `patternPicked: true` — new event posts come
-  pre-populated with the with-title venue layout.
-- The `gatherpress/venue-template` hook anchor pattern's content is
-  `<!-- wp:gatherpress/venue {"patternPicked":true} /-->` — new venue posts
-  come pre-populated with the without-title layout.
+- The `gatherpress/event-with-rsvp` starter pattern (surfaced in the
+  new-event chooser modal) includes `gatherpress/venue` with
+  `patternPicked: true` — picking it from the modal pre-populates the
+  with-title venue layout.
+- The `gatherpress/venue-with-map` starter pattern (surfaced in the
+  new-venue chooser modal) carries the same `patternPicked: true` —
+  picking it pre-populates the without-title layout.
 
 Manual venue inserts on other post types still hit the picker.
 
@@ -228,10 +229,11 @@ addFilter(
 
 ### Auto-loaded RSVP instances
 
-The RSVP block instance auto-loaded into a new event post (via the
-`gatherpress_event` post type's `template` arg) carries `patternPicked: true`
-so the picker is suppressed and the existing hydration `useEffect` seeds the
-default status templates directly.
+The RSVP block seeded into a new event post (via the
+`gatherpress/event-with-rsvp` starter pattern surfaced in the new-event
+chooser modal) carries `patternPicked: true` so the picker is suppressed
+and the existing hydration `useEffect` seeds the default status templates
+directly.
 
 ### Swapping the RSVP auto-loaded bundle — `gatherpress.rsvpDefaultStatusTemplates`
 

--- a/includes/core/classes/class-starter-pattern-loader.php
+++ b/includes/core/classes/class-starter-pattern-loader.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Loads starter pattern definitions from a templates directory.
+ *
+ * Centralizes the file-per-pattern convention used by the new-event and
+ * new-venue starter pattern modals so adding a new pattern is just
+ * dropping a `*.php` file into `includes/core/templates/<subsystem>/`.
+ * Each file returns an associative array with `name`, `title`,
+ * `description`, and `content` keys.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Core;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+/**
+ * Class Starter_Pattern_Loader.
+ *
+ * Stateless helper — no constructor, no singleton. Callers pass a directory
+ * path and receive the list of pattern definitions found there. Filtering
+ * (e.g., `gatherpress_event_starter_patterns`) is the caller's responsibility
+ * so the filter name stays scoped to each subsystem.
+ *
+ * @since 1.0.0
+ */
+class Starter_Pattern_Loader {
+	/**
+	 * Load every starter pattern definition found in a directory.
+	 *
+	 * Skips files that do not return an array or omit a `name` key — the
+	 * `name` is what `register_block_pattern()` keys on, so without it
+	 * the entry can never be registered.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $dir Absolute path to a directory of pattern files.
+	 *                    Each file must `return` a definition array.
+	 * @return array<int, array<string, mixed>> List of pattern definitions.
+	 */
+	public static function load( string $dir ): array {
+		$patterns = array();
+		$files    = glob( rtrim( $dir, '/' ) . '/*.php' );
+
+		foreach ( (array) $files as $file ) {
+			$pattern = require $file;
+
+			if ( is_array( $pattern ) && ! empty( $pattern['name'] ) ) {
+				$patterns[] = $pattern;
+			}
+		}
+
+		return $patterns;
+	}
+}

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -92,6 +92,8 @@ class Setup {
 	protected function setup_hooks(): void {
 		add_action( 'init', array( $this, 'register_post_type' ) );
 		add_action( 'init', array( $this, 'register_calendar_rewrite_rule' ) );
+		// Priority 11 so post types registered at default priority 10 are available for get_post_types_by_support().
+		add_action( 'init', array( $this, 'register_starter_pattern' ), 11 );
 		add_action( 'parse_request', array( $this, 'handle_calendar_ics_request' ) );
 		add_action( 'template_redirect', array( $this, 'handle_event_archive_redirect' ) );
 		add_action( 'delete_post', array( $this, 'delete_event' ) );
@@ -170,56 +172,6 @@ class Setup {
 				'rest_base'     => 'gatherpress_events',
 				'public'        => true,
 				'hierarchical'  => false,
-				'template'      => array(
-					array( 'gatherpress/event-date' ),
-					array( 'gatherpress/add-to-calendar' ),
-					array(
-						'gatherpress/venue',
-						// Marking the attribute pre-picked tells the block to
-						// skip the pattern-picker UI and seed the default
-						// layout directly — this is the canonical auto-loaded
-						// instance, not a fresh manual insert. Users who want
-						// a different layout can still trigger the picker via
-						// the block toolbar's "Choose pattern" button.
-						array( 'patternPicked' => true ),
-					),
-					array( 'gatherpress/online-event' ),
-					array(
-						'gatherpress/rsvp',
-						// Marking the attribute pre-picked tells the block to
-						// skip the pattern-picker UI and seed the default
-						// per-status layouts directly — this is the canonical
-						// auto-loaded instance, not a fresh manual insert.
-						// Users who want a different layout can still trigger
-						// the picker via the block toolbar's "Choose pattern"
-						// button.
-						array( 'patternPicked' => true ),
-					),
-					array(
-						'core/paragraph',
-						array(
-							'placeholder' => __(
-								// phpcs:ignore Generic.Files.LineLength.TooLong
-								'Add a description of the event and let people know what to expect, including the agenda, what they need to bring, and how to find the group.',
-								'gatherpress'
-							),
-						),
-					),
-					array(
-						'gatherpress/rsvp-response',
-						// Marking the attribute pre-picked tells the block to
-						// skip the pattern-picker UI and seed the default
-						// layout directly — this is the canonical auto-loaded
-						// instance, not a fresh manual insert. Users who want
-						// a different layout can still trigger the picker via
-						// the block toolbar's "Choose pattern" button.
-						array( 'patternPicked' => true ),
-					),
-				),
-				// @todo continue to work on the event-template.
-				// 'template'      => array(
-				// array( 'core/pattern', array( 'slug' => 'gatherpress/event-template' ) ),
-				// ),
 				'menu_position' => 4,
 				'supports'      => array(
 					'title',
@@ -270,10 +222,85 @@ class Setup {
 		}
 		return $slug;
 	}
+
 	/**
-	 * Register a rewrite rule and query var for serving .ics calendar downloads.
+	 * Register the user-facing "Event with RSVP" starter pattern.
 	 *
-	 * This adds support for URLs like /events/my-event.ics that serve
+	 * Scopes to every post type declaring `gatherpress-event-date`
+	 * support so the WordPress block editor's starter pattern modal —
+	 * the same UX Twenty Twenty-Five uses on new pages — surfaces this
+	 * pattern when authors create a new event. Companion plugins that
+	 * declare the support on custom event post types get the chooser
+	 * for free.
+	 *
+	 * Per-user dismissal is handled by the modal's own "Always show
+	 * starter patterns for new pages" toggle, so no site-wide setting
+	 * is needed here.
+	 *
+	 * The wrapper-`<div>` blocks (add-to-calendar, online-event, rsvp,
+	 * rsvp-response) include the empty wrapper in their serialized
+	 * markup so the block parser's view matches the empty-state output
+	 * of each block's `save()` — without this, the editor flags
+	 * "unexpected or invalid content" on insert. Each block's edit
+	 * component then seeds its own inner-block template at runtime so
+	 * the user sees the populated UI immediately.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function register_starter_pattern(): void {
+		$post_types = get_post_types_by_support( 'gatherpress-event-date' );
+
+		if ( empty( $post_types ) ) {
+			return;
+		}
+
+		$paragraph_placeholder = __(
+			// phpcs:ignore Generic.Files.LineLength.TooLong
+			'Add a description of the event and let people know what to expect, including the agenda, what they need to bring, and how to find the group.',
+			'gatherpress'
+		);
+
+		$content  = '<!-- wp:gatherpress/event-date /-->';
+		$content .= '<!-- wp:gatherpress/add-to-calendar -->';
+		$content .= '<div class="wp-block-gatherpress-add-to-calendar"></div>';
+		$content .= '<!-- /wp:gatherpress/add-to-calendar -->';
+		$content .= '<!-- wp:gatherpress/venue {"patternPicked":true} /-->';
+		$content .= '<!-- wp:gatherpress/online-event -->';
+		$content .= '<div class="wp-block-gatherpress-online-event"></div>';
+		$content .= '<!-- /wp:gatherpress/online-event -->';
+		$content .= '<!-- wp:gatherpress/rsvp {"patternPicked":true} -->';
+		$content .= '<div class="wp-block-gatherpress-rsvp"></div>';
+		$content .= '<!-- /wp:gatherpress/rsvp -->';
+		$content .= sprintf(
+			'<!-- wp:paragraph {"placeholder":%s} --><p></p><!-- /wp:paragraph -->',
+			wp_json_encode( $paragraph_placeholder )
+		);
+		$content .= '<!-- wp:gatherpress/rsvp-response {"patternPicked":true} -->';
+		$content .= '<div class="wp-block-gatherpress-rsvp-response"></div>';
+		$content .= '<!-- /wp:gatherpress/rsvp-response -->';
+
+		register_block_pattern(
+			'gatherpress/event-with-rsvp',
+			array(
+				'title'       => __( 'Event with RSVP', 'gatherpress' ),
+				'description' => __(
+					'Date, calendar link, venue, online link, RSVP, description, and attendee list.',
+					'gatherpress'
+				),
+				'content'     => $content,
+				'blockTypes'  => array( 'core/post-content' ),
+				'postTypes'   => $post_types,
+				'source'      => 'plugin',
+			)
+		);
+	}
+
+	/**
+	 * Register the calendar rewrite rule for ICS file URLs.
+	 *
+	 * Sets up the URL pattern /event-slug/event-name.ics that serves
 	 * dynamically generated ICS files for individual events. The URL slug
 	 * matches the configured event post type slug from GatherPress settings.
 	 *

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -19,6 +19,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Feed;
 use GatherPress\Core\Rsvp\Rsvp;
 use GatherPress\Core\Settings;
+use GatherPress\Core\Starter_Pattern_Loader;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP;
@@ -224,26 +225,20 @@ class Setup {
 	}
 
 	/**
-	 * Register the user-facing "Event with RSVP" starter pattern.
+	 * Register the user-facing event starter patterns.
 	 *
-	 * Scopes to every post type declaring `gatherpress-event-date`
-	 * support so the WordPress block editor's starter pattern modal —
-	 * the same UX Twenty Twenty-Five uses on new pages — surfaces this
-	 * pattern when authors create a new event. Companion plugins that
-	 * declare the support on custom event post types get the chooser
-	 * for free.
+	 * Loads every pattern definition from `includes/core/templates/event/`
+	 * (each file returns a `name/title/description/content` array), runs
+	 * the list through the `gatherpress_event_starter_patterns` filter so
+	 * third parties can append their own, and registers each entry scoped
+	 * to `core/post-content` plus every post type declaring
+	 * `gatherpress-event-date` support. The block editor's starter pattern
+	 * modal — the same UX Twenty Twenty-Five uses on new pages — then
+	 * surfaces them when authors create a new event.
 	 *
 	 * Per-user dismissal is handled by the modal's own "Always show
 	 * starter patterns for new pages" toggle, so no site-wide setting
 	 * is needed here.
-	 *
-	 * The wrapper-`<div>` blocks (add-to-calendar, online-event, rsvp,
-	 * rsvp-response) include the empty wrapper in their serialized
-	 * markup so the block parser's view matches the empty-state output
-	 * of each block's `save()` — without this, the editor flags
-	 * "unexpected or invalid content" on insert. Each block's edit
-	 * component then seeds its own inner-block template at runtime so
-	 * the user sees the populated UI immediately.
 	 *
 	 * @since 1.0.0
 	 *
@@ -256,45 +251,44 @@ class Setup {
 			return;
 		}
 
-		$paragraph_placeholder = __(
-			// phpcs:ignore Generic.Files.LineLength.TooLong
-			'Add a description of the event and let people know what to expect, including the agenda, what they need to bring, and how to find the group.',
-			'gatherpress'
+		$patterns = Starter_Pattern_Loader::load(
+			GATHERPRESS_CORE_PATH . '/includes/core/templates/event'
 		);
 
-		$content  = '<!-- wp:gatherpress/event-date /-->';
-		$content .= '<!-- wp:gatherpress/add-to-calendar -->';
-		$content .= '<div class="wp-block-gatherpress-add-to-calendar"></div>';
-		$content .= '<!-- /wp:gatherpress/add-to-calendar -->';
-		$content .= '<!-- wp:gatherpress/venue {"patternPicked":true} /-->';
-		$content .= '<!-- wp:gatherpress/online-event -->';
-		$content .= '<div class="wp-block-gatherpress-online-event"></div>';
-		$content .= '<!-- /wp:gatherpress/online-event -->';
-		$content .= '<!-- wp:gatherpress/rsvp {"patternPicked":true} -->';
-		$content .= '<div class="wp-block-gatherpress-rsvp"></div>';
-		$content .= '<!-- /wp:gatherpress/rsvp -->';
-		$content .= sprintf(
-			'<!-- wp:paragraph {"placeholder":%s} --><p></p><!-- /wp:paragraph -->',
-			wp_json_encode( $paragraph_placeholder )
-		);
-		$content .= '<!-- wp:gatherpress/rsvp-response {"patternPicked":true} -->';
-		$content .= '<div class="wp-block-gatherpress-rsvp-response"></div>';
-		$content .= '<!-- /wp:gatherpress/rsvp-response -->';
+		/**
+		 * Filters the array of event starter pattern definitions.
+		 *
+		 * Each entry is an associative array with `name`, `title`,
+		 * `description`, and `content` keys. Returned patterns are
+		 * registered with `core/post-content` `blockTypes` scoping plus
+		 * every post type declaring `gatherpress-event-date` support, so
+		 * they appear in the new-event chooser modal for any post type
+		 * acting as an event source.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array $patterns Pattern definitions loaded from the
+		 *                        `includes/core/templates/event/` directory.
+		 */
+		$patterns = apply_filters( 'gatherpress_event_starter_patterns', $patterns );
 
-		register_block_pattern(
-			'gatherpress/event-with-rsvp',
-			array(
-				'title'       => __( 'Event with RSVP', 'gatherpress' ),
-				'description' => __(
-					'Date, calendar link, venue, online link, RSVP, description, and attendee list.',
-					'gatherpress'
-				),
-				'content'     => $content,
-				'blockTypes'  => array( 'core/post-content' ),
-				'postTypes'   => $post_types,
-				'source'      => 'plugin',
-			)
-		);
+		foreach ( (array) $patterns as $pattern ) {
+			if ( ! is_array( $pattern ) || empty( $pattern['name'] ) ) {
+				continue;
+			}
+
+			register_block_pattern(
+				$pattern['name'],
+				array(
+					'title'       => $pattern['title'] ?? '',
+					'description' => $pattern['description'] ?? '',
+					'content'     => $pattern['content'] ?? '',
+					'blockTypes'  => array( 'core/post-content' ),
+					'postTypes'   => $post_types,
+					'source'      => 'plugin',
+				)
+			);
+		}
 	}
 
 	/**

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -22,6 +22,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 use GatherPress\Core\Event\Event;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Shadow_Source;
+use GatherPress\Core\Starter_Pattern_Loader;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Venue\Map\Setup as Map_Setup;
@@ -270,14 +271,16 @@ class Setup {
 	}
 
 	/**
-	 * Register the user-facing "Venue with Map" starter pattern.
+	 * Register the user-facing venue starter patterns.
 	 *
-	 * Scopes to every post type declaring `gatherpress-venue-information`
-	 * support so the WordPress block editor's starter pattern modal —
-	 * the same UX Twenty Twenty-Five uses on new pages — surfaces this
-	 * pattern when authors create a new venue. Companion plugins that
-	 * declare the support on custom venue post types get the chooser
-	 * for free.
+	 * Loads every pattern definition from `includes/core/templates/venue/`
+	 * (each file returns a `name/title/description/content` array), runs
+	 * the list through the `gatherpress_venue_starter_patterns` filter so
+	 * third parties can append their own, and registers each entry scoped
+	 * to `core/post-content` plus every post type declaring
+	 * `gatherpress-venue-information` support. The block editor's starter
+	 * pattern modal — the same UX Twenty Twenty-Five uses on new pages —
+	 * then surfaces them when authors create a new venue.
 	 *
 	 * Per-user dismissal is handled by the modal's own "Always show
 	 * starter patterns for new pages" toggle, so no site-wide setting
@@ -294,20 +297,44 @@ class Setup {
 			return;
 		}
 
-		register_block_pattern(
-			'gatherpress/venue-with-map',
-			array(
-				'title'       => __( 'Venue with Map', 'gatherpress' ),
-				'description' => __(
-					'Address, contact details, and an embedded map.',
-					'gatherpress'
-				),
-				'content'     => '<!-- wp:gatherpress/venue {"patternPicked":true} /-->',
-				'blockTypes'  => array( 'core/post-content' ),
-				'postTypes'   => $post_types,
-				'source'      => 'plugin',
-			)
+		$patterns = Starter_Pattern_Loader::load(
+			GATHERPRESS_CORE_PATH . '/includes/core/templates/venue'
 		);
+
+		/**
+		 * Filters the array of venue starter pattern definitions.
+		 *
+		 * Each entry is an associative array with `name`, `title`,
+		 * `description`, and `content` keys. Returned patterns are
+		 * registered with `core/post-content` `blockTypes` scoping plus
+		 * every post type declaring `gatherpress-venue-information`
+		 * support, so they appear in the new-venue chooser modal for any
+		 * post type acting as a venue source.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array $patterns Pattern definitions loaded from the
+		 *                        `includes/core/templates/venue/` directory.
+		 */
+		$patterns = apply_filters( 'gatherpress_venue_starter_patterns', $patterns );
+
+		foreach ( (array) $patterns as $pattern ) {
+			if ( ! is_array( $pattern ) || empty( $pattern['name'] ) ) {
+				continue;
+			}
+
+			register_block_pattern(
+				$pattern['name'],
+				array(
+					'title'       => $pattern['title'] ?? '',
+					'description' => $pattern['description'] ?? '',
+					'content'     => $pattern['content'] ?? '',
+					'blockTypes'  => array( 'core/post-content' ),
+					'postTypes'   => $post_types,
+					'source'      => 'plugin',
+				)
+			);
+		}
 	}
 
 	/**

--- a/includes/core/templates/event/event-with-rsvp.php
+++ b/includes/core/templates/event/event-with-rsvp.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * "Event with RSVP" starter pattern.
+ *
+ * Seeds the canonical event layout when chosen from the block editor's
+ * starter pattern modal: event-date + add-to-calendar + venue +
+ * online-event + rsvp + description paragraph + rsvp-response.
+ *
+ * Wrapper-`<div>` blocks (add-to-calendar, online-event, rsvp,
+ * rsvp-response) include the empty wrapper in their serialized markup
+ * so the parser's view matches the empty-state output of each block's
+ * `save()` — without it, the editor flags "unexpected or invalid
+ * content" on insert. Each block's edit component then seeds its own
+ * inner-block template at runtime.
+ *
+ * Venue / RSVP / RSVP Response carry `patternPicked: true` so their
+ * in-block pattern pickers stay suppressed — those layouts are seeded
+ * here as the canonical default, not a fresh manual insert.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+$gatherpress_paragraph_placeholder = wp_json_encode(
+	__(
+		// phpcs:ignore Generic.Files.LineLength.TooLong -- Single translator-facing sentence; keep on one line for the .pot extractor.
+		'Add a description of the event and let people know what to expect, including the agenda, what they need to bring, and how to find the group.',
+		'gatherpress'
+	)
+);
+
+return array(
+	'name'        => 'gatherpress/event-with-rsvp',
+	'title'       => __( 'Event with RSVP', 'gatherpress' ),
+	'description' => __(
+		'Date, calendar link, venue, online link, RSVP, description, and attendee list.',
+		'gatherpress'
+	),
+	'content'     => <<<HTML
+<!-- wp:gatherpress/event-date /-->
+<!-- wp:gatherpress/add-to-calendar -->
+<div class="wp-block-gatherpress-add-to-calendar"></div>
+<!-- /wp:gatherpress/add-to-calendar -->
+<!-- wp:gatherpress/venue {"patternPicked":true} /-->
+<!-- wp:gatherpress/online-event -->
+<div class="wp-block-gatherpress-online-event"></div>
+<!-- /wp:gatherpress/online-event -->
+<!-- wp:gatherpress/rsvp {"patternPicked":true} -->
+<div class="wp-block-gatherpress-rsvp"></div>
+<!-- /wp:gatherpress/rsvp -->
+<!-- wp:paragraph {"placeholder":$gatherpress_paragraph_placeholder} -->
+<p></p>
+<!-- /wp:paragraph -->
+<!-- wp:gatherpress/rsvp-response {"patternPicked":true} -->
+<div class="wp-block-gatherpress-rsvp-response"></div>
+<!-- /wp:gatherpress/rsvp-response -->
+HTML
+	,
+);

--- a/includes/core/templates/venue/venue-with-map.php
+++ b/includes/core/templates/venue/venue-with-map.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * "Venue with Map" starter pattern.
+ *
+ * Seeds a single `gatherpress/venue` block (address + phone + website +
+ * embedded map) when chosen from the block editor's starter pattern
+ * modal. `patternPicked: true` skips the venue block's in-block pattern
+ * picker so the canonical layout renders directly; authors can still
+ * swap layouts via the block toolbar's "Choose pattern" action.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+return array(
+	'name'        => 'gatherpress/venue-with-map',
+	'title'       => __( 'Venue with Map', 'gatherpress' ),
+	'description' => __(
+		'Address, contact details, and an embedded map.',
+		'gatherpress'
+	),
+	'content'     => '<!-- wp:gatherpress/venue {"patternPicked":true} /-->',
+);

--- a/test/unit/php/fixtures/starter-pattern-loader/valid/missing-name.php
+++ b/test/unit/php/fixtures/starter-pattern-loader/valid/missing-name.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Test fixture — array without a `name` key. The loader skips entries
+ * like this so callers never try to register a nameless pattern.
+ *
+ * @package GatherPress\Tests
+ * @since 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+return array(
+	'content' => '<p>nope</p>',
+);

--- a/test/unit/php/fixtures/starter-pattern-loader/valid/non-array.php
+++ b/test/unit/php/fixtures/starter-pattern-loader/valid/non-array.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Test fixture — file that returns a non-array value. The loader
+ * skips these so non-pattern files in the directory don't break it.
+ *
+ * @package GatherPress\Tests
+ * @since 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+return 'not an array';

--- a/test/unit/php/fixtures/starter-pattern-loader/valid/valid-pattern.php
+++ b/test/unit/php/fixtures/starter-pattern-loader/valid/valid-pattern.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Test fixture — valid starter pattern definition.
+ *
+ * @package GatherPress\Tests
+ * @since 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+return array(
+	'name'        => 'unit-test/valid',
+	'title'       => 'Valid',
+	'description' => 'Valid pattern fixture.',
+	'content'     => '<p>ok</p>',
+);

--- a/test/unit/php/includes/tests/core/classes/class-test-starter-pattern-loader.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-starter-pattern-loader.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Class handles unit tests for GatherPress\Core\Starter_Pattern_Loader.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Core;
+
+use GatherPress\Core\Starter_Pattern_Loader;
+use GatherPress\Tests\Base;
+
+/**
+ * Class Test_Starter_Pattern_Loader.
+ *
+ * @coversDefaultClass \GatherPress\Core\Starter_Pattern_Loader
+ */
+class Test_Starter_Pattern_Loader extends Base {
+	/**
+	 * Loads each `*.php` file in the fixtures directory and returns the
+	 * union of their pattern definitions, skipping anything that does
+	 * not return an array with a `name` key (the fixtures cover both
+	 * the missing-name and non-array branches).
+	 *
+	 * @covers ::load
+	 *
+	 * @return void
+	 */
+	public function test_load_collects_pattern_definitions(): void {
+		$dir = dirname( __DIR__, 4 ) . '/fixtures/starter-pattern-loader/valid';
+
+		$patterns = Starter_Pattern_Loader::load( $dir );
+
+		$this->assertCount(
+			1,
+			$patterns,
+			'Loader should return only the entries that supplied a name.'
+		);
+		$this->assertSame( 'unit-test/valid', $patterns[0]['name'] );
+	}
+
+	/**
+	 * Returns an empty array when the directory has no `*.php` files —
+	 * lets callers safely apply their filter and `foreach` without an
+	 * explicit empty-check.
+	 *
+	 * @covers ::load
+	 *
+	 * @return void
+	 */
+	public function test_load_returns_empty_array_for_empty_directory(): void {
+		$dir = dirname( __DIR__, 4 ) . '/fixtures/starter-pattern-loader/empty';
+
+		$patterns = Starter_Pattern_Loader::load( $dir );
+
+		$this->assertSame( array(), $patterns );
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -281,6 +281,47 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * Third parties can append their own pattern definitions via the
+	 * `gatherpress_event_starter_patterns` filter without having to
+	 * call `register_block_pattern()` themselves.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_filter_extends(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'unit-test/extra-event-pattern' ) ) {
+			$registry->unregister( 'unit-test/extra-event-pattern' );
+		}
+
+		$append_pattern = static function ( array $patterns ): array {
+			$patterns[] = array(
+				'name'        => 'unit-test/extra-event-pattern',
+				'title'       => 'Extra Event Pattern',
+				'description' => 'Added through the filter.',
+				'content'     => '<!-- wp:paragraph --><p>Extra</p><!-- /wp:paragraph -->',
+			);
+			return $patterns;
+		};
+
+		add_filter( 'gatherpress_event_starter_patterns', $append_pattern );
+
+		$instance->register_starter_pattern();
+
+		remove_filter( 'gatherpress_event_starter_patterns', $append_pattern );
+
+		$this->assertTrue(
+			$registry->is_registered( 'unit-test/extra-event-pattern' ),
+			'Patterns appended via the filter must be registered alongside the bundled defaults.'
+		);
+
+		$registry->unregister( 'unit-test/extra-event-pattern' );
+	}
+
+	/**
 	 * Bails before registering when no post type declares
 	 * `gatherpress-event-date` support. Without the guard,
 	 * `register_block_pattern` would be called with an empty

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -20,6 +20,7 @@ use PMC\Unit_Test\Utility;
 use stdClass;
 use WP;
 use WP_Block;
+use WP_Block_Patterns_Registry;
 use WP_REST_Request;
 
 /**
@@ -99,6 +100,12 @@ class Test_Setup extends Base {
 				'name'     => 'init',
 				'priority' => 10,
 				'callback' => array( $instance, 'register_calendar_rewrite_rule' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'init',
+				'priority' => 11,
+				'callback' => array( $instance, 'register_starter_pattern' ),
 			),
 			array(
 				'type'     => 'action',
@@ -221,6 +228,95 @@ class Test_Setup extends Base {
 			implode( '', $wp_rewrite->rules ),
 			"The 'gatherpress_ics' query parameter was not found in any rewrite rule"
 		);
+	}
+
+	/**
+	 * Registers the user-facing starter pattern scoped to core/post-content
+	 * and every post type declaring `gatherpress-event-date` so the starter
+	 * pattern modal surfaces it on new event posts.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'gatherpress/event-with-rsvp' ) ) {
+			$registry->unregister( 'gatherpress/event-with-rsvp' );
+		}
+
+		$instance->register_starter_pattern();
+
+		$this->assertTrue(
+			$registry->is_registered( 'gatherpress/event-with-rsvp' ),
+			'Starter pattern should be registered.'
+		);
+
+		$pattern = $registry->get_registered( 'gatherpress/event-with-rsvp' );
+
+		$this->assertContains(
+			'core/post-content',
+			$pattern['blockTypes'],
+			'Starter pattern must scope to core/post-content so the chooser modal surfaces it.'
+		);
+		$this->assertContains(
+			Event::POST_TYPE,
+			$pattern['postTypes'],
+			'Starter pattern must scope to gatherpress_event post type.'
+		);
+		$this->assertStringContainsString(
+			'gatherpress/event-date',
+			$pattern['content'],
+			'Starter pattern body must seed the event-date block.'
+		);
+		$this->assertStringContainsString(
+			'"patternPicked":true',
+			$pattern['content'],
+			'Wrapper-div blocks must be flagged pattern-picked so the nested pickers stay suppressed.'
+		);
+
+		$registry->unregister( 'gatherpress/event-with-rsvp' );
+	}
+
+	/**
+	 * Bails before registering when no post type declares
+	 * `gatherpress-event-date` support. Without the guard,
+	 * `register_block_pattern` would be called with an empty
+	 * `postTypes` array and the chooser modal would have no
+	 * post-type scope to match against.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_bails_without_supported_post_types(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'gatherpress/event-with-rsvp' ) ) {
+			$registry->unregister( 'gatherpress/event-with-rsvp' );
+		}
+
+		// Strip the support from every post type that currently declares
+		// it so `get_post_types_by_support()` returns an empty array.
+		$supported = get_post_types_by_support( 'gatherpress-event-date' );
+		foreach ( $supported as $post_type ) {
+			remove_post_type_support( $post_type, 'gatherpress-event-date' );
+		}
+
+		$instance->register_starter_pattern();
+
+		$this->assertFalse(
+			$registry->is_registered( 'gatherpress/event-with-rsvp' ),
+			'Starter pattern must not be registered when no post type declares the event-date support.'
+		);
+
+		// Restore support.
+		foreach ( $supported as $post_type ) {
+			add_post_type_support( $post_type, 'gatherpress-event-date' );
+		}
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -322,6 +322,44 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * Filter callbacks may return entries that aren't valid pattern
+	 * definitions (missing `name`, non-array values). The registration
+	 * loop must skip those gracefully so one bad entry from a
+	 * third-party filter doesn't bring down the rest of the chooser.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_skips_malformed_filter_entries(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'gatherpress/event-with-rsvp' ) ) {
+			$registry->unregister( 'gatherpress/event-with-rsvp' );
+		}
+
+		$inject_garbage = static function ( array $patterns ): array {
+			$patterns[] = array( 'title' => 'No name key — must be skipped.' );
+			$patterns[] = 'not-an-array — must be skipped.';
+			return $patterns;
+		};
+
+		add_filter( 'gatherpress_event_starter_patterns', $inject_garbage );
+
+		$instance->register_starter_pattern();
+
+		remove_filter( 'gatherpress_event_starter_patterns', $inject_garbage );
+
+		$this->assertTrue(
+			$registry->is_registered( 'gatherpress/event-with-rsvp' ),
+			'Bundled pattern should still register when filter entries before/after it are malformed.'
+		);
+
+		$registry->unregister( 'gatherpress/event-with-rsvp' );
+	}
+
+	/**
 	 * Bails before registering when no post type declares
 	 * `gatherpress-event-date` support. Without the guard,
 	 * `register_block_pattern` would be called with an empty

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -284,6 +284,47 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * Third parties can append their own pattern definitions via the
+	 * `gatherpress_venue_starter_patterns` filter without having to
+	 * call `register_block_pattern()` themselves.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_filter_extends(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'unit-test/extra-venue-pattern' ) ) {
+			$registry->unregister( 'unit-test/extra-venue-pattern' );
+		}
+
+		$append_pattern = static function ( array $patterns ): array {
+			$patterns[] = array(
+				'name'        => 'unit-test/extra-venue-pattern',
+				'title'       => 'Extra Venue Pattern',
+				'description' => 'Added through the filter.',
+				'content'     => '<!-- wp:paragraph --><p>Extra</p><!-- /wp:paragraph -->',
+			);
+			return $patterns;
+		};
+
+		add_filter( 'gatherpress_venue_starter_patterns', $append_pattern );
+
+		$instance->register_starter_pattern();
+
+		remove_filter( 'gatherpress_venue_starter_patterns', $append_pattern );
+
+		$this->assertTrue(
+			$registry->is_registered( 'unit-test/extra-venue-pattern' ),
+			'Patterns appended via the filter must be registered alongside the bundled defaults.'
+		);
+
+		$registry->unregister( 'unit-test/extra-venue-pattern' );
+	}
+
+	/**
 	 * Coverage for get_venue_meta method.
 	 *
 	 * @covers ::get_venue_meta

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -205,6 +205,44 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * Filter callbacks may return entries that aren't valid pattern
+	 * definitions (missing `name`, non-array values). The registration
+	 * loop must skip those gracefully so one bad entry from a
+	 * third-party filter doesn't bring down the rest of the chooser.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_skips_malformed_filter_entries(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'gatherpress/venue-with-map' ) ) {
+			$registry->unregister( 'gatherpress/venue-with-map' );
+		}
+
+		$inject_garbage = static function ( array $patterns ): array {
+			$patterns[] = array( 'title' => 'No name key — must be skipped.' );
+			$patterns[] = 'not-an-array — must be skipped.';
+			return $patterns;
+		};
+
+		add_filter( 'gatherpress_venue_starter_patterns', $inject_garbage );
+
+		$instance->register_starter_pattern();
+
+		remove_filter( 'gatherpress_venue_starter_patterns', $inject_garbage );
+
+		$this->assertTrue(
+			$registry->is_registered( 'gatherpress/venue-with-map' ),
+			'Bundled pattern should still register when filter entries before/after it are malformed.'
+		);
+
+		$registry->unregister( 'gatherpress/venue-with-map' );
+	}
+
+	/**
 	 * Bails before registering when no post type declares
 	 * `gatherpress-venue-information` support. Without the guard,
 	 * `register_block_pattern` would be called with an empty


### PR DESCRIPTION
### Description of the Change

Mirrors the venue starter pattern work — replaces the always-on auto-loaded event template with WordPress's "Choose a pattern" starter modal (the same UX Twenty Twenty-Five uses on new pages). New events open the modal with a single **Event with RSVP** pattern that seeds the canonical layout: event-date + add-to-calendar + venue + online-event + RSVP + description paragraph + rsvp-response.

The pattern is registered via `register_block_pattern` scoped to `core/post-content` + `get_post_types_by_support( 'gatherpress-event-date' )`, hooked on `init` priority 11 so any post type declaring the support gets the chooser. The block markup is hardcoded so wrapper-`<div>` blocks (`add-to-calendar`, `online-event`, `rsvp`, `rsvp-response`) carry the empty wrapper that matches each block's `save()` empty-state output — without it the parser flags "unexpected or invalid content" on insert. Venue / RSVP / rsvp-response ship with `patternPicked: true` so their in-block pickers stay suppressed.

The `template` arg has been removed from the event post type. The `gatherpress/event-template` pattern remains as a Block Hooks anchor for companion plugins.

Closes #1576

### How to test the Change

1. Create a new event (`/wp-admin/post-new.php?post_type=gatherpress_event`) — modal appears with the "Event with RSVP" preview. Click it and confirm the canonical layout inserts (date, calendar link, venue card, online event, RSVP button, description paragraph, attendee list).
2. Confirm none of the inserted blocks show "Block contains unexpected or invalid content."
3. Confirm the venue / RSVP / rsvp-response blocks do **not** show their own in-block pattern pickers — those are skipped by `patternPicked`.

### Changelog Entry

> Added - "Choose a pattern" starter modal on new events with a default "Event with RSVP" pattern.

### Credits

Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.