### PR TITLE
WordPress conventions cleanup + settings tweaks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,22 @@ When working with this codebase:
     - ✅ Good (in `GatherPress\Core\Event\Admin_List`): `use GatherPress\Core\Venue\Setup as Venue_Setup;` → `Venue_Setup::get_instance()`
     - ❌ Bad (silently shadows the local `Event\Setup`): `use GatherPress\Core\Venue\Setup;` → `Setup::get_instance()`
     - Within one subsystem (e.g. `Event\Admin_List` referencing `Event\Query`), no alias needed.
+- **Class body opens with a blank line**: Every `class|trait|interface Foo {` declaration is followed by an empty line before the first member, matching WordPress core's house style. Don't let the first docblock or `use` statement sit flush against the opening brace.
+    - ✅ Good:
+
+        ```php
+        class Setup {
+
+            /**
+             * Enforces a single instance of this class.
+             */
+            use Singleton;
+        ```
+
+    - ❌ Bad: `class Setup {` immediately followed by `\t/**` on the next line.
+- **Prefer `str_contains` / `str_starts_with` / `str_ends_with` over `strpos`**: WordPress ships polyfills for these PHP 8 string helpers back to PHP 7.0, so they're safe under our PHP 7.4 floor. They read better than the `false ===` / `0 ===` dance and SonarCloud flags the legacy form.
+    - ✅ Good: `if ( str_contains( $haystack, $needle ) )` / `if ( str_starts_with( $key, 'gatherpress_' ) )` / `if ( ! str_contains( $content, $token ) )`
+    - ❌ Bad: `if ( false !== strpos( $haystack, $needle ) )` / `if ( 0 === strpos( $key, 'gatherpress_' ) )` / `if ( false === strpos( $content, $token ) )`
 - **Method organization**: Place related methods in logically grouped classes (e.g., form-related methods in `Rsvp_Form`)
 - **Singleton pattern**: Many GatherPress classes use the Singleton trait - check if a class has `use Singleton;`
     - **Singleton classes** (Blocks, Settings, Setup classes): Use `ClassName::get_instance()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,17 @@ When working with JavaScript code:
     - ❌ Bad: `// Check if this is a form-field block with guest count field name`
 - **Comment consistency**: Apply the same punctuation standards across PHP and JavaScript for consistency
 - **Block comments**: Multi-line JSDoc comments should follow proper formatting with periods in descriptions
+- **Dependency-section docblocks have no trailing period**: The `WordPress dependencies` / `Internal dependencies` / `External dependencies` (and `Mock …` test variants) section headers above import groups are labels, not sentences — leave the period off.
+    - ✅ Good:
+
+        ```js
+        /**
+         * WordPress dependencies
+         */
+        import { __ } from '@wordpress/i18n';
+        ```
+
+    - ❌ Bad: `* WordPress dependencies.` (with the period)
 
 ## Known Issues / Technical Debt
 

--- a/includes/core/classes/blocks/class-add-to-calendar.php
+++ b/includes/core/classes/blocks/class-add-to-calendar.php
@@ -27,6 +27,7 @@ use WP_HTML_Tag_Processor;
  * @since 1.0.0
  */
 class Add_To_Calendar {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-dropdown-item.php
+++ b/includes/core/classes/blocks/class-dropdown-item.php
@@ -25,6 +25,7 @@ use WP_HTML_Tag_Processor;
  * @since 1.0.0
  */
 class Dropdown_Item {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-dropdown.php
+++ b/includes/core/classes/blocks/class-dropdown.php
@@ -25,6 +25,7 @@ use WP_HTML_Tag_Processor;
  * @since 1.0.0
  */
 class Dropdown {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-event-date.php
+++ b/includes/core/classes/blocks/class-event-date.php
@@ -25,6 +25,7 @@ use GatherPress\Core\Traits\Singleton;
  * @since 1.0.0
  */
 class Event_Date {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -25,6 +25,7 @@ use WP_REST_Request;
  * @since 1.0.0
  */
 class Event_Query {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-form-field.php
+++ b/includes/core/classes/blocks/class-form-field.php
@@ -24,6 +24,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  * @since 1.0.0
  */
 class Form_Field {
+
 	/**
 	 * Processed form field attributes with defaults applied.
 	 *

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -30,6 +30,7 @@ use WP_HTML_Tag_Processor;
  * @since 1.0.0
  */
 class General_Block {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-modal-manager.php
+++ b/includes/core/classes/blocks/class-modal-manager.php
@@ -26,6 +26,7 @@ use WP_HTML_Tag_Processor;
  * @since 1.0.0
  */
 class Modal_Manager {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-modal.php
+++ b/includes/core/classes/blocks/class-modal.php
@@ -27,6 +27,7 @@ use WP_HTML_Tag_Processor;
  * @since 1.0.0
  */
 class Modal {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -23,6 +23,7 @@ use WP_Block;
  * @since 1.0.0
  */
 class Online_Event {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -31,6 +31,7 @@ use WP_HTML_Tag_Processor;
  * @since 1.0.0
  */
 class Rsvp_Form {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -29,6 +29,7 @@ use WP_User;
  * @since 1.0.0
  */
 class Rsvp_Response {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -31,6 +31,7 @@ use WP_HTML_Tag_Processor;
  * @since 1.0.0
  */
 class Rsvp_Template {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -28,6 +28,7 @@ use WP_HTML_Tag_Processor;
  * @since 1.0.0
  */
 class Rsvp {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-setup.php
+++ b/includes/core/classes/blocks/class-setup.php
@@ -25,6 +25,7 @@ use WP_Post;
  * @since 1.0.0
  */
 class Setup {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/blocks/class-venue.php
+++ b/includes/core/classes/blocks/class-venue.php
@@ -27,6 +27,7 @@ use WP_Post;
  * @since 1.0.0
  */
 class Venue {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -23,6 +23,7 @@ use GatherPress\Core\Traits\Singleton;
  * @since 1.0.0
  */
 class Assets {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-autoloader.php
+++ b/includes/core/classes/class-autoloader.php
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  * @since 1.0.0
  */
 class Autoloader {
+
 	/**
 	 * Register method for autoloader.
 	 *
@@ -71,8 +72,8 @@ class Autoloader {
 
 					if (
 						empty( $class_string ) ||
-						false === strpos( $class_string, '\\' ) ||
-						0 !== strpos( $class_string, $namespace_root )
+						! str_contains( $class_string, '\\' ) ||
+						! str_starts_with( $class_string, $namespace_root )
 					) {
 						continue;
 					}

--- a/includes/core/classes/class-cli.php
+++ b/includes/core/classes/class-cli.php
@@ -28,6 +28,7 @@ use WP_CLI;
  * @since 1.0.0
  */
 class Cli {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-coexistence-guard.php
+++ b/includes/core/classes/class-coexistence-guard.php
@@ -29,6 +29,7 @@ use GatherPress\Core\Traits\Singleton;
  * @since 1.0.0
  */
 class Coexistence_Guard {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -119,7 +120,7 @@ class Coexistence_Guard {
 				continue;
 			}
 
-			if ( $slug !== $folder && 0 !== strpos( $folder, $folder_prefix ) ) {
+			if ( $slug !== $folder && ! str_starts_with( $folder, $folder_prefix ) ) {
 				continue;
 			}
 

--- a/includes/core/classes/class-export.php
+++ b/includes/core/classes/class-export.php
@@ -24,6 +24,7 @@ use WP_Post;
  * @since 1.0.0
  */
 class Export extends Migrate {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -27,6 +27,7 @@ use WP_Query;
  * @since 1.0.0
  */
 class Feed {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -32,6 +32,7 @@ use WP_REST_Server;
  * @since 1.0.0
  */
 class Geocoding {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-import.php
+++ b/includes/core/classes/class-import.php
@@ -25,6 +25,7 @@ use GatherPress\Core\Traits\Singleton;
  * @since 1.0.0
  */
 class Import extends Migrate {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-migrate.php
+++ b/includes/core/classes/class-migrate.php
@@ -22,6 +22,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  * @since 1.0.0
  */
 class Migrate {
+
 	/**
 	 * List of non-existent post_meta keys with array values containing getter and setter callback definitions.
 	 *

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -25,6 +25,7 @@ use GatherPress\Core\Traits\Singleton;
  * @since 1.0.0
  */
 class Settings {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -26,6 +26,7 @@ use WP_Site;
  * @since 1.0.0
  */
 class Setup {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-shadow-source.php
+++ b/includes/core/classes/class-shadow-source.php
@@ -41,6 +41,7 @@ use WP_Term;
  * @since 1.0.0
  */
 class Shadow_Source {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-starter-pattern-loader.php
+++ b/includes/core/classes/class-starter-pattern-loader.php
@@ -28,6 +28,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  * @since 1.0.0
  */
 class Starter_Pattern_Loader {
+
 	/**
 	 * Load every starter pattern definition found in a directory.
 	 *

--- a/includes/core/classes/class-topic.php
+++ b/includes/core/classes/class-topic.php
@@ -23,6 +23,7 @@ use GatherPress\Core\Traits\Singleton;
  * @since 1.0.0
  */
 class Topic {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/class-user.php
+++ b/includes/core/classes/class-user.php
@@ -29,6 +29,7 @@ use WP_User;
  * @since 1.0.0
  */
 class User {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -98,7 +99,7 @@ class User {
 			if ( static::HOUR_12 === $user_time_format ) {
 				$time_format = str_replace( 'G', 'g', $time_format );
 
-				if ( false === strpos( $time_format, 'a' ) ) {
+				if ( ! str_contains( $time_format, 'a' ) ) {
 					$time_format = str_replace( 'i', 'ia', $time_format );
 				}
 			} elseif ( static::HOUR_24 === $user_time_format ) {

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -25,6 +25,7 @@ use WP_HTML_Tag_Processor;
  * @since 1.0.0
  */
 class Utility {
+
 	/**
 	 * Renders a template file.
 	 *
@@ -69,7 +70,7 @@ class Utility {
 	 * @return string The key with the 'gatherpress_' prefix.
 	 */
 	public static function prefix_key( string $key ): string {
-		if ( 0 !== strpos( $key, 'gatherpress_' ) ) {
+		if ( ! str_starts_with( $key, 'gatherpress_' ) ) {
 			$key = sprintf( 'gatherpress_%s', $key );
 		}
 
@@ -337,7 +338,7 @@ class Utility {
 		$timezone_string = get_option( 'timezone_string' );
 
 		// Remove old Etc mappings. Fallback to gmt_offset.
-		if ( false !== strpos( $timezone_string, 'Etc/GMT' ) ) {
+		if ( str_contains( $timezone_string, 'Etc/GMT' ) ) {
 			$timezone_string = '';
 		}
 
@@ -412,9 +413,9 @@ class Utility {
 			$hours   = 0;
 			$minutes = 0;
 
-			if ( false !== strpos( $value, ':' ) ) {
+			if ( str_contains( $value, ':' ) ) {
 				list( $hours, $minutes ) = array_map( 'intval', explode( ':', $value ) );
-			} elseif ( false !== strpos( $value, '.' ) ) {
+			} elseif ( str_contains( $value, '.' ) ) {
 				$hours   = (int) $value;
 				$minutes = (int) round( ( (float) $value - $hours ) * 60 );
 			} else {

--- a/includes/core/classes/commands/class-event-cli.php
+++ b/includes/core/classes/commands/class-event-cli.php
@@ -27,6 +27,7 @@ use WP_CLI;
  * @since 1.0.0
  */
 class Event_Cli extends WP_CLI {
+
 	/**
 	 * Update RSVP status for an event.
 	 *

--- a/includes/core/classes/commands/class-settings-cli.php
+++ b/includes/core/classes/commands/class-settings-cli.php
@@ -24,6 +24,7 @@ use WP_CLI;
  * @since 1.0.0
  */
 class Settings_Cli extends WP_CLI {
+
 	/**
 	 * Export GatherPress settings to JSON.
 	 *

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -33,6 +33,7 @@ use WP_Query;
  * @since 1.0.0
  */
 class Admin_List {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -193,7 +194,7 @@ class Admin_List {
 					'',
 					$view_links['all']
 				);
-			} elseif ( false === strpos( $view_links['all'], 'class="current"' ) ) {
+			} elseif ( ! str_contains( $view_links['all'], 'class="current"' ) ) {
 				// Add "current" to "All" only when no other view is current.
 				// We must not stomp on a built-in status filter (Published /
 				// Draft / Trash): when the user clicks one of those, that
@@ -204,7 +205,7 @@ class Admin_List {
 					if ( 'all' === $other_key ) {
 						continue;
 					}
-					if ( false !== strpos( (string) $other_link, 'class="current"' ) ) {
+					if ( str_contains( (string) $other_link, 'class="current"' ) ) {
 						$another_view_is_current = true;
 						break;
 					}
@@ -569,7 +570,7 @@ class Admin_List {
 		$venue_taxonomy_key     = 'taxonomy-' . Venue_Setup::get_instance()->taxonomy_for_event_post_type( $post_type );
 
 		foreach ( $columns as $key => $label ) {
-			if ( 0 !== strpos( $key, 'taxonomy-' ) ) {
+			if ( ! str_starts_with( $key, 'taxonomy-' ) ) {
 				continue;
 			}
 

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -33,6 +33,7 @@ use WP_Post;
  * @since 1.0.0
  */
 class Event {
+
 	/**
 	 * Cache key format for storing and retrieving event datetimes.
 	 *

--- a/includes/core/classes/event/class-meta.php
+++ b/includes/core/classes/event/class-meta.php
@@ -41,6 +41,7 @@ use WP_REST_Request;
  * @since 1.0.0
  */
 class Meta {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -32,6 +32,7 @@ use WP_Query;
  * @since 1.0.0
  */
 class Query {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -42,6 +42,7 @@ use WP_User;
  * @since 1.0.0
  */
 class Rest_Api {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -903,7 +904,7 @@ class Rest_Api {
 
 		// Add custom fields to data.
 		foreach ( $params as $key => $value ) {
-			if ( 0 === strpos( $key, 'gatherpress_custom_' ) ) {
+			if ( str_starts_with( $key, 'gatherpress_custom_' ) ) {
 				$data[ $key ] = $value;
 			}
 		}

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -34,6 +34,7 @@ use WP_Post;
  * @since 1.0.0
  */
 class Setup {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -328,7 +329,7 @@ class Setup {
 	 * @return string|false The filtered redirect URL or false to cancel redirect.
 	 */
 	public function disable_ics_canonical_redirect( $redirect_url, string $requested_url ) {
-		if ( false !== strpos( $requested_url, '.ics' ) ) {
+		if ( str_contains( $requested_url, '.ics' ) ) {
 			return false; // prevent canonical redirect.
 		}
 

--- a/includes/core/classes/rsvp/class-cleanup.php
+++ b/includes/core/classes/rsvp/class-cleanup.php
@@ -23,6 +23,7 @@ use GatherPress\Core\Traits\Singleton;
  * This class manages rsvp cleanup events.
  */
 class Cleanup {
+
 	use Singleton;
 
 	/**

--- a/includes/core/classes/rsvp/class-form.php
+++ b/includes/core/classes/rsvp/class-form.php
@@ -31,6 +31,7 @@ use WP_User;
  * @since 1.0.0
  */
 class Form {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -252,7 +253,7 @@ class Form {
 
 			// Add custom fields to data.
 			foreach ( $_POST as $key => $value ) {
-				if ( 0 === strpos( $key, 'gatherpress_custom_' ) ) {
+				if ( str_starts_with( $key, 'gatherpress_custom_' ) ) {
 					$data[ $key ] = $value;
 				}
 			}

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -29,6 +29,7 @@ use WP_List_Table;
  * @since 1.0.0
  */
 class List_Table extends WP_List_Table {
+
 	/**
 	 * Default number of RSVPs to display per page in the admin list table.
 	 *

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -28,6 +28,7 @@ use WP_Tax_Query;
  * @since 1.0.0
  */
 class Query {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -26,6 +26,7 @@ use WP_Post;
  * @since 1.0.0
  */
 class Rsvp {
+
 	/**
 	 * Capability required to manage RSVPs.
 	 *

--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -36,6 +36,7 @@ use WP_User;
  * @since 1.0.0
  */
 class Setup {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/rsvp/class-token.php
+++ b/includes/core/classes/rsvp/class-token.php
@@ -29,6 +29,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  * @since 1.0.0
  */
 class Token {
+
 	/**
 	 * The parameter name used for RSVP tokens in URLs.
 	 *

--- a/includes/core/classes/settings/class-base.php
+++ b/includes/core/classes/settings/class-base.php
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  * @since 1.0.0
  */
 abstract class Base {
+
 	/**
 	 * The slug used to identify the settings page.
 	 *

--- a/includes/core/classes/settings/class-credits.php
+++ b/includes/core/classes/settings/class-credits.php
@@ -25,6 +25,7 @@ use GatherPress\Core\Utility;
  * @since 1.0.0
  */
 class Credits extends Base {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -15,7 +15,7 @@ namespace GatherPress\Core\Settings;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Event\Setup as Event_Setup;
+use GatherPress\Core\Event\Setup;
 use GatherPress\Core\Topic;
 
 /**
@@ -228,7 +228,7 @@ class Events extends Base {
 							'rewrite' => true,
 							'options' => array(
 								'label'   => __( 'Permalink base of Events.', 'gatherpress' ),
-								'default' => Event_Setup::get_localized_post_type_slug(),
+								'default' => Setup::get_localized_post_type_slug(),
 							),
 							'preview' => array(
 								'template' => 'url-rewrite-preview',

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -16,7 +16,6 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Event\Setup as Event_Setup;
-use GatherPress\Core\Venue\Setup as Venue_Setup;
 use GatherPress\Core\Topic;
 
 /**
@@ -27,6 +26,7 @@ use GatherPress\Core\Topic;
  * @since 1.0.0
  */
 class Events extends Base {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -235,27 +235,6 @@ class Events extends Base {
 								'suffix'   => _x(
 									'sample-event',
 									'URL permalink structure example for events',
-									'gatherpress'
-								),
-							),
-						),
-					),
-					'venues_url' => array(
-						'labels' => array(
-							'name' => __( 'Venues', 'gatherpress' ),
-						),
-						'field'  => array(
-							'type'    => 'text',
-							'rewrite' => true,
-							'options' => array(
-								'label'   => __( 'Permalink base of Venues.', 'gatherpress' ),
-								'default' => Venue_Setup::get_instance()->get_localized_post_type_slug(),
-							),
-							'preview' => array(
-								'template' => 'url-rewrite-preview',
-								'suffix'   => _x(
-									'sample-venue',
-									'URL permalink structure example for venues',
 									'gatherpress'
 								),
 							),

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -29,6 +29,7 @@ use GatherPress\Core\Utility;
  * @since 1.0.0
  */
 class Network {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/settings/class-roles.php
+++ b/includes/core/classes/settings/class-roles.php
@@ -25,6 +25,7 @@ use GatherPress\Core\Traits\Singleton;
  * @since 1.0.0
  */
 class Roles extends Base {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/settings/class-rsvp-settings.php
+++ b/includes/core/classes/settings/class-rsvp-settings.php
@@ -24,6 +24,7 @@ use GatherPress\Core\Traits\Singleton;
  * @since 1.0.0
  */
 class Rsvp_Settings extends Base {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/settings/class-tools.php
+++ b/includes/core/classes/settings/class-tools.php
@@ -26,6 +26,7 @@ use GatherPress\Core\Utility;
  * @since 1.0.0
  */
 class Tools extends Base {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Venue\Map;
-use GatherPress\Core\Venue\Setup as Venue_Setup;
+use GatherPress\Core\Venue\Setup;
 
 /**
  * Class Venues.
@@ -269,7 +269,7 @@ class Venues extends Base {
 							'rewrite' => true,
 							'options' => array(
 								'label'   => __( 'Permalink base of Venues.', 'gatherpress' ),
-								'default' => Venue_Setup::get_instance()->get_localized_post_type_slug(),
+								'default' => Setup::get_instance()->get_localized_post_type_slug(),
 							),
 							'preview' => array(
 								'template' => 'url-rewrite-preview',

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Venue\Map;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 
 /**
  * Class Venues.
@@ -26,6 +27,7 @@ use GatherPress\Core\Venue\Map;
  * @since 1.0.0
  */
 class Venues extends Base {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -248,6 +250,33 @@ class Venues extends Base {
 									'satellite' => __( 'Satellite', 'gatherpress' ),
 									'hybrid'    => __( 'Hybrid', 'gatherpress' ),
 									'terrain'   => __( 'Terrain', 'gatherpress' ),
+								),
+							),
+						),
+					),
+				),
+			),
+			'urls' => array(
+				'name'        => __( 'Permalinks', 'gatherpress' ),
+				'description' => __( 'Change permalink bases.', 'gatherpress' ),
+				'options'     => array(
+					'venues_url' => array(
+						'labels' => array(
+							'name' => __( 'Venues', 'gatherpress' ),
+						),
+						'field'  => array(
+							'type'    => 'text',
+							'rewrite' => true,
+							'options' => array(
+								'label'   => __( 'Permalink base of Venues.', 'gatherpress' ),
+								'default' => Venue_Setup::get_instance()->get_localized_post_type_slug(),
+							),
+							'preview' => array(
+								'template' => 'url-rewrite-preview',
+								'suffix'   => _x(
+									'sample-venue',
+									'URL permalink structure example for venues',
+									'gatherpress'
 								),
 							),
 						),

--- a/includes/core/classes/venue/class-meta.php
+++ b/includes/core/classes/venue/class-meta.php
@@ -38,6 +38,7 @@ use WP_REST_Request;
  * @since 1.0.0
  */
 class Meta {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -42,6 +42,7 @@ use WP_Post;
  * @since 1.0.0
  */
 class Setup {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/venue/class-venue.php
+++ b/includes/core/classes/venue/class-venue.php
@@ -31,6 +31,7 @@ use WP_Term;
  * @since 1.0.0
  */
 class Venue {
+
 	/**
 	 * Default venue post type slug.
 	 *

--- a/includes/core/classes/venue/map/class-manager.php
+++ b/includes/core/classes/venue/map/class-manager.php
@@ -40,6 +40,7 @@ use GatherPress\Core\Venue\Map\Provider\OSM;
  * @since 1.0.0
  */
 class Manager {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -54,6 +54,7 @@ use WP_REST_Server;
  * @phpstan-type ProviderDescriptorMap array<string, DescriptorMap>
  */
 class Map {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/venue/map/class-prewarm.php
+++ b/includes/core/classes/venue/map/class-prewarm.php
@@ -41,6 +41,7 @@ use WP_Post;
  * @since 1.0.0
  */
 class Prewarm {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */
@@ -513,7 +514,7 @@ class Prewarm {
 	 * @return array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}>
 	 */
 	protected function collect_combos_from_content( string $content ): array {
-		if ( '' === $content || false === strpos( $content, self::BLOCK_NAME ) ) {
+		if ( '' === $content || ! str_contains( $content, self::BLOCK_NAME ) ) {
 			return array();
 		}
 

--- a/includes/core/classes/venue/map/class-setup.php
+++ b/includes/core/classes/venue/map/class-setup.php
@@ -28,6 +28,7 @@ use GatherPress\Core\Traits\Singleton;
  * @since 1.0.0
  */
 class Setup {
+
 	/**
 	 * Enforces a single instance of this class.
 	 */

--- a/includes/core/classes/venue/map/provider/class-base.php
+++ b/includes/core/classes/venue/map/provider/class-base.php
@@ -32,6 +32,7 @@ use GdImage;
  * @since 1.0.0
  */
 abstract class Base {
+
 	/**
 	 * Stable identifier used in post meta keys, filename slugs, and the
 	 * `map_platform` setting.

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -33,6 +33,7 @@ use Throwable;
  * @since 1.0.0
  */
 class OSM extends Base {
+
 	/**
 	 * Default XYZ tile URL template. CartoDB's "light_all" basemap —
 	 * keyless, fast CDN, fits the GatherPress aesthetic.

--- a/includes/templates/admin/settings/partials/url-rewrite-preview.php
+++ b/includes/templates/admin/settings/partials/url-rewrite-preview.php
@@ -17,9 +17,13 @@ if ( ! isset( $name, $value, $suffix ) ) {
 }
 
 $gatherpress_component_attrs = array(
-	'name'   => $name,
-	'value'  => ! empty( $value ) ? $value : '',
-	'suffix' => $suffix,
+	'name'    => $name,
+	'value'   => ! empty( $value ) ? $value : '',
+	'suffix'  => $suffix,
+	// Settings page is a non-block-editor screen, so the home URL has to
+	// ride along on the data attrs. Reading it from the editor settings
+	// store the way block-editor components do would resolve to undefined.
+	'homeUrl' => home_url(),
 );
 ?>
 <p>

--- a/includes/templates/admin/settings/partials/url-rewrite-preview.php
+++ b/includes/templates/admin/settings/partials/url-rewrite-preview.php
@@ -20,9 +20,6 @@ $gatherpress_component_attrs = array(
 	'name'    => $name,
 	'value'   => ! empty( $value ) ? $value : '',
 	'suffix'  => $suffix,
-	// Settings page is a non-block-editor screen, so the home URL has to
-	// ride along on the data attrs. Reading it from the editor settings
-	// store the way block-editor components do would resolve to undefined.
 	'homeUrl' => home_url(),
 );
 ?>

--- a/src/blocks/add-to-calendar/edit.js
+++ b/src/blocks/add-to-calendar/edit.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import TEMPLATE from './template';
 import { hasValidEventId, usePostTypeSupports, DISABLED_FIELD_OPACITY } from '../../helpers/event';

--- a/src/blocks/add-to-calendar/index.js
+++ b/src/blocks/add-to-calendar/index.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/add-to-calendar/template.js
+++ b/src/blocks/add-to-calendar/template.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 

--- a/src/blocks/dropdown-item/edit.js
+++ b/src/blocks/dropdown-item/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {

--- a/src/blocks/dropdown-item/save.js
+++ b/src/blocks/dropdown-item/save.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useBlockProps, RichText } from '@wordpress/block-editor';
 

--- a/src/blocks/dropdown/edit.js
+++ b/src/blocks/dropdown/edit.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { v4 as uuidv4 } from 'uuid';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	BlockControls,
@@ -33,7 +33,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { dispatch, select, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { useIsBlockOrDescendantSelected } from './helpers';
 

--- a/src/blocks/dropdown/helpers.js
+++ b/src/blocks/dropdown/helpers.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
 

--- a/src/blocks/dropdown/save.js
+++ b/src/blocks/dropdown/save.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 

--- a/src/blocks/dropdown/view.js
+++ b/src/blocks/dropdown/view.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { store, getElement } from '@wordpress/interactivity';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	manageFocusTrap,

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import moment from 'moment';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {
@@ -26,7 +26,7 @@ import {
 import { useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	convertPHPToMomentFormat,

--- a/src/blocks/event-date/index.js
+++ b/src/blocks/event-date/index.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/event-date/transforms.js
+++ b/src/blocks/event-date/transforms.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
 

--- a/src/blocks/form-field/edit.js
+++ b/src/blocks/form-field/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/components';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import DefaultField from './types/default';
 import RadioField from './types/radio';

--- a/src/blocks/form-field/helpers.js
+++ b/src/blocks/form-field/helpers.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {

--- a/src/blocks/form-field/index.js
+++ b/src/blocks/form-field/index.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/form-field/panels/checkbox-field-panels.js
+++ b/src/blocks/form-field/panels/checkbox-field-panels.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { FontSizePicker, PanelColorSettings } from '@wordpress/block-editor';

--- a/src/blocks/form-field/panels/default-field-panels.js
+++ b/src/blocks/form-field/panels/default-field-panels.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { FontSizePicker, PanelColorSettings } from '@wordpress/block-editor';

--- a/src/blocks/form-field/panels/radio-field-panels.js
+++ b/src/blocks/form-field/panels/radio-field-panels.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { v4 as uuidv4 } from 'uuid';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { FontSizePicker, PanelColorSettings } from '@wordpress/block-editor';

--- a/src/blocks/form-field/types/checkbox.js
+++ b/src/blocks/form-field/types/checkbox.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	getInputStyles,

--- a/src/blocks/form-field/types/default.js
+++ b/src/blocks/form-field/types/default.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	getInputStyles,

--- a/src/blocks/form-field/types/hidden.js
+++ b/src/blocks/form-field/types/hidden.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getWrapperClasses } from '../helpers';
 

--- a/src/blocks/form-field/types/radio.js
+++ b/src/blocks/form-field/types/radio.js
@@ -1,15 +1,15 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { v4 as uuidv4 } from 'uuid';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	getInputStyles,

--- a/src/blocks/form-field/types/textarea.js
+++ b/src/blocks/form-field/types/textarea.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	getInputStyles,

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import {

--- a/src/blocks/icon/index.js
+++ b/src/blocks/icon/index.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/modal-content/edit.js
+++ b/src/blocks/modal-content/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	useBlockProps,

--- a/src/blocks/modal-content/index.js
+++ b/src/blocks/modal-content/index.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/modal-manager/edit.js
+++ b/src/blocks/modal-manager/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {

--- a/src/blocks/modal-manager/index.js
+++ b/src/blocks/modal-manager/index.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/modal-manager/template.js
+++ b/src/blocks/modal-manager/template.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 

--- a/src/blocks/modal-manager/view.js
+++ b/src/blocks/modal-manager/view.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { store } from '@wordpress/interactivity';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	manageFocusTrap,

--- a/src/blocks/modal/edit.js
+++ b/src/blocks/modal/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	useBlockProps,

--- a/src/blocks/modal/index.js
+++ b/src/blocks/modal/index.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/online-event-link/edit.js
+++ b/src/blocks/online-event-link/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
@@ -8,7 +8,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { isPostTypeSupporting } from '../../helpers/event';
 

--- a/src/blocks/online-event-link/index.js
+++ b/src/blocks/online-event-link/index.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/online-event-link/view.js
+++ b/src/blocks/online-event-link/view.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { store, getElement, getContext } from '@wordpress/interactivity';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { initPostContext } from '../../helpers/interactivity';
 import { stripScriptsAndEventHandlers } from '../../helpers/globals';

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	BlockContextProvider,
@@ -13,7 +13,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import TEMPLATE from './template';
 import { hasValidBlockContext, isInFSETemplate } from '../../helpers/editor';

--- a/src/blocks/online-event/index.js
+++ b/src/blocks/online-event/index.js
@@ -1,11 +1,11 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/online-event/template.js
+++ b/src/blocks/online-event/template.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
 

--- a/src/blocks/rsvp-count/edit.js
+++ b/src/blocks/rsvp-count/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
@@ -9,7 +9,7 @@ import { useSelect } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { hasValidEventId, DISABLED_FIELD_OPACITY, getEventMeta, usePostTypeSupports, isRsvpEnabledForEvent } from '../../helpers/event';
 import { EVENT_REST_API } from '../../helpers/namespace';

--- a/src/blocks/rsvp-count/index.js
+++ b/src/blocks/rsvp-count/index.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/rsvp-count/view.js
+++ b/src/blocks/rsvp-count/view.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { store, getElement, getContext } from '@wordpress/interactivity';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { initPostContext } from '../../helpers/interactivity';
 

--- a/src/blocks/rsvp-form/edit.js
+++ b/src/blocks/rsvp-form/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	BlockControls,
@@ -21,7 +21,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock, getBlockTypes } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import STANDARD_RSVP_FORM_TEMPLATE from './templates/standard-rsvp-form';
 import PatternPicker, { PatternChooserModal } from '../../components/PatternPicker';

--- a/src/blocks/rsvp-form/index.js
+++ b/src/blocks/rsvp-form/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks, InspectorAdvancedControls } from '@wordpress/block-editor';
@@ -11,7 +11,7 @@ import { addFilter } from '@wordpress/hooks';
 import { select, dispatch, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/rsvp-form/templates/standard-rsvp-form.js
+++ b/src/blocks/rsvp-form/templates/standard-rsvp-form.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 

--- a/src/blocks/rsvp-form/view.js
+++ b/src/blocks/rsvp-form/view.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { store, getElement, getContext } from '@wordpress/interactivity';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { initPostContext, getNonce } from '../../helpers/interactivity';
 const { state } = store( 'gatherpress', {

--- a/src/blocks/rsvp-guest-count-display/edit.js
+++ b/src/blocks/rsvp-guest-count-display/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { _n, sprintf } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
@@ -7,7 +7,7 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getEditorDocument } from '../../helpers/editor';
 import { DISABLED_FIELD_OPACITY, usePostTypeSupports } from '../../helpers/event';

--- a/src/blocks/rsvp-guest-count-display/index.js
+++ b/src/blocks/rsvp-guest-count-display/index.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/rsvp-response-toggle/index.js
+++ b/src/blocks/rsvp-response-toggle/index.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/rsvp-response/edit.js
+++ b/src/blocks/rsvp-response/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
@@ -26,7 +26,7 @@ import { createBlock } from '@wordpress/blocks';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import RsvpManager from './rsvp-manager';
 import ATTENDEE_GRID_WITH_FILTER_TEMPLATE from './templates/attendee-grid-with-filter';

--- a/src/blocks/rsvp-response/index.js
+++ b/src/blocks/rsvp-response/index.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/rsvp-response/rsvp-manager.js
+++ b/src/blocks/rsvp-response/rsvp-manager.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -9,7 +9,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { EVENT_REST_API } from '../../helpers/namespace';
 

--- a/src/blocks/rsvp-response/templates/attendee-grid-with-filter.js
+++ b/src/blocks/rsvp-response/templates/attendee-grid-with-filter.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
 

--- a/src/blocks/rsvp-response/view.js
+++ b/src/blocks/rsvp-response/view.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { store, getElement, getContext } from '@wordpress/interactivity';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { initPostContext } from '../../helpers/interactivity';
 import { toCamelCase } from '../../helpers/globals';

--- a/src/blocks/rsvp-template/edit.js
+++ b/src/blocks/rsvp-template/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -13,7 +13,7 @@ import { useSelect } from '@wordpress/data';
 import { memo, useState } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import TEMPLATE from './template';
 

--- a/src/blocks/rsvp-template/index.js
+++ b/src/blocks/rsvp-template/index.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import Edit from './edit';
 import './style.scss';

--- a/src/blocks/rsvp-template/template.js
+++ b/src/blocks/rsvp-template/template.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { _x } from '@wordpress/i18n';
 

--- a/src/blocks/rsvp-template/view.js
+++ b/src/blocks/rsvp-template/view.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { store, getContext, getElement } from '@wordpress/interactivity';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { stripScriptsAndEventHandlers } from '../../helpers/globals';
 

--- a/src/blocks/rsvp/edit.js
+++ b/src/blocks/rsvp/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	BlockControls,
@@ -21,7 +21,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock, parse, serialize } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import RSVP_BUTTON_WITH_MODAL_TEMPLATES from './templates/rsvp-button-with-modal';
 import PatternPicker, { PatternChooserModal } from '../../components/PatternPicker';

--- a/src/blocks/rsvp/index.js
+++ b/src/blocks/rsvp/index.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/rsvp/templates/attending.js
+++ b/src/blocks/rsvp/templates/attending.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 

--- a/src/blocks/rsvp/templates/no-status.js
+++ b/src/blocks/rsvp/templates/no-status.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 

--- a/src/blocks/rsvp/templates/not-attending.js
+++ b/src/blocks/rsvp/templates/not-attending.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 

--- a/src/blocks/rsvp/templates/past.js
+++ b/src/blocks/rsvp/templates/past.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { _x } from '@wordpress/i18n';
 

--- a/src/blocks/rsvp/templates/rsvp-button-with-modal.js
+++ b/src/blocks/rsvp/templates/rsvp-button-with-modal.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import ATTENDING from './attending';
 import NO_STATUS from './no-status';

--- a/src/blocks/rsvp/templates/waiting-list.js
+++ b/src/blocks/rsvp/templates/waiting-list.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
 

--- a/src/blocks/rsvp/view.js
+++ b/src/blocks/rsvp/view.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { store, getElement, getContext } from '@wordpress/interactivity';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	initPostContext,

--- a/src/blocks/venue-detail/edit.js
+++ b/src/blocks/venue-detail/edit.js
@@ -1,12 +1,12 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, SelectControl } from '@wordpress/components';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { useVenueData, useGeocoding, useBlockInsertion } from './hooks';
 import { AddressField, PhoneField, UrlField, TextField } from './fields';

--- a/src/blocks/venue-detail/fields/address-field.js
+++ b/src/blocks/venue-detail/fields/address-field.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import AddressAutocompleteField from '../../../components/AddressAutocompleteField';
 

--- a/src/blocks/venue-detail/fields/phone-field.js
+++ b/src/blocks/venue-detail/fields/phone-field.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
 

--- a/src/blocks/venue-detail/fields/text-field.js
+++ b/src/blocks/venue-detail/fields/text-field.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
 

--- a/src/blocks/venue-detail/fields/url-field.js
+++ b/src/blocks/venue-detail/fields/url-field.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, RichText } from '@wordpress/block-editor';
@@ -13,7 +13,7 @@ import { useState, useRef } from '@wordpress/element';
 import { link as linkIcon } from '@wordpress/icons';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { cleanUrlForDisplay } from '../helpers';
 

--- a/src/blocks/venue-detail/hooks/use-block-insertion.js
+++ b/src/blocks/venue-detail/hooks/use-block-insertion.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';

--- a/src/blocks/venue-detail/hooks/use-geocoding.js
+++ b/src/blocks/venue-detail/hooks/use-geocoding.js
@@ -1,12 +1,12 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { geocodeAddress } from '../../../helpers/geocoding';
 

--- a/src/blocks/venue-detail/hooks/use-venue-data.js
+++ b/src/blocks/venue-detail/hooks/use-venue-data.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -8,7 +8,7 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { useCallback } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { isPostTypeSupporting } from '../../../helpers/event';
 import { getMetaKey } from '../helpers';

--- a/src/blocks/venue-detail/index.js
+++ b/src/blocks/venue-detail/index.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { mapMarker as icon } from '@wordpress/icons';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import './editor.scss';
 import edit from './edit';

--- a/src/blocks/venue-detail/variations.js
+++ b/src/blocks/venue-detail/variations.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {
@@ -29,7 +29,7 @@ import { useEffect } from '@wordpress/element';
 import { Icon, link as linkIcon, mapMarker } from '@wordpress/icons';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { isVenuePostType } from '../../helpers/venue';
 import { isInFSETemplate } from '../../helpers/editor';

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
@@ -8,7 +8,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { REST_NAMESPACE } from '../../helpers/namespace';
 

--- a/src/blocks/venue-map/index.js
+++ b/src/blocks/venue-map/index.js
@@ -1,17 +1,17 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import 'leaflet/dist/leaflet.css';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/venue-map/view.js
+++ b/src/blocks/venue-map/view.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
 import { createRoot } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import MapEmbed from '../../components/MapEmbed';
 

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	BlockContextProvider,

--- a/src/blocks/venue/index.js
+++ b/src/blocks/venue/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/block-editor';

--- a/src/components/AddressAutocompleteField/index.js
+++ b/src/components/AddressAutocompleteField/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Popover, Spinner, TextControl } from '@wordpress/components';
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { useAddressFieldAntiAutofill } from './use-address-field-anti-autofill';
 import {

--- a/src/components/AddressAutocompleteField/use-address-autocomplete.js
+++ b/src/components/AddressAutocompleteField/use-address-autocomplete.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useDebounce } from '@wordpress/compose';
 import {
@@ -11,7 +11,7 @@ import {
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	fetchAddressSuggestions,

--- a/src/components/AddressAutocompleteField/use-address-field-anti-autofill.js
+++ b/src/components/AddressAutocompleteField/use-address-field-anti-autofill.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useCallback, useEffect, useState } from '@wordpress/element';
 

--- a/src/components/AnonymousRsvp.js
+++ b/src/components/AnonymousRsvp.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
@@ -7,7 +7,7 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromSettings } from '../helpers/editor-settings';
 

--- a/src/components/Autocomplete.js
+++ b/src/components/Autocomplete.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { includes } from 'lodash';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { FormTokenField } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/src/components/DateTimeEnd.js
+++ b/src/components/DateTimeEnd.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	Button,
@@ -14,7 +14,7 @@ import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getStartOfWeek } from '../helpers/editor';
 import { hasEventPastNotice } from '../helpers/event';

--- a/src/components/DateTimePreview.js
+++ b/src/components/DateTimePreview.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { format } from '@wordpress/date';
 import { useState } from '@wordpress/element';

--- a/src/components/DateTimeRange.js
+++ b/src/components/DateTimeRange.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	dateTimeDatabaseFormat,

--- a/src/components/DateTimeStart.js
+++ b/src/components/DateTimeStart.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	Button,
@@ -14,7 +14,7 @@ import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getStartOfWeek } from '../helpers/editor';
 import { hasEventPastNotice } from '../helpers/event';

--- a/src/components/Duration.js
+++ b/src/components/Duration.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/src/components/EmailNotificationManager.js
+++ b/src/components/EmailNotificationManager.js
@@ -1,12 +1,12 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { isEventPostType, hasEventPast } from '../helpers/event';
 

--- a/src/components/EnableOpenRsvp.js
+++ b/src/components/EnableOpenRsvp.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';

--- a/src/components/EnableRsvp.js
+++ b/src/components/EnableRsvp.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl } from '@wordpress/components';
@@ -7,7 +7,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from '@wordpress/el
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromSettings } from '../helpers/editor-settings';
 

--- a/src/components/GoogleMap.js
+++ b/src/components/GoogleMap.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { select } from '@wordpress/data';
 

--- a/src/components/GuestLimit.js
+++ b/src/components/GuestLimit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {
@@ -10,7 +10,7 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromSettings } from '../helpers/editor-settings';
 

--- a/src/components/MapEmbed.js
+++ b/src/components/MapEmbed.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { select } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import GoogleMap from './GoogleMap';
 import OpenStreetMap from './OpenStreetMap';

--- a/src/components/MaxAttendanceLimit.js
+++ b/src/components/MaxAttendanceLimit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {
@@ -10,7 +10,7 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromSettings } from '../helpers/editor-settings';
 

--- a/src/components/OnlineEvent.js
+++ b/src/components/OnlineEvent.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
 import { TextControl, ToggleControl } from '@wordpress/components';
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getVenuePostType, getVenueTaxonomy } from '../helpers/venue';
 

--- a/src/components/OpenStreetMap.js
+++ b/src/components/OpenStreetMap.js
@@ -1,17 +1,17 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { v4 as uuidv4 } from 'uuid';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { sprintf, __ } from '@wordpress/i18n';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { select } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromConfig } from '../helpers/editor-settings';
 

--- a/src/components/PatternPicker/index.js
+++ b/src/components/PatternPicker/index.js
@@ -1,12 +1,12 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { Button, Placeholder } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import PatternChooserModal from './modal';
 

--- a/src/components/PatternPicker/modal.js
+++ b/src/components/PatternPicker/modal.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { BlockPreview } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';

--- a/src/components/Timezone.js
+++ b/src/components/Timezone.js
@@ -1,12 +1,12 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { PanelRow, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromConfig } from '../helpers/editor-settings';
 import { enableSave } from '../helpers/editor';

--- a/src/components/UrlRewritePreview.js
+++ b/src/components/UrlRewritePreview.js
@@ -1,12 +1,7 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-
-/**
- * Internal dependencies.
- */
-import { getFromConfig } from '../helpers/editor-settings';
 
 /**
  * UrlRewritePreview component for GatherPress.
@@ -17,20 +12,20 @@ import { getFromConfig } from '../helpers/editor-settings';
  *
  * @since 1.0.0
  *
- * @param {Object} props             - Component props.
- * @param {Object} props.attrs       - Component attributes.
- * @param {string} props.attrs.name  - The name of the input field.
- * @param {string} props.attrs.value - The initial value of the input field (rewritten url).
+ * @param {Object} props               - Component props.
+ * @param {Object} props.attrs         - Component attributes.
+ * @param {string} props.attrs.name    - The name of the input field.
+ * @param {string} props.attrs.value   - The initial value of the input field (rewritten url).
+ * @param {string} props.attrs.suffix  - Sample suffix appended after the rewrite slug.
+ * @param {string} props.attrs.homeUrl - Site home URL injected by the PHP partial.
  *
  * @return {JSX.Element} The rendered React component.
  */
 const UrlRewritePreview = ( props ) => {
-	const { name, value, suffix } = props.attrs;
+	const { name, value, suffix, homeUrl } = props.attrs;
 	const [ rewrittenUrlPart, setRewrittenUrlPart ] = useState( value );
 
 	const input = document.querySelector( `[name="${ name }"]` );
-
-	const homeUrl = getFromConfig( 'homeUrl' );
 
 	input.addEventListener(
 		'input',

--- a/src/components/VenueForm.js
+++ b/src/components/VenueForm.js
@@ -16,7 +16,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getVenuePostType, getVenueTaxonomy } from '../helpers/venue';
 import { isPostTypeSupporting } from '../helpers/event';

--- a/src/components/VenueInformation.js
+++ b/src/components/VenueInformation.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -8,7 +8,7 @@ import { useEffect, useCallback, useRef } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { geocodeAddress, GEOCODE_LOCK_NAME } from '../helpers/geocoding';
 import AddressAutocompleteField from './AddressAutocompleteField';

--- a/src/components/VenuePostsCombobox.js
+++ b/src/components/VenuePostsCombobox.js
@@ -7,7 +7,7 @@ import { useDebounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { useVenueOptions, getVenuePostType } from '../helpers/venue';
 

--- a/src/components/VenueSelector.js
+++ b/src/components/VenueSelector.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { PanelRow, SelectControl } from '@wordpress/components';

--- a/src/components/VenueTermsCombobox.js
+++ b/src/components/VenueTermsCombobox.js
@@ -8,7 +8,7 @@ import { useDebounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getCurrentContextualPostId } from '../helpers/editor';
 import { getVenuePostType, getVenueTaxonomy, useVenueOptions, useVenueTaxonomyIds } from '../helpers/venue';

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
 import { dispatch, select } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { hasEventPastNotice } from './helpers/event';
 import EmailNotificationManager from './components/EmailNotificationManager';

--- a/src/formats/tooltip/edit.js
+++ b/src/formats/tooltip/edit.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -24,7 +24,7 @@ import {
 import { comment } from '@wordpress/icons';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { FORMAT_NAME, DEFAULT_COLORS } from './constants';
 import { getTooltipAttributes } from './helpers';

--- a/src/formats/tooltip/helpers.js
+++ b/src/formats/tooltip/helpers.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { DEFAULT_COLORS } from './constants';
 

--- a/src/formats/tooltip/index.js
+++ b/src/formats/tooltip/index.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { registerFormatType } from '@wordpress/rich-text';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { FORMAT_NAME } from './constants';
 import { TooltipEdit } from './edit';

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import moment from 'moment';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { createRoot } from '@wordpress/element';
@@ -12,7 +12,7 @@ import { applyFilters } from '@wordpress/hooks';
 import { select } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromSettings } from './editor-settings';
 import { enableSave } from './editor';

--- a/src/helpers/editor-settings.js
+++ b/src/helpers/editor-settings.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { select } from '@wordpress/data';
 

--- a/src/helpers/editor.js
+++ b/src/helpers/editor.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { dispatch, select } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { isPostTypeSupporting } from './event';
 

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -1,16 +1,16 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import moment from 'moment';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { dispatch, select, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { createMomentWithTimezone, getTimezone } from './datetime';
 import { getVenueTaxonomy, getVenuePostType } from './venue';

--- a/src/helpers/geocoding.js
+++ b/src/helpers/geocoding.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromConfig } from './editor-settings';
 import { REST_NAMESPACE } from './namespace';

--- a/src/helpers/interactivity.js
+++ b/src/helpers/interactivity.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { store } from '@wordpress/interactivity';
 

--- a/src/helpers/urlrewrite.js
+++ b/src/helpers/urlrewrite.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { createRoot } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import UrlRewritePreview from '../components/UrlRewritePreview';
 

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { select, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';

--- a/src/modals/email-communication/index.js
+++ b/src/modals/email-communication/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
@@ -16,7 +16,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { select, useSelect, useDispatch } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { EVENT_REST_API } from '../../helpers/namespace';
 

--- a/src/modals/index.js
+++ b/src/modals/index.js
@@ -1,4 +1,4 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import './email-communication';

--- a/src/panels/event-settings/datetime-range/index.js
+++ b/src/panels/event-settings/datetime-range/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import DateTimeRange from '../../../components/DateTimeRange';
 

--- a/src/panels/event-settings/index.js
+++ b/src/panels/event-settings/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
@@ -12,7 +12,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { isEventPostType } from '../../helpers/event';
 import DateTimeRangePanel from './datetime-range';

--- a/src/panels/event-settings/notify-members/index.js
+++ b/src/panels/event-settings/notify-members/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
@@ -7,7 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { hasEventPast } from '../../../helpers/event';
 

--- a/src/panels/event-settings/venue-selector/index.js
+++ b/src/panels/event-settings/venue-selector/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import VenueSelector from '../../../components/VenueSelector';
 

--- a/src/panels/index.js
+++ b/src/panels/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import './event-settings';
 import './rsvp-settings';

--- a/src/panels/rsvp-settings/anonymous-rsvp/index.js
+++ b/src/panels/rsvp-settings/anonymous-rsvp/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import AnonymousRsvp from '../../../components/AnonymousRsvp';
 

--- a/src/panels/rsvp-settings/enable-open-rsvp/index.js
+++ b/src/panels/rsvp-settings/enable-open-rsvp/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import EnableOpenRsvp from '../../../components/EnableOpenRsvp';
 

--- a/src/panels/rsvp-settings/enable-rsvp/index.js
+++ b/src/panels/rsvp-settings/enable-rsvp/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import EnableRsvp from '../../../components/EnableRsvp';
 

--- a/src/panels/rsvp-settings/guest-limit/index.js
+++ b/src/panels/rsvp-settings/guest-limit/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import GuestLimit from '../../../components/GuestLimit';
 

--- a/src/panels/rsvp-settings/index.js
+++ b/src/panels/rsvp-settings/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {
@@ -10,7 +10,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { isEventPostType, isOpenRsvpEnabled, isPerEventRsvpMode } from '../../helpers/event';
 import { getFromSettings } from '../../helpers/editor-settings';

--- a/src/panels/rsvp-settings/max-attendance-limit/index.js
+++ b/src/panels/rsvp-settings/max-attendance-limit/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import MaxAttendanceLimit from '../../../components/MaxAttendanceLimit';
 

--- a/src/panels/rsvp-settings/slot.js
+++ b/src/panels/rsvp-settings/slot.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { createSlotFill, PanelRow } from '@wordpress/components';
 

--- a/src/panels/venue-settings/index.js
+++ b/src/panels/venue-settings/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {
@@ -10,7 +10,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { isVenuePostType } from '../../helpers/venue';
 import VenueInformationPanel from './venue-information';

--- a/src/panels/venue-settings/online-event/index.js
+++ b/src/panels/venue-settings/online-event/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import OnlineEvent from '../../../components/OnlineEvent';
 

--- a/src/panels/venue-settings/venue-information/index.js
+++ b/src/panels/venue-settings/venue-information/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import VenueInformation from '../../../components/VenueInformation';
 

--- a/src/profile/index.js
+++ b/src/profile/index.js
@@ -1,3 +1,3 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { createRoot } from '@wordpress/element';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import Autocomplete from '../components/Autocomplete';
 import { dateTimePreview } from '../helpers/datetime';

--- a/src/stores/datetime.js
+++ b/src/stores/datetime.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { createReduxStore, dispatch, register, select, subscribe } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	defaultDateTimeEnd,

--- a/src/stores/email-modal.js
+++ b/src/stores/email-modal.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { createReduxStore, register } from '@wordpress/data';
 

--- a/src/stores/venue.js
+++ b/src/stores/venue.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { createReduxStore, register } from '@wordpress/data';
 

--- a/src/supports/block-guard.js
+++ b/src/supports/block-guard.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';

--- a/src/supports/post-date-convert.js
+++ b/src/supports/post-date-convert.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
@@ -10,7 +10,7 @@ import { useDispatch } from '@wordpress/data';
 import { switchToBlockType } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { usePostTypeSupports } from '../helpers/event';
 

--- a/src/supports/post-date-override.js
+++ b/src/supports/post-date-override.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -7,7 +7,7 @@ import { useSelect } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromSettings } from '../helpers/editor-settings';
 import { isEventPostType } from '../helpers/event';

--- a/src/supports/post-id-override.js
+++ b/src/supports/post-id-override.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { getBlockType } from '@wordpress/blocks';

--- a/test/unit/js/src/blocks/dropdown/helpers.test.js
+++ b/test/unit/js/src/blocks/dropdown/helpers.test.js
@@ -1,16 +1,16 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { useIsBlockOrDescendantSelected } from '@src/blocks/dropdown/helpers';
 

--- a/test/unit/js/src/blocks/event-date/transforms.test.js
+++ b/test/unit/js/src/blocks/event-date/transforms.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 
@@ -9,12 +9,12 @@ jest.mock( '@wordpress/blocks', () => ( {
 } ) );
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import transforms from '@src/blocks/event-date/transforms';
 

--- a/test/unit/js/src/blocks/form-field/helpers.test.js
+++ b/test/unit/js/src/blocks/form-field/helpers.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import FieldValue, {
 	getInputStyles,

--- a/test/unit/js/src/blocks/rsvp-form/visibility.test.js
+++ b/test/unit/js/src/blocks/rsvp-form/visibility.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { shouldHideBlock } from '@src/blocks/rsvp-form/visibility';
 

--- a/test/unit/js/src/blocks/rsvp/templates/rsvp-button-with-modal.test.js
+++ b/test/unit/js/src/blocks/rsvp/templates/rsvp-button-with-modal.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import RSVP_BUTTON_WITH_MODAL_TEMPLATES from '@src/blocks/rsvp/templates/rsvp-button-with-modal';
 import ATTENDING from '@src/blocks/rsvp/templates/attending';

--- a/test/unit/js/src/blocks/venue-detail/fields/address-field.test.js
+++ b/test/unit/js/src/blocks/venue-detail/fields/address-field.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
 import {
@@ -11,7 +11,7 @@ import {
 } from '@testing-library/react';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
 import AddressField from '@src/blocks/venue-detail/fields/address-field';

--- a/test/unit/js/src/blocks/venue-detail/fields/phone-field.test.js
+++ b/test/unit/js/src/blocks/venue-detail/fields/phone-field.test.js
@@ -1,11 +1,11 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest } from '@jest/globals';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import PhoneField from '@src/blocks/venue-detail/fields/phone-field';
 

--- a/test/unit/js/src/blocks/venue-detail/fields/text-field.test.js
+++ b/test/unit/js/src/blocks/venue-detail/fields/text-field.test.js
@@ -1,11 +1,11 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import TextField from '@src/blocks/venue-detail/fields/text-field';
 

--- a/test/unit/js/src/blocks/venue-detail/fields/url-field.test.js
+++ b/test/unit/js/src/blocks/venue-detail/fields/url-field.test.js
@@ -1,11 +1,11 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import UrlField from '@src/blocks/venue-detail/fields/url-field';
 

--- a/test/unit/js/src/blocks/venue-detail/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-detail/helpers.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	VENUE_FIELDS,

--- a/test/unit/js/src/blocks/venue-detail/variations.test.js
+++ b/test/unit/js/src/blocks/venue-detail/variations.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import variations from '@src/blocks/venue-detail/variations';
 

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -48,7 +48,7 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	MAX_POLLS,

--- a/test/unit/js/src/blocks/venue/helpers.test.js
+++ b/test/unit/js/src/blocks/venue/helpers.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { calculateMode, getNewTaxonomyIds } from '@src/blocks/venue/helpers';
 

--- a/test/unit/js/src/blocks/venue/slotfill.test.js
+++ b/test/unit/js/src/blocks/venue/slotfill.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { render } from '@testing-library/react';
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
@@ -17,7 +17,7 @@ jest.mock( '@wordpress/components', () => ( {
 } ) );
 
 /**
- * Mock internal dependencies.
+ * Mock internal dependencies
  */
 jest.mock( '@src/components/VenueNavigator', () => {
 	return function MockVenueNavigator() {
@@ -30,7 +30,7 @@ jest.mock( '@src/helpers/event', () => ( {
 } ) );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import VenueBlockPluginFill from '@src/blocks/venue/slotfill';
 import { isPostTypeSupporting } from '@src/helpers/event';

--- a/test/unit/js/src/components/DateTimePreview.test.js
+++ b/test/unit/js/src/components/DateTimePreview.test.js
@@ -1,19 +1,19 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { render, act } from '@testing-library/react';
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 import '@testing-library/jest-dom';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 jest.mock( '@wordpress/date', () => ( {
 	format: jest.fn( ( dateFormat ) => `Formatted: ${ dateFormat }` ),
 } ) );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import DateTimePreview from '@src/components/DateTimePreview';
 import { format } from '@wordpress/date';

--- a/test/unit/js/src/components/MapEmbed.test.js
+++ b/test/unit/js/src/components/MapEmbed.test.js
@@ -1,19 +1,19 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { render, act } from '@testing-library/react';
 import { expect, test, jest, beforeEach } from '@jest/globals';
 import '@testing-library/jest-dom';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 jest.mock( '@wordpress/data', () => ( {
 	select: jest.fn(),
 } ) );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import MapEmbed from '@src/components/MapEmbed';
 import { select } from '@wordpress/data';

--- a/test/unit/js/src/formats/tooltip/constants.test.js
+++ b/test/unit/js/src/formats/tooltip/constants.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { FORMAT_NAME, DEFAULT_COLORS } from '@src/formats/tooltip/constants';
 

--- a/test/unit/js/src/formats/tooltip/edit.test.js
+++ b/test/unit/js/src/formats/tooltip/edit.test.js
@@ -1,12 +1,12 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { useCachedTruthy } from '@wordpress/block-editor';
 import {

--- a/test/unit/js/src/formats/tooltip/helpers.test.js
+++ b/test/unit/js/src/formats/tooltip/helpers.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getTooltipAttributes } from '@src/formats/tooltip/helpers';
 import { DEFAULT_COLORS } from '@src/formats/tooltip/constants';

--- a/test/unit/js/src/formats/tooltip/index.test.js
+++ b/test/unit/js/src/formats/tooltip/index.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeAll } from '@jest/globals';
 

--- a/test/unit/js/src/formats/tooltip/view.test.js
+++ b/test/unit/js/src/formats/tooltip/view.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import {
 	describe,

--- a/test/unit/js/src/helpers/datetime.test.js
+++ b/test/unit/js/src/helpers/datetime.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { expect, test, jest, describe, beforeEach } from '@jest/globals';
 import 'moment-timezone';
@@ -45,7 +45,7 @@ jest.mock( '@wordpress/core-data', () => ( {
 } ) );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromSettings } from '@src/helpers/editor-settings';
 

--- a/test/unit/js/src/helpers/editor-settings.test.js
+++ b/test/unit/js/src/helpers/editor-settings.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest } from '@jest/globals';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { select } from '@wordpress/data';
 
@@ -13,7 +13,7 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { getFromSettings, getFromConfig } from '@src/helpers/editor-settings';
 

--- a/test/unit/js/src/helpers/editor.test.js
+++ b/test/unit/js/src/helpers/editor.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { dispatch, select } from '@wordpress/data';
 
@@ -15,7 +15,7 @@ jest.mock( '@wordpress/core-data', () => ( {
 } ) );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	enableSave,

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -1,12 +1,12 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, jest, it, beforeEach } from '@jest/globals';
 import moment from 'moment';
 import 'moment-timezone';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { dispatch } from '@wordpress/data';
 
@@ -24,7 +24,7 @@ jest.mock( '@wordpress/core-data', () => ( {
 } ) );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	hasEventPast,

--- a/test/unit/js/src/helpers/geocoding.test.js
+++ b/test/unit/js/src/helpers/geocoding.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import {
 	describe,
@@ -11,7 +11,7 @@ import {
 } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	ADDRESS_SEARCH_MIN_QUERY_LENGTH,

--- a/test/unit/js/src/helpers/globals.test.js
+++ b/test/unit/js/src/helpers/globals.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	toCamelCase,

--- a/test/unit/js/src/helpers/namespace.test.js
+++ b/test/unit/js/src/helpers/namespace.test.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it } from '@jest/globals';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { REST_NAMESPACE } from '@src/helpers/namespace';
 

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, jest, it, beforeEach } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
@@ -30,7 +30,7 @@ jest.mock( '@wordpress/html-entities', () => ( {
 import { select, useSelect } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	isVenuePostType,

--- a/test/unit/js/src/integrations/aql/index.test.js
+++ b/test/unit/js/src/integrations/aql/index.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { render } from '@testing-library/react';
 import {
@@ -13,7 +13,7 @@ import {
 import '@testing-library/jest-dom';
 
 /**
- * Mock WordPress dependencies.
+ * Mock WordPress dependencies
  */
 jest.mock( '@wordpress/block-editor', () => ( {
 	InspectorControls: ( { children } ) => (
@@ -42,7 +42,7 @@ jest.mock( '@wordpress/i18n', () => ( {
 } ) );
 
 /**
- * Mock internal dependencies.
+ * Mock internal dependencies
  */
 jest.mock( '@src/helpers/event', () => ( {
 	isPostTypeSupporting: jest.fn(),
@@ -59,7 +59,7 @@ jest.mock( '@src/variations/core/query/components', () => ( {
 } ) );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { addFilter } from '@wordpress/hooks';
 import { useEffect } from '@wordpress/element';

--- a/test/unit/js/src/stores/datetime-subscribe.test.js
+++ b/test/unit/js/src/stores/datetime-subscribe.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 

--- a/test/unit/js/src/stores/datetime.test.js
+++ b/test/unit/js/src/stores/datetime.test.js
@@ -1,15 +1,15 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { select, dispatch } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 jest.mock( '@src/helpers/datetime', () => ( {
 	defaultDateTimeStart: '2025-01-15 18:00:00',

--- a/test/unit/js/src/stores/email-modal.test.js
+++ b/test/unit/js/src/stores/email-modal.test.js
@@ -1,15 +1,15 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it } from '@jest/globals';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { select, dispatch } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 // Import the actual store to get coverage.
 import '@src/stores/email-modal';

--- a/test/unit/js/src/stores/venue.test.js
+++ b/test/unit/js/src/stores/venue.test.js
@@ -1,15 +1,15 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it } from '@jest/globals';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { select, dispatch } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 // Import the actual store to get coverage.
 import '@src/stores/venue';

--- a/test/unit/js/src/supports/block-guard.test.js
+++ b/test/unit/js/src/supports/block-guard.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import {
 	describe,
@@ -12,7 +12,7 @@ import {
 import '@testing-library/jest-dom';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 jest.mock( '@wordpress/data', () => ( {
 	dispatch: jest.fn( () => ( {
@@ -62,7 +62,7 @@ jest.mock( '@wordpress/element', () => ( {
 } ) );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import {
 	generateBlockGuardStateKey,

--- a/test/unit/js/src/supports/post-date-convert.test.js
+++ b/test/unit/js/src/supports/post-date-convert.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import {
 	describe,
@@ -12,14 +12,14 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
 import { switchToBlockType } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { usePostTypeSupports } from '@src/helpers/event';
 

--- a/test/unit/js/src/variations/core/query/components.test.js
+++ b/test/unit/js/src/variations/core/query/components.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
@@ -80,13 +80,13 @@ jest.mock( '@src/helpers/editor', () => ( {
 } ) );
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { isEventPostType, usePostTypeSupports } from '@src/helpers/event';
 import { isInFSETemplate } from '@src/helpers/editor';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { EventQueryControlsSlotFill } from '@src/variations/core/query/components';
 

--- a/test/unit/js/src/variations/core/query/controls.test.js
+++ b/test/unit/js/src/variations/core/query/controls.test.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
@@ -65,12 +65,12 @@ jest.mock( '@src/helpers/event', () => ( {
 } ) );
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { usePostTypeSupports } from '@src/helpers/event';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { EventQueryControlsPanel } from '@src/variations/core/query/controls';
 

--- a/test/unit/php/class-test-gatherpress.php
+++ b/test/unit/php/class-test-gatherpress.php
@@ -15,6 +15,7 @@ use GatherPress\Tests\Base;
  * Class Test_GatherPress.
  */
 class Test_GatherPress extends Base {
+
 	/**
 	 * Check plugin version.
 	 *

--- a/test/unit/php/includes/tests/classes/class-base.php
+++ b/test/unit/php/includes/tests/classes/class-base.php
@@ -16,6 +16,7 @@ use ReflectionMethod;
  * Define as abstract class to prevent test suite from scanning for test methods.
  */
 abstract class Base extends PMC_Base {
+
 	/**
 	 * Asserts hooks are registered correctly and counts them.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-add-to-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-add-to-calendar.php
@@ -19,6 +19,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Add_To_Calendar
  */
 class Test_Add_To_Calendar extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-dropdown-item.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-dropdown-item.php
@@ -17,6 +17,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Dropdown_Item
  */
 class Test_Dropdown_Item extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-dropdown.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-dropdown.php
@@ -17,6 +17,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Dropdown
  */
 class Test_Dropdown extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-date.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-date.php
@@ -18,6 +18,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Event_Date
  */
 class Test_Event_Date extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -18,6 +18,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Event_Query
  */
 class Test_Event_Query extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-form-field.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-form-field.php
@@ -17,6 +17,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Form_Field
  */
 class Test_Form_Field extends Base {
+
 	/**
 	 * Tests the constructor and attribute processing.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-general-block.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-general-block.php
@@ -21,6 +21,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\General_Block
  */
 class Test_General_Block extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-modal-manager.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-modal-manager.php
@@ -17,6 +17,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Modal_Manager
  */
 class Test_Modal_Manager extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-modal.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-modal.php
@@ -17,6 +17,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Modal
  */
 class Test_Modal extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-online-event.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-online-event.php
@@ -21,6 +21,7 @@ use WP_Block;
  * @coversDefaultClass \GatherPress\Core\Blocks\Online_Event
  */
 class Test_Online_Event extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-form.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-form.php
@@ -21,6 +21,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Blocks\Rsvp_Form
  */
 class Test_Rsvp_Form extends Base {
+
 	/**
 	 * Enable open RSVP for all tests in this class since most exercise the form rendering path.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-response.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-response.php
@@ -19,6 +19,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Rsvp_Response
  */
 class Test_Rsvp_Response extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-template.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-template.php
@@ -22,6 +22,7 @@ use WP_Block_Type_Registry;
  * @coversDefaultClass \GatherPress\Core\Blocks\Rsvp_Template
  */
 class Test_Rsvp_Template extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
@@ -20,6 +20,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Rsvp
  */
 class Test_Rsvp extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-setup.php
@@ -22,6 +22,7 @@ use WP_Block_Type_Registry;
  * @group              blocks
  */
 class Test_Setup extends Base {
+
 	/**
 	 * Coverage for setup_hooks.
 	 *

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-venue.php
@@ -21,6 +21,7 @@ use WP_Block;
  * @coversDefaultClass \GatherPress\Core\Blocks\Venue
  */
 class Test_Venue extends Base {
+
 	/**
 	 * Tests the setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -19,6 +19,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Assets
  */
 class Test_Assets extends Base {
+
 	/**
 	 * Coverage for setup_hooks.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-cli.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-cli.php
@@ -18,6 +18,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Cli
  */
 class Test_Cli extends Base {
+
 	/**
 	 * Coverage for constructor.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-coexistence-guard.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-coexistence-guard.php
@@ -17,6 +17,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Coexistence_Guard
  */
 class Test_Coexistence_Guard extends Base {
+
 	/**
 	 * Reset cached plugin list and the active-plugins option after each test so
 	 * later tests start from a clean slate.
@@ -31,7 +32,7 @@ class Test_Coexistence_Guard extends Base {
 		// synthetic test slugs so they don't leak into other tests.
 		global $wp_filter;
 		foreach ( array_keys( $wp_filter ) as $tag ) {
-			if ( 0 === strpos( $tag, 'activate_test-coexistence' ) ) {
+			if ( str_starts_with( $tag, 'activate_test-coexistence' ) ) {
 				unset( $wp_filter[ $tag ] );
 			}
 		}

--- a/test/unit/php/includes/tests/core/classes/class-test-export.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-export.php
@@ -20,6 +20,7 @@ use PMC\Unit_Test\Utility;
  * @group migrate
  */
 class Test_Export extends Base {
+
 	/**
 	 * Coverage for setup_hooks.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-feed.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-feed.php
@@ -21,6 +21,7 @@ use WP_Query;
  * @coversDefaultClass \GatherPress\Core\Feed
  */
 class Test_Feed extends Base {
+
 	/**
 	 * Test instance of Feed.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding-multisite.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding-multisite.php
@@ -16,4 +16,5 @@ namespace GatherPress\Tests\Core;
  * @group multisite
  */
 class Test_Geocoding_Multisite extends Test_Geocoding {
+
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -26,6 +26,7 @@ use WP_REST_Server;
  * @coversDefaultClass \GatherPress\Core\Geocoding
  */
 class Test_Geocoding extends Base {
+
 	/**
 	 * HTTP mock instance.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-import.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-import.php
@@ -20,6 +20,7 @@ use PMC\Unit_Test\Utility;
  * @group migrate
  */
 class Test_Import extends Base {
+
 	/**
 	 * Coverage for setup_hooks.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-migrate.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-migrate.php
@@ -18,6 +18,7 @@ use GatherPress\Tests\Base;
  * @group migrate
  */
 class Test_Migrate extends Base {
+
 	/**
 	 * Coverage for get_pseudopostmetas method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -26,6 +26,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Settings
  */
 class Test_Settings extends Base {
+
 	/**
 	 * Settings now owns the instantiation of every settings-page subclass
 	 * (Credits, Events, Network, Roles, Rsvp_Settings, Tools, Venues) so

--- a/test/unit/php/includes/tests/core/classes/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-setup.php
@@ -23,6 +23,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Setup
  */
 class Test_Setup extends Base {
+
 	/**
 	 * Coverage for setup_hooks.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-shadow-source.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-shadow-source.php
@@ -22,6 +22,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Shadow_Source
  */
 class Test_Shadow_Source extends Base {
+
 	/**
 	 * Coverage for __construct and setup_hooks.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-starter-pattern-loader.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-starter-pattern-loader.php
@@ -17,6 +17,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Starter_Pattern_Loader
  */
 class Test_Starter_Pattern_Loader extends Base {
+
 	/**
 	 * Loads each `*.php` file in the fixtures directory and returns the
 	 * union of their pattern definitions, skipping anything that does

--- a/test/unit/php/includes/tests/core/classes/class-test-topic.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-topic.php
@@ -17,6 +17,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Topic
  */
 class Test_Topic extends Base {
+
 	/**
 	 * Coverage for __construct and setup_hooks.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-user.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-user.php
@@ -18,6 +18,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\User
  */
 class Test_User extends Base {
+
 	/**
 	 * Coverage for setup_hooks.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -19,6 +19,7 @@ use PMC\Unit_Test\Utility as PMC_Utility;
  * @coversDefaultClass \GatherPress\Core\Utility
  */
 class Test_Utility extends Base {
+
 	/**
 	 * Coverage for render_template method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-validate.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-validate.php
@@ -18,6 +18,7 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Validate
  */
 class Test_Validate extends Base {
+
 	/**
 	 * Coverage for rsvp_status method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/commands/class-test-event-cli.php
+++ b/test/unit/php/includes/tests/core/classes/commands/class-test-event-cli.php
@@ -19,6 +19,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Commands\Event_Cli
  */
 class Test_Event_Cli extends Base {
+
 	/**
 	 * Coverage for rsvp.
 	 *

--- a/test/unit/php/includes/tests/core/classes/commands/class-test-settings-cli.php
+++ b/test/unit/php/includes/tests/core/classes/commands/class-test-settings-cli.php
@@ -18,6 +18,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Commands\Settings_Cli
  */
 class Test_Settings_Cli extends Base {
+
 	/**
 	 * Coverage for export to stdout.
 	 *

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -21,6 +21,7 @@ use WP_Query;
  * @coversDefaultClass \GatherPress\Core\Event\Admin_List
  */
 class Test_Admin_List extends Base {
+
 	/**
 	 * Coverage for setup_hooks method.
 	 *
@@ -1006,7 +1007,7 @@ class Test_Admin_List extends Base {
 
 		// Should contain either ASC or DESC (defaults to ASC).
 		$this->assertTrue(
-			strpos( $result, 'ASC' ) !== false || strpos( $result, 'DESC' ) !== false,
+			str_contains( $result, 'ASC' ) || str_contains( $result, 'DESC' ),
 			'ORDER BY clause should contain ASC or DESC'
 		);
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -24,6 +24,7 @@ use WP_Post;
  * @coversDefaultClass \GatherPress\Core\Event\Event
  */
 class Test_Event extends Base {
+
 	/**
 	 * Coverage for __construct method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/event/class-test-meta.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-meta.php
@@ -20,6 +20,7 @@ use WP_REST_Request;
  * @coversDefaultClass \GatherPress\Core\Event\Meta
  */
 class Test_Meta extends Base {
+
 	/**
 	 * Coverage for `__construct` and `setup_hooks`.
 	 *

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -24,6 +24,7 @@ use WP_Query;
  * @coversDefaultClass \GatherPress\Core\Event\Query
  */
 class Test_Query extends Base {
+
 	/**
 	 * Coverage for setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -28,6 +28,7 @@ use WP_REST_Server;
  * @coversDefaultClass \GatherPress\Core\Event\Rest_Api
  */
 class Test_Rest_Api extends Base {
+
 	/**
 	 * Enable open RSVP for all tests in this class so RSVP form submission paths are exercisable.
 	 *

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -29,6 +29,7 @@ use WP_REST_Request;
  * @coversDefaultClass \GatherPress\Core\Event\Setup
  */
 class Test_Setup extends Base {
+
 	/**
 	 * Event\Setup now owns the instantiation of the Event\* sibling
 	 * singletons (Admin_List, Query, Rest_Api) so the outer

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-form.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-form.php
@@ -21,6 +21,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Rsvp\Form
  */
 class Test_Form extends Base {
+
 	/**
 	 * Enable open RSVP for all tests in this class so form processing paths are exercisable.
 	 *

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
@@ -21,6 +21,7 @@ use WP_Screen;
  * @coversDefaultClass \GatherPress\Core\Rsvp\List_Table
  */
 class Test_List_Table extends Base {
+
 	/**
 	 * The RSVP list table instance.
 	 *

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
@@ -22,6 +22,7 @@ use WP_Comment_Query;
  * @coversDefaultClass \GatherPress\Core\Rsvp\Query
  */
 class Test_Query extends Base {
+
 	/**
 	 * Coverage for __construct and setup_hooks.
 	 *

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
@@ -22,6 +22,7 @@ use WP_Error;
  * @coversDefaultClass \GatherPress\Core\Rsvp\Rsvp
  */
 class Test_Rsvp extends Base {
+
 	/**
 	 * Asserts that the prior fully-qualified class name `GatherPress\Core\Rsvp` continues
 	 * to resolve to the current class `GatherPress\Core\Rsvp\Rsvp` via the alias map in

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-token.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-token.php
@@ -22,6 +22,7 @@ use WP_Post;
  * @coversDefaultClass \GatherPress\Core\Rsvp\Token
  */
 class Test_Token extends Base {
+
 	/**
 	 * Coverage for __construct method with invalid comment ID.
 	 *

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-base-concrete.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-base-concrete.php
@@ -16,6 +16,7 @@ use GatherPress\Core\Settings\Base;
  * Since Base is now abstract, we need a concrete implementation for testing.
  */
 class Test_Base_Concrete extends Base {
+
 	/**
 	 * Get the slug for testing.
 	 *

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-base.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-base.php
@@ -18,6 +18,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Settings\Base
  */
 class Test_Base extends Base_Unit_Test {
+
 	/**
 	 * Coverage for setup_up method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-credits.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-credits.php
@@ -19,6 +19,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Settings\Credits
  */
 class Test_Credits extends Base {
+
 	/**
 	 * Coverage for setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-events.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-events.php
@@ -18,6 +18,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Settings\Events
  */
 class Test_Events extends Base {
+
 	/**
 	 * Coverage for get_slug method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-network.php
@@ -20,6 +20,7 @@ use ReflectionClass;
  * @coversDefaultClass \GatherPress\Core\Settings\Network
  */
 class Test_Network extends Base {
+
 	/**
 	 * Reset the Network site option after each test.
 	 *

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-roles.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-roles.php
@@ -18,6 +18,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Settings\Roles
  */
 class Test_Roles extends Base {
+
 	/**
 	 * Coverage for get_slug method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-rsvp-settings.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-rsvp-settings.php
@@ -18,6 +18,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Settings\Rsvp_Settings
  */
 class Test_Rsvp_Settings extends Base {
+
 	/**
 	 * Coverage for get_slug method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-tools.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-tools.php
@@ -19,6 +19,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Settings\Tools
  */
 class Test_Tools extends Base_Ajax {
+
 	/**
 	 * Coverage for setup_hooks method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
@@ -18,6 +18,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Settings\Venues
  */
 class Test_Venues extends Base {
+
 	/**
 	 * Coverage for get_slug method.
 	 *

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-meta.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-meta.php
@@ -20,6 +20,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Venue\Meta
  */
 class Test_Meta extends Base {
+
 	/**
 	 * Coverage for `__construct` and `setup_hooks`.
 	 *

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -24,6 +24,7 @@ use WP_Block_Patterns_Registry;
  * @coversDefaultClass \GatherPress\Core\Venue\Setup
  */
 class Test_Setup extends Base {
+
 	/**
 	 * Venue\Setup hands the map subsystem off to `Map\Setup` and the
 	 * meta surface off to `Venue\Meta`. Per-sibling internals are

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-venue.php
@@ -25,6 +25,7 @@ use WP_Term;
  * @coversDefaultClass \GatherPress\Core\Venue\Venue
  */
 class Test_Venue extends Base {
+
 	/**
 	 * Asserts that the prior fully-qualified class name `GatherPress\Core\Venue` continues
 	 * to resolve to the current class `GatherPress\Core\Venue\Venue` via the alias map in

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
@@ -21,6 +21,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Venue\Map\Manager
  */
 class Test_Manager extends Base {
+
 	/**
 	 * Reset the registry between tests so a stub provider added in one
 	 * case doesn't bleed into the next case's `get_active()` resolution.

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
@@ -27,6 +27,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Venue\Map\Map
  */
 class Test_Map extends Base {
+
 	/**
 	 * Minimal valid 1×1 PNG used as a stand-in for every tile fetch.
 	 *

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
@@ -21,6 +21,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Venue\Map\Prewarm
  */
 class Test_Prewarm extends Base {
+
 	/**
 	 * Clear scheduled warm events between tests — wp_next_scheduled lookups
 	 * otherwise leak across cases and skew dedup assertions.

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-setup.php
@@ -21,6 +21,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Venue\Map\Setup
  */
 class Test_Setup extends Base {
+
 	/**
 	 * Map\Setup is the hub for the venue map subsystem — its
 	 * `instantiate_classes()` is what wires Manager / Map / Prewarm so

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-base.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-base.php
@@ -21,6 +21,7 @@ use GatherPress\Tests\Base as GatherPress_Test_Base;
  * @coversDefaultClass \GatherPress\Core\Venue\Map\Provider\Base
  */
 class Test_Base extends GatherPress_Test_Base {
+
 	/**
 	 * Default `attribution_html()` returns an empty string — providers that
 	 * bake attribution into the rendered PNG (Google) inherit this; OSM

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -25,6 +25,7 @@ use PMC\Unit_Test\Utility;
  * @coversDefaultClass \GatherPress\Core\Venue\Map\Provider\OSM
  */
 class Test_OSM extends Base {
+
 	/**
 	 * Minimal valid 1×1 PNG used as a stand-in for every tile fetch.
 	 * Keeping the payload tiny means tests stay fast and any code path


### PR DESCRIPTION
### Description of the Change

Three sweeping conventions plus two small settings fixes.

**Conventions sweep:**

- Insert a blank line after every `class|trait|interface Foo {` opening brace so the body's first member doesn't sit right under the brace (matches WordPress core's house style). ~130 PHP files.
- Strip the trailing period from JS docblock dependency headers (`* WordPress dependencies`, `* Internal dependencies`, `* External dependencies`, plus the `Mock …` variants in tests). ~190 JS files.
- Replace 17 `strpos` call sites with `str_contains` / `str_starts_with` (and their negated forms). WordPress ships polyfills for both back to PHP 7.0, so they're safe under our 7.4 minimum.

**Settings fixes:**

- The URL rewrite preview on the settings page used to render `Preview: undefined/event/sample-event` because the React component pulled `homeUrl` from the block-editor settings store — which doesn't exist on the non-block-editor settings screen. Now `home_url()` is passed inline through the PHP partial's `data-gatherpress_component_attrs` and the component reads it directly.
- Moved the **Venues** permalink field out of *Events → Permalinks* into a new *Venues → Permalinks* section so it lives next to the rest of the venue settings.

### How to test the Change

1. *Settings → Events → Permalinks* — preview now reads `Preview: http://yoursite.tld/event/sample-event` (no more `undefined`). The Venues row is gone.
2. *Settings → Venues* — new **Permalinks** section at the bottom with the **Venues** field and a working preview.
3. `npm run lint:php`, `npm run lint:js`, `npm run test:unit:js`, `npm run build` — all clean.
4. Block editor + admin events list + frontend smoke unaffected by the conventions sweep.

### Changelog Entry

> Changed - Apply WordPress coding conventions across the codebase (blank line after class declarations, no trailing period on JS dependency-header docblocks, `strpos` replaced with `str_contains` / `str_starts_with`).
> Fixed - URL rewrite preview on the settings page no longer renders "undefined" before the slug.
> Changed - Venues permalink setting moved from the Events tab to the Venues tab.

### Credits

Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.