### PR TITLE
Fix #1591 follow-ups: gate Send Updates and add post-type-aware label/pattern filters

### DIFF
--- a/docs/developer/blocks/hookable-patterns/README.md
+++ b/docs/developer/blocks/hookable-patterns/README.md
@@ -38,12 +38,18 @@ The bundled default ships with the plugin:
   in-block pattern pickers stay suppressed.
 
 Third parties can append their own without forking by hooking the
-`gatherpress_event_starter_patterns` filter:
+`gatherpress_event_starter_patterns` filter. The second argument is the
+array of post types declaring `gatherpress-event-date` support that the
+patterns will be registered against — branch on it to scope an entry to
+your own event-acting post type only:
 
 ```php
 add_filter(
     'gatherpress_event_starter_patterns',
-    function ( array $patterns ): array {
+    function ( array $patterns, array $post_types ): array {
+        if ( ! in_array( 'production', $post_types, true ) ) {
+            return $patterns;
+        }
         $patterns[] = array(
             'name'        => 'my-plugin/minimal-event',
             'title'       => __( 'Minimal Event', 'my-plugin' ),
@@ -51,7 +57,9 @@ add_filter(
             'content'     => '<!-- wp:gatherpress/event-date /--><!-- wp:gatherpress/rsvp {"patternPicked":true} --><div class="wp-block-gatherpress-rsvp"></div><!-- /wp:gatherpress/rsvp -->',
         );
         return $patterns;
-    }
+    },
+    10,
+    2
 );
 ```
 

--- a/docs/developer/blocks/pattern-pickers.md
+++ b/docs/developer/blocks/pattern-pickers.md
@@ -140,6 +140,12 @@ Two patterns ship by default, both always available in the chooser:
 Authors can pick either regardless of host post type — the auto-load just
 picks the context-appropriate one when the picker is suppressed.
 
+The second callback argument is the **host post type** — the post type of
+the post being edited (resolved from block context, falling back to the
+editor's current post type). Branch on it to scope a pattern to a specific
+host (e.g. only on a companion plugin's `production` post type) without
+affecting the standard event/venue picker.
+
 ```js
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
@@ -147,18 +153,23 @@ import { __ } from '@wordpress/i18n';
 addFilter(
     'gatherpress.venuePatterns',
     'my-plugin/extra-venue-pattern',
-    ( patterns ) => [
-        ...patterns,
-        {
-            name: 'my-plugin/map-only',
-            title: __( 'Map only', 'my-plugin' ),
-            description: __(
-                'Just the embedded venue map, no contact details.',
-                'my-plugin'
-            ),
-            template: [ [ 'gatherpress/venue-map' ] ],
-        },
-    ]
+    ( patterns, hostPostType ) => {
+        if ( 'production' !== hostPostType ) {
+            return patterns;
+        }
+        return [
+            ...patterns,
+            {
+                name: 'my-plugin/map-only',
+                title: __( 'Map only', 'my-plugin' ),
+                description: __(
+                    'Just the embedded venue map, no contact details.',
+                    'my-plugin'
+                ),
+                template: [ [ 'gatherpress/venue-map' ] ],
+            },
+        ];
+    }
 );
 ```
 

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -52,7 +52,7 @@ The default "Event date & time" admin column header and "Event settings" sidebar
 ```php
 // Relabel the admin list column for a "production" post type.
 add_filter(
-    'gatherpress_event_date_column_label',
+    'gatherpress_event_datetime_label',
     function ( string $label, string $post_type ): string {
         return 'production' === $post_type ? __( 'Premiere date', 'my-plugin' ) : $label;
     },

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -45,6 +45,35 @@ $event->save_datetimes( array(
 ) );
 ```
 
+#### Relabeling the date column and editor panel
+
+The default "Event date & time" admin column header and "Event settings" sidebar panel title can be relabeled per post type without re-implementing either surface. The column key (`datetime`) and panel name stay the same — only the visible label changes.
+
+```php
+// Relabel the admin list column for a "production" post type.
+add_filter(
+    'gatherpress_event_date_column_label',
+    function ( string $label, string $post_type ): string {
+        return 'production' === $post_type ? __( 'Premiere date', 'my-plugin' ) : $label;
+    },
+    10,
+    2
+);
+```
+
+```js
+// Relabel the editor sidebar panel title for the same post type.
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+addFilter(
+    'gatherpress.eventSettingsPanelTitle',
+    'my-plugin/production-panel-title',
+    ( title, postType ) =>
+        'production' === postType ? __( 'Production settings', 'my-plugin' ) : title
+);
+```
+
 ### `gatherpress-rsvp`
 
 Enables the comment-based RSVP system for a post type. This includes:

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -628,7 +628,7 @@ class Admin_List {
 			 * @param string $post_type Post type the admin list is currently rendering.
 			 */
 			'datetime' => apply_filters(
-				'gatherpress_event_date_column_label',
+				'gatherpress_event_datetime_label',
 				__( 'Event date &amp; time', 'gatherpress' ),
 				$post_type
 			),

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -612,7 +612,26 @@ class Admin_List {
 
 		$placement = 2;
 		$insert    = array(
-			'datetime' => __( 'Event date &amp; time', 'gatherpress' ),
+			/**
+			 * Filters the label used for the event-date admin list column.
+			 *
+			 * Lets post types that declare `gatherpress-event-date` support relabel the
+			 * column without having to drop and re-add it via WordPress core's
+			 * `manage_{$post_type}_posts_columns` filter. A `production` post type can
+			 * surface the column as "Premiere date", a `release` post type as "Release
+			 * date", etc., while keeping the underlying `datetime` column key (and its
+			 * sortable behavior) unchanged.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param string $label     Default column label.
+			 * @param string $post_type Post type the admin list is currently rendering.
+			 */
+			'datetime' => apply_filters(
+				'gatherpress_event_date_column_label',
+				__( 'Event date &amp; time', 'gatherpress' ),
+				$post_type
+			),
 		);
 
 		// Only show the RSVPs column for post types that declare gatherpress-rsvp support.

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -266,12 +266,20 @@ class Setup {
 		 * they appear in the new-event chooser modal for any post type
 		 * acting as an event source.
 		 *
+		 * The `$post_types` array lets consumers tailor the returned
+		 * patterns to the post types about to receive them — useful for
+		 * companion plugins that register their own event-acting post
+		 * type and want to swap a pattern in only when their post type
+		 * is in scope.
+		 *
 		 * @since 1.0.0
 		 *
-		 * @param array $patterns Pattern definitions loaded from the
-		 *                        `includes/core/templates/event/` directory.
+		 * @param array $patterns   Pattern definitions loaded from the
+		 *                          `includes/core/templates/event/` directory.
+		 * @param array $post_types Post type slugs declaring `gatherpress-event-date`
+		 *                          support that the patterns will be registered against.
 		 */
-		$patterns = apply_filters( 'gatherpress_event_starter_patterns', $patterns );
+		$patterns = apply_filters( 'gatherpress_event_starter_patterns', $patterns, $post_types );
 
 		foreach ( (array) $patterns as $pattern ) {
 			if ( ! is_array( $pattern ) || empty( $pattern['name'] ) ) {

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -312,12 +312,20 @@ class Setup {
 		 * support, so they appear in the new-venue chooser modal for any
 		 * post type acting as a venue source.
 		 *
+		 * The `$post_types` array lets consumers tailor the returned
+		 * patterns to the post types about to receive them — useful for
+		 * companion plugins that register their own venue-acting post
+		 * type and want to swap a pattern in only when their post type
+		 * is in scope.
+		 *
 		 * @since 1.0.0
 		 *
-		 * @param array $patterns Pattern definitions loaded from the
-		 *                        `includes/core/templates/venue/` directory.
+		 * @param array $patterns   Pattern definitions loaded from the
+		 *                          `includes/core/templates/venue/` directory.
+		 * @param array $post_types Post type slugs declaring `gatherpress-venue-information`
+		 *                          support that the patterns will be registered against.
 		 */
-		$patterns = apply_filters( 'gatherpress_venue_starter_patterns', $patterns );
+		$patterns = apply_filters( 'gatherpress_venue_starter_patterns', $patterns, $post_types );
 
 		foreach ( (array) $patterns as $pattern ) {
 			if ( ! is_array( $pattern ) || empty( $pattern['name'] ) ) {

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -19,7 +19,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -49,7 +49,7 @@ function templateToBlocks( template ) {
 }
 
 /**
- * Starter patterns offered by the Venue block's pattern picker.
+ * Default starter patterns offered by the Venue block's pattern picker.
  *
  * Two layouts that share the address + phone + website + map base — one
  * prepends a `core/post-title` (intended for event posts where the title
@@ -59,31 +59,15 @@ function templateToBlocks( template ) {
  * type — the picker lists both and `<defaultTemplate>` (computed from
  * host context) decides which auto-loads when `patternPicked` is true.
  *
- * Filterable via `gatherpress.venuePatterns` so other plugins or themes
- * can register their own venue layouts. Each entry is shaped
+ * Run through the `gatherpress.venuePatterns` filter inside `Edit` (see
+ * the call site below for the post-type-aware contract) so other plugins
+ * or themes can register their own venue layouts. Each entry is shaped
  * `{ name, title, description, template }` — `template` is an `InnerBlocks`
  * tuple tree (`[ blockName, attributes, innerBlocks ]`).
  *
  * @since 1.0.0
- *
- * @param {Array} patterns Default array containing the bundled
- *                         "Venue Details with Title" and "Venue Details"
- *                         patterns.
- * @return {Array} Patterns shown in the picker modal, in display order.
- *
- * @example
- *   addFilter(
- *     'gatherpress.venuePatterns',
- *     'my-plugin/extra-venue-pattern',
- *     ( patterns ) => [ ...patterns, {
- *       name: 'my-plugin/map-only',
- *       title: __( 'Map only', 'my-plugin' ),
- *       description: __( '...', 'my-plugin' ),
- *       template: [ [ 'gatherpress/venue-map' ] ],
- *     } ]
- *   );
  */
-const PATTERNS = applyFilters( 'gatherpress.venuePatterns', [
+const DEFAULT_PATTERNS = [
 	{
 		name: 'gatherpress/venue-details-with-title',
 		title: __( 'Venue Details with Title', 'gatherpress' ),
@@ -102,7 +86,7 @@ const PATTERNS = applyFilters( 'gatherpress.venuePatterns', [
 		),
 		template: TEMPLATE_WITHOUT_TITLE,
 	},
-] );
+];
 
 const Edit = ( props ) => {
 	const { attributes, setAttributes, clientId, context } = props;
@@ -285,6 +269,52 @@ const Edit = ( props ) => {
 		isEventContext ? TEMPLATE_WITH_TITLE : TEMPLATE_WITHOUT_TITLE
 	);
 
+	/**
+	 * Patterns shown in the Venue block's picker modal.
+	 *
+	 * Receives the bundled defaults plus the host post type so consumers
+	 * can vary the offered patterns by where the block is being edited —
+	 * e.g. a companion plugin's `production` post type can swap in a
+	 * production-specific layout, while leaving the standard event/venue
+	 * picker untouched. `hostPostType` is the post type of the post being
+	 * edited (resolved from block context, falling back to the editor's
+	 * current post type).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param {Array}       patterns     Default array containing the bundled
+	 *                                   "Venue Details with Title" and
+	 *                                   "Venue Details" patterns.
+	 * @param {string|null} hostPostType Post type of the post being edited.
+	 * @return {Array} Patterns shown in the picker modal, in display order.
+	 *
+	 * @example
+	 *   addFilter(
+	 *     'gatherpress.venuePatterns',
+	 *     'my-plugin/extra-venue-pattern',
+	 *     ( patterns, hostPostType ) => {
+	 *       if ( 'production' !== hostPostType ) {
+	 *         return patterns;
+	 *       }
+	 *       return [ ...patterns, {
+	 *         name: 'my-plugin/map-only',
+	 *         title: __( 'Map only', 'my-plugin' ),
+	 *         description: __( '...', 'my-plugin' ),
+	 *         template: [ [ 'gatherpress/venue-map' ] ],
+	 *       } ];
+	 *     }
+	 *   );
+	 */
+	const patterns = useMemo(
+		() =>
+			applyFilters(
+				'gatherpress.venuePatterns',
+				DEFAULT_PATTERNS,
+				effectivePostType
+			),
+		[ effectivePostType ]
+	);
+
 	const innerBlockCount = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getBlocks( clientId ).length,
@@ -332,7 +362,7 @@ const Edit = ( props ) => {
 			) }
 			{ isToolbarChooserOpen && (
 				<PatternChooserModal
-					patterns={ PATTERNS }
+					patterns={ patterns }
 					onPick={ handlePatternPick }
 					onClose={ () => setIsToolbarChooserOpen( false ) }
 				/>
@@ -351,7 +381,7 @@ const Edit = ( props ) => {
 							'Choose a pattern for the venue.',
 							'gatherpress'
 						) }
-						patterns={ PATTERNS }
+						patterns={ patterns }
 						showStartBlank={ false }
 						onPick={ handlePatternPick }
 					/>

--- a/src/panels/event-settings/index.js
+++ b/src/panels/event-settings/index.js
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
-import { dispatch, select } from '@wordpress/data';
+import { dispatch, select, useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
@@ -32,11 +33,26 @@ import { EventPluginDocumentSettings } from './slot';
  * the current post type is an event; otherwise, returns null.
  */
 const EventSettings = () => {
+	const currentPostType = useSelect(
+		( s ) => s( 'core/editor' )?.getCurrentPostType(),
+		[]
+	);
+
+	// Lets post types that declare `gatherpress-event-date` support relabel
+	// the sidebar panel without re-implementing the slotfill — e.g. a
+	// `production` post type can surface "Production settings" instead of
+	// the default "Event settings".
+	const panelTitle = applyFilters(
+		'gatherpress.eventSettingsPanelTitle',
+		__( 'Event settings', 'gatherpress' ),
+		currentPostType
+	);
+
 	return (
 		isEventPostType() && (
 			<PluginDocumentSettingPanel
 				name="gatherpress-event-settings"
-				title={ __( 'Event settings', 'gatherpress' ) }
+				title={ panelTitle }
 				className="gatherpress-event-settings"
 			>
 				{ /* Extendable entry point for "Event Settings" panel. */ }

--- a/src/panels/event-settings/index.js
+++ b/src/panels/event-settings/index.js
@@ -38,10 +38,34 @@ const EventSettings = () => {
 		[]
 	);
 
-	// Lets post types that declare `gatherpress-event-date` support relabel
-	// the sidebar panel without re-implementing the slotfill — e.g. a
-	// `production` post type can surface "Production settings" instead of
-	// the default "Event settings".
+	/**
+	 * Title of the editor's "Event settings" sidebar panel.
+	 *
+	 * Lets post types that declare `gatherpress-event-date` support relabel
+	 * the sidebar panel without re-implementing the slotfill — a
+	 * `production` post type can surface "Production settings" instead of
+	 * the default "Event settings", a `release` post type "Release settings",
+	 * etc. The panel name (`gatherpress-event-settings`) and its slot
+	 * registration are unchanged, so existing `EventPluginDocumentSettings`
+	 * fills keep mounting in the same panel.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param {string}      title    Default panel title ("Event settings").
+	 * @param {string|null} postType Post type currently being edited, or null
+	 *                               if the editor has not yet resolved one.
+	 * @return {string} Panel title rendered in the sidebar.
+	 *
+	 * @example
+	 *   addFilter(
+	 *     'gatherpress.eventSettingsPanelTitle',
+	 *     'my-plugin/production-panel-title',
+	 *     ( title, postType ) =>
+	 *       'production' === postType
+	 *         ? __( 'Production settings', 'my-plugin' )
+	 *         : title
+	 *   );
+	 */
 	const panelTitle = applyFilters(
 		'gatherpress.eventSettingsPanelTitle',
 		__( 'Event settings', 'gatherpress' ),

--- a/src/panels/event-settings/notify-members/index.js
+++ b/src/panels/event-settings/notify-members/index.js
@@ -9,7 +9,7 @@ import { useState, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { hasEventPast } from '../../../helpers/event';
+import { hasEventPast, usePostTypeSupports } from '../../../helpers/event';
 
 /**
  * A panel component for notifying members about an event update.
@@ -25,6 +25,11 @@ const NotifyMembersPanel = () => {
 	const [ showNotifyPanel, setShowNotifyPanel ] = useState( false );
 	const { openModal } = useDispatch( 'gatherpress/email-modal' );
 	const isEmailSaving = useSelect( ( select ) => select( 'gatherpress/email-modal' ).isSaving(), [] );
+	// Email-update target is the RSVP attendee list, so the panel must only
+	// surface on post types that declare `gatherpress-rsvp` support. Event-
+	// date-only post types (e.g. theater productions) have no attendee list
+	// to email and would render a button that opens an empty-recipient modal.
+	const supportsRsvp = usePostTypeSupports( 'gatherpress-rsvp' );
 
 	const { currentStatus, isSaving, isDirty } = useSelect( ( select ) => {
 		const editorSelect = select( 'core/editor' );
@@ -39,8 +44,8 @@ const NotifyMembersPanel = () => {
 	useEffect( () => {
 		const isPostPublished = 'publish' === currentStatus && ! hasEventPast();
 
-		setShowNotifyPanel( isPostPublished );
-	}, [ currentStatus ] );
+		setShowNotifyPanel( isPostPublished && supportsRsvp );
+	}, [ currentStatus, supportsRsvp ] );
 
 	return (
 		showNotifyPanel && (

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -1405,6 +1405,51 @@ class Test_Admin_List extends Base {
 	}
 
 	/**
+	 * The `gatherpress_event_date_column_label` filter relabels the
+	 * datetime column header without changing the column key, and receives
+	 * the screen's post type so consumers can vary the label per post type.
+	 *
+	 * @covers ::set_custom_columns
+	 *
+	 * @return void
+	 */
+	public function test_set_custom_columns_filters_datetime_label(): void {
+		$instance        = Admin_List::get_instance();
+		$captured_pt_arg = null;
+
+		set_current_screen( 'edit-' . Event::POST_TYPE );
+
+		$relabel = static function ( string $label, string $post_type ) use ( &$captured_pt_arg ): string {
+			$captured_pt_arg = $post_type;
+			return 'Premiere date';
+		};
+
+		add_filter( 'gatherpress_event_date_column_label', $relabel, 10, 2 );
+
+		$result = $instance->set_custom_columns(
+			array(
+				'cb'    => '<input type="checkbox" />',
+				'title' => 'Title',
+				'date'  => 'Date',
+			)
+		);
+
+		remove_filter( 'gatherpress_event_date_column_label', $relabel, 10 );
+		set_current_screen( 'front' );
+
+		$this->assertSame(
+			'Premiere date',
+			$result['datetime'],
+			'Datetime column header must reflect the filtered label.'
+		);
+		$this->assertSame(
+			Event::POST_TYPE,
+			$captured_pt_arg,
+			'Filter must receive the screen post type as its second argument.'
+		);
+	}
+
+	/**
 	 * Coverage for remove_comments_column method.
 	 *
 	 * @covers ::remove_comments_column

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -1405,7 +1405,7 @@ class Test_Admin_List extends Base {
 	}
 
 	/**
-	 * The `gatherpress_event_date_column_label` filter relabels the
+	 * The `gatherpress_event_datetime_label` filter relabels the
 	 * datetime column header without changing the column key, and receives
 	 * the screen's post type so consumers can vary the label per post type.
 	 *
@@ -1424,7 +1424,7 @@ class Test_Admin_List extends Base {
 			return 'Premiere date';
 		};
 
-		add_filter( 'gatherpress_event_date_column_label', $relabel, 10, 2 );
+		add_filter( 'gatherpress_event_datetime_label', $relabel, 10, 2 );
 
 		$result = $instance->set_custom_columns(
 			array(
@@ -1434,7 +1434,7 @@ class Test_Admin_List extends Base {
 			)
 		);
 
-		remove_filter( 'gatherpress_event_date_column_label', $relabel, 10 );
+		remove_filter( 'gatherpress_event_datetime_label', $relabel, 10 );
 		set_current_screen( 'front' );
 
 		$this->assertSame(

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -323,6 +323,42 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * The `gatherpress_event_starter_patterns` filter passes the array of
+	 * post types about to receive the registered patterns as its second
+	 * argument, so consumers can vary the returned patterns based on which
+	 * event-acting post types are in scope.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_filter_receives_post_types(): void {
+		$instance        = Setup::get_instance();
+		$captured_pt_arg = null;
+
+		$capture_post_types = static function ( array $patterns, array $post_types ) use ( &$captured_pt_arg ): array {
+			$captured_pt_arg = $post_types;
+			return $patterns;
+		};
+
+		add_filter( 'gatherpress_event_starter_patterns', $capture_post_types, 10, 2 );
+
+		$instance->register_starter_pattern();
+
+		remove_filter( 'gatherpress_event_starter_patterns', $capture_post_types, 10 );
+
+		$this->assertIsArray(
+			$captured_pt_arg,
+			'Filter must receive the post-type array as its second argument.'
+		);
+		$this->assertContains(
+			Event::POST_TYPE,
+			$captured_pt_arg,
+			'Post-type array must include every post type declaring gatherpress-event-date support.'
+		);
+	}
+
+	/**
 	 * Filter callbacks may return entries that aren't valid pattern
 	 * definitions (missing `name`, non-array values). The registration
 	 * loop must skip those gracefully so one bad entry from a

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -364,6 +364,42 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * The `gatherpress_venue_starter_patterns` filter passes the array of
+	 * post types about to receive the registered patterns as its second
+	 * argument, so consumers can vary the returned patterns based on which
+	 * venue-acting post types are in scope.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_filter_receives_post_types(): void {
+		$instance        = Setup::get_instance();
+		$captured_pt_arg = null;
+
+		$capture_post_types = static function ( array $patterns, array $post_types ) use ( &$captured_pt_arg ): array {
+			$captured_pt_arg = $post_types;
+			return $patterns;
+		};
+
+		add_filter( 'gatherpress_venue_starter_patterns', $capture_post_types, 10, 2 );
+
+		$instance->register_starter_pattern();
+
+		remove_filter( 'gatherpress_venue_starter_patterns', $capture_post_types, 10 );
+
+		$this->assertIsArray(
+			$captured_pt_arg,
+			'Filter must receive the post-type array as its second argument.'
+		);
+		$this->assertContains(
+			Venue::POST_TYPE,
+			$captured_pt_arg,
+			'Post-type array must include every post type declaring gatherpress-venue-information support.'
+		);
+	}
+
+	/**
 	 * Coverage for get_venue_meta method.
 	 *
 	 * @covers ::get_venue_meta


### PR DESCRIPTION
### Description of the Change

Addresses three of @carstingaxion's follow-up findings on #1591:

- **#2 Send Updates panel:** `NotifyMembersPanel` now gates on `gatherpress-rsvp` support (mirroring `EmailNotificationManager`) so event-date-only post types don't see a button that opens an empty-recipient modal.
- **#3 Labels:** new `gatherpress_event_datetime_label` (PHP) and `gatherpress.eventSettingsPanelTitle` (JS) filters let post types relabel the admin column and sidebar panel — both receive the post type so consumers can branch on it.
- **#4 Pattern filters:** `gatherpress_event_starter_patterns`, `gatherpress_venue_starter_patterns`, and the JS `gatherpress.venuePatterns` filter now pass post-type context as their second arg. The JS filter was moved off module scope into a `useMemo` inside `Edit` so it sees the host post type and re-runs on context change.

#1 (mixed post types in a custom post type's archive) is left open pending repro details — asked the reporter for the exact URL, archive-page configuration, and whether other plugins are hooking `pre_get_posts`.

Closes #1591 (partial — #2/#3/#4 only; #1 tracked in issue thread)

### How to test the Change

**#2 — Send Updates gating:**
1. Register a custom post type with `'supports' => array( 'title', 'editor', 'gatherpress-event-date' )` (no `gatherpress-rsvp`).
2. Open a post of that type in the editor — confirm the "Send an event update via email" panel does **not** appear.
3. Open a regular `gatherpress_event` post — confirm the panel still appears.

**#3 — Label filters:**
1. `add_filter( 'gatherpress_event_datetime_label', fn( $label, $pt ) => 'production' === $pt ? 'Premiere date' : $label, 10, 2 );` — confirm the admin column header on the production list reads "Premiere date" and remains "Event date & time" on events.
2. JS-side: `addFilter( 'gatherpress.eventSettingsPanelTitle', 'my/relabel', ( title, pt ) => 'production' === pt ? 'Production settings' : title );` — confirm the sidebar panel title swaps per post type.

**#4 — Pattern filters:**
1. Hook each filter, log/inspect the second arg, confirm it's the expected post type / post-type array.
2. Conditionally append a pattern based on post type and verify it shows in the chooser only for the matching post type.

### Changelog Entry

> Fixed - Send Updates panel surfacing on event-date-only post types; added post-type-aware filters for the admin event-date column label, the editor "Event settings" panel title, and the event/venue starter pattern + JS venue pattern filters.

### Credits

Props @carstingaxion, @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.