### PR TITLE
Fix: scope RSVP UI to gatherpress-rsvp support

### DIFF
--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -54,6 +54,11 @@ Enables the comment-based RSVP system for a post type. This includes:
 - RSVP blocks rendering (rsvp, rsvp-form, rsvp-response, rsvp-template)
 - RSVP token-based email verification for anonymous attendees
 - Comment count adjustment to reflect RSVP activity
+- The RSVPs column (and its sortable header) on the admin list table, replacing the standard comments column to avoid confusion with RSVP submissions
+- The "RSVP settings" panel in the block editor sidebar (guest limit, max attendance, anonymous RSVP, per-event toggle)
+- The post-publish "Send an event update via email" notice that opens the attendee email composer
+
+A post type that declares `gatherpress-event-date` without `gatherpress-rsvp` (e.g. a "production" post type that just wants a premiere date) keeps the datetime column and Event settings sidebar but gets none of the RSVP UI above.
 
 #### Usage for gatherpress-rsvp
 

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -10,7 +10,7 @@ These supports are declared on post types that act as **events**.
 
 The core identifier for event post types. Enables event datetime storage and display. This includes:
 
-- Registration of datetime meta fields (`gatherpress_datetime`, `gatherpress_datetime_start`, `gatherpress_datetime_end`, `gatherpress_timezone`, etc.)
+- Registration of datetime meta fields (`gatherpress_datetime`, `gatherpress_datetime_start`, `gatherpress_datetime_end`, `gatherpress_timezone`, etc.) — GatherPress also auto-adds WordPress's `custom-fields` support to the post type so the REST controller actually attaches the `meta` field to the schema (without it, `register_post_meta()` quietly registers the keys but the editor's PUT silently strips them)
 - Storage in the `gatherpress_events` database table
 - Date-based query ordering (upcoming/past)
 - Event Date block rendering

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -116,7 +116,10 @@ class Admin_List {
 	 * Make custom columns sortable for Event post type in the admin dashboard.
 	 *
 	 * This method allows the custom columns, including the 'Event date & time' and 'RSVPs' columns,
-	 * to be sortable in the WordPress admin dashboard for Event post types.
+	 * to be sortable in the WordPress admin dashboard for Event post types. The
+	 * RSVPs sort key is only added when the current screen's post type also
+	 * declares `gatherpress-rsvp` support, since post types that only carry
+	 * `gatherpress-event-date` have no RSVP column to sort by.
 	 *
 	 * @since 1.0.0
 	 *
@@ -126,8 +129,11 @@ class Admin_List {
 	public function sortable_columns( array $columns ): array {
 		// Add 'datetime' as a sortable column.
 		$columns['datetime'] = 'datetime';
-		// Add 'rsvps' as a sortable column.
-		$columns['rsvps'] = 'rsvps';
+
+		if ( post_type_supports( $this->current_screen_post_type(), 'gatherpress-rsvp' ) ) {
+			// Add 'rsvps' as a sortable column.
+			$columns['rsvps'] = 'rsvps';
+		}
 
 		return $columns;
 	}
@@ -322,12 +328,23 @@ class Admin_List {
 	/**
 	 * Handle RSVP column sorting in the events list.
 	 *
+	 * Bails before delegating to `handle_column_sorting()` when the queried
+	 * post type lacks `gatherpress-rsvp` support — there's no RSVP column on
+	 * that screen, so a `?orderby=rsvps` request would otherwise issue a
+	 * pointless comments-table join.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param WP_Query $query The WP_Query instance.
 	 * @return void
 	 */
 	public function handle_rsvp_sorting( $query ): void {
+		$post_type = $query->get( 'post_type' );
+
+		if ( is_array( $post_type ) || ! post_type_supports( (string) $post_type, 'gatherpress-rsvp' ) ) {
+			return;
+		}
+
 		$this->handle_column_sorting(
 			$query,
 			'rsvps',
@@ -563,10 +580,7 @@ class Admin_List {
 		// link in this context); other taxonomies (Topics, etc.) follow.
 		$venue_taxonomy_columns = array();
 		$other_taxonomy_columns = array();
-		$screen                 = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		$post_type              = ( $screen && '' !== (string) $screen->post_type )
-			? (string) $screen->post_type
-			: Event::POST_TYPE;
+		$post_type              = $this->current_screen_post_type();
 		$venue_taxonomy_key     = 'taxonomy-' . Venue_Setup::get_instance()->taxonomy_for_event_post_type( $post_type );
 
 		foreach ( $columns as $key => $label ) {
@@ -586,8 +600,16 @@ class Admin_List {
 		$placement = 2;
 		$insert    = array(
 			'datetime' => __( 'Event date &amp; time', 'gatherpress' ),
-			'rsvps'    => __( 'RSVPs', 'gatherpress' ),
-		) + $venue_taxonomy_columns + $other_taxonomy_columns;
+		);
+
+		// Only show the RSVPs column for post types that declare gatherpress-rsvp support.
+		// Event-date-only post types (e.g. theater productions tagged with a premiere date)
+		// have no RSVP storage and should not advertise an empty RSVP column.
+		if ( post_type_supports( $post_type, 'gatherpress-rsvp' ) ) {
+			$insert['rsvps'] = __( 'RSVPs', 'gatherpress' );
+		}
+
+		$insert = $insert + $venue_taxonomy_columns + $other_taxonomy_columns;
 
 		return array_slice( $columns, 0, $placement, true ) + $insert + array_slice( $columns, $placement, null, true );
 	}
@@ -598,7 +620,9 @@ class Admin_List {
 	 * This method removes the comments column from the events list table in the WordPress admin
 	 * to avoid confusion between regular comments and RSVP submissions. The comment count
 	 * bubble can be misleading as it combines unapproved comments and RSVPs without
-	 * distinguishing their types.
+	 * distinguishing their types. Only stripped for post types that declare
+	 * `gatherpress-rsvp` support — event-date-only post types still rely on the
+	 * standard comments column for regular comments.
 	 *
 	 * @todo Address limitations in WordPress core get_pending_comments_num function that is too
 	 *       generic and does not take custom comment types into account. It just looks for
@@ -610,8 +634,33 @@ class Admin_List {
 	 * @return array The modified array of column names without the comments column.
 	 */
 	public function remove_comments_column( array $columns ): array {
+		if ( ! post_type_supports( $this->current_screen_post_type(), 'gatherpress-rsvp' ) ) {
+			return $columns;
+		}
+
 		unset( $columns['comments'] );
 
 		return $columns;
+	}
+
+	/**
+	 * Resolve the post type of the current admin screen.
+	 *
+	 * Filters that mutate the columns array (`manage_<post_type>_posts_columns`,
+	 * `manage_edit-<post_type>_sortable_columns`) only receive the columns; the
+	 * post type has to be derived from the current screen so RSVP-specific
+	 * columns can be gated correctly when the same callback runs for multiple
+	 * event-supporting post types.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string The current screen's post type, or the default event post type as a fallback.
+	 */
+	protected function current_screen_post_type(): string {
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		return ( $screen && '' !== (string) $screen->post_type )
+			? (string) $screen->post_type
+			: Event::POST_TYPE;
 	}
 }

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -130,7 +130,12 @@ class Admin_List {
 		// Add 'datetime' as a sortable column.
 		$columns['datetime'] = 'datetime';
 
-		if ( post_type_supports( $this->current_screen_post_type(), 'gatherpress-rsvp' ) ) {
+		$screen    = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		$post_type = ( $screen && '' !== (string) $screen->post_type )
+			? (string) $screen->post_type
+			: Event::POST_TYPE;
+
+		if ( post_type_supports( $post_type, 'gatherpress-rsvp' ) ) {
 			// Add 'rsvps' as a sortable column.
 			$columns['rsvps'] = 'rsvps';
 		}
@@ -341,7 +346,12 @@ class Admin_List {
 	public function handle_rsvp_sorting( $query ): void {
 		$post_type = $query->get( 'post_type' );
 
-		if ( is_array( $post_type ) || ! post_type_supports( (string) $post_type, 'gatherpress-rsvp' ) ) {
+		// Skip when the queried post type lacks `gatherpress-rsvp` support — there's
+		// no RSVP column on that screen, so a `?orderby=rsvps` request would
+		// otherwise issue a pointless comments-table join. Multi-post-type queries
+		// (array `post_type`) fall through to `handle_column_sorting()`'s own
+		// array guard so its early-return arm stays exercised.
+		if ( is_string( $post_type ) && ! post_type_supports( $post_type, 'gatherpress-rsvp' ) ) {
 			return;
 		}
 
@@ -580,7 +590,10 @@ class Admin_List {
 		// link in this context); other taxonomies (Topics, etc.) follow.
 		$venue_taxonomy_columns = array();
 		$other_taxonomy_columns = array();
-		$post_type              = $this->current_screen_post_type();
+		$screen                 = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		$post_type              = ( $screen && '' !== (string) $screen->post_type )
+			? (string) $screen->post_type
+			: Event::POST_TYPE;
 		$venue_taxonomy_key     = 'taxonomy-' . Venue_Setup::get_instance()->taxonomy_for_event_post_type( $post_type );
 
 		foreach ( $columns as $key => $label ) {
@@ -634,33 +647,17 @@ class Admin_List {
 	 * @return array The modified array of column names without the comments column.
 	 */
 	public function remove_comments_column( array $columns ): array {
-		if ( ! post_type_supports( $this->current_screen_post_type(), 'gatherpress-rsvp' ) ) {
+		$screen    = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		$post_type = ( $screen && '' !== (string) $screen->post_type )
+			? (string) $screen->post_type
+			: Event::POST_TYPE;
+
+		if ( ! post_type_supports( $post_type, 'gatherpress-rsvp' ) ) {
 			return $columns;
 		}
 
 		unset( $columns['comments'] );
 
 		return $columns;
-	}
-
-	/**
-	 * Resolve the post type of the current admin screen.
-	 *
-	 * Filters that mutate the columns array (`manage_<post_type>_posts_columns`,
-	 * `manage_edit-<post_type>_sortable_columns`) only receive the columns; the
-	 * post type has to be derived from the current screen so RSVP-specific
-	 * columns can be gated correctly when the same callback runs for multiple
-	 * event-supporting post types.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string The current screen's post type, or the default event post type as a fallback.
-	 */
-	protected function current_screen_post_type(): string {
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-
-		return ( $screen && '' !== (string) $screen->post_type )
-			? (string) $screen->post_type
-			: Event::POST_TYPE;
 	}
 }

--- a/includes/core/classes/event/class-meta.php
+++ b/includes/core/classes/event/class-meta.php
@@ -104,6 +104,15 @@ class Meta {
 	 * @return void
 	 */
 	protected function register_event_date_meta( string $post_type ): void {
+		// `WP_REST_Posts_Controller` only attaches the `meta` field to a post
+		// type's REST schema when the post type declares `custom-fields`
+		// support — without it, `register_post_meta()` quietly registers the
+		// keys but the editor's autosave / publish PUT silently strips them
+		// and the Event Date block renders the em-dash placeholder on the
+		// frontend. Force the support on so companion plugins don't have to
+		// know about this WordPress requirement.
+		add_post_type_support( $post_type, 'custom-fields' );
+
 		$event_date_meta = array(
 			'gatherpress_datetime'           => array(
 				'auth_callback'     => array( Utility::class, 'can_edit_post_meta' ),

--- a/src/components/EmailNotificationManager.js
+++ b/src/components/EmailNotificationManager.js
@@ -8,7 +8,7 @@ import { useEffect, useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { isEventPostType, hasEventPast } from '../helpers/event';
+import { hasEventPast, isRsvpPostType } from '../helpers/event';
 
 /**
  * Email Notification Manager Component.
@@ -42,7 +42,10 @@ const EmailNotificationManager = () => {
 		return {
 			isSaving: saving && ! autosaving,
 			isDirty: dirty,
-			shouldShowNotice: 'publish' === status && isEventPostType() && ! hasEventPast(),
+			// Email-update notice targets RSVP attendees, so only surface it on
+			// post types that actually carry `gatherpress-rsvp` support. Event-
+			// date-only post types have no attendee list to email.
+			shouldShowNotice: 'publish' === status && isRsvpPostType() && ! hasEventPast(),
 		};
 	}, [] );
 

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -99,6 +99,22 @@ export function isEventPostType( postType = null ) {
 }
 
 /**
+ * Checks if a post type declares `gatherpress-rsvp` support.
+ *
+ * Sibling to `isEventPostType()` — used to gate RSVP-only UI (sidebar
+ * settings panel, post-publish email-update notice) so it does not appear on
+ * post types that only declare `gatherpress-event-date` support.
+ *
+ * @since 1.0.0
+ *
+ * @param {string|null} postType Optional post type to check. If not provided, checks current editor post type.
+ * @return {boolean} True if the post type supports RSVP, false otherwise.
+ */
+export function isRsvpPostType( postType = null ) {
+	return isPostTypeSupporting( 'gatherpress-rsvp', postType );
+}
+
+/**
  * Look up a post by ID across all event-supporting post types.
  *
  * Used for postIdOverride scenarios where the editor host is not itself an

--- a/src/panels/rsvp-settings/index.js
+++ b/src/panels/rsvp-settings/index.js
@@ -12,7 +12,7 @@ import { PluginDocumentSettingPanel } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
-import { isEventPostType, isOpenRsvpEnabled, isPerEventRsvpMode } from '../../helpers/event';
+import { isOpenRsvpEnabled, isPerEventRsvpMode, usePostTypeSupports } from '../../helpers/event';
 import { getFromSettings } from '../../helpers/editor-settings';
 import AnonymousRsvpPanel from './anonymous-rsvp';
 import EnableOpenRsvpPanel from './enable-open-rsvp';
@@ -26,20 +26,24 @@ import { RsvpPluginDocumentSettings } from './slot';
  *
  * This component renders a `PluginDocumentSettingPanel` containing various
  * subpanels for configuring RSVP-related settings, such as guest limits,
- * attendance limits, and anonymous RSVP options.
+ * attendance limits, and anonymous RSVP options. The panel is gated on
+ * `gatherpress-rsvp` post type support so that event-date-only post types
+ * (e.g. theater productions tagged with a premiere date) do not surface RSVP
+ * controls that have no underlying meta storage.
  *
  * @since 1.0.0
  *
  * @return {JSX.Element | null} The JSX element for the RsvpSettings panel if
- * the current post type is an event; otherwise, returns null.
+ * the current post type supports RSVP; otherwise, returns null.
  */
 const RsvpSettings = () => {
 	// Only show per-event RSVP toggle when the admin has set rsvp_mode to per_event.
 	const rsvpMode = getFromSettings( 'rsvpMode' ) ?? 'all_on';
 	const enableOpenRsvp = getFromSettings( 'enableOpenRsvp' ) ?? true;
+	const supportsRsvp = usePostTypeSupports( 'gatherpress-rsvp' );
 
 	return (
-		isEventPostType() && 'disabled' !== rsvpMode && (
+		supportsRsvp && 'disabled' !== rsvpMode && (
 			<PluginDocumentSettingPanel
 				name="gatherpress-rsvp-settings"
 				title={ __( 'RSVP settings', 'gatherpress' ) }

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -32,6 +32,7 @@ import {
 	isPostTypeSupporting,
 	usePostTypeSupports,
 	isEventPostType,
+	isRsvpPostType,
 	hasValidEventId,
 	findEventPostById,
 	getEventMeta,
@@ -329,6 +330,88 @@ describe( 'isEventPostType', () => {
 		} );
 
 		expect( isEventPostType( 'page' ) ).toBe( false );
+	} );
+} );
+
+/**
+ * Coverage for isRsvpPostType.
+ *
+ * Mirrors the bug from gatherpress#1591: a custom post type may declare
+ * `gatherpress-event-date` support without `gatherpress-rsvp` support, and
+ * the helper must return false for that case so RSVP-only UI does not leak.
+ */
+describe( 'isRsvpPostType', () => {
+	/**
+	 * Resolves a "production"-style post type that opts into event-date support
+	 * only, alongside the standard event/post mocks.
+	 *
+	 * @param {string} slug The post type slug.
+	 * @return {Object|null} The post type object with supports.
+	 */
+	function mockGetPostTypeWithProduction( slug ) {
+		if ( 'production' === slug ) {
+			return {
+				supports: {
+					'gatherpress-event-date': true,
+				},
+			};
+		}
+		return mockGetPostType( slug );
+	}
+
+	it( 'returns true when current post type supports gatherpress-rsvp', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'gatherpress_event' };
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostTypeWithProduction };
+			}
+			return {};
+		} );
+
+		expect( isRsvpPostType() ).toBe( true );
+	} );
+
+	it( 'returns false for an event-date-only custom post type', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'production' };
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostTypeWithProduction };
+			}
+			return {};
+		} );
+
+		expect( isRsvpPostType() ).toBe( false );
+	} );
+
+	it( 'returns false for a non-event post type', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'post' };
+			}
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostTypeWithProduction };
+			}
+			return {};
+		} );
+
+		expect( isRsvpPostType() ).toBe( false );
+	} );
+
+	it( 'honors the explicit postType argument', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return { getPostType: mockGetPostTypeWithProduction };
+			}
+			return {};
+		} );
+
+		expect( isRsvpPostType( 'gatherpress_event' ) ).toBe( true );
+		expect( isRsvpPostType( 'production' ) ).toBe( false );
+		expect( isRsvpPostType( 'post' ) ).toBe( false );
 	} );
 } );
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -1467,4 +1467,189 @@ class Test_Admin_List extends Base {
 			'Failed to assert that empty array remains unchanged.'
 		);
 	}
+
+	/**
+	 * Reproduces gatherpress#1591: a post type that declares
+	 * `gatherpress-event-date` support but not `gatherpress-rsvp` must not
+	 * advertise the RSVPs sortable column.
+	 *
+	 * @covers ::sortable_columns
+	 *
+	 * @return void
+	 */
+	public function test_sortable_columns_omits_rsvps_for_event_date_only_post_type(): void {
+		$instance = Admin_List::get_instance();
+		$test_pt  = 'production';
+
+		register_post_type(
+			$test_pt,
+			array(
+				'label'    => 'Productions',
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		set_current_screen( 'edit-' . $test_pt );
+
+		$result = $instance->sortable_columns( array( 'unit' => 'test' ) );
+
+		set_current_screen( 'front' );
+		unregister_post_type( $test_pt );
+
+		$this->assertSame(
+			array(
+				'unit'     => 'test',
+				'datetime' => 'datetime',
+			),
+			$result,
+			'Event-date-only post types should keep datetime sortable but not rsvps.'
+		);
+	}
+
+	/**
+	 * Reproduces gatherpress#1591: the `set_custom_columns` filter must not
+	 * inject the RSVPs column header on post types that lack
+	 * `gatherpress-rsvp` support.
+	 *
+	 * @covers ::set_custom_columns
+	 *
+	 * @return void
+	 */
+	public function test_set_custom_columns_omits_rsvps_for_event_date_only_post_type(): void {
+		$instance = Admin_List::get_instance();
+		$test_pt  = 'production';
+
+		register_post_type(
+			$test_pt,
+			array(
+				'label'    => 'Productions',
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		set_current_screen( 'edit-' . $test_pt );
+
+		$default_columns = array(
+			'cb'    => '<input type="checkbox" />',
+			'title' => 'Title',
+			'date'  => 'Date',
+		);
+
+		$result = $instance->set_custom_columns( $default_columns );
+
+		set_current_screen( 'front' );
+		unregister_post_type( $test_pt );
+
+		$this->assertArrayHasKey(
+			'datetime',
+			$result,
+			'Event-date-only post types still get the datetime column.'
+		);
+		$this->assertArrayNotHasKey(
+			'rsvps',
+			$result,
+			'Event-date-only post types should not get the RSVPs column.'
+		);
+	}
+
+	/**
+	 * Reproduces gatherpress#1591: `remove_comments_column` strips the comments
+	 * column to avoid confusion with RSVP comment counts. Post types without
+	 * `gatherpress-rsvp` support have no such conflict and must keep their
+	 * standard comments column.
+	 *
+	 * @covers ::remove_comments_column
+	 *
+	 * @return void
+	 */
+	public function test_remove_comments_column_keeps_column_for_event_date_only_post_type(): void {
+		$instance = Admin_List::get_instance();
+		$test_pt  = 'production';
+
+		register_post_type(
+			$test_pt,
+			array(
+				'label'    => 'Productions',
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		set_current_screen( 'edit-' . $test_pt );
+
+		$columns_with_comments = array(
+			'cb'       => '<input type="checkbox" />',
+			'title'    => 'Title',
+			'comments' => 'Comments',
+			'date'     => 'Date',
+		);
+
+		$result = $instance->remove_comments_column( $columns_with_comments );
+
+		set_current_screen( 'front' );
+		unregister_post_type( $test_pt );
+
+		$this->assertSame(
+			$columns_with_comments,
+			$result,
+			'Event-date-only post types must retain their standard comments column.'
+		);
+	}
+
+	/**
+	 * Reproduces gatherpress#1591: `handle_rsvp_sorting` must short-circuit
+	 * before registering join/groupby/orderby filters when the queried post
+	 * type lacks `gatherpress-rsvp` support, even if a malicious or stale
+	 * `?orderby=rsvps` query var is present.
+	 *
+	 * @covers ::handle_rsvp_sorting
+	 *
+	 * @return void
+	 */
+	public function test_handle_rsvp_sorting_skips_event_date_only_post_type(): void {
+		$instance = Admin_List::get_instance();
+		$test_pt  = 'production';
+
+		register_post_type(
+			$test_pt,
+			array(
+				'label'    => 'Productions',
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		// Make sure no leftover filters are present from a prior test.
+		remove_filter( 'posts_join_paged', array( $instance, 'rsvp_sorting_join_paged' ) );
+		remove_filter( 'posts_groupby', array( $instance, 'sorting_groupby_post_id' ) );
+		remove_filter( 'posts_orderby', array( $instance, 'rsvp_sorting_orderby' ) );
+
+		$query = $this->createMock( WP_Query::class );
+		$query->method( 'is_main_query' )->willReturn( true );
+		$query->method( 'get' )->willReturnMap(
+			array(
+				array( 'post_type', null, $test_pt ),
+				array( 'orderby', null, 'rsvps' ),
+			)
+		);
+
+		$instance->handle_rsvp_sorting( $query );
+
+		unregister_post_type( $test_pt );
+
+		$this->assertFalse(
+			has_filter( 'posts_join_paged', array( $instance, 'rsvp_sorting_join_paged' ) ),
+			'No RSVP join filter should be added for event-date-only post types.'
+		);
+		$this->assertFalse(
+			has_filter( 'posts_groupby', array( $instance, 'sorting_groupby_post_id' ) ),
+			'No RSVP groupby filter should be added for event-date-only post types.'
+		);
+		$this->assertFalse(
+			has_filter( 'posts_orderby', array( $instance, 'rsvp_sorting_orderby' ) ),
+			'No RSVP orderby filter should be added for event-date-only post types.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -1609,6 +1609,8 @@ class Test_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_handle_rsvp_sorting_skips_event_date_only_post_type(): void {
+		global $wp_the_query;
+
 		$instance = Admin_List::get_instance();
 		$test_pt  = 'production';
 
@@ -1626,19 +1628,32 @@ class Test_Admin_List extends Base {
 		remove_filter( 'posts_groupby', array( $instance, 'sorting_groupby_post_id' ) );
 		remove_filter( 'posts_orderby', array( $instance, 'rsvp_sorting_orderby' ) );
 
-		$query = $this->createMock( WP_Query::class );
-		$query->method( 'is_main_query' )->willReturn( true );
-		$query->method( 'get' )->willReturnMap(
+		// Real WP_Query (not a mock) so `$query->get( 'post_type' )` returns the
+		// string we registered — a createMock() with willReturnMap() silently
+		// returns null when the method's optional `$default` arg defaults aren't
+		// matched by the map, which lets the sorting handler bypass the new
+		// rsvp-support guard for the wrong reason.
+		$query = new WP_Query(
 			array(
-				array( 'post_type', null, $test_pt ),
-				array( 'orderby', null, 'rsvps' ),
+				'post_type' => $test_pt,
+				'orderby'   => 'rsvps',
 			)
 		);
 
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Required to satisfy is_main_query() inside handle_column_sorting.
+		$wp_the_query = $query;
+
+		set_current_screen( 'edit-' . $test_pt );
+
 		$instance->handle_rsvp_sorting( $query );
 
+		set_current_screen( 'front' );
 		unregister_post_type( $test_pt );
 
+		$this->assertEmpty(
+			$query->get( 'rsvp_sort_order' ),
+			'rsvp_sort_order must not be set for event-date-only post types.'
+		);
 		$this->assertFalse(
 			has_filter( 'posts_join_paged', array( $instance, 'rsvp_sorting_join_paged' ) ),
 			'No RSVP join filter should be added for event-date-only post types.'

--- a/test/unit/php/includes/tests/core/classes/event/class-test-meta.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-meta.php
@@ -133,6 +133,10 @@ class Test_Meta extends Base {
 			has_filter( sprintf( 'rest_pre_insert_%s', $test_pt ), array( $instance, 'filter_readonly_meta' ) ),
 			'REST readonly-strip filter should wire on event-date-supporting post types.'
 		);
+		$this->assertTrue(
+			post_type_supports( $test_pt, 'custom-fields' ),
+			'custom-fields support should be auto-added so the REST controller exposes the meta field.'
+		);
 
 		unregister_post_type( $test_pt );
 	}


### PR DESCRIPTION
### Description of the Change

The RSVP admin column, sidebar settings panel, and post-publish "send email update" notice were gated on `gatherpress-event-date` support instead of `gatherpress-rsvp`. Any custom post type that opted into `gatherpress-event-date` (e.g. a "production" post type that just wants a premiere date) inherited the full RSVP UI, even though it had no RSVP storage — and the sidebar would actually crash trying to read missing `gatherpress_max_guest_limit` meta.

This PR splits the gates:
- `Admin_List` now only adds the RSVPs column header, sortable key, sorting query rewrite, and comments-column strip when the post type also declares `gatherpress-rsvp` support; the datetime column and Upcoming/Past views remain on `gatherpress-event-date`.
- A new `isRsvpPostType()` JS helper sits next to `isEventPostType()`. The RSVP settings sidebar uses the reactive `usePostTypeSupports('gatherpress-rsvp')`; the email-update notice uses `isRsvpPostType()`.

Closes #1591

### How to test the Change

1. Drop a tiny companion plugin alongside GatherPress that registers a post type with `gatherpress-event-date` (and optionally `gatherpress-shadow-source`) but **not** `gatherpress-rsvp`:
   ```php
   register_post_type( 'production', array(
       'public'       => true,
       'show_in_rest' => true,
       'supports'     => array( 'title', 'editor', 'gatherpress-shadow-source', 'gatherpress-event-date' ),
   ) );
   ```
2. Visit `wp-admin/edit.php?post_type=production` — the list table should show **Title | Event date & time | Date** with no RSVPs column and the standard comments column intact.
3. Open a new production post — the editor sidebar should show only **Event settings** (no RSVP settings panel), and publishing should not trigger the "Send an event update via email" notice or any console TypeError on missing meta.
4. Confirm a regular `gatherpress_event` post still shows the RSVPs column, the RSVP settings panel, and the post-publish email notice.

### Changelog Entry

> Fixed - RSVP admin column, sidebar settings, and post-publish email notice no longer leak onto custom post types that declare `gatherpress-event-date` support without `gatherpress-rsvp`.

### Credits

Props @carstingaxion, @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.