### PR TITLE
Fix #1607 datetime picker stack overflow on year-down in relative mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 		"screenshots:wporg": "WP_BASE_URL='http://127.0.0.1:9400/' wp-scripts test-playwright --config .github/scripts/wordpress-org-screenshots/playwright.config.ts",
 		"screenshots:wporg:debug": "npm run screenshots:wporg -- --debug",
 		"screenshots:wporg:ui": "npm run screenshots:wporg -- --ui",
+		"pretest:e2e": "wp-env start --config .wp-env.test.json",
 		"test:e2e": "playwright test --config=playwright.config.js",
 		"test:unit:js": "wp-scripts test-unit-js --coverage --testResultsProcessor=jest-sonar-reporter",
 		"pretest:unit:php": "wp-env start --config .wp-env.test.json --xdebug",

--- a/src/components/DateTimeEnd.js
+++ b/src/components/DateTimeEnd.js
@@ -20,7 +20,6 @@ import { getStartOfWeek } from '../helpers/editor';
 import { hasEventPastNotice } from '../helpers/event';
 import {
 	createMomentWithTimezone,
-	dateTimeDatabaseFormat,
 	dateTimeLabelFormat,
 	getTimezone,
 	updateDateTimeEnd,
@@ -59,13 +58,15 @@ const DateTimeEnd = () => {
 			.join( '' ),
 	);
 
+	// Normalization that used to live here moved into `updateDateTimeEnd`
+	// so it runs once per user action (#1607). Running it inside a useEffect
+	// without a deps array — as the previous version did — fires on every
+	// render, and with non-idempotent `moment.tz` output on DST-gap times
+	// the store kept changing on every pass, producing an infinite
+	// re-render loop that overflowed the stack on arrows-down.
 	useEffect( () => {
-		setDateTimeEnd(
-			createMomentWithTimezone( dateTimeEnd, getTimezone() ).format( dateTimeDatabaseFormat ),
-		);
-
 		hasEventPastNotice();
-	} );
+	}, [ dateTimeEnd ] );
 
 	return (
 		<PanelRow>

--- a/src/components/DateTimeEnd.js
+++ b/src/components/DateTimeEnd.js
@@ -20,6 +20,7 @@ import { getStartOfWeek } from '../helpers/editor';
 import { hasEventPastNotice } from '../helpers/event';
 import {
 	createMomentWithTimezone,
+	dateTimeDatabaseFormat,
 	dateTimeLabelFormat,
 	getTimezone,
 	updateDateTimeEnd,
@@ -58,15 +59,13 @@ const DateTimeEnd = () => {
 			.join( '' ),
 	);
 
-	// Normalization that used to live here moved into `updateDateTimeEnd`
-	// so it runs once per user action (#1607). Running it inside a useEffect
-	// without a deps array — as the previous version did — fires on every
-	// render, and with non-idempotent `moment.tz` output on DST-gap times
-	// the store kept changing on every pass, producing an infinite
-	// re-render loop that overflowed the stack on arrows-down.
 	useEffect( () => {
+		setDateTimeEnd(
+			createMomentWithTimezone( dateTimeEnd, getTimezone() ).format( dateTimeDatabaseFormat ),
+		);
+
 		hasEventPastNotice();
-	}, [ dateTimeEnd ] );
+	} );
 
 	return (
 		<PanelRow>

--- a/src/components/DateTimeRange.js
+++ b/src/components/DateTimeRange.js
@@ -10,6 +10,7 @@ import { useEffect } from '@wordpress/element';
 import {
 	dateTimeDatabaseFormat,
 	createMomentWithTimezone,
+	useMatchedDuration,
 } from '../helpers/datetime';
 import DateTimeStart from '../components/DateTimeStart';
 import DateTimeEnd from '../components/DateTimeEnd';
@@ -49,16 +50,18 @@ const DateTimeRange = () => {
 		dateTimeMetaData = {};
 	}
 
-	const { dateTimeStart, dateTimeEnd, duration, timezone } = useSelect(
+	const { dateTimeStart, dateTimeEnd, timezone } = useSelect(
 		( select ) => ( {
 			dateTimeStart: select( 'gatherpress/datetime' ).getDateTimeStart(),
 			dateTimeEnd: select( 'gatherpress/datetime' ).getDateTimeEnd(),
-			duration: select( 'gatherpress/datetime' ).getDuration(),
 			timezone: select( 'gatherpress/datetime' ).getTimezone(),
 		} ),
 		[],
 	);
-	const { setDuration } = useDispatch( 'gatherpress/datetime' );
+	// Matched preset (or `false`) for the start/end pair. Memoized on the
+	// inputs so the moment.tz comparisons run once per real change rather
+	// than once per render — see `useMatchedDuration` for the #1607 context.
+	const matchedDuration = useMatchedDuration();
 
 	useEffect( () => {
 		const payload = JSON.stringify( {
@@ -78,8 +81,6 @@ const DateTimeRange = () => {
 		timezone,
 		dateTimeMetaData,
 		editPost,
-		setDuration,
-		duration,
 	] );
 
 	return (
@@ -87,7 +88,9 @@ const DateTimeRange = () => {
 			<section>
 				<DateTimeStart />
 			</section>
-			<section>{ duration ? <Duration /> : <DateTimeEnd /> }</section>
+			<section>
+				{ matchedDuration ? <Duration /> : <DateTimeEnd /> }
+			</section>
 			<section>
 				<Timezone />
 			</section>

--- a/src/components/DateTimeStart.js
+++ b/src/components/DateTimeStart.js
@@ -25,6 +25,7 @@ import {
 	dateTimeOffset,
 	getTimezone,
 	updateDateTimeStart,
+	useMatchedDuration,
 } from '../helpers/datetime';
 import { getSettings } from '@wordpress/date';
 
@@ -41,13 +42,15 @@ import { getSettings } from '@wordpress/date';
  * @return {JSX.Element} The rendered React component.
  */
 const DateTimeStart = () => {
-	const { dateTimeStart, duration } = useSelect(
-		( select ) => ( {
-			dateTimeStart: select( 'gatherpress/datetime' ).getDateTimeStart(),
-			duration: select( 'gatherpress/datetime' ).getDuration(),
-		} ),
+	const dateTimeStart = useSelect(
+		( select ) => select( 'gatherpress/datetime' ).getDateTimeStart(),
 		[],
 	);
+	// Use the memoized matched-preset hook so the gating below only fires
+	// the auto-end-sync when the current end actually equals start + N
+	// hours — same semantics as the previous getDuration selector, but
+	// without that selector's per-call moment.tz comparison loop (#1607).
+	const duration = useMatchedDuration();
 	const { setDateTimeStart, setDateTimeEnd } = useDispatch(
 		'gatherpress/datetime',
 	);

--- a/src/components/DateTimeStart.js
+++ b/src/components/DateTimeStart.js
@@ -20,7 +20,6 @@ import { getStartOfWeek } from '../helpers/editor';
 import { hasEventPastNotice } from '../helpers/event';
 import {
 	createMomentWithTimezone,
-	dateTimeDatabaseFormat,
 	dateTimeLabelFormat,
 	dateTimeOffset,
 	getTimezone,
@@ -61,18 +60,18 @@ const DateTimeStart = () => {
 			.join( '' ),
 	);
 
+	// Normalization that used to live here moved into `updateDateTimeStart`
+	// so it runs once per user action (#1607) — running it inside a useEffect
+	// that depends on `dateTimeStart` produced an infinite re-render loop on
+	// DST-gap times since `moment.tz` can return a different normalized
+	// string each pass.
 	useEffect( () => {
-		setDateTimeStart(
-			createMomentWithTimezone( dateTimeStart, getTimezone() )
-				.format( dateTimeDatabaseFormat ),
-		);
-
 		if ( duration ) {
 			setDateTimeEnd( dateTimeOffset( duration ) );
 		}
 
 		hasEventPastNotice();
-	}, [ dateTimeStart, duration, setDateTimeStart, setDateTimeEnd ] );
+	}, [ dateTimeStart, duration, setDateTimeEnd ] );
 
 	return (
 		<PanelRow>

--- a/src/components/DateTimeStart.js
+++ b/src/components/DateTimeStart.js
@@ -20,6 +20,7 @@ import { getStartOfWeek } from '../helpers/editor';
 import { hasEventPastNotice } from '../helpers/event';
 import {
 	createMomentWithTimezone,
+	dateTimeDatabaseFormat,
 	dateTimeLabelFormat,
 	dateTimeOffset,
 	getTimezone,
@@ -60,18 +61,18 @@ const DateTimeStart = () => {
 			.join( '' ),
 	);
 
-	// Normalization that used to live here moved into `updateDateTimeStart`
-	// so it runs once per user action (#1607) — running it inside a useEffect
-	// that depends on `dateTimeStart` produced an infinite re-render loop on
-	// DST-gap times since `moment.tz` can return a different normalized
-	// string each pass.
 	useEffect( () => {
+		setDateTimeStart(
+			createMomentWithTimezone( dateTimeStart, getTimezone() )
+				.format( dateTimeDatabaseFormat ),
+		);
+
 		if ( duration ) {
 			setDateTimeEnd( dateTimeOffset( duration ) );
 		}
 
 		hasEventPastNotice();
-	}, [ dateTimeStart, duration, setDateTimeEnd ] );
+	}, [ dateTimeStart, duration, setDateTimeStart, setDateTimeEnd ] );
 
 	return (
 		<PanelRow>

--- a/src/components/Duration.js
+++ b/src/components/Duration.js
@@ -3,8 +3,12 @@
  */
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { dateTimeOffset, durationOptions } from '../helpers/datetime';
+import { useDispatch } from '@wordpress/data';
+import {
+	dateTimeOffset,
+	durationOptions,
+	useMatchedDuration,
+} from '../helpers/datetime';
 
 /**
  * Duration component for GatherPress.
@@ -23,12 +27,11 @@ import { dateTimeOffset, durationOptions } from '../helpers/datetime';
  * @return {JSX.Element} The rendered Duration React component.
  */
 const Duration = () => {
-	const { duration } = useSelect(
-		( select ) => ( {
-			duration: select( 'gatherpress/datetime' ).getDuration(),
-		} ),
-		[],
-	);
+	// Read the matched preset via the memoized hook rather than the raw
+	// store value — only the matched preset reflects "the current end
+	// equals start + N hours", which is what the SelectControl's display
+	// needs to track. See `useMatchedDuration` for the #1607 context.
+	const duration = useMatchedDuration();
 	const dispatch = useDispatch();
 	const { setDateTimeEnd, setDuration } = dispatch( 'gatherpress/datetime' );
 	return (

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -415,16 +415,6 @@ export function updateDateTimeStart(
 	setDateTimeStart = null,
 	setDateTimeEnd = null,
 ) {
-	// Normalize the picker's ISO output to the canonical database format
-	// once, here at the entry point. The DateTimePicker emits dates with a
-	// 'T' separator (e.g. "2024-03-15T10:30:00") and timezone-edge inputs
-	// (DST gaps/overlaps) need a single tz-aware canonicalization. Doing
-	// this in a useEffect that depends on the value being normalized
-	// trips an infinite re-render loop on DST-gap times — see #1607.
-	date = createMomentWithTimezone( date, getTimezone() ).format(
-		dateTimeDatabaseFormat,
-	);
-
 	// Store the current duration before updating the start time.
 	const currentDuration = getDateTimeOffset();
 
@@ -469,15 +459,6 @@ export function updateDateTimeEnd(
 	setDateTimeEnd = null,
 	setDateTimeStart = null,
 ) {
-	// Normalize the picker's ISO output to the canonical database format
-	// once, here at the entry point. See updateDateTimeStart for the full
-	// rationale (#1607 — non-idempotent moment.tz normalization on DST-gap
-	// inputs causes an infinite re-render loop when done in a useEffect
-	// that depends on the value being normalized).
-	date = createMomentWithTimezone( date, getTimezone() ).format(
-		dateTimeDatabaseFormat,
-	);
-
 	validateDateTimeEnd( date, setDateTimeStart );
 
 	if ( null !== setDateTimeEnd ) {

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -7,9 +7,9 @@ import moment from 'moment';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createRoot } from '@wordpress/element';
+import { createRoot, useMemo } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
-import { select } from '@wordpress/data';
+import { select, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -163,6 +163,93 @@ export function getDateTimeOffset() {
 		durationOptions().find(
 			( option ) => dateTimeOffset( option.value ) === getDateTimeEnd(),
 		)?.value || false
+	);
+}
+
+/**
+ * Pure matched-preset lookup. Given a start/end/timezone/duration tuple,
+ * returns the duration option whose `(start + value hours)` matches the
+ * given end, or `false` when no preset matches (or when the caller has
+ * explicitly opted out by passing `false` for `duration`).
+ *
+ * Extracted from `useMatchedDuration` so the matching logic is testable
+ * in isolation — the hook is just a `useSelect`/`useMemo` wrapper around
+ * this function.
+ *
+ * @since 1.0.0
+ *
+ * @param {string}         dateTimeStart Start datetime string.
+ * @param {string}         dateTimeEnd   End datetime string.
+ * @param {string}         timezone      Timezone (IANA name or manual offset).
+ * @param {number|boolean} duration      Raw stored duration: `false` to
+ *                                       opt out, anything else to compute.
+ * @return {number|boolean} Matched duration option value, or `false`.
+ */
+export function findMatchedDuration(
+	dateTimeStart,
+	dateTimeEnd,
+	timezone,
+	duration,
+) {
+	if ( false === duration ) {
+		return false;
+	}
+	return (
+		durationOptions().find( ( option ) => {
+			const computedEnd = createMomentWithTimezone(
+				dateTimeStart,
+				timezone,
+			)
+				.add( option.value, 'hours' )
+				.format( dateTimeDatabaseFormat );
+			return computedEnd === dateTimeEnd;
+		} )?.value || false
+	);
+}
+
+/**
+ * Reactive, memoized matched-preset duration for the event datetime range.
+ *
+ * Returns the duration option whose `(start + value hours)` matches the
+ * current end, or `false` when no preset matches (or when the user has
+ * explicitly opted out via `setDuration(false)`). Components use this to
+ * decide between rendering `<Duration />` (preset mode) vs `<DateTimeEnd />`
+ * (absolute mode) and to drive the duration `<SelectControl>`'s value.
+ *
+ * Why a hook instead of a store selector: the previous `getDuration`
+ * selector ran the full `dateTimeOffset` × N moment.tz comparison on every
+ * call, which @wordpress/data invokes once per subscriber per render. Under
+ * IANA timezones the multiplied moment.tz cost compounded with the WP
+ * picker's render cascade and overflowed the call stack on a single
+ * year-arrow keypress (#1607). Computing in a `useMemo` keyed on the
+ * actual inputs runs the comparison once per real change instead.
+ *
+ * @since 1.0.0
+ *
+ * @return {number|boolean} Matched duration option value, or `false`.
+ */
+export function useMatchedDuration() {
+	const dateTimeStart = useSelect(
+		( s ) => s( 'gatherpress/datetime' ).getDateTimeStart(),
+		[],
+	);
+	const dateTimeEnd = useSelect(
+		( s ) => s( 'gatherpress/datetime' ).getDateTimeEnd(),
+		[],
+	);
+	const timezone = useSelect(
+		( s ) => s( 'gatherpress/datetime' ).getTimezone(),
+		[],
+	);
+	const duration = useSelect(
+		( s ) => s( 'gatherpress/datetime' ).getDuration(),
+		[],
+	);
+
+	return useMemo(
+		() =>
+			findMatchedDuration( dateTimeStart, dateTimeEnd, timezone, duration ),
+		[ dateTimeStart, dateTimeEnd, timezone, duration ],
 	);
 }
 
@@ -415,8 +502,25 @@ export function updateDateTimeStart(
 	setDateTimeStart = null,
 	setDateTimeEnd = null,
 ) {
-	// Store the current duration before updating the start time.
+	// Capture the matched preset BEFORE we dispatch the new start so the
+	// lookup runs against the previous start/end pair — we're trying to
+	// detect "was the event in relative (preset-duration) mode?", which is
+	// a property of the OLD state.
 	const currentDuration = getDateTimeOffset();
+
+	// Dispatch the new start FIRST so the validation cascade below — which
+	// reads the start back via `select( 'gatherpress/datetime' )...` — sees
+	// the new value rather than the stale one. Without this, year-down on
+	// the start picker in relative mode (#1607) computed a new end that's
+	// less than the OLD store start, `validateDateTimeEnd` then recursively
+	// called `updateDateTimeStart` to fix the gap, and the recursion never
+	// terminated because the store never got updated inside the synchronous
+	// chain. Stack overflowed inside `moment.tz`. This mirrors the previous
+	// `setToGlobal( 'eventDetails.dateTime.datetime_start', date )` write
+	// that the old global-object architecture used to perform here.
+	if ( 'function' === typeof setDateTimeStart ) {
+		setDateTimeStart( date );
+	}
 
 	// If in relative mode (duration is numeric), always update the end time to maintain the offset.
 	if ( 'number' === typeof currentDuration ) {
@@ -428,10 +532,6 @@ export function updateDateTimeStart(
 	} else {
 		// Otherwise, only validate to ensure end is after start.
 		validateDateTimeStart( date, setDateTimeEnd, currentDuration );
-	}
-
-	if ( 'function' === typeof setDateTimeStart ) {
-		setDateTimeStart( date );
 	}
 
 	enableSave();
@@ -459,11 +559,16 @@ export function updateDateTimeEnd(
 	setDateTimeEnd = null,
 	setDateTimeStart = null,
 ) {
-	validateDateTimeEnd( date, setDateTimeStart );
-
+	// Dispatch the new end FIRST so any subsequent reads of the end via
+	// `select( 'gatherpress/datetime' ).getDateTimeEnd()` (e.g. through
+	// `validateDateTimeStart` if a recursive call back into the start path
+	// fires) see the new value rather than the stale store value. Same
+	// reasoning as the matching reorder in `updateDateTimeStart` (#1607).
 	if ( null !== setDateTimeEnd ) {
 		setDateTimeEnd( date );
 	}
+
+	validateDateTimeEnd( date, setDateTimeStart );
 
 	enableSave();
 }

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -415,6 +415,16 @@ export function updateDateTimeStart(
 	setDateTimeStart = null,
 	setDateTimeEnd = null,
 ) {
+	// Normalize the picker's ISO output to the canonical database format
+	// once, here at the entry point. The DateTimePicker emits dates with a
+	// 'T' separator (e.g. "2024-03-15T10:30:00") and timezone-edge inputs
+	// (DST gaps/overlaps) need a single tz-aware canonicalization. Doing
+	// this in a useEffect that depends on the value being normalized
+	// trips an infinite re-render loop on DST-gap times — see #1607.
+	date = createMomentWithTimezone( date, getTimezone() ).format(
+		dateTimeDatabaseFormat,
+	);
+
 	// Store the current duration before updating the start time.
 	const currentDuration = getDateTimeOffset();
 
@@ -459,6 +469,15 @@ export function updateDateTimeEnd(
 	setDateTimeEnd = null,
 	setDateTimeStart = null,
 ) {
+	// Normalize the picker's ISO output to the canonical database format
+	// once, here at the entry point. See updateDateTimeStart for the full
+	// rationale (#1607 — non-idempotent moment.tz normalization on DST-gap
+	// inputs causes an infinite re-render loop when done in a useEffect
+	// that depends on the value being normalized).
+	date = createMomentWithTimezone( date, getTimezone() ).format(
+		dateTimeDatabaseFormat,
+	);
+
 	validateDateTimeEnd( date, setDateTimeStart );
 
 	if ( null !== setDateTimeEnd ) {

--- a/src/stores/datetime.js
+++ b/src/stores/datetime.js
@@ -9,7 +9,6 @@ import { createReduxStore, dispatch, register, select, subscribe } from '@wordpr
 import {
 	defaultDateTimeEnd,
 	defaultDateTimeStart,
-	getDateTimeOffset,
 } from '../helpers/datetime';
 const DEFAULT_STATE = {
 	dateTimeStart: defaultDateTimeStart,
@@ -66,8 +65,16 @@ const store = createReduxStore( 'gatherpress/datetime', {
 	selectors: {
 		getDateTimeStart: ( state ) => state.dateTimeStart,
 		getDateTimeEnd: ( state ) => state.dateTimeEnd,
-		getDuration: ( state ) =>
-			false === state.duration ? false : getDateTimeOffset(),
+		// Return the raw stored value. Computing the matched preset here
+		// ran a moment.tz comparison loop on every selector call, which
+		// @wordpress/data invokes per subscriber per render — under IANA
+		// timezones the multiplied moment.tz cost overflowed the call
+		// stack on a single picker arrow keypress (#1607). Consumers that
+		// need the matched preset (the conditional in DateTimeRange, the
+		// SelectControl value in Duration, the gating in DateTimeStart's
+		// effect) call `useMatchedDuration()` from `helpers/datetime`,
+		// which memoizes the comparison on the actual store inputs.
+		getDuration: ( state ) => state.duration,
 		getTimezone: ( state ) => state.timezone,
 	},
 } );

--- a/test/e2e/event-tests/datetime-picker-regression.spec.js
+++ b/test/e2e/event-tests/datetime-picker-regression.spec.js
@@ -1,5 +1,4 @@
 const { test, expect } = require( '@playwright/test' );
-const { execSync } = require( 'child_process' );
 
 /**
  * Regression test for #1607: stack overflow when changing the year in the
@@ -25,110 +24,127 @@ const { execSync } = require( 'child_process' );
  *    a different code path inside `createMomentWithTimezone` that does
  *    not call `moment.tz` (and so never built up the deep stack frames
  *    that overflowed).
+ *
+ * Why we seed via `wp.apiFetch` from inside the page rather than wp-cli:
+ * `npm run wp-env run` spins up a separate Docker compose run that
+ * conflicts on port 8888 with the test environment that `pretest:e2e`
+ * already started. Going through `wp.apiFetch` reuses the existing
+ * authenticated browser context (cookies + WordPress nonce) and writes
+ * to the same DB Playwright connects to.
  */
 test.describe( '#1607 datetime picker year-down regression', () => {
-	let eventId;
-
-	test.beforeAll( async () => {
-		// Create a published event so the editor opens cleanly.
-		execSync(
-			'npm run wp-env run cli -- wp post generate --post_type=gatherpress_event --post_status=publish --count=1 2>&1 | grep -v "Xdebug"'
-		);
-
-		const idResult = execSync(
-			'npm run wp-env run cli -- wp post list --post_type=gatherpress_event --posts_per_page=1 --orderby=ID --order=DESC --field=ID 2>&1 | grep -v "Xdebug\\|Ran\\|Starting\\|gatherpress@\\|^>" | grep -v "^$" | tail -1',
-			{ encoding: 'utf-8' }
-		);
-		eventId = idResult.trim();
-
-		// 2099 is far enough in the future that no DST / calendar edge case
-		// shifts the picker behavior; pressing Down on the year decrements
-		// to 2098 deterministically. End is exactly start + 2h so the
-		// duration SelectControl resolves to the "2 hours" preset (relative
-		// mode) — the precondition that put `updateDateTimeStart` on the
-		// recursive code path before the fix.
-		const start = '2099-04-29 18:00:00';
-		const end = '2099-04-29 20:00:00';
-		const timezone = 'America/New_York';
-
-		execSync(
-			`npm run wp-env run cli -- wp post meta update ${ eventId } gatherpress_datetime_start '${ start }' 2>&1 | grep -v "Xdebug"`
-		);
-		execSync(
-			`npm run wp-env run cli -- wp post meta update ${ eventId } gatherpress_datetime_end '${ end }' 2>&1 | grep -v "Xdebug"`
-		);
-		execSync(
-			`npm run wp-env run cli -- wp post meta update ${ eventId } gatherpress_timezone '${ timezone }' 2>&1 | grep -v "Xdebug"`
-		);
-	} );
-
-	test.afterAll( async () => {
-		if ( eventId ) {
-			execSync(
-				`npm run wp-env run cli -- wp post delete ${ eventId } --force 2>&1 | grep -v "Xdebug"`
-			);
-		}
-	} );
-
 	test( 'year-down on start picker does not crash the editor', async ( {
 		page,
 	} ) => {
-		await page.goto( `/wp-admin/post.php?post=${ eventId }&action=edit` );
+		// Land on a wp-admin page first so wp.apiFetch is available with
+		// the right nonce for authenticated REST writes.
+		await page.goto( '/wp-admin/' );
 		await page.waitForLoadState( 'load' );
 
-		// Dismiss any first-run modals (welcome guide, etc).
-		await page.waitForTimeout( 500 );
-		await page.keyboard.press( 'Escape' );
-		await page.waitForTimeout( 200 );
-		await page.keyboard.press( 'Escape' );
+		// Seed an event via the REST API. The `gatherpress_datetime` meta
+		// is the authoritative writable field — the individual `_start`,
+		// `_end`, and `_timezone` keys are derived from it on save.
+		const eventId = await page.evaluate( async () => {
+			const res = await window.wp.apiFetch( {
+				path: '/wp/v2/gatherpress_events',
+				method: 'POST',
+				data: {
+					title: 'E2E #1607 datetime picker regression',
+					status: 'publish',
+					meta: {
+						gatherpress_datetime: JSON.stringify( {
+							dateTimeStart: '2099-04-29 18:00:00',
+							dateTimeEnd: '2099-04-29 20:00:00',
+							timezone: 'America/New_York',
+						} ),
+					},
+				},
+			} );
+			return res.id;
+		} );
 
-		// Make sure the Event settings panel is open. WP usually opens it
-		// by default on first load, but a previous visit could have
-		// collapsed it via persisted UI state.
-		const eventSettingsButton = page
-			.getByRole( 'button', { name: /event settings/i } )
-			.first();
-		if ( 0 < ( await eventSettingsButton.count() ) ) {
-			const expanded =
-				await eventSettingsButton.getAttribute( 'aria-expanded' );
-			if ( 'true' !== expanded ) {
-				await eventSettingsButton.click();
+		expect(
+			eventId,
+			'event creation via REST returned an id'
+		).toBeTruthy();
+
+		try {
+			await page.goto(
+				`/wp-admin/post.php?post=${ eventId }&action=edit`
+			);
+			await page.waitForLoadState( 'load' );
+
+			// Dismiss any first-run modals (welcome guide, etc).
+			await page.waitForTimeout( 500 );
+			await page.keyboard.press( 'Escape' );
+			await page.waitForTimeout( 200 );
+			await page.keyboard.press( 'Escape' );
+
+			// Make sure the Event settings panel is open. WP usually opens
+			// it by default on first load, but a previous visit could have
+			// collapsed it via persisted UI state.
+			const eventSettingsButton = page
+				.getByRole( 'button', { name: /event settings/i } )
+				.first();
+			if ( 0 < ( await eventSettingsButton.count() ) ) {
+				const expanded =
+					await eventSettingsButton.getAttribute(
+						'aria-expanded'
+					);
+				if ( 'true' !== expanded ) {
+					await eventSettingsButton.click();
+				}
 			}
+
+			// Open the start datetime picker. The button id is set in
+			// DateTimeStart.js and is stable across @wordpress/components
+			// versions.
+			const startButton = page.locator( '#gatherpress-datetime-start' );
+			await expect( startButton ).toBeVisible( { timeout: 15000 } );
+			await expect( startButton ).toContainText( '2099' );
+			await startButton.click();
+
+			// Locate the year input inside the picker. WP's DateTimePicker
+			// renders an `<input type="number">` with aria-label "Year",
+			// which Playwright's spinbutton role matches.
+			const yearInput = page.getByRole( 'spinbutton', {
+				name: /year/i,
+			} );
+			await expect( yearInput ).toBeVisible( { timeout: 5000 } );
+
+			// Focus the input and press Down — the exact gesture from
+			// #1607.
+			await yearInput.click();
+			await page.keyboard.press( 'ArrowDown' );
+
+			// Give React a moment to either crash (old behavior) or
+			// successfully re-render (new behavior).
+			await page.waitForTimeout( 1000 );
+
+			// Editor must NOT have surfaced the React error boundary
+			// overlay. This is the assertion that would have failed before
+			// the fix.
+			await expect(
+				page.getByText(
+					/editor has encountered an unexpected error/i
+				)
+			).toHaveCount( 0 );
+
+			// Close the picker so the start label sits in the foreground
+			// for the textContent assertion below.
+			await page.keyboard.press( 'Escape' );
+
+			// Start label should now reflect the previous year.
+			await expect( startButton ).toContainText( '2098' );
+		} finally {
+			// Always clean up the seed event, even if assertions fail, so
+			// repeated local runs don't accumulate orphans in the test DB.
+			await page.evaluate( async ( id ) => {
+				await window.wp.apiFetch( {
+					path: `/wp/v2/gatherpress_events/${ id }?force=true`,
+					method: 'DELETE',
+				} );
+			}, eventId );
 		}
-
-		// Open the start datetime picker. The button id is set in
-		// DateTimeStart.js and is stable across @wordpress/components
-		// versions.
-		const startButton = page.locator( '#gatherpress-datetime-start' );
-		await expect( startButton ).toBeVisible( { timeout: 15000 } );
-		await expect( startButton ).toContainText( '2099' );
-		await startButton.click();
-
-		// Locate the year input inside the picker. WP's DateTimePicker
-		// renders an `<input type="number">` with aria-label "Year",
-		// which Playwright's spinbutton role matches.
-		const yearInput = page.getByRole( 'spinbutton', { name: /year/i } );
-		await expect( yearInput ).toBeVisible( { timeout: 5000 } );
-
-		// Focus the input and press Down — the exact gesture from #1607.
-		await yearInput.click();
-		await page.keyboard.press( 'Down' );
-
-		// Give React a moment to either crash (old behavior) or
-		// successfully re-render (new behavior).
-		await page.waitForTimeout( 1000 );
-
-		// Editor must NOT have surfaced the React error boundary overlay.
-		// This is the assertion that would have failed before the fix.
-		await expect(
-			page.getByText( /editor has encountered an unexpected error/i )
-		).toHaveCount( 0 );
-
-		// Close the picker so the start label sits in the foreground for
-		// the textContent assertion below.
-		await page.keyboard.press( 'Escape' );
-
-		// Start label should now reflect the previous year.
-		await expect( startButton ).toContainText( '2098' );
 	} );
 } );

--- a/test/e2e/event-tests/datetime-picker-regression.spec.js
+++ b/test/e2e/event-tests/datetime-picker-regression.spec.js
@@ -1,0 +1,134 @@
+const { test, expect } = require( '@playwright/test' );
+const { execSync } = require( 'child_process' );
+
+/**
+ * Regression test for #1607: stack overflow when changing the year in the
+ * Date & time start picker.
+ *
+ * Before the fix, pressing Down on the year input of the start datetime
+ * picker (in relative-duration mode under an IANA timezone) caused
+ * `validateDateTimeEnd` to recursively call `updateDateTimeStart` against
+ * the stale store state. The recursion exhausted the call stack inside
+ * `moment.tz` and the editor crashed with a "The editor has encountered
+ * an unexpected error" overlay.
+ *
+ * Preconditions required to reproduce the original crash — keep these
+ * in place if you ever rework the test setup, or you'll silently stop
+ * exercising the regression:
+ *  - Event has start + end times that match a preset duration (relative
+ *    mode). With end = start + 2h the duration `SelectControl` matches
+ *    the "2 hours" preset and `useMatchedDuration` returns 2 — which is
+ *    what makes `updateDateTimeStart` enter the relative-mode branch
+ *    that triggered the recursion.
+ *  - Event timezone is an IANA identifier (e.g. America/New_York). Manual
+ *    UTC offsets like `+05:00` do not trigger the bug because they take
+ *    a different code path inside `createMomentWithTimezone` that does
+ *    not call `moment.tz` (and so never built up the deep stack frames
+ *    that overflowed).
+ */
+test.describe( '#1607 datetime picker year-down regression', () => {
+	let eventId;
+
+	test.beforeAll( async () => {
+		// Create a published event so the editor opens cleanly.
+		execSync(
+			'npm run wp-env run cli -- wp post generate --post_type=gatherpress_event --post_status=publish --count=1 2>&1 | grep -v "Xdebug"'
+		);
+
+		const idResult = execSync(
+			'npm run wp-env run cli -- wp post list --post_type=gatherpress_event --posts_per_page=1 --orderby=ID --order=DESC --field=ID 2>&1 | grep -v "Xdebug\\|Ran\\|Starting\\|gatherpress@\\|^>" | grep -v "^$" | tail -1',
+			{ encoding: 'utf-8' }
+		);
+		eventId = idResult.trim();
+
+		// 2099 is far enough in the future that no DST / calendar edge case
+		// shifts the picker behavior; pressing Down on the year decrements
+		// to 2098 deterministically. End is exactly start + 2h so the
+		// duration SelectControl resolves to the "2 hours" preset (relative
+		// mode) — the precondition that put `updateDateTimeStart` on the
+		// recursive code path before the fix.
+		const start = '2099-04-29 18:00:00';
+		const end = '2099-04-29 20:00:00';
+		const timezone = 'America/New_York';
+
+		execSync(
+			`npm run wp-env run cli -- wp post meta update ${ eventId } gatherpress_datetime_start '${ start }' 2>&1 | grep -v "Xdebug"`
+		);
+		execSync(
+			`npm run wp-env run cli -- wp post meta update ${ eventId } gatherpress_datetime_end '${ end }' 2>&1 | grep -v "Xdebug"`
+		);
+		execSync(
+			`npm run wp-env run cli -- wp post meta update ${ eventId } gatherpress_timezone '${ timezone }' 2>&1 | grep -v "Xdebug"`
+		);
+	} );
+
+	test.afterAll( async () => {
+		if ( eventId ) {
+			execSync(
+				`npm run wp-env run cli -- wp post delete ${ eventId } --force 2>&1 | grep -v "Xdebug"`
+			);
+		}
+	} );
+
+	test( 'year-down on start picker does not crash the editor', async ( {
+		page,
+	} ) => {
+		await page.goto( `/wp-admin/post.php?post=${ eventId }&action=edit` );
+		await page.waitForLoadState( 'load' );
+
+		// Dismiss any first-run modals (welcome guide, etc).
+		await page.waitForTimeout( 500 );
+		await page.keyboard.press( 'Escape' );
+		await page.waitForTimeout( 200 );
+		await page.keyboard.press( 'Escape' );
+
+		// Make sure the Event settings panel is open. WP usually opens it
+		// by default on first load, but a previous visit could have
+		// collapsed it via persisted UI state.
+		const eventSettingsButton = page
+			.getByRole( 'button', { name: /event settings/i } )
+			.first();
+		if ( 0 < ( await eventSettingsButton.count() ) ) {
+			const expanded =
+				await eventSettingsButton.getAttribute( 'aria-expanded' );
+			if ( 'true' !== expanded ) {
+				await eventSettingsButton.click();
+			}
+		}
+
+		// Open the start datetime picker. The button id is set in
+		// DateTimeStart.js and is stable across @wordpress/components
+		// versions.
+		const startButton = page.locator( '#gatherpress-datetime-start' );
+		await expect( startButton ).toBeVisible( { timeout: 15000 } );
+		await expect( startButton ).toContainText( '2099' );
+		await startButton.click();
+
+		// Locate the year input inside the picker. WP's DateTimePicker
+		// renders an `<input type="number">` with aria-label "Year",
+		// which Playwright's spinbutton role matches.
+		const yearInput = page.getByRole( 'spinbutton', { name: /year/i } );
+		await expect( yearInput ).toBeVisible( { timeout: 5000 } );
+
+		// Focus the input and press Down — the exact gesture from #1607.
+		await yearInput.click();
+		await page.keyboard.press( 'Down' );
+
+		// Give React a moment to either crash (old behavior) or
+		// successfully re-render (new behavior).
+		await page.waitForTimeout( 1000 );
+
+		// Editor must NOT have surfaced the React error boundary overlay.
+		// This is the assertion that would have failed before the fix.
+		await expect(
+			page.getByText( /editor has encountered an unexpected error/i )
+		).toHaveCount( 0 );
+
+		// Close the picker so the start label sits in the foreground for
+		// the textContent assertion below.
+		await page.keyboard.press( 'Escape' );
+
+		// Start label should now reflect the previous year.
+		await expect( startButton ).toContainText( '2098' );
+	} );
+} );

--- a/test/e2e/event-tests/event-display.spec.js
+++ b/test/e2e/event-tests/event-display.spec.js
@@ -1,49 +1,101 @@
 const { test, expect } = require( '@playwright/test' );
-const { execSync } = require( 'child_process' );
 
 /**
  * Basic Event Display Tests
  *
  * Simple tests to verify events display correctly on the frontend.
+ *
+ * Why we seed via `wp.apiFetch` from inside the page rather than wp-cli:
+ * `npm run wp-env run` spins up a separate Docker compose run that
+ * conflicts on port 8888 with the test environment that `pretest:e2e`
+ * already started. Going through `wp.apiFetch` reuses the existing
+ * authenticated browser context (cookies + WordPress nonce) and writes
+ * to the same DB Playwright connects to.
  */
 test.describe( 'Event Display', () => {
-	let eventId;
-
-	test.beforeAll( async () => {
-		// Create a simple test event via wp-cli.
-		const futureDate = new Date();
-		futureDate.setDate( futureDate.getDate() + 7 );
-		const dateString = futureDate.toISOString();
-
-		// Generate an event post with publish status.
-		execSync( 'npm run wp-env run cli -- wp post generate --post_type=gatherpress_event --post_status=publish --count=1 2>&1 | grep -v "Xdebug"' );
-
-		// Get the latest event ID.
-		const idResult = execSync(
-			'npm run wp-env run cli -- wp post list --post_type=gatherpress_event --posts_per_page=1 --orderby=ID --order=DESC --field=ID 2>&1 | grep -v "Xdebug\\|Ran\\|Starting\\|gatherpress@\\|^>" | grep -v "^$" | tail -1',
-			{ encoding: 'utf-8' }
-		);
-		eventId = idResult.trim();
-
-		// Set event datetime meta.
-		execSync( `npm run wp-env run cli -- wp post meta update ${ eventId } gatherpress_datetime_start '${ dateString }' 2>&1 | grep -v "Xdebug"` );
-	} );
-
 	test( 'should load event page and display content', async ( { page } ) => {
-		// Visit the event page using query string format (works regardless of permalink settings).
-		await page.goto( `http://localhost:8889/?p=${ eventId }` );
+		// Land on a wp-admin page first so wp.apiFetch is available with
+		// the right nonce for authenticated REST writes.
+		await page.goto( '/wp-admin/' );
 		await page.waitForLoadState( 'load' );
 
-		// Check that page has a title.
-		const title = await page.title();
-		expect( title ).toBeTruthy();
+		// Seed an event via the REST API. 7 days in the future so it's
+		// upcoming when the frontend renders it. The `gatherpress_datetime`
+		// meta is the authoritative writable field — the individual
+		// `_start`, `_end`, and `_timezone` keys are derived from it on
+		// save.
+		const futureDate = new Date();
+		futureDate.setDate( futureDate.getDate() + 7 );
+		const startIso = futureDate.toISOString().slice( 0, 19 ).replace( 'T', ' ' );
+		const endDate = new Date( futureDate.getTime() + ( 2 * 60 * 60 * 1000 ) );
+		const endIso = endDate.toISOString().slice( 0, 19 ).replace( 'T', ' ' );
 
-		// Verify page has content (not just a blank page).
-		const bodyText = await page.locator( 'body' ).textContent();
-		expect( bodyText.length ).toBeGreaterThan( 0 );
+		const eventTitle = 'E2E Event Display Test';
 
-		// Verify no PHP errors or warnings are visible.
-		const hasError = await page.locator( 'body:has-text("Fatal error"), body:has-text("Warning:"), body:has-text("Notice:")' ).count();
-		expect( hasError ).toBe( 0 );
+		const eventId = await page.evaluate(
+			async ( { title, dateTimeStart, dateTimeEnd } ) => {
+				const res = await window.wp.apiFetch( {
+					path: '/wp/v2/gatherpress_events',
+					method: 'POST',
+					data: {
+						title,
+						status: 'publish',
+						meta: {
+							gatherpress_datetime: JSON.stringify( {
+								dateTimeStart,
+								dateTimeEnd,
+								timezone: 'America/New_York',
+							} ),
+						},
+					},
+				} );
+				return res.id;
+			},
+			{
+				title: eventTitle,
+				dateTimeStart: startIso,
+				dateTimeEnd: endIso,
+			}
+		);
+
+		expect(
+			eventId,
+			'event creation via REST returned an id'
+		).toBeTruthy();
+
+		try {
+			// Visit the event page using query-string format (works
+			// regardless of permalink settings).
+			await page.goto( `/?p=${ eventId }` );
+			await page.waitForLoadState( 'load' );
+
+			// Check that page has a title.
+			const title = await page.title();
+			expect( title ).toBeTruthy();
+
+			// Verify the seeded event actually rendered on the frontend
+			// (not just any non-empty page like a 404).
+			await expect(
+				page.locator( 'body' )
+			).toContainText( eventTitle );
+
+			// Verify no PHP errors or warnings are visible.
+			const hasError = await page
+				.locator(
+					'body:has-text("Fatal error"), body:has-text("Warning:"), body:has-text("Notice:")'
+				)
+				.count();
+			expect( hasError ).toBe( 0 );
+		} finally {
+			// Always clean up the seed event, even if assertions fail, so
+			// repeated local runs don't accumulate orphans in the test DB.
+			await page.goto( '/wp-admin/' );
+			await page.evaluate( async ( id ) => {
+				await window.wp.apiFetch( {
+					path: `/wp/v2/gatherpress_events/${ id }?force=true`,
+					method: 'DELETE',
+				} );
+			}, eventId );
+		}
 	} );
 } );

--- a/test/unit/js/src/helpers/datetime.test.js
+++ b/test/unit/js/src/helpers/datetime.test.js
@@ -17,26 +17,42 @@ jest.mock( '@wordpress/data', () => {
 		dateTimeStart: '',
 		dateTimeEnd: '',
 		timezone: '',
+		duration: null,
 	};
 
+	const mockSelect = jest.fn( ( storeName ) => {
+		if ( 'gatherpress/datetime' === storeName ) {
+			return {
+				getDateTimeStart: () => global.__gpDatetime.dateTimeStart,
+				getDateTimeEnd: () => global.__gpDatetime.dateTimeEnd,
+				getTimezone: () => global.__gpDatetime.timezone,
+				getDuration: () => global.__gpDatetime.duration,
+			};
+		}
+		return {};
+	} );
+
 	return {
-		select: jest.fn( ( storeName ) => {
-			if ( 'gatherpress/datetime' === storeName ) {
-				return {
-					getDateTimeStart: () =>
-						global.__gpDatetime.dateTimeStart,
-					getDateTimeEnd: () =>
-						global.__gpDatetime.dateTimeEnd,
-					getTimezone: () => global.__gpDatetime.timezone,
-				};
-			}
-			return {};
-		} ),
+		select: mockSelect,
+		// Run the user's mapSelect synchronously against our mocked
+		// `select` so hooks like `useMatchedDuration` resolve to their
+		// real values in tests without needing React infrastructure.
+		useSelect: jest.fn( ( mapSelect ) => mapSelect( mockSelect ) ),
 		dispatch: jest.fn(),
 		subscribe: jest.fn(),
 		createReduxStore: jest.fn(),
 		register: jest.fn(),
 		createSelector: jest.fn( ( fn ) => fn ),
+	};
+} );
+
+// Stub `useMemo` to just invoke the factory — we don't need memoization
+// semantics in unit tests, only the result.
+jest.mock( '@wordpress/element', () => {
+	const actual = jest.requireActual( '@wordpress/element' );
+	return {
+		...actual,
+		useMemo: jest.fn( ( factory ) => factory() ),
 	};
 } );
 
@@ -65,6 +81,7 @@ import {
 	dateTimePreview,
 	defaultDateTimeEnd,
 	defaultDateTimeStart,
+	findMatchedDuration,
 	getDateTimeEnd,
 	getDateTimeOffset,
 	getDateTimeStart,
@@ -77,6 +94,7 @@ import {
 	removeNonTimePHPFormatChars,
 	updateDateTimeEnd,
 	updateDateTimeStart,
+	useMatchedDuration,
 	validateDateTimeEnd,
 	validateDateTimeStart,
 } from '@src/helpers/datetime';
@@ -721,6 +739,47 @@ describe( 'Relative mode duration tests', () => {
 		// Should maintain 3-hour offset.
 		expect( setDateTimeEnd ).toHaveBeenCalledWith( '2023-11-26 21:00:00' );
 	} );
+
+	test( '#1607: year-down on start picker in relative mode does not recurse', () => {
+		// Regression test for the recursive validation cascade introduced when
+		// the global GatherPress object was removed in 7772acf9. Before the
+		// fix, moving the start backward in relative mode (e.g. pressing Down
+		// on the year input) led to an infinite recursion: the new end was
+		// computed as `(new start) + duration`, which is BEFORE the OLD store
+		// start; `validateDateTimeEnd` then read the stale store start, saw
+		// `new end < old start`, and recursively called `updateDateTimeStart`
+		// to fix the gap — and recursed forever because the store was never
+		// updated inside the synchronous chain. The editor crashed with a
+		// "Maximum call stack size exceeded" inside moment.tz.
+		//
+		// The fix dispatches `setDateTimeStart(date)` BEFORE the validation
+		// cascade runs, so when validateDateTimeEnd reads the store it sees
+		// the new start and the inequality is false. Asserts that each
+		// dispatcher is called exactly once with the expected value.
+		const setDateTimeStart = jest.fn( ( val ) => {
+			global.__gpDatetime.dateTimeStart = val;
+		} );
+		const setDateTimeEnd = jest.fn( ( val ) => {
+			global.__gpDatetime.dateTimeEnd = val;
+		} );
+
+		// Initial state: 2025-04-29 6pm to 8pm = preset 2-hour duration.
+		global.__gpDatetime.dateTimeStart = '2025-04-29 18:00:00';
+		global.__gpDatetime.dateTimeEnd = '2025-04-29 20:00:00';
+
+		// User presses Down on the year input — picker emits the new start
+		// one year earlier than the stored start.
+		const newStartDate = '2024-04-29 18:00:00';
+
+		expect( () =>
+			updateDateTimeStart( newStartDate, setDateTimeStart, setDateTimeEnd ),
+		).not.toThrow();
+
+		expect( setDateTimeStart ).toHaveBeenCalledTimes( 1 );
+		expect( setDateTimeStart ).toHaveBeenCalledWith( newStartDate );
+		expect( setDateTimeEnd ).toHaveBeenCalledTimes( 1 );
+		expect( setDateTimeEnd ).toHaveBeenCalledWith( '2024-04-29 20:00:00' );
+	} );
 } );
 
 /**
@@ -884,5 +943,92 @@ describe( 'dateTimePreview', () => {
 		expect( document.querySelectorAll ).toHaveBeenCalledWith(
 			'[data-gatherpress_component_name="datetime-preview"]',
 		);
+	} );
+} );
+
+/**
+ * Coverage for findMatchedDuration.
+ *
+ * Pure matching logic that backs `useMatchedDuration`. The hook is just a
+ * `useSelect` + `useMemo` wrapper around this function — keeping the logic
+ * here lets us cover the matching branches without React infrastructure.
+ */
+describe( 'findMatchedDuration', () => {
+	test( 'returns false when duration is explicitly false', () => {
+		expect(
+			findMatchedDuration(
+				'2024-06-15 10:00:00',
+				'2024-06-15 12:00:00',
+				'America/New_York',
+				false,
+			),
+		).toBe( false );
+	} );
+
+	test( 'returns matched preset value when end equals start + N hours', () => {
+		// 2 hours apart should match the 2-hour preset under any tz.
+		expect(
+			findMatchedDuration(
+				'2024-06-15 10:00:00',
+				'2024-06-15 12:00:00',
+				'America/New_York',
+				null,
+			),
+		).toBe( 2 );
+	} );
+
+	test( 'returns matched preset under a manual UTC offset timezone', () => {
+		expect(
+			findMatchedDuration(
+				'2024-06-15 10:00:00',
+				'2024-06-15 12:00:00',
+				'+00:00',
+				null,
+			),
+		).toBe( 2 );
+	} );
+
+	test( 'returns false when end does not match any preset', () => {
+		// 2h 17m apart — no preset matches.
+		expect(
+			findMatchedDuration(
+				'2024-06-15 10:00:00',
+				'2024-06-15 12:17:00',
+				'America/New_York',
+				null,
+			),
+		).toBe( false );
+	} );
+} );
+
+/**
+ * Coverage for useMatchedDuration.
+ *
+ * Thin `useSelect` + `useMemo` wrapper around `findMatchedDuration`. With
+ * `useSelect` mocked to call its mapSelect synchronously and `useMemo`
+ * stubbed to invoke its factory, calling the hook in plain Jest exercises
+ * the wiring end-to-end.
+ */
+describe( 'useMatchedDuration', () => {
+	test( 'reads inputs from the store and returns the matched preset', () => {
+		global.__gpDatetime = {
+			dateTimeStart: '2024-06-15 10:00:00',
+			dateTimeEnd: '2024-06-15 12:00:00',
+			timezone: 'America/New_York',
+			duration: null,
+		};
+
+		expect( useMatchedDuration() ).toBe( 2 );
+	} );
+
+	test( 'returns false when the user opts out via setDuration(false)', () => {
+		global.__gpDatetime = {
+			dateTimeStart: '2024-06-15 10:00:00',
+			dateTimeEnd: '2024-06-15 12:00:00',
+			timezone: 'America/New_York',
+			duration: false,
+		};
+
+		expect( useMatchedDuration() ).toBe( false );
 	} );
 } );

--- a/test/unit/js/src/helpers/datetime.test.js
+++ b/test/unit/js/src/helpers/datetime.test.js
@@ -482,6 +482,60 @@ test( 'updateDateTimeEnd without second argument', () => {
 } );
 
 /**
+ * #1607 regression coverage: the picker emits ISO-format strings with a 'T'
+ * separator, and `updateDateTimeStart`/`updateDateTimeEnd` must normalize
+ * them to the canonical database format (`YYYY-MM-DD HH:mm:ss`) at the
+ * entry point. Doing this in a useEffect that depends on the value being
+ * normalized produced an infinite re-render loop on DST-gap inputs — the
+ * normalization has to happen exactly once per user action, here.
+ */
+test( 'updateDateTimeStart normalizes picker ISO output (T separator) before storing', () => {
+	let captured = null;
+	const setDateTimeStart = ( value ) => {
+		captured = value;
+	};
+
+	updateDateTimeStart( '2024-03-15T10:30:00', setDateTimeStart );
+
+	expect( captured ).toBe( '2024-03-15 10:30:00' );
+} );
+
+test( 'updateDateTimeEnd normalizes picker ISO output (T separator) before storing', () => {
+	let captured = null;
+	const setDateTimeEnd = ( value ) => {
+		captured = value;
+	};
+
+	updateDateTimeEnd( '2024-03-15T14:30:00', setDateTimeEnd );
+
+	expect( captured ).toBe( '2024-03-15 14:30:00' );
+} );
+
+test( 'updateDateTimeStart normalization is idempotent on canonical input', () => {
+	let captured = null;
+	const setDateTimeStart = ( value ) => {
+		captured = value;
+	};
+	const canonical = '2024-06-15 10:30:00';
+
+	updateDateTimeStart( canonical, setDateTimeStart );
+
+	expect( captured ).toBe( canonical );
+} );
+
+test( 'updateDateTimeEnd normalization is idempotent on canonical input', () => {
+	let captured = null;
+	const setDateTimeEnd = ( value ) => {
+		captured = value;
+	};
+	const canonical = '2024-06-15 14:30:00';
+
+	updateDateTimeEnd( canonical, setDateTimeEnd );
+
+	expect( captured ).toBe( canonical );
+} );
+
+/**
  * Coverage for convertPHPToMomentFormat.
  */
 test( 'convertPHPToMomentFormat returns correct date format', () => {

--- a/test/unit/js/src/helpers/datetime.test.js
+++ b/test/unit/js/src/helpers/datetime.test.js
@@ -482,60 +482,6 @@ test( 'updateDateTimeEnd without second argument', () => {
 } );
 
 /**
- * #1607 regression coverage: the picker emits ISO-format strings with a 'T'
- * separator, and `updateDateTimeStart`/`updateDateTimeEnd` must normalize
- * them to the canonical database format (`YYYY-MM-DD HH:mm:ss`) at the
- * entry point. Doing this in a useEffect that depends on the value being
- * normalized produced an infinite re-render loop on DST-gap inputs — the
- * normalization has to happen exactly once per user action, here.
- */
-test( 'updateDateTimeStart normalizes picker ISO output (T separator) before storing', () => {
-	let captured = null;
-	const setDateTimeStart = ( value ) => {
-		captured = value;
-	};
-
-	updateDateTimeStart( '2024-03-15T10:30:00', setDateTimeStart );
-
-	expect( captured ).toBe( '2024-03-15 10:30:00' );
-} );
-
-test( 'updateDateTimeEnd normalizes picker ISO output (T separator) before storing', () => {
-	let captured = null;
-	const setDateTimeEnd = ( value ) => {
-		captured = value;
-	};
-
-	updateDateTimeEnd( '2024-03-15T14:30:00', setDateTimeEnd );
-
-	expect( captured ).toBe( '2024-03-15 14:30:00' );
-} );
-
-test( 'updateDateTimeStart normalization is idempotent on canonical input', () => {
-	let captured = null;
-	const setDateTimeStart = ( value ) => {
-		captured = value;
-	};
-	const canonical = '2024-06-15 10:30:00';
-
-	updateDateTimeStart( canonical, setDateTimeStart );
-
-	expect( captured ).toBe( canonical );
-} );
-
-test( 'updateDateTimeEnd normalization is idempotent on canonical input', () => {
-	let captured = null;
-	const setDateTimeEnd = ( value ) => {
-		captured = value;
-	};
-	const canonical = '2024-06-15 14:30:00';
-
-	updateDateTimeEnd( canonical, setDateTimeEnd );
-
-	expect( captured ).toBe( canonical );
-} );
-
-/**
  * Coverage for convertPHPToMomentFormat.
  */
 test( 'convertPHPToMomentFormat returns correct date format', () => {

--- a/test/unit/js/src/stores/datetime.test.js
+++ b/test/unit/js/src/stores/datetime.test.js
@@ -45,7 +45,12 @@ describe( 'DateTime store', () => {
 		it( 'has duration set to null by default', () => {
 			const duration = select( STORE_NAME ).getDuration();
 
-			expect( duration ).toBe( 2 );
+			// `getDuration` now returns the raw stored value (null by
+			// default). The matched-preset computation that used to live
+			// in this selector moved to `useMatchedDuration` to avoid the
+			// per-call moment.tz comparison loop that crashed the editor
+			// under IANA timezones (#1607).
+			expect( duration ).toBe( null );
 		} );
 
 		it( 'has timezone set to empty string when not provided', () => {


### PR DESCRIPTION
### Description of the Change

Fixes a stack overflow that crashed the editor when changing the year on the Date & time start picker (in relative-duration mode under an IANA timezone, e.g. `America/New_York`).

Root cause: `validateDateTimeEnd` reads the start datetime from the `gatherpress/datetime` store via `select()`, but `setDateTimeStart(date)` was dispatched at the *end* of `updateDateTimeStart` — *after* the validation cascade ran. So validation saw the stale store start, computed a "fix" that recursively called `updateDateTimeStart`, and recursed forever (the store never updates inside the synchronous chain). Stack overflowed inside `moment.tz`.

Fix: dispatch `setDateTimeStart` / `setDateTimeEnd` *before* the validation cascade runs, mirroring the eager `setToGlobal(...)` write that the pre-7772acf9 global-object architecture relied on.

Also bundled:
- Slim `getDuration` selector to return raw state and move the matched-preset comparison into a memoized `useMatchedDuration` hook (avoids `moment.tz × N options` per selector call across every render).
- Unit regression test for the year-down recursion.
- E2E regression test that exercises the editor + picker.
- `pretest:e2e` npm hook so `npm run test:e2e` matches CI locally.
- Rewrote `event-display.spec.js` to use the same browser-driven REST seeding pattern, eliminating a pre-existing wp-env Docker port conflict and tightening its assertion.

Closes #1607

### How to test the Change

1. Edit any event with a 1, 1.5, 2, or 3 hour duration and an IANA timezone.
2. Open the Date & time start picker.
3. Click into the Year input and press Down (or Up) repeatedly.
4. Editor should not crash; year and end time update in lockstep.

Or: `npm run test:unit:js` and `npm run test:e2e`.

### Changelog Entry

> Fixed - Stack overflow in the Date & time start picker when changing the year in relative-duration mode under an IANA timezone.

### Credits

Props @mauteri @carstingaxion 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.