### PR TITLE
Fix admin datetime column sort for event-supporting custom post types

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ GatherPress calls the following services when editing venues or displaying maps.
 ---
 
 *GatherPress is still in active development. Thank you for helping us build a better way to gather.*
+

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -244,7 +244,9 @@ class Admin_List {
 	 * match the actual list. Both buckets pivot on `datetime_end_gmt`:
 	 * upcoming = end time is still in the future (running + future);
 	 * past = end time has already passed. Mutually exclusive — running
-	 * events appear only in upcoming, never in both.
+	 * events appear only in upcoming, never in both. Events with no row
+	 * in the events table (no date set yet) are excluded from both
+	 * buckets — they only appear under the All view.
 	 *
 	 * @since 1.0.0
 	 *
@@ -261,15 +263,15 @@ class Admin_List {
 		$table   = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 		$current = gmdate( Event::DATETIME_FORMAT, time() );
 
-		// Upcoming: events whose end time is still in the future (includes currently running),
-		// or events with no row in the events table (no date set yet).
+		// Upcoming: events whose end time is still in the future (includes
+		// currently running). Events with no row in the events table are
+		// not counted — they only show under the All view.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$upcoming = (int) $wpdb->get_var(
 			$wpdb->prepare(
-				'SELECT COUNT(1) FROM %i LEFT JOIN %i ON %i.ID = %i.post_id'
+				'SELECT COUNT(1) FROM %i INNER JOIN %i ON %i.ID = %i.post_id'
 				. ' WHERE %i.post_type = %s AND %i.post_status NOT IN'
-				. " ('trash', 'auto-draft') AND (%i.datetime_end_gmt >= %s"
-				. ' OR %i.post_id IS NULL)',
+				. " ('trash', 'auto-draft') AND %i.datetime_end_gmt >= %s",
 				$wpdb->posts,
 				$table,
 				$wpdb->posts,
@@ -278,20 +280,19 @@ class Admin_List {
 				$post_type,
 				$wpdb->posts,
 				$table,
-				$current,
-				$table
+				$current
 			)
 		);
 
-		// Past: events whose end time has already passed,
-		// excluding events with no row in the events table.
+		// Past: events whose end time has already passed. Events with no
+		// row in the events table are excluded — they only show under the
+		// All view.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$past = (int) $wpdb->get_var(
 			$wpdb->prepare(
-				'SELECT COUNT(1) FROM %i LEFT JOIN %i ON %i.ID = %i.post_id'
+				'SELECT COUNT(1) FROM %i INNER JOIN %i ON %i.ID = %i.post_id'
 				. ' WHERE %i.post_type = %s AND %i.post_status NOT IN'
-				. " ('trash', 'auto-draft') AND %i.datetime_end_gmt < %s"
-				. ' AND %i.post_id IS NOT NULL',
+				. " ('trash', 'auto-draft') AND %i.datetime_end_gmt < %s",
 				$wpdb->posts,
 				$table,
 				$wpdb->posts,
@@ -300,8 +301,7 @@ class Admin_List {
 				$post_type,
 				$wpdb->posts,
 				$table,
-				$current,
-				$table
+				$current
 			)
 		);
 

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -70,6 +70,11 @@ class Query {
 		add_action( 'pre_get_posts', array( $this, 'prepare_event_query_before_execution' ) );
 		// Priority 9 to run before the upcoming/past adjustments at priority 10.
 		add_filter( 'posts_clauses', array( $this, 'adjust_admin_event_sorting' ), 9, 2 );
+		add_action( 'pre_get_posts', function ( WP_Query $wp_query ) {
+			if ( empty( $wp_query->get( self::EVENT_QUERY_PARAM ) ) && post_type_supports( $wp_query->get( 'post_type' ), 'gatherpress-event-date' ) ) {
+				$wp_query->set( self::EVENT_QUERY_PARAM, 'all' );
+			}
+		}, 8 );
 	}
 
 	/**
@@ -361,7 +366,7 @@ class Query {
 		}
 
 		/**
-		 * Run only for Event post listings.
+		 * Run only for listings of posts, that support event dates.
 		 *
 		 * First checks whether the get_current_screen function exists,
 		 * because it is loaded only after the 'admin_init' hook.
@@ -371,9 +376,13 @@ class Query {
 		 * This sanity check was added after it's been reported that some admin screens may not have $wp_query set.
 		 * @see https://wordpress.org/support/topic/gatherpress-has-critical-error-when-i-access-wpforms-payment-settings/
 		 */
-		$screen_id      = sprintf( 'edit-%s', Event::POST_TYPE );
 		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		if ( ! $current_screen || $screen_id !== $current_screen->id ) {
+		if (
+			! $current_screen ||
+			'edit' !== $current_screen->base ||
+			! post_type_supports( $current_screen->post_type, 'gatherpress-event-date' ) ||
+			$wp_query->get( 'post_type' ) !== $current_screen->post_type
+		) {
 			return $query_pieces;
 		}
 

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -70,11 +70,6 @@ class Query {
 		add_action( 'pre_get_posts', array( $this, 'prepare_event_query_before_execution' ) );
 		// Priority 9 to run before the upcoming/past adjustments at priority 10.
 		add_filter( 'posts_clauses', array( $this, 'adjust_admin_event_sorting' ), 9, 2 );
-		add_action( 'pre_get_posts', function ( WP_Query $wp_query ) {
-			if ( empty( $wp_query->get( self::EVENT_QUERY_PARAM ) ) && post_type_supports( $wp_query->get( 'post_type' ), 'gatherpress-event-date' ) ) {
-				$wp_query->set( self::EVENT_QUERY_PARAM, 'all' );
-			}
-		}, 8 );
 	}
 
 	/**
@@ -404,8 +399,7 @@ class Query {
 			$gatherpress_events_query,
 			$wp_query->get( 'order' ),
 			$wp_query->get( 'orderby' ),
-			$inclusive,
-			true
+			$inclusive
 		);
 
 		return $query_pieces;
@@ -424,16 +418,14 @@ class Query {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array           $pieces    An array of query pieces, including join, where, orderby,
-	 *                                   and more.
-	 * @param string          $type      The type of events to query (options: 'all', 'upcoming', 'past')
-	 *                                   (Default: 'all').
-	 * @param string          $order     The event order ('DESC' for descending or 'ASC' for ascending)
-	 *                                   (Default: 'DESC').
-	 * @param string[]|string $order_by  List  or singular string of ORDERBY statement(s) (Default: ['datetime']).
-	 * @param bool            $inclusive      Whether to include currently running events in the query (Default: true).
-	 * @param bool            $include_no_date Whether to include events with no date set in upcoming
-	 *                                         and exclude them from past (Default: false).
+	 * @param array           $pieces   An array of query pieces, including join, where, orderby,
+	 *                                  and more.
+	 * @param string          $type     The type of events to query (options: 'all', 'upcoming', 'past')
+	 *                                  (Default: 'all').
+	 * @param string          $order    The event order ('DESC' for descending or 'ASC' for ascending)
+	 *                                  (Default: 'DESC').
+	 * @param string[]|string $order_by List or singular string of ORDERBY statement(s) (Default: ['datetime']).
+	 * @param bool            $inclusive Whether to include currently running events in the query (Default: true).
 	 * @return array An array containing adjusted SQL clauses for the Event query.
 	 */
 	public function adjust_event_sql(
@@ -441,8 +433,7 @@ class Query {
 		string $type = 'all',
 		string $order = 'DESC',
 		$order_by = array( 'datetime' ),
-		bool $inclusive = true,
-		bool $include_no_date = false
+		bool $inclusive = true
 	): array {
 		global $wpdb;
 
@@ -500,30 +491,14 @@ class Query {
 		$current = gmdate( Event::DATETIME_FORMAT, time() );
 		$column  = $this->get_datetime_comparison_column( $type, $inclusive );
 
-		// Appends a date-based condition to the WHERE clause of the SQL query,
-		// filtering events as either upcoming or past.
+		// Append a date-based condition to the WHERE clause, filtering as
+		// either upcoming or past. Events with no row in the events table
+		// (no date set yet) are excluded from both buckets — they only
+		// appear under the All view.
 		if ( 'upcoming' === $type ) {
-			if ( $include_no_date ) {
-				// Include events on or after the current date/time, or events with no row in the events table.
-				$pieces['where'] .= $wpdb->prepare(
-					' AND (%i.%i >= %s OR %i.post_id IS NULL)',
-					$table,
-					$column,
-					$current,
-					$table
-				);
-			} else {
-				// Include only events starting on or after the current date/time (upcoming).
-				$pieces['where'] .= $wpdb->prepare( ' AND %i.%i >= %s', $table, $column, $current );
-			}
+			$pieces['where'] .= $wpdb->prepare( ' AND %i.%i >= %s', $table, $column, $current );
 		} elseif ( 'past' === $type ) {
-			// Include only events starting before the current date/time (past).
 			$pieces['where'] .= $wpdb->prepare( ' AND %i.%i < %s', $table, $column, $current );
-
-			if ( $include_no_date ) {
-				// Exclude events with no row in the events table.
-				$pieces['where'] .= $wpdb->prepare( ' AND %i.post_id IS NOT NULL', $table );
-			}
 		}
 
 		return $pieces;

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -753,10 +753,15 @@ class Test_Admin_List extends Base {
 	}
 
 	/**
-	 * Coverage for get_event_counts method with events that have no date set.
+	 * Events without a date set don't appear in the upcoming/past view counts.
 	 *
-	 * Events without a date/time set have no row in the gatherpress_events table.
-	 * These should be counted as upcoming, not past.
+	 * Events with no row in the `gatherpress_events` table show up only
+	 * under the All view — they're neither upcoming nor past, since
+	 * there's no datetime to compare against. The counts mirror the
+	 * filter in `Query::adjust_admin_event_sorting()`, which uses an
+	 * INNER JOIN that drops these rows. Was previously counted as
+	 * upcoming via `OR post_id IS NULL`, removed when the admin
+	 * defaulted to the All view (see #1610).
 	 *
 	 * @covers ::get_event_counts
 	 *
@@ -778,7 +783,7 @@ class Test_Admin_List extends Base {
 
 		$counts = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
 
-		$this->assertSame( 1, $counts['upcoming'], 'Event without date should count as upcoming.' );
+		$this->assertSame( 0, $counts['upcoming'], 'Event without date should not count as upcoming.' );
 		$this->assertSame( 0, $counts['past'], 'Event without date should not count as past.' );
 	}
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -690,6 +690,11 @@ class Test_Query extends Base {
 		$this->mock->user( true, 'admin' );
 		set_current_screen( 'edit-gatherpress_event' );
 
+		// Set 'post_type' to match the current screen (the function bails if
+		// they differ, to avoid altering secondary queries fired from the
+		// same admin page).
+		$wp_query->set( 'post_type', Event::POST_TYPE );
+
 		// Set 'orderby' admin query to 'datetime'.
 		$wp_query->set( 'orderby', 'datetime' );
 
@@ -703,6 +708,7 @@ class Test_Query extends Base {
 		);
 
 		$wp_query = new WP_Query();
+		$wp_query->set( 'post_type', Event::POST_TYPE );
 
 		$wp_query->set( 'gatherpress_event_query', 'upcoming' );
 		$response = $instance->adjust_admin_event_sorting( array(), $wp_query );
@@ -748,6 +754,89 @@ class Test_Query extends Base {
 			$query_pieces,
 			$response,
 			'Should return query_pieces unchanged when screen is not edit-gatherpress_event'
+		);
+	}
+
+	/**
+	 * Reproduces #1610: clicking the "Event date & time" column header on
+	 * the admin list of a custom event-supporting post type (e.g.
+	 * `production`) must apply the datetime sort. Before the fix the
+	 * function bailed early because the screen check was hardcoded to
+	 * `edit-gatherpress_event`, leaving the click a no-op on every other
+	 * post type that declares `gatherpress-event-date` support.
+	 *
+	 * @covers ::adjust_admin_event_sorting
+	 *
+	 * @return void
+	 */
+	public function test_adjust_admin_event_sorting_runs_for_event_supporting_post_type(): void {
+		$instance = Query::get_instance();
+		$test_pt  = 'production';
+
+		register_post_type(
+			$test_pt,
+			array(
+				'label'    => 'Productions',
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		$this->mock->user( true, 'admin' );
+		set_current_screen( 'edit-' . $test_pt );
+
+		$wp_query = new WP_Query();
+		$wp_query->set( 'post_type', $test_pt );
+		$wp_query->set( 'orderby', 'datetime' );
+		$wp_query->set( 'order', 'asc' );
+
+		$response = $instance->adjust_admin_event_sorting( array(), $wp_query );
+
+		set_current_screen( 'front' );
+		unregister_post_type( $test_pt );
+
+		$this->assertNotEmpty(
+			$response,
+			'Should produce a non-empty pieces array for an event-supporting custom post type.'
+		);
+		$this->assertStringContainsString(
+			'datetime_start_gmt ASC',
+			$response['orderby'] ?? '',
+			'Should sort by the events table datetime_start_gmt column.'
+		);
+	}
+
+	/**
+	 * Guards against secondary queries on the admin list table — a
+	 * `WP_Query` whose `post_type` does not match the screen's post
+	 * type (for example, a sidebar widget or related-content lookup
+	 * fired from the admin list page) must not get the datetime sort
+	 * grafted onto its SQL.
+	 *
+	 * @covers ::adjust_admin_event_sorting
+	 *
+	 * @return void
+	 */
+	public function test_adjust_admin_event_sorting_skips_when_post_type_mismatches_screen(): void {
+		$instance     = Query::get_instance();
+		$query_pieces = array( 'orderby' => 'post_date' );
+
+		$this->mock->user( true, 'admin' );
+		set_current_screen( 'edit-' . Event::POST_TYPE );
+
+		$wp_query = new WP_Query();
+		// Different post type than the screen — a secondary query.
+		$wp_query->set( 'post_type', 'post' );
+		$wp_query->set( 'orderby', 'datetime' );
+
+		$response = $instance->adjust_admin_event_sorting( $query_pieces, $wp_query );
+
+		set_current_screen( 'front' );
+
+		$this->assertSame(
+			$query_pieces,
+			$response,
+			'Secondary queries with a different post_type than the screen should pass through untouched.'
 		);
 	}
 
@@ -1284,105 +1373,46 @@ class Test_Query extends Base {
 	}
 
 	/**
-	 * Test that events without dates appear in upcoming admin queries with include_no_date.
+	 * Events with no row in the events table fall out of upcoming/past
+	 * (they only show under the admin All view).
 	 *
-	 * Events without a date/time set have no row in the gatherpress_events table.
-	 * When include_no_date is true (admin context), these should appear in upcoming
-	 * and be excluded from past.
+	 * Previously the admin variant of `adjust_event_sql` accepted an
+	 * `include_no_date` flag that wove `OR post_id IS NULL` into the
+	 * upcoming WHERE clause. That clause has been removed — the LEFT
+	 * JOIN's NULL row naturally fails the `datetime_end_gmt >= NOW()`
+	 * comparison, so no-date events are excluded from both buckets.
 	 *
 	 * @covers ::adjust_event_sql
 	 *
 	 * @return void
 	 */
-	public function test_events_without_dates_in_admin_upcoming(): void {
-		global $wpdb;
-
+	public function test_no_date_events_excluded_from_upcoming_and_past(): void {
 		$instance = Query::get_instance();
-		$table    = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 
-		// Create an event without setting any dates (no row in gatherpress_events).
-		$no_date_post = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
-
-		// Verify there is no row in the events table for this post.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$row = $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT post_id FROM %i WHERE post_id = %d',
-				$table,
-				$no_date_post->ID
-			)
-		);
-		$this->assertNull( $row, 'Event without dates should have no row in gatherpress_events.' );
-
-		// Create a normal upcoming event for comparison.
-		$upcoming_post  = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
-		$upcoming_event = new Event( $upcoming_post->ID );
-		$date           = new \DateTime( 'tomorrow' );
-
-		$params = array(
-			'datetime_start' => $date->format( 'Y-m-d H:i:s' ),
-			'datetime_end'   => $date->modify( '+1 day' )->format( 'Y-m-d H:i:s' ),
-			'timezone'       => 'America/New_York',
-		);
-
-		$upcoming_event->save_datetimes( $params );
-
-		// Create a normal past event for comparison.
-		$past_post  = $this->mock->post( array( 'post_type' => 'gatherpress_event' ) )->get();
-		$past_event = new Event( $past_post->ID );
-		$past_date  = new \DateTime( 'yesterday' );
-
-		$params = array(
-			'datetime_start' => $past_date->modify( '-1 day' )->format( 'Y-m-d H:i:s' ),
-			'datetime_end'   => $past_date->format( 'Y-m-d H:i:s' ),
-			'timezone'       => 'America/New_York',
-		);
-
-		$past_event->save_datetimes( $params );
-
-		// With include_no_date=true (admin), upcoming should include IS NULL.
 		$retval = $instance->adjust_event_sql(
 			array(),
 			'upcoming',
 			'ASC',
 			'datetime',
-			true,
 			true
 		);
-		$this->assertStringContainsString(
+		$this->assertStringNotContainsString(
 			'IS NULL',
 			$retval['where'],
-			'Admin upcoming query should include IS NULL.'
+			'Upcoming query should not have an IS NULL escape hatch for no-date events.'
 		);
 
-		// With include_no_date=true (admin), past should exclude via IS NOT NULL.
 		$retval = $instance->adjust_event_sql(
 			array(),
 			'past',
 			'DESC',
 			'datetime',
-			true,
 			true
 		);
-		$this->assertStringContainsString(
+		$this->assertStringNotContainsString(
 			'IS NOT NULL',
 			$retval['where'],
-			'Admin past query should include IS NOT NULL.'
-		);
-
-		// With include_no_date=false (frontend), no IS NULL check.
-		$retval = $instance->adjust_event_sql(
-			array(),
-			'upcoming',
-			'ASC',
-			'datetime',
-			true,
-			false
-		);
-		$this->assertStringNotContainsString(
-			'IS NULL',
-			$retval['where'],
-			'Frontend query should not have IS NULL.'
+			'Past query should not have an IS NOT NULL guard — no-date events are already excluded by the join.'
 		);
 	}
 


### PR DESCRIPTION
### Description of the Change

`Event\Query::adjust_admin_event_sorting()` was hardcoded to bail unless the current screen was `edit-gatherpress_event`, so clicking the **Event date & time** column header on the admin list of any other event-supporting post type (e.g. `production`) was a silent no-op. The screen check now uses `post_type_supports( $current_screen->post_type, 'gatherpress-event-date' )` and also requires the wp_query's `post_type` to match the screen — that guards secondary queries fired from the same admin page.

While here, drop the `$include_no_date` escape hatch from `adjust_event_sql()`. It existed to keep no-date events visible when the admin defaulted to Upcoming; now that the admin defaults to All, that view already shows them, and weaving `OR post_id IS NULL` into Upcoming just made the SQL noisier and the buckets less mutually exclusive. `get_event_counts()` swapped to `INNER JOIN` so the tab counts agree with the rendered rows.

Closes #1610

### How to test the Change

1. Activate a plugin that registers a post type with `gatherpress-event-date` support (e.g. `gatherpress-productions` companion).
2. Open **Productions → All Productions** in wp-admin.
3. Click the **Event date & time** column header — list should sort ascending. Click again — descending. URL should reflect `&orderby=datetime&order=asc|desc`.
4. Repeat on **Events → All Events** to confirm no regression.
5. On Events, switch to **Upcoming** — events without a date should no longer appear; tab count and rendered rows should match.

### Changelog Entry

> Fixed - Admin column header sort by event datetime on custom post types that declare `gatherpress-event-date` support, and excluded no-date events from the Upcoming view counts.

### Credits

Props @carstingaxion, @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.