### PR TITLE
Chore: clear 6 more SonarCloud findings

### DIFF
--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -577,32 +577,35 @@ class Rest_Api {
 	 */
 	public function get_recipients( array $send, int $post_id ): array {
 		$recipients    = array();
-		$rsvp          = new Rsvp( $post_id );
-		$all_responses = $rsvp->responses();
-		$rsvp_query    = Rsvp_Query::get_instance();
+		$all_responses = ( new Rsvp( $post_id ) )->responses();
 
-		// Handle 'all' members (WordPress users only).
+		// Handle 'all' members (WordPress users only) — array_map keeps the
+		// per-user shape declarative.
 		if ( ! empty( $send['all'] ) ) {
-			$users = get_users();
-
-			foreach ( $users as $user ) {
-				$recipients[] = array(
-					'is_user'    => true,
-					'user_id'    => $user->ID,
-					'comment_id' => 0,
-					'email'      => $user->user_email,
-					'name'       => $user->display_name,
-				);
-			}
+			$recipients = array_map(
+				static function ( $user ): array {
+					return array(
+						'is_user'    => true,
+						'user_id'    => $user->ID,
+						'comment_id' => 0,
+						'email'      => $user->user_email,
+						'name'       => $user->display_name,
+					);
+				},
+				get_users()
+			);
 		}
 
-		// Collect comment IDs for RSVP statuses.
+		// Collect comment IDs for the requested RSVP statuses — `array_column`
+		// flattens each status's records to its commentId list in one pass,
+		// avoiding the inner foreach.
 		$comment_ids = array();
 		foreach ( array( 'attending', 'waiting_list', 'not_attending' ) as $status ) {
 			if ( ! empty( $send[ $status ] ) ) {
-				foreach ( $all_responses[ $status ]['records'] as $record ) {
-					$comment_ids[] = $record['commentId'];
-				}
+				$comment_ids = array_merge(
+					$comment_ids,
+					array_column( $all_responses[ $status ]['records'], 'commentId' )
+				);
 			}
 		}
 
@@ -610,8 +613,8 @@ class Rest_Api {
 			return $recipients;
 		}
 
-		// Get full comment data for the RSVPs.
-		$comments = $rsvp_query->get_rsvps(
+		// Get full comment data for the RSVPs and build recipient rows.
+		$comments = Rsvp_Query::get_instance()->get_rsvps(
 			array(
 				'post_id'     => $post_id,
 				'status'      => 'approve',
@@ -620,35 +623,55 @@ class Rest_Api {
 		);
 
 		foreach ( $comments as $comment ) {
-			$user_id = intval( $comment->user_id );
-			$user    = false;
-			$email   = $comment->comment_author_email;
-			$name    = $comment->comment_author;
+			$recipient = $this->build_comment_recipient( $comment );
 
-			if ( $user_id ) {
-				$user = get_userdata( $user_id );
-
-				if ( $user ) {
-					$email = $user->user_email;
-					$name  = $user->display_name;
-				}
+			if ( null !== $recipient ) {
+				$recipients[] = $recipient;
 			}
-
-			// Skip if no email address.
-			if ( empty( $email ) ) {
-				continue;
-			}
-
-			$recipients[] = array(
-				'is_user'    => (bool) $user_id,
-				'user_id'    => $user_id,
-				'comment_id' => $comment->comment_ID,
-				'email'      => $email,
-				'name'       => $name,
-			);
 		}
 
 		return $recipients;
+	}
+
+	/**
+	 * Build a single recipient row from an approved RSVP comment, resolving
+	 * the user's email/display name when the comment is tied to a WordPress
+	 * user. Returns null when no email can be determined so the caller can
+	 * skip the row.
+	 *
+	 * Extracted from `get_recipients()` so the outer dispatch stays under
+	 * SonarCloud's cognitive-complexity threshold.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param object $comment RSVP comment row from `Rsvp_Query::get_rsvps()`.
+	 * @return array|null Recipient row, or null when no email is on file.
+	 */
+	protected function build_comment_recipient( $comment ): ?array {
+		$user_id = intval( $comment->user_id );
+		$email   = $comment->comment_author_email;
+		$name    = $comment->comment_author;
+
+		if ( $user_id ) {
+			$user = get_userdata( $user_id );
+
+			if ( $user ) {
+				$email = $user->user_email;
+				$name  = $user->display_name;
+			}
+		}
+
+		if ( empty( $email ) ) {
+			return null;
+		}
+
+		return array(
+			'is_user'    => (bool) $user_id,
+			'user_id'    => $user_id,
+			'comment_id' => $comment->comment_ID,
+			'email'      => $email,
+			'name'       => $name,
+		);
 	}
 
 	/**

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -418,18 +418,14 @@ class Setup {
 	public function handle_event_archive_redirect(): void {
 		global $wp_query;
 
-		// Only handle event post type archive requests.
-		if ( ! is_post_type_archive( Event::POST_TYPE ) ) {
-			return;
-		}
-
-		// Don't interfere with feed requests - those are handled by the Feed class.
-		if ( is_feed() ) {
-			return;
-		}
-
-		// Don't interfere if event-query already assigned this as an archive page.
-		if ( $wp_query->get( Query::EVENT_QUERY_PARAM ) ) {
+		// Bail when not the event post-type archive, when on a feed (the Feed
+		// class handles those separately), or when event-query already claimed
+		// this page as an archive — combined into one guard so the function
+		// reads as a dispatch.
+		if ( ! is_post_type_archive( Event::POST_TYPE )
+			|| is_feed()
+			|| $wp_query->get( Query::EVENT_QUERY_PARAM )
+		) {
 			return;
 		}
 
@@ -442,29 +438,8 @@ class Setup {
 
 		if ( ! ( $page instanceof WP_Post ) || 'publish' !== $page->post_status ) {
 			// No page exists with this slug — fall back to the configured
-			// archive mode.
-			$mode = $this->get_event_archive_mode();
-
-			if ( 'upcoming' === $mode || 'past' === $mode ) {
-				$paged = get_query_var( 'paged', 1 );
-
-				$wp_query->query(
-					array(
-						'post_type'              => Event::POST_TYPE,
-						Query::EVENT_QUERY_PARAM => $mode,
-						'paged'                  => $paged,
-					)
-				);
-
-				$wp_query->is_page              = false;
-				$wp_query->is_singular          = false;
-				$wp_query->is_archive           = true;
-				$wp_query->is_post_type_archive = true;
-				return;
-			}
-
-			$wp_query->set_404();
-			status_header( 404 );
+			// archive mode (or 404 if no mode is configured).
+			$this->fall_back_to_archive_mode( $wp_query );
 			return;
 		}
 
@@ -515,6 +490,43 @@ class Setup {
 		$wp_query->is_singular          = true;
 		$wp_query->queried_object       = $page;
 		$wp_query->queried_object_id    = $page->ID;
+	}
+
+	/**
+	 * Mutate the global query to render the configured fallback archive mode
+	 * (upcoming/past) when no page is assigned to the events rewrite slug, or
+	 * 404 when no mode is configured. Extracted from
+	 * `handle_event_archive_redirect()` to keep that dispatch under
+	 * SonarCloud's three-return ceiling.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_Query $wp_query The global query, mutated in place.
+	 * @return void
+	 */
+	protected function fall_back_to_archive_mode( \WP_Query $wp_query ): void {
+		$mode = $this->get_event_archive_mode();
+
+		if ( 'upcoming' !== $mode && 'past' !== $mode ) {
+			$wp_query->set_404();
+			status_header( 404 );
+			return;
+		}
+
+		$paged = get_query_var( 'paged', 1 );
+
+		$wp_query->query(
+			array(
+				'post_type'              => Event::POST_TYPE,
+				Query::EVENT_QUERY_PARAM => $mode,
+				'paged'                  => $paged,
+			)
+		);
+
+		$wp_query->is_page              = false;
+		$wp_query->is_singular          = false;
+		$wp_query->is_archive           = true;
+		$wp_query->is_post_type_archive = true;
 	}
 
 	/**

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -426,45 +426,42 @@ class List_Table extends WP_List_Table {
 	 * @return string Formatted content for the specified column.
 	 */
 	public function column_default( $item, $column_name ): string {
+		// Default fall-through (matches the original switch's `default` arm).
+		$output = isset( $item[ $column_name ] ) ? $item[ $column_name ] : '-';
+
 		switch ( $column_name ) {
 			case 'response':
-				$terms = wp_get_object_terms( $item['comment_ID'], Rsvp::TAXONOMY );
-				$name  = '-';
-
-				if ( empty( $terms ) ) {
-					return $name;
-				}
-
-				switch ( $terms[0]->slug ) {
-					case 'attending':
-						$name = __( 'Attending', 'gatherpress' );
-						break;
-					case 'not_attending':
-						$name = __( 'Not Attending', 'gatherpress' );
-						break;
-					case 'waiting_list':
-						$name = __( 'Waiting List', 'gatherpress' );
-						break;
-					default:
-						$name = '-';
-				}
-
-				return $name;
+				$terms          = wp_get_object_terms( $item['comment_ID'], Rsvp::TAXONOMY );
+				$response_names = array(
+					'attending'     => __( 'Attending', 'gatherpress' ),
+					'not_attending' => __( 'Not Attending', 'gatherpress' ),
+					'waiting_list'  => __( 'Waiting List', 'gatherpress' ),
+				);
+				$output         = empty( $terms )
+					? '-'
+					: ( $response_names[ $terms[0]->slug ] ?? '-' );
+				break;
 			case 'event':
-				return '<a href="' . esc_url( get_permalink( $item['comment_post_ID'] ) ) . '">' .
+				$output = '<a href="' . esc_url( get_permalink( $item['comment_post_ID'] ) ) . '">' .
 					wp_kses_post( $item['event_title'] ) . '</a>';
+				break;
 			case 'approved':
 				$statuses = array(
 					'1'    => __( 'Approved', 'gatherpress' ),
 					'0'    => __( 'Pending', 'gatherpress' ),
 					'spam' => __( 'Spam', 'gatherpress' ),
 				);
-				return $statuses[ $item['comment_approved'] ];
+				$output   = $statuses[ $item['comment_approved'] ];
+				break;
 			case 'date':
-				return get_comment_date( 'Y/m/d \a\t g:i a', $item['comment_ID'] );
+				$output = get_comment_date( 'Y/m/d \a\t g:i a', $item['comment_ID'] );
+				break;
 			default:
-				return isset( $item[ $column_name ] ) ? $item[ $column_name ] : '-';
+				// Default assignment already covers this arm.
+				break;
 		}
+
+		return $output;
 	}
 
 	/**

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -900,7 +900,7 @@ class Map {
 		// unreachable, GD missing, brand-new provider not yet warmed). Walk
 		// other providers' stored entries for the same combo so a switch
 		// from OSM to Google still shows the OSM PNG until the new one
-		// lands. Return the first matching entry; ordering follows whatever
+		// lands. Take the first matching entry; ordering follows whatever
 		// post meta gives us (last-saved-wins by storage order).
 		$key         = $this->combo_key(
 			$this->clamp_zoom( $resolved_zoom ),
@@ -909,17 +909,16 @@ class Map {
 		);
 		$all         = $this->get_all_descriptors( $venue_post_id );
 		$active_slug = Manager::get_instance()->get_active_slug();
+		$fallback    = null;
 
 		foreach ( $all as $slug => $combos ) {
-			if ( $slug === $active_slug ) {
-				continue;
-			}
-			if ( isset( $combos[ $key ] ) ) {
-				return $combos[ $key ];
+			if ( $slug !== $active_slug && isset( $combos[ $key ] ) ) {
+				$fallback = $combos[ $key ];
+				break;
 			}
 		}
 
-		return null;
+		return $fallback;
 	}
 
 	/**

--- a/src/blocks/rsvp-guest-count-display/edit.js
+++ b/src/blocks/rsvp-guest-count-display/edit.js
@@ -53,25 +53,23 @@ const Edit = ( { context, clientId } ) => {
 	// Get max attendance limit from meta - check Post ID override first.
 	const maxAttendanceLimit = useSelect(
 		( select ) => {
-			// Check if parent RSVP or RSVP Response block has a postId override.
-			const parentBlocks = select( 'core/block-editor' ).getBlockParents( clientId, true );
-			let postIdOverride = null;
+			// Find the first ancestor RSVP or RSVP Response block that
+			// declared a postId override — replaces the original `for` loop
+			// with `find` so the dispatch is one expression.
+			const parentBlocks =
+				select( 'core/block-editor' ).getBlockParents( clientId, true ) || [];
+			const overrideParent = parentBlocks
+				.map( ( id ) => select( 'core/block-editor' ).getBlock( id ) )
+				.find(
+					( parent ) =>
+						( 'gatherpress/rsvp' === parent?.name ||
+							'gatherpress/rsvp-response' === parent?.name ) &&
+						parent.attributes?.postId,
+				);
 
-			if ( parentBlocks && 0 < parentBlocks.length ) {
-				for ( const parentId of parentBlocks ) {
-					const parent = select( 'core/block-editor' ).getBlock( parentId );
-					if ( 'gatherpress/rsvp' === parent?.name && parent.attributes?.postId ) {
-						postIdOverride = parent.attributes.postId;
-						break;
-					}
-					if ( 'gatherpress/rsvp-response' === parent?.name && parent.attributes?.postId ) {
-						postIdOverride = parent.attributes.postId;
-						break;
-					}
-				}
-			}
+			let postIdOverride = overrideParent?.attributes?.postId ?? null;
 
-			// If no parent block postId, check context postId only if it's an event.
+			// Fall back to context postId only if it's an event.
 			if ( ! postIdOverride && contextPostId && isEventContext ) {
 				postIdOverride = contextPostId;
 			}
@@ -94,12 +92,10 @@ const Edit = ( { context, clientId } ) => {
 			const currentSupportsRsvp = !! select( 'core' )
 				.getPostType( currentPostType )?.supports?.[ 'gatherpress-rsvp' ];
 
-			if ( currentSupportsRsvp ) {
-				return select( 'core/editor' ).getEditedPostAttribute( 'meta' )
-					?.gatherpress_max_guest_limit || 0;
-			}
-
-			return 0;
+			return currentSupportsRsvp
+				? ( select( 'core/editor' ).getEditedPostAttribute( 'meta' )
+					?.gatherpress_max_guest_limit || 0 )
+				: 0;
 		},
 		[ clientId, contextPostId, isEventContext, context?.postType ],
 	);

--- a/src/blocks/rsvp-template/view.js
+++ b/src/blocks/rsvp-template/view.js
@@ -8,6 +8,60 @@ import { store, getContext, getElement } from '@wordpress/interactivity';
  */
 import { stripScriptsAndEventHandlers } from '../../helpers/globals';
 
+/**
+ * Toggle a `.gatherpress--is-visible` / `.gatherpress--is-hidden` class
+ * pair on an element. Centralized so the empty-/has-responses pair share
+ * one implementation and the caller stays a one-liner.
+ *
+ * @param {Element} element The element to toggle.
+ * @param {boolean} visible Whether the element should be visible.
+ */
+const setResponseVisibility = ( element, visible ) => {
+	element.classList.add(
+		visible ? 'gatherpress--is-visible' : 'gatherpress--is-hidden',
+	);
+	element.classList.remove(
+		visible ? 'gatherpress--is-hidden' : 'gatherpress--is-visible',
+	);
+};
+
+/**
+ * Update the empty-/has-responses message pair next to the rendered RSVP
+ * template. Extracted from the renderBlocks `.then` callback so that
+ * callback stays under SonarCloud's cognitive-complexity threshold.
+ *
+ * @param {Element} grandParent    Container holding the message elements.
+ * @param {string}  rsvpSelection  Currently selected RSVP filter.
+ * @param {number}  attendingCount Number of attendees in the response.
+ */
+const updateEmptyResponseMessages = (
+	grandParent,
+	rsvpSelection,
+	attendingCount,
+) => {
+	const emptyEl = grandParent.querySelector(
+		'.gatherpress-rsvp-response--no-responses',
+	);
+
+	if ( ! emptyEl ) {
+		return;
+	}
+
+	const hasNoAttendees =
+		[ 'attending', 'no_status' ].includes( rsvpSelection ) &&
+		0 === attendingCount;
+
+	setResponseVisibility( emptyEl, hasNoAttendees );
+
+	const hasResponsesEl = grandParent.querySelector(
+		'.gatherpress-rsvp-response--has-responses',
+	);
+
+	if ( hasResponsesEl ) {
+		setResponseVisibility( hasResponsesEl, ! hasNoAttendees );
+	}
+};
+
 const { state } = store( 'gatherpress', {
 	callbacks: {
 		renderBlocks() {
@@ -34,87 +88,37 @@ const { state } = store( 'gatherpress', {
 			} )
 				.then( ( response ) => response.json() ) // Parse the JSON response.
 				.then( ( res ) => {
-					if ( res.success ) {
-						const parent = element.ref.parentElement;
-
-						Array.from( parent.children ).forEach( ( sibling ) => {
-							if (
-								sibling !== element.ref &&
-								'id' in sibling.dataset
-							) {
-								sibling.remove();
-							}
-						} );
-
-						const grandParent = parent.parentElement;
-						const emptyRsvpMessageElement =
-							grandParent.querySelector(
-								'.gatherpress-rsvp-response--no-responses',
-							);
-
-						if ( emptyRsvpMessageElement ) {
-							// Default to 'attending' to match the fetch status default above.
-							const rsvpSelection =
-								state.posts[ context.postId ]
-									?.rsvpSelection || 'attending';
-
-							const hasNoAttendees =
-								[ 'attending', 'no_status' ].includes(
-									rsvpSelection,
-								) &&
-								0 === res.responses.attending.count;
-
-							if ( hasNoAttendees ) {
-								emptyRsvpMessageElement.classList.add(
-									'gatherpress--is-visible',
-								);
-								emptyRsvpMessageElement.classList.remove(
-									'gatherpress--is-hidden',
-								);
-							} else {
-								emptyRsvpMessageElement.classList.add(
-									'gatherpress--is-hidden',
-								);
-								emptyRsvpMessageElement.classList.remove(
-									'gatherpress--is-visible',
-								);
-							}
-
-							// Toggle the inverse has-responses element.
-							const hasResponsesElement =
-								grandParent.querySelector(
-									'.gatherpress-rsvp-response--has-responses',
-								);
-
-							if ( hasResponsesElement ) {
-								if ( hasNoAttendees ) {
-									hasResponsesElement.classList.add(
-										'gatherpress--is-hidden',
-									);
-									hasResponsesElement.classList.remove(
-										'gatherpress--is-visible',
-									);
-								} else {
-									hasResponsesElement.classList.add(
-										'gatherpress--is-visible',
-									);
-									hasResponsesElement.classList.remove(
-										'gatherpress--is-hidden',
-									);
-								}
-							}
-						}
-
-						// `res.content` is HTML rendered by GatherPress's own
-						// `/rsvp-status-html` REST endpoint, which escapes
-						// at template time. The strip pass here is
-						// defense-in-depth — not a substitute for proper
-						// server-side escaping.
-						element.ref.insertAdjacentHTML(
-							'beforebegin',
-							stripScriptsAndEventHandlers( res.content ),
-						);
+					if ( ! res.success ) {
+						return;
 					}
+
+					const parent = element.ref.parentElement;
+
+					Array.from( parent.children ).forEach( ( sibling ) => {
+						if (
+							sibling !== element.ref &&
+							'id' in sibling.dataset
+						) {
+							sibling.remove();
+						}
+					} );
+
+					updateEmptyResponseMessages(
+						parent.parentElement,
+						state.posts[ context.postId ]?.rsvpSelection ||
+							'attending',
+						res.responses.attending.count,
+					);
+
+					// `res.content` is HTML rendered by GatherPress's own
+					// `/rsvp-status-html` REST endpoint, which escapes
+					// at template time. The strip pass here is
+					// defense-in-depth — not a substitute for proper
+					// server-side escaping.
+					element.ref.insertAdjacentHTML(
+						'beforebegin',
+						stripScriptsAndEventHandlers( res.content ),
+					);
 				} )
 				.catch( () => {} );
 		},

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -2433,4 +2433,102 @@ class Test_Rest_Api extends Base {
 
 		$this->assertTrue( true, 'Helper returned without sending mail.' );
 	}
+
+	/**
+	 * Direct-invoke coverage for `build_comment_recipient` (extracted from
+	 * `get_recipients`) — happy path with a registered user pulls email and
+	 * display name from the user record rather than the comment fields.
+	 *
+	 * Reflection-invoked because xdebug doesn't reliably trace lines inside
+	 * same-class protected helpers called from a foreach in the parent.
+	 *
+	 * @covers ::build_comment_recipient
+	 *
+	 * @return void
+	 */
+	public function test_build_comment_recipient_uses_user_data_when_user_id_present(): void {
+		$instance = Rest_Api::get_instance();
+		$user_id  = $this->factory->user->create(
+			array(
+				'user_email'   => 'user-recipient@example.test',
+				'display_name' => 'User Recipient',
+			)
+		);
+
+		$comment                       = new \stdClass();
+		$comment->comment_ID           = 42;
+		$comment->user_id              = $user_id;
+		$comment->comment_author_email = 'comment-fallback@example.test';
+		$comment->comment_author       = 'Comment Author';
+
+		$recipient = Utility::invoke_hidden_method(
+			$instance,
+			'build_comment_recipient',
+			array( $comment )
+		);
+
+		$this->assertIsArray( $recipient );
+		$this->assertTrue( $recipient['is_user'] );
+		$this->assertSame( $user_id, $recipient['user_id'] );
+		$this->assertSame( 42, $recipient['comment_id'] );
+		// User data wins over comment-author fields when user_id resolves.
+		$this->assertSame( 'user-recipient@example.test', $recipient['email'] );
+		$this->assertSame( 'User Recipient', $recipient['name'] );
+	}
+
+	/**
+	 * Direct-invoke coverage for `build_comment_recipient` — anonymous-RSVP
+	 * branch (no user_id) keeps the comment's own author email/name.
+	 *
+	 * @covers ::build_comment_recipient
+	 *
+	 * @return void
+	 */
+	public function test_build_comment_recipient_falls_back_to_comment_fields(): void {
+		$instance = Rest_Api::get_instance();
+
+		$comment                       = new \stdClass();
+		$comment->comment_ID           = 7;
+		$comment->user_id              = 0;
+		$comment->comment_author_email = 'anon@example.test';
+		$comment->comment_author       = 'Anon';
+
+		$recipient = Utility::invoke_hidden_method(
+			$instance,
+			'build_comment_recipient',
+			array( $comment )
+		);
+
+		$this->assertIsArray( $recipient );
+		$this->assertFalse( $recipient['is_user'] );
+		$this->assertSame( 0, $recipient['user_id'] );
+		$this->assertSame( 'anon@example.test', $recipient['email'] );
+		$this->assertSame( 'Anon', $recipient['name'] );
+	}
+
+	/**
+	 * Direct-invoke coverage for `build_comment_recipient` — returns null
+	 * for a comment with no email on file so the caller can skip it.
+	 *
+	 * @covers ::build_comment_recipient
+	 *
+	 * @return void
+	 */
+	public function test_build_comment_recipient_returns_null_without_email(): void {
+		$instance = Rest_Api::get_instance();
+
+		$comment                       = new \stdClass();
+		$comment->comment_ID           = 1;
+		$comment->user_id              = 0;
+		$comment->comment_author_email = '';
+		$comment->comment_author       = 'No Email';
+
+		$recipient = Utility::invoke_hidden_method(
+			$instance,
+			'build_comment_recipient',
+			array( $comment )
+		);
+
+		$this->assertNull( $recipient );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -1779,4 +1779,70 @@ class Test_Setup extends Base {
 		// Clean up.
 		Utility::set_and_get_hidden_property( $instance, 'archive_title', '' );
 	}
+
+	/**
+	 * Direct-invoke coverage for `fall_back_to_archive_mode` (extracted from
+	 * `handle_event_archive_redirect`) — happy path: an `upcoming`/`past`
+	 * mode setting rewrites the query as the matching event archive.
+	 *
+	 * Reflection-invoked because xdebug doesn't reliably trace lines inside
+	 * same-class protected helpers called from the parent dispatch.
+	 *
+	 * @covers ::fall_back_to_archive_mode
+	 *
+	 * @return void
+	 */
+	public function test_fall_back_to_archive_mode_sets_query_for_upcoming(): void {
+		$instance = Setup::get_instance();
+
+		update_option( Settings::OPTION_NAME, array( 'event_archive' => 'upcoming' ) );
+
+		$wp_query = new \WP_Query();
+
+		Utility::invoke_hidden_method(
+			$instance,
+			'fall_back_to_archive_mode',
+			array( $wp_query )
+		);
+
+		delete_option( Settings::OPTION_NAME );
+
+		$this->assertTrue( $wp_query->is_archive );
+		$this->assertTrue( $wp_query->is_post_type_archive );
+		$this->assertFalse( $wp_query->is_page );
+		$this->assertFalse( $wp_query->is_singular );
+		$this->assertSame( 'upcoming', $wp_query->get( Query::EVENT_QUERY_PARAM ) );
+	}
+
+	/**
+	 * Direct-invoke coverage for `fall_back_to_archive_mode` 404 branch:
+	 * when the configured mode is neither `upcoming` nor `past`, the helper
+	 * sets the global query to a 404.
+	 *
+	 * @covers ::fall_back_to_archive_mode
+	 *
+	 * @return void
+	 */
+	public function test_fall_back_to_archive_mode_sets_404_when_no_mode(): void {
+		$instance = Setup::get_instance();
+
+		// `none` is a valid archive mode that means "no archive" — neither
+		// upcoming nor past — so it lands on the 404 arm.
+		$mode_filter = static function (): string {
+			return 'none';
+		};
+		add_filter( 'gatherpress_event_archive_mode', $mode_filter );
+
+		$wp_query = new \WP_Query();
+
+		Utility::invoke_hidden_method(
+			$instance,
+			'fall_back_to_archive_mode',
+			array( $wp_query )
+		);
+
+		remove_filter( 'gatherpress_event_archive_mode', $mode_filter );
+
+		$this->assertTrue( $wp_query->is_404() );
+	}
 }


### PR DESCRIPTION
### Description of the Change

Fourth pass clearing SonarCloud findings on `develop`. No behavior change. Same B-style approach.

- **3 `php:S1142`** (multi-return methods)
  - `Map::get_descriptor_for_post` — assign-to-variable + break instead of mid-loop returns.
  - `Event\Setup::handle_event_archive_redirect` — combined three early-bail guards into one and extracted `fall_back_to_archive_mode()`.
  - `Rsvp\List_Table::column_default` — switch dispatch now assigns to `$output` and returns once.
- **2 `javascript:S3776`** (cognitive complexity)
  - `rsvp-template/view.js` `renderBlocks` `.then` — extracted `setResponseVisibility` and `updateEmptyResponseMessages`.
  - `rsvp-guest-count-display/edit.js` — replaced parent-block `for` loop with `find`, collapsed final `if/else` into a ternary.
- **1 `php:S3776`** — `Rest_Api::get_recipients` extracted `build_comment_recipient` and replaced the inner `foreach` over RSVP records with `array_column`.

5 reflection-invoke direct tests added for the three extracted helpers (`fall_back_to_archive_mode`, `build_comment_recipient`) since xdebug doesn't trace lines inside same-class private/protected helpers called from the parent dispatch.

Skipped (genuinely too tangled to combine cleanly without hurting readability — better as their own focused PRs):
- `Map::ensure_descriptor_for_combo` — 6 real failure modes need explicit returns.
- `Settings_Cli::import` — per-branch logging.
- `Rsvp\Rsvp::save` — paired with cognitive complexity 29; deserves a dedicated refactor.

### How to test the Change

- `npm run lint:php`, `npm run lint:phpstan`, `npm run lint:js` should all pass.
- `npm run test:unit:php` (1343 tests, +5 new) and `npm run test:unit:js` (772 tests) should all pass.
- After CI runs, the `develop` SonarCloud "in new code" count should drop from 48 → ~42 and total open from 61 → ~55.

### Changelog Entry

> Changed - SonarCloud cleanup: extract `fall_back_to_archive_mode` and `build_comment_recipient` helpers, consolidate 3 multi-return methods, and reduce cognitive complexity in 2 JS callbacks.

### Credits

Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.