### PR TITLE
Fix Event Query Settings panel and REST params for event-supporting custom post types

### DIFF
--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -234,8 +234,13 @@ class Event_Query {
 		// Generate a new custom query with all potential query vars.
 		$query_args = array();
 
-		// Post Related.
-		$query_args['post_type'] = get_post_types_by_support( 'gatherpress-event-date' );
+		// Honor the block's selected post type when present so a Query Loop
+		// pinned to e.g. `production` doesn't leak `gatherpress_event` posts
+		// (#1609). Fall back to all event-supporting post types only when
+		// the block didn't pick one explicitly.
+		$query_args['post_type'] = ! empty( $block_query['postType'] )
+			? $block_query['postType']
+			: get_post_types_by_support( 'gatherpress-event-date' );
 
 		// Type of event list: 'upcoming' or 'past',
 		// @see wp-content/plugins/gatherpress/includes/core/classes/class-event-query.php.

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -69,6 +69,9 @@ class Event_Query {
 			2
 		);
 		add_action( 'registered_post_type', array( $this, 'maybe_register_event_date_rest_hooks' ) );
+		// Sweep last so post types registered before our listener was
+		// added still get their REST filters installed (#1608).
+		add_action( 'init', array( $this, 'register_existing_event_date_post_types' ), PHP_INT_MAX );
 
 		// Integrate with Advanced Query Loop plugin to pass event query params through.
 		add_filter(
@@ -77,6 +80,25 @@ class Event_Query {
 			10,
 			2
 		);
+	}
+
+	/**
+	 * Register REST hooks for every event-supporting post type that's
+	 * already in the registry by the time we run.
+	 *
+	 * Companion to the `registered_post_type` listener — that one catches
+	 * post types registered AFTER `Event_Query` is instantiated, this one
+	 * catches the ones registered BEFORE. Idempotent: `add_filter` is a
+	 * no-op when the same callback is already registered.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function register_existing_event_date_post_types(): void {
+		foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $post_type ) {
+			$this->maybe_register_event_date_rest_hooks( $post_type );
+		}
 	}
 
 	/**

--- a/src/blocks/rsvp/edit.js
+++ b/src/blocks/rsvp/edit.js
@@ -196,9 +196,16 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 	// the override target's entity record loads — `hasValidEventId` reads
 	// `getEntityRecord` / `getEntityRecords`, which only emit subscription
 	// updates when called via the `useSelect` callback's `select`.
+	//
+	// Inside a Query Loop the host's `context.postType` is the iterated
+	// post type (e.g. `production`). If that post type doesn't declare
+	// `gatherpress-rsvp` support, the block is in a context where there's
+	// no RSVP to render — gate on `isEventContext` so the loop-iterated
+	// case dims with the rest, instead of staying bright on every
+	// production card just because the post exists (#1608 follow-on).
 	const isValidEvent = useSelect(
 		( select ) =>
-			( hasExplicitOverride || isDescendentOfQueryLoop || isEventContext ) &&
+			( hasExplicitOverride || ( isDescendentOfQueryLoop && isEventContext ) || isEventContext ) &&
 			hasValidEventId( select, postId, context?.postType ),
 		[
 			postId,

--- a/src/integrations/aql/index.js
+++ b/src/integrations/aql/index.js
@@ -15,7 +15,7 @@ import {
 	EventIncludeUnfinishedControls,
 	EventOrderControls,
 } from '../../variations/core/query/components';
-import { isPostTypeSupporting } from '../../helpers/event';
+import { usePostTypeSupports } from '../../helpers/event';
 
 /**
  * Component that auto-sets GatherPress event defaults when the post type
@@ -28,11 +28,16 @@ import { isPostTypeSupporting } from '../../helpers/event';
  */
 const AQLEventDefaults = ( { attributes, setAttributes } ) => {
 	const { postType, gatherpress_event_query: eventQuery } = attributes.query;
+	// Reactive so the gate flips when the post-type registry resolves (#1608).
+	const supportsEventDate = usePostTypeSupports(
+		'gatherpress-event-date',
+		postType,
+	);
 
 	useEffect( () => {
 		// Set GatherPress defaults when post type supports event-date
 		// but event query params haven't been set yet.
-		if ( isPostTypeSupporting( 'gatherpress-event-date', postType ) && ! eventQuery ) {
+		if ( supportsEventDate && ! eventQuery ) {
 			setAttributes( {
 				query: {
 					...attributes.query,
@@ -43,37 +48,28 @@ const AQLEventDefaults = ( { attributes, setAttributes } ) => {
 				},
 			} );
 		}
-	}, [ postType, eventQuery, attributes, setAttributes ] );
+	}, [ supportsEventDate, eventQuery, attributes, setAttributes ] );
 
 	return null;
 };
 
 /**
- * Higher Order Component that adds GatherPress event controls to AQL blocks
- * as a separate InspectorControls panel, rendered as a sibling to AQL's
- * "Advanced Query Settings" panel.
+ * Renders the AQL event controls panel and the defaults observer.
  *
- * @param {Function} BlockEdit The block's edit component.
- * @return {Function} Enhanced edit component.
+ * Extracted from the HOC so `usePostTypeSupports` only runs for AQL blocks,
+ * not every block in the editor. Reactive so the panel appears on first
+ * selection of an event-supporting post type (#1608).
+ *
+ * @param {Object}   props           Block edit props plus BlockEdit injection.
+ * @param {Function} props.BlockEdit The wrapped block's BlockEdit component.
+ * @return {JSX.Element} Edit output augmented with event controls when applicable.
  */
-const withAQLEventControls = ( BlockEdit ) => ( props ) => {
-	if ( 'core/query' !== props.name ) {
-		return <BlockEdit { ...props } />;
-	}
-
-	const { namespace } = props.attributes;
-
-	// Only handle AQL blocks.
-	if ( 'advanced-query-loop' !== namespace ) {
-		return <BlockEdit { ...props } />;
-	}
-
-	const isEvent = isPostTypeSupporting(
+const AQLBlockEdit = ( { BlockEdit, ...props } ) => {
+	const isEvent = usePostTypeSupports(
 		'gatherpress-event-date',
-		props.attributes.query?.postType
+		props.attributes.query?.postType,
 	);
 
-	// For AQL blocks with gatherpress_event post type, add the controls panel.
 	if ( isEvent ) {
 		return (
 			<>
@@ -81,10 +77,7 @@ const withAQLEventControls = ( BlockEdit ) => ( props ) => {
 				<BlockEdit { ...props } />
 				<InspectorControls>
 					<PanelBody
-						title={ __(
-							'Event Query Settings',
-							'gatherpress'
-						) }
+						title={ __( 'Event Query Settings', 'gatherpress' ) }
 					>
 						<EventListTypeControls { ...props } />
 						<EventIncludeUnfinishedControls { ...props } />
@@ -102,6 +95,27 @@ const withAQLEventControls = ( BlockEdit ) => ( props ) => {
 			<BlockEdit { ...props } />
 		</>
 	);
+};
+
+/**
+ * Higher Order Component that adds GatherPress event controls to AQL blocks
+ * as a separate InspectorControls panel, rendered as a sibling to AQL's
+ * "Advanced Query Settings" panel.
+ *
+ * @param {Function} BlockEdit The block's edit component.
+ * @return {Function} Enhanced edit component.
+ */
+const withAQLEventControls = ( BlockEdit ) => ( props ) => {
+	if ( 'core/query' !== props.name ) {
+		return <BlockEdit { ...props } />;
+	}
+
+	// Only handle AQL blocks.
+	if ( 'advanced-query-loop' !== props.attributes.namespace ) {
+		return <BlockEdit { ...props } />;
+	}
+
+	return <AQLBlockEdit BlockEdit={ BlockEdit } { ...props } />;
 };
 
 addFilter(

--- a/src/variations/core/query/controls.js
+++ b/src/variations/core/query/controls.js
@@ -35,10 +35,12 @@ const isEventQueryLoop = ( props ) => {
 };
 
 /**
- * Watches the Query block's `postType` attribute and, if changed to "gatherpress_event",
- * automatically transforms it into a GatherPress "Event Query" variation by updating
- * relevant attributes. Only transforms blocks without an existing namespace (plain core/query),
- * so blocks belonging to other variations (e.g., Advanced Query Loop) are not hijacked.
+ * Auto-transforms a plain `core/query` block into the GatherPress "Event
+ * Query" variation when the user selects any post type that declares
+ * `gatherpress-event-date` support. Reactive so the transform fires on
+ * first selection of a custom event-supporting post type, not only after
+ * routing through `gatherpress_event` first (#1608). Skips blocks that
+ * already carry a namespace so other variations (e.g. AQL) aren't hijacked.
  *
  * @param {Object}   props
  * @param {Object}   props.attributes    - Block attributes.
@@ -48,10 +50,14 @@ const isEventQueryLoop = ( props ) => {
 const QueryPosttypeObserver = ( { attributes, setAttributes } ) => {
 	const { postType } = attributes.query;
 	const { namespace } = attributes;
+	const supportsEventDate = usePostTypeSupports(
+		'gatherpress-event-date',
+		postType
+	);
 	useEffect( () => {
 		// Only auto-transform blocks without a namespace set.
 		// Blocks with an existing namespace (e.g., 'advanced-query-loop') should not be overwritten.
-		if ( 'gatherpress_event' === postType && ! namespace ) {
+		if ( supportsEventDate && ! namespace ) {
 			const newAttributes = {
 				...attributes,
 				namespace: NAME,
@@ -66,9 +72,7 @@ const QueryPosttypeObserver = ( { attributes, setAttributes } ) => {
 			};
 			setAttributes( newAttributes );
 		}
-		// Dependency array ensures this runs
-		// whenever postType, namespace, attributes, or setAttributes changes.
-	}, [ postType, namespace, attributes, setAttributes ] );
+	}, [ supportsEventDate, namespace, attributes, setAttributes ] );
 };
 
 /**

--- a/src/variations/core/query/index.js
+++ b/src/variations/core/query/index.js
@@ -33,9 +33,9 @@ const VARIATION_ATTRIBUTES = {
 	keywords: [ __( 'Events', 'gatherpress' ), __( 'Dates', 'gatherpress' ) ],
 	// Gate on `namespace` only. Including `query.postType` here would
 	// drop the variation match the moment a user picks a custom event-
-	// supporting post type (e.g. `production`), which in turn drops the
-	// "Event Card with RSVP" starter pattern out of the Change design
-	// picker since that pattern is scoped to this variation.
+	// supporting post type, which in turn drops the "Event Card with
+	// RSVP" starter pattern out of the Change design picker since that
+	// pattern is scoped to this variation.
 	isActive: [ 'namespace' ],
 	attributes: {
 		...QUERY_ATTRIBUTES,

--- a/src/variations/core/query/index.js
+++ b/src/variations/core/query/index.js
@@ -31,7 +31,12 @@ const QUERY_ATTRIBUTES = {
 const VARIATION_ATTRIBUTES = {
 	category: 'gatherpress',
 	keywords: [ __( 'Events', 'gatherpress' ), __( 'Dates', 'gatherpress' ) ],
-	isActive: [ 'namespace', 'query.postType' ],
+	// Gate on `namespace` only. Including `query.postType` here would
+	// drop the variation match the moment a user picks a custom event-
+	// supporting post type (e.g. `production`), which in turn drops the
+	// "Event Card with RSVP" starter pattern out of the Change design
+	// picker since that pattern is scoped to this variation.
+	isActive: [ 'namespace' ],
 	attributes: {
 		...QUERY_ATTRIBUTES,
 		className: 'gatherpress-event-query',

--- a/src/variations/core/query/patterns/templates/event-card-with-rsvp.js
+++ b/src/variations/core/query/patterns/templates/event-card-with-rsvp.js
@@ -224,6 +224,11 @@ const EVENT_CARD_WITH_RSVP_TEMPLATE = [
 							[
 								'gatherpress/rsvp',
 								{
+									// Skip the pattern picker: seeded by the
+									// Event Card with RSVP template, so it
+									// should render the default rather than
+									// prompting "Choose".
+									patternPicked: true,
 									layout: {
 										type: 'flex',
 										justifyContent: 'right',

--- a/src/variations/core/query/patterns/templates/event-card-with-rsvp.js
+++ b/src/variations/core/query/patterns/templates/event-card-with-rsvp.js
@@ -224,10 +224,6 @@ const EVENT_CARD_WITH_RSVP_TEMPLATE = [
 							[
 								'gatherpress/rsvp',
 								{
-									// Skip the pattern picker: seeded by the
-									// Event Card with RSVP template, so it
-									// should render the default rather than
-									// prompting "Choose".
 									patternPicked: true,
 									layout: {
 										type: 'flex',

--- a/test/unit/js/src/integrations/aql/index.test.js
+++ b/test/unit/js/src/integrations/aql/index.test.js
@@ -45,7 +45,7 @@ jest.mock( '@wordpress/i18n', () => ( {
  * Mock internal dependencies
  */
 jest.mock( '@src/helpers/event', () => ( {
-	isPostTypeSupporting: jest.fn(),
+	usePostTypeSupports: jest.fn(),
 } ) );
 
 jest.mock( '@src/variations/core/query/components', () => ( {
@@ -63,7 +63,7 @@ jest.mock( '@src/variations/core/query/components', () => ( {
  */
 import { addFilter } from '@wordpress/hooks';
 import { useEffect } from '@wordpress/element';
-import { isPostTypeSupporting } from '@src/helpers/event';
+import { usePostTypeSupports } from '@src/helpers/event';
 
 // Import the module to trigger the addFilter side effect.
 import '@src/integrations/aql/index';
@@ -81,7 +81,7 @@ describe( 'AQL Integration', () => {
 		// Restore default useEffect behavior for each test.
 		useEffect.mockImplementation( ( fn ) => fn() );
 		// Default: return true only for gatherpress_event post type.
-		isPostTypeSupporting.mockImplementation(
+		usePostTypeSupports.mockImplementation(
 			( support, postType ) =>
 				'gatherpress-event-date' === support &&
 				'gatherpress_event' === postType
@@ -178,7 +178,7 @@ describe( 'AQL Integration', () => {
 
 		it( 'renders event controls panel for AQL blocks with custom event-date-supporting post type', () => {
 			// Mock gatherpress_shindig as a post type that supports gatherpress-event-date.
-			isPostTypeSupporting.mockImplementation(
+			usePostTypeSupports.mockImplementation(
 				( support, postType ) =>
 					'gatherpress-event-date' === support &&
 					'gatherpress_shindig' === postType
@@ -357,11 +357,14 @@ describe( 'AQL Integration', () => {
 				/>
 			);
 
-			// Verify useEffect was called with a callback and dependency array.
+			// Verify useEffect was called with a callback and dependency
+			// array keyed on the resolved support gate (true/false from
+			// usePostTypeSupports), not the raw postType string — so the
+			// effect re-runs the moment the post-type registry resolves.
 			expect( useEffect ).toHaveBeenCalledWith(
 				expect.any( Function ),
 				expect.arrayContaining( [
-					'gatherpress_event',
+					true,
 					undefined,
 					expect.any( Object ),
 					mockSetAttributes,

--- a/test/unit/js/src/variations/core/query/controls.test.js
+++ b/test/unit/js/src/variations/core/query/controls.test.js
@@ -11,7 +11,9 @@ jest.mock( '@wordpress/hooks', () => ( {
 
 jest.mock( '@wordpress/element', () => {
 	const actual = jest.requireActual( '@wordpress/element' );
-	return { ...actual, useEffect: jest.fn() };
+	// Invoke the effect synchronously so QueryPosttypeObserver's auto-
+	// transform fires during render in the HOC tests below.
+	return { ...actual, useEffect: jest.fn( ( fn ) => fn() ) };
 } );
 
 jest.mock( '@wordpress/plugins', () => ( {
@@ -67,12 +69,19 @@ jest.mock( '@src/helpers/event', () => ( {
 /**
  * WordPress dependencies
  */
+import { addFilter } from '@wordpress/hooks';
 import { usePostTypeSupports } from '@src/helpers/event';
 
 /**
  * Internal dependencies
  */
 import { EventQueryControlsPanel } from '@src/variations/core/query/controls';
+
+// Importing the module above runs its side effects, including the
+// `addFilter` registration of the `withEventQueryControls` HOC. Capture the
+// HOC reference here so the QueryPosttypeObserver tests below can render
+// with it.
+const withEventQueryControls = addFilter.mock.calls[ 0 ][ 2 ];
 
 describe( 'EventQueryControlsPanel', () => {
 	const baseProps = ( { postType = 'gatherpress_event', inherit = false } = {} ) => ( {
@@ -160,5 +169,66 @@ describe( 'EventQueryControlsPanel', () => {
 			'gatherpress-event-date',
 			undefined
 		);
+	} );
+} );
+
+describe( 'QueryPosttypeObserver auto-transform', () => {
+	const renderQuery = ( query = {}, namespace = undefined ) => {
+		const setAttributes = jest.fn();
+		const MockBlockEdit = () => <div data-testid="block-edit" />;
+		const Enhanced = withEventQueryControls( MockBlockEdit );
+		render(
+			<Enhanced
+				name="core/query"
+				attributes={ { namespace, query } }
+				setAttributes={ setAttributes }
+			/>
+		);
+		return setAttributes;
+	};
+
+	beforeEach( () => {
+		usePostTypeSupports.mockReset();
+	} );
+
+	it( 'transforms a plain core/query block into the event variation when the post type supports event-date', () => {
+		// Reproduces #1608: any custom post type that declares
+		// gatherpress-event-date support (e.g. `production`) should
+		// trigger the auto-transform on first selection, not just the
+		// hardcoded `gatherpress_event` post type.
+		usePostTypeSupports.mockReturnValue( true );
+
+		const setAttributes = renderQuery( { postType: 'production' } );
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		const next = setAttributes.mock.calls[ 0 ][ 0 ];
+		expect( next.namespace ).toBe( 'gatherpress-event-query' );
+		expect( next.query ).toMatchObject( {
+			postType: 'production',
+			gatherpress_event_query: 'upcoming',
+			include_unfinished: 1,
+			order: 'asc',
+			orderBy: 'datetime',
+			inherit: false,
+		} );
+	} );
+
+	it( 'does not transform when the post type does not support event-date', () => {
+		usePostTypeSupports.mockReturnValue( false );
+
+		const setAttributes = renderQuery( { postType: 'post' } );
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not transform when the block already has a namespace (e.g. AQL)', () => {
+		usePostTypeSupports.mockReturnValue( true );
+
+		const setAttributes = renderQuery(
+			{ postType: 'production' },
+			'advanced-query-loop'
+		);
+
+		expect( setAttributes ).not.toHaveBeenCalled();
 	} );
 } );

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -499,6 +499,37 @@ class Test_Event_Query extends Base {
 	}
 
 	/**
+	 * The block's selected `postType` is honored as the `post_type` query
+	 * arg when present. Without this, a Query Loop pinned to a specific
+	 * event-supporting post type (e.g. `production`) would leak posts
+	 * from every event-supporting post type on the site (#1609).
+	 *
+	 * @since 1.0.0
+	 * @covers ::query_loop_block_query_vars
+	 *
+	 * @return void
+	 */
+	public function test_query_loop_block_query_vars_honors_block_post_type(): void {
+		$instance = Event_Query::get_instance();
+		$block    = $this->createMock( \WP_Block::class );
+
+		$block->context = array(
+			'query' => array(
+				'gatherpress_event_query' => 'upcoming',
+				'postType'                => 'production',
+			),
+		);
+
+		$result = $instance->query_loop_block_query_vars( array(), $block );
+
+		$this->assertSame(
+			'production',
+			$result['post_type'],
+			'Should pass the block-selected post type through verbatim, not the union of all event-supporting post types.'
+		);
+	}
+
+	/**
 	 * Test query_loop_block_query_vars with DESC order.
 	 *
 	 * @since 1.0.0

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -525,7 +525,7 @@ class Test_Event_Query extends Base {
 		$this->assertSame(
 			'production',
 			$result['post_type'],
-			'Should pass the block-selected post type through verbatim, not the union of all event-supporting post types.'
+			'Should pass the block-selected post type through verbatim, not the union of every event-supporting type.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -47,6 +47,12 @@ class Test_Event_Query extends Base {
 				'callback' => array( $instance, 'maybe_register_event_date_rest_hooks' ),
 			),
 			array(
+				'type'     => 'action',
+				'name'     => 'init',
+				'priority' => PHP_INT_MAX,
+				'callback' => array( $instance, 'register_existing_event_date_post_types' ),
+			),
+			array(
 				'type'     => 'filter',
 				'name'     => 'aql_query_vars',
 				'priority' => 10,
@@ -113,6 +119,63 @@ class Test_Event_Query extends Base {
 			has_filter( 'rest_post_query', array( $instance, 'rest_query' ) ),
 			'Failed to assert that no REST filters are registered for a post type without event-date support.'
 		);
+	}
+
+	/**
+	 * Sweep registers REST filters for every event-supporting post type
+	 * already in the registry.
+	 *
+	 * Reproduces #1608: post types registered by other plugins before
+	 * `Event_Query` boots (e.g. `gatherpress-productions`) miss the
+	 * `registered_post_type` listener, so without this sweep their REST
+	 * endpoints lack `orderby=datetime`, `gatherpress_event_query`, and
+	 * `include_unfinished` and the editor 400s when the Query Loop block
+	 * tries to fetch them.
+	 *
+	 * @since 1.0.0
+	 * @covers ::register_existing_event_date_post_types
+	 *
+	 * @return void
+	 */
+	public function test_register_existing_event_date_post_types_sweeps_registry(): void {
+		$instance  = Event_Query::get_instance();
+		$post_type = 'shindig';
+
+		register_post_type(
+			$post_type,
+			array(
+				'label'    => 'Test Productions',
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		// Strip any filters so we observe the sweep installing them, not
+		// a pre-existing registration from the `registered_post_type`
+		// listener that fired during `register_post_type()`.
+		remove_all_filters( sprintf( 'rest_%s_query', $post_type ) );
+		remove_all_filters( sprintf( 'rest_%s_collection_params', $post_type ) );
+
+		$instance->register_existing_event_date_post_types();
+
+		$this->assertSame(
+			10,
+			has_filter(
+				sprintf( 'rest_%s_query', $post_type ),
+				array( $instance, 'rest_query' )
+			),
+			'Sweep should install rest_query filter for every event-supporting post type.'
+		);
+		$this->assertSame(
+			10,
+			has_filter(
+				sprintf( 'rest_%s_collection_params', $post_type ),
+				array( $instance, 'rest_collection_params' )
+			),
+			'Sweep should install rest_collection_params filter for every event-supporting post type.'
+		);
+
+		unregister_post_type( $post_type );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Five fixes for the same end-to-end symptom: switching a Query Loop block's post type to a custom event-supporting post type (e.g. `production`) leaves the editor and frontend non-functional.

1. **JS panel never appears.** `QueryPosttypeObserver` in `src/variations/core/query/controls.js` hardcoded `'gatherpress_event' === postType`, so selecting any other event-supporting post type didn't trigger the auto-transform into the GatherPress event variation, and the Event Query Settings panel never rendered. Switched to the reactive `usePostTypeSupports` hook so the gate flips for any post type that declares `gatherpress-event-date` support, the moment the post-type registry resolves. Same swap applied in `src/integrations/aql/index.js` for the AQL integration's defaults observer + HOC, with a sub-component extraction so the hook only fires for AQL blocks rather than every block in the editor.

2. **REST endpoint 400s.** `Blocks\Event_Query::maybe_register_event_date_rest_hooks` is hooked on `registered_post_type`, but `Event_Query` is instantiated on `init` priority 10. Any post type registered earlier (companion plugin loaded before GatherPress, or earlier callback in the same priority bucket) misses the listener, so its REST endpoint never gets `orderby=datetime`, `gatherpress_event_query`, or `include_unfinished` registered. Added a one-line sweep on `init` at `PHP_INT_MAX` that catches the leftovers before `rest_api_init` builds route schemas.

3. **Frontend leaks across post types** (closes #1609). `Blocks\Event_Query::query_loop_block_query_vars` overwrote `post_type` with `get_post_types_by_support( 'gatherpress-event-date' )`, so a Query Loop pinned to `production` rendered events and productions together. Now honors `$block_query['postType']` when present and only falls back to the union when the block didn't pick one.

4. **RSVP block stays bright in non-RSVP loops.** Inside a Query Loop iterating productions (which support event-date but not `gatherpress-rsvp`), the RSVP block stayed at full opacity even though there's no RSVP to render. The dim gate in `src/blocks/rsvp/edit.js` now also requires `isEventContext` (RSVP support on the queried post type) when inside a Query Loop, so the block dims correctly per iterated post.

5. **"Change design" picker drops the Event pattern.** The Event Query Loop variation declared `isActive: [ 'namespace', 'query.postType' ]`, so the moment the user picked any post type other than `gatherpress_event` the variation no longer matched and the Change design picker fell back to generic core post patterns. Gated `isActive` on `namespace` alone so the variation (and its scoped "Event Card with RSVP" pattern) stays available regardless of selected post type.

Plus a small follow-on in the Event Card with RSVP starter template: the embedded `gatherpress/rsvp` block now seeds with `patternPicked: true` so it renders the default RSVP UI instead of prompting "Choose pattern" on insert.

Closes #1608. Closes #1609.

### How to test the Change

1. Activate `gatherpress-productions` (or any companion plugin that registers a post type with `gatherpress-event-date` support).
2. Edit any post or template, add a Query Loop block, switch from Inherit to Custom.
3. Set the Post type to **Production**.
4. Event Query Settings panel should appear in the inspector immediately. Block preview should render Production posts (no console 400 against `/wp-json/wp/v2/production`).
5. Pick the **Event Card with RSVP** starter from the Change design picker. The embedded RSVP block should render its default UI (no "Choose" prompt), dimmed since productions don't support RSVP.
6. View the page on the frontend. Only Production posts should appear, not a mix of productions and events.

### Changelog Entry

> Fixed - Event Query Loop on custom event-supporting post types: settings panel renders on first selection, REST collection params accept GatherPress query args, frontend rendering no longer leaks across post types, RSVP block dims when iterating non-RSVP types, and the Change design picker keeps the Event Card with RSVP starter pattern.

### Credits

Props @mauteri, @carstingaxion

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.