### PR TITLE
Fix default archive temporal handling for event-supporting custom post types

### DIFF
--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -74,6 +74,29 @@ addFilter(
 );
 ```
 
+#### Bare archive temporal handling
+
+The bare post-type archive URL (e.g. `/my_custom_event/`) doesn't apply any upcoming/past temporal filter by default for custom event-supporting post types. Past and future entries appear together unless one of the following narrows the result:
+
+1. URL parameters: appending `?gatherpress_event_query=upcoming` (or `past`) to the archive URL narrows that page load to the matching subset. This works out of the box.
+2. The `gatherpress_event_archive_mode` filter, which receives the queried post type as its second argument and lets you pin a default mode for any event-supporting post type. Returned values must be `upcoming`, `past`, or `none` — anything else is coerced (`upcoming` for `gatherpress_event`, `none` otherwise).
+
+```php
+add_filter(
+    'gatherpress_event_archive_mode',
+    function ( string $mode, string $post_type ): string {
+        if ( 'my_custom_event' === $post_type ) {
+            return 'upcoming';
+        }
+        return $mode;
+    },
+    10,
+    2
+);
+```
+
+The standard `gatherpress_event` post type seeds `$mode` from the Event Archive setting and 404s when set to `none`. Other event-supporting post types start at `none` and pass through to the default WP archive when the filter doesn't opt them into temporal handling.
+
 ### `gatherpress-rsvp`
 
 Enables the comment-based RSVP system for a post type. This includes:

--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -76,17 +76,17 @@ addFilter(
 
 #### Bare archive temporal handling
 
-The bare post-type archive URL (e.g. `/my_custom_event/`) doesn't apply any upcoming/past temporal filter by default for custom event-supporting post types. Past and future entries appear together unless one of the following narrows the result:
+The bare post-type archive URL (e.g. `/my_custom_event/`) defaults to **upcoming** for every event-supporting post type, so past entries don't appear alongside future ones in the same list. Two knobs override that default:
 
-1. URL parameters: appending `?gatherpress_event_query=upcoming` (or `past`) to the archive URL narrows that page load to the matching subset. This works out of the box.
-2. The `gatherpress_event_archive_mode` filter, which receives the queried post type as its second argument and lets you pin a default mode for any event-supporting post type. Returned values must be `upcoming`, `past`, or `none` — anything else is coerced (`upcoming` for `gatherpress_event`, `none` otherwise).
+1. URL parameters: appending `?gatherpress_event_query=upcoming` (or `past`) narrows that page load to the matching subset.
+2. The `gatherpress_event_archive_mode` filter receives the queried post type as its second argument and lets you pin a different mode for any event-supporting post type. Valid return values are `upcoming`, `past`, or `none` — anything else is coerced back to `upcoming`. Returning `none` opts the archive out entirely (404).
 
 ```php
 add_filter(
     'gatherpress_event_archive_mode',
     function ( string $mode, string $post_type ): string {
         if ( 'my_custom_event' === $post_type ) {
-            return 'upcoming';
+            return 'past';
         }
         return $mode;
     },
@@ -95,7 +95,7 @@ add_filter(
 );
 ```
 
-The standard `gatherpress_event` post type seeds `$mode` from the Event Archive setting and 404s when set to `none`. Other event-supporting post types start at `none` and pass through to the default WP archive when the filter doesn't opt them into temporal handling.
+The standard `gatherpress_event` post type also lets the Event Archive setting choose the default before the filter runs.
 
 ### `gatherpress-rsvp`
 

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -511,15 +511,12 @@ class Setup {
 	 * Mutate the global query to render the configured archive mode for an
 	 * event-supporting post type.
 	 *
-	 * The mode comes from `get_event_archive_mode( $post_type )`, which
-	 * reads the Event Archive setting for `gatherpress_event` (and `none`
-	 * for every other event-supporting post type) and then runs the
-	 * `gatherpress_event_archive_mode` filter so the resolved mode can
-	 * be overridden programmatically per post type. When the resolved
-	 * mode is `upcoming` or `past`, the archive is re-queried with that
-	 * temporal filter applied; when it's `none`, `gatherpress_event`
-	 * 404s (preserving the opt-out admins rely on) and other post types
-	 * pass through to the default WP archive (#1611).
+	 * The mode comes from `get_event_archive_mode( $post_type )` —
+	 * defaults to `upcoming`, with the Event Archive setting and the
+	 * `gatherpress_event_archive_mode` filter as the override knobs.
+	 * `upcoming` / `past` re-query with the matching temporal filter;
+	 * `none` 404s, since the only way to land there is an explicit
+	 * opt-out (#1611).
 	 *
 	 * @since 1.0.0
 	 *
@@ -530,14 +527,9 @@ class Setup {
 	protected function fall_back_to_archive_mode( WP_Query $wp_query, string $post_type ): void {
 		$mode = $this->get_event_archive_mode( $post_type );
 
-		if ( 'upcoming' !== $mode && 'past' !== $mode ) {
-			// `gatherpress_event` keeps its 404-on-`none` semantics so
-			// admins can opt the events archive out entirely. Other
-			// post types pass through to the default WP archive.
-			if ( Event::POST_TYPE === $post_type ) {
-				$wp_query->set_404();
-				status_header( 404 );
-			}
+		if ( 'none' === $mode ) {
+			$wp_query->set_404();
+			status_header( 404 );
 			return;
 		}
 
@@ -571,12 +563,12 @@ class Setup {
 	/**
 	 * Resolve the configured event archive mode for a given post type.
 	 *
-	 * For `gatherpress_event` the mode is read from the Event Archive
-	 * setting and coerced into one of `upcoming`, `past`, or `none`.
-	 * For other event-supporting post types the mode starts at `none`
-	 * (no settings dropdown exists for them) and only the
-	 * `gatherpress_event_archive_mode` filter can opt the archive into
-	 * upcoming/past handling.
+	 * Every event-supporting post type defaults to `upcoming`. For
+	 * `gatherpress_event` the Event Archive setting overrides the
+	 * default when it carries a valid value. The
+	 * `gatherpress_event_archive_mode` filter then runs for every post
+	 * type and gets the last word. Anything outside `upcoming` / `past`
+	 * / `none` is coerced back to `upcoming` (#1611).
 	 *
 	 * @since 1.0.0
 	 *
@@ -584,31 +576,24 @@ class Setup {
 	 * @return string One of `upcoming`, `past`, or `none`.
 	 */
 	public function get_event_archive_mode( string $post_type = Event::POST_TYPE ): string {
-		if ( Event::POST_TYPE === $post_type ) {
-			$settings = Settings::get_instance();
-			$mode     = (string) $settings->get( 'event_archive' );
+		$valid_modes = array( 'upcoming', 'past', 'none' );
+		$mode        = 'upcoming';
 
-			if ( ! in_array( $mode, array( 'upcoming', 'past', 'none' ), true ) ) {
-				$mode = 'upcoming';
+		if ( Event::POST_TYPE === $post_type ) {
+			$stored = (string) Settings::get_instance()->get( 'event_archive' );
+
+			if ( in_array( $stored, $valid_modes, true ) ) {
+				$mode = $stored;
 			}
-		} else {
-			// Other event-supporting post types have no settings dropdown,
-			// so the filter below is the sole knob. `none` keeps the bare
-			// archive on the default WP query path until a filter opts in.
-			$mode = 'none';
 		}
 
 		/**
 		 * Filters the resolved event archive mode.
 		 *
-		 * For `gatherpress_event` the incoming `$mode` reflects the Event
-		 * Archive setting; the filter lets plugins programmatically
-		 * override it (force `none` during maintenance, pin `past` for a
-		 * specific request, etc.). For other event-supporting post types
-		 * the incoming `$mode` is always `none` and the filter is the
-		 * only way to opt the archive into upcoming/past handling.
-		 * Returned values outside `upcoming`/`past`/`none` are coerced
-		 * to `upcoming` for `gatherpress_event` and `none` for others.
+		 * Lets plugins pin a post type's archive to `upcoming`, `past`,
+		 * or `none` programmatically — including overriding the Event
+		 * Archive setting for `gatherpress_event`. Returned values
+		 * outside the valid set are coerced to `upcoming`.
 		 *
 		 * @since 1.0.0
 		 *
@@ -617,11 +602,7 @@ class Setup {
 		 */
 		$mode = (string) apply_filters( 'gatherpress_event_archive_mode', $mode, $post_type );
 
-		if ( ! in_array( $mode, array( 'upcoming', 'past', 'none' ), true ) ) {
-			$mode = ( Event::POST_TYPE === $post_type ) ? 'upcoming' : 'none';
-		}
-
-		return $mode;
+		return in_array( $mode, $valid_modes, true ) ? $mode : 'upcoming';
 	}
 
 	/**

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -25,6 +25,7 @@ use GatherPress\Core\Utility;
 use WP;
 use WP_Block;
 use WP_Post;
+use WP_Query;
 
 /**
  * Class Setup.
@@ -418,14 +419,28 @@ class Setup {
 	public function handle_event_archive_redirect(): void {
 		global $wp_query;
 
-		// Bail when not the event post-type archive, when on a feed (the Feed
-		// class handles those separately), or when event-query already claimed
-		// this page as an archive — combined into one guard so the function
-		// reads as a dispatch.
-		if ( ! is_post_type_archive( Event::POST_TYPE )
-			|| is_feed()
-			|| $wp_query->get( Query::EVENT_QUERY_PARAM )
-		) {
+		// Bail on feeds (handled separately by Feed) or when something
+		// else already claimed this page as an event archive.
+		if ( is_feed() || $wp_query->get( Query::EVENT_QUERY_PARAM ) ) {
+			return;
+		}
+
+		// Bail when not on a post type archive at all, or when the
+		// queried post type doesn't declare event-date support.
+		$post_type = (string) get_query_var( 'post_type' );
+
+		if ( ! is_post_type_archive() || ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+			return;
+		}
+
+		// The page-as-archive flow below reads settings that exist only
+		// for the standard event post type (`events_url`,
+		// `upcoming_events`, `past_events`). Other event-supporting post
+		// types skip straight to the mode resolver, which honors the
+		// `gatherpress_event_archive_mode` filter the same way for every
+		// post type that goes through it (#1611).
+		if ( Event::POST_TYPE !== $post_type ) {
+			$this->fall_back_to_archive_mode( $wp_query, $post_type );
 			return;
 		}
 
@@ -439,7 +454,7 @@ class Setup {
 		if ( ! ( $page instanceof WP_Post ) || 'publish' !== $page->post_status ) {
 			// No page exists with this slug — fall back to the configured
 			// archive mode (or 404 if no mode is configured).
-			$this->fall_back_to_archive_mode( $wp_query );
+			$this->fall_back_to_archive_mode( $wp_query, $post_type );
 			return;
 		}
 
@@ -493,23 +508,36 @@ class Setup {
 	}
 
 	/**
-	 * Mutate the global query to render the configured fallback archive mode
-	 * (upcoming/past) when no page is assigned to the events rewrite slug, or
-	 * 404 when no mode is configured. Extracted from
-	 * `handle_event_archive_redirect()` to keep that dispatch under
-	 * SonarCloud's three-return ceiling.
+	 * Mutate the global query to render the configured archive mode for an
+	 * event-supporting post type.
+	 *
+	 * The mode comes from `get_event_archive_mode( $post_type )`, which
+	 * reads the Event Archive setting for `gatherpress_event` (and `none`
+	 * for every other event-supporting post type) and then runs the
+	 * `gatherpress_event_archive_mode` filter so the resolved mode can
+	 * be overridden programmatically per post type. When the resolved
+	 * mode is `upcoming` or `past`, the archive is re-queried with that
+	 * temporal filter applied; when it's `none`, `gatherpress_event`
+	 * 404s (preserving the opt-out admins rely on) and other post types
+	 * pass through to the default WP archive (#1611).
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param \WP_Query $wp_query The global query, mutated in place.
+	 * @param WP_Query $wp_query  The global query, mutated in place.
+	 * @param string   $post_type The event-supporting post type being archived.
 	 * @return void
 	 */
-	protected function fall_back_to_archive_mode( \WP_Query $wp_query ): void {
-		$mode = $this->get_event_archive_mode();
+	protected function fall_back_to_archive_mode( WP_Query $wp_query, string $post_type ): void {
+		$mode = $this->get_event_archive_mode( $post_type );
 
 		if ( 'upcoming' !== $mode && 'past' !== $mode ) {
-			$wp_query->set_404();
-			status_header( 404 );
+			// `gatherpress_event` keeps its 404-on-`none` semantics so
+			// admins can opt the events archive out entirely. Other
+			// post types pass through to the default WP archive.
+			if ( Event::POST_TYPE === $post_type ) {
+				$wp_query->set_404();
+				status_header( 404 );
+			}
 			return;
 		}
 
@@ -517,7 +545,7 @@ class Setup {
 
 		$wp_query->query(
 			array(
-				'post_type'              => Event::POST_TYPE,
+				'post_type'              => $post_type,
 				Query::EVENT_QUERY_PARAM => $mode,
 				'paged'                  => $paged,
 			)
@@ -541,42 +569,56 @@ class Setup {
 	}
 
 	/**
-	 * Resolve the configured event archive mode.
+	 * Resolve the configured event archive mode for a given post type.
 	 *
-	 * Reads the `event_archive` setting and normalizes it against the
-	 * three valid modes (`upcoming`, `past`, `none`). Anything outside
-	 * that set falls back to `upcoming` so a malformed stored value
-	 * doesn't break archive resolution.
+	 * For `gatherpress_event` the mode is read from the Event Archive
+	 * setting and coerced into one of `upcoming`, `past`, or `none`.
+	 * For other event-supporting post types the mode starts at `none`
+	 * (no settings dropdown exists for them) and only the
+	 * `gatherpress_event_archive_mode` filter can opt the archive into
+	 * upcoming/past handling.
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param string $post_type Post type to resolve the mode for. Defaults to the standard event post type.
 	 * @return string One of `upcoming`, `past`, or `none`.
 	 */
-	public function get_event_archive_mode(): string {
-		$settings = Settings::get_instance();
-		$mode     = (string) $settings->get( 'event_archive' );
+	public function get_event_archive_mode( string $post_type = Event::POST_TYPE ): string {
+		if ( Event::POST_TYPE === $post_type ) {
+			$settings = Settings::get_instance();
+			$mode     = (string) $settings->get( 'event_archive' );
 
-		if ( ! in_array( $mode, array( 'upcoming', 'past', 'none' ), true ) ) {
-			$mode = 'upcoming';
+			if ( ! in_array( $mode, array( 'upcoming', 'past', 'none' ), true ) ) {
+				$mode = 'upcoming';
+			}
+		} else {
+			// Other event-supporting post types have no settings dropdown,
+			// so the filter below is the sole knob. `none` keeps the bare
+			// archive on the default WP query path until a filter opts in.
+			$mode = 'none';
 		}
 
 		/**
 		 * Filters the resolved event archive mode.
 		 *
-		 * Lets plugins override the user-configured mode at runtime —
-		 * e.g., force `none` while a maintenance flag is set, or pin
-		 * `upcoming` for a specific request context. Returned values
-		 * outside the valid set are coerced back to `upcoming`.
+		 * For `gatherpress_event` the incoming `$mode` reflects the Event
+		 * Archive setting; the filter lets plugins programmatically
+		 * override it (force `none` during maintenance, pin `past` for a
+		 * specific request, etc.). For other event-supporting post types
+		 * the incoming `$mode` is always `none` and the filter is the
+		 * only way to opt the archive into upcoming/past handling.
+		 * Returned values outside `upcoming`/`past`/`none` are coerced
+		 * to `upcoming` for `gatherpress_event` and `none` for others.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $mode The current archive mode (`upcoming`,
-		 *                     `past`, or `none`).
+		 * @param string $mode      Current archive mode (`upcoming`, `past`, or `none`).
+		 * @param string $post_type Post type being archived.
 		 */
-		$mode = (string) apply_filters( 'gatherpress_event_archive_mode', $mode );
+		$mode = (string) apply_filters( 'gatherpress_event_archive_mode', $mode, $post_type );
 
 		if ( ! in_array( $mode, array( 'upcoming', 'past', 'none' ), true ) ) {
-			$mode = 'upcoming';
+			$mode = ( Event::POST_TYPE === $post_type ) ? 'upcoming' : 'none';
 		}
 
 		return $mode;

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -1576,6 +1576,162 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * `get_event_archive_mode()` returns `none` for a non-event post type
+	 * by default, leaving the bare archive on WordPress's default query
+	 * path. Without a `gatherpress_event_archive_mode` filter override
+	 * there's no settings dropdown to read from, so no temporal filter
+	 * applies (#1611).
+	 *
+	 * @covers ::get_event_archive_mode
+	 *
+	 * @return void
+	 */
+	public function test_get_event_archive_mode_defaults_to_none_for_non_event_post_type(): void {
+		$instance = Setup::get_instance();
+
+		register_post_type(
+			'shindig',
+			array(
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		// Even with the events setting present, a non-event post type
+		// must not pick up the events dropdown's value.
+		update_option( Settings::OPTION_NAME, array( 'event_archive' => 'past' ) );
+
+		$this->assertSame(
+			'none',
+			$instance->get_event_archive_mode( 'shindig' ),
+			'Non-event post types must default to `none` and ignore the events setting.'
+		);
+
+		delete_option( Settings::OPTION_NAME );
+		unregister_post_type( 'shindig' );
+	}
+
+	/**
+	 * `get_event_archive_mode()` passes the queried post type to the
+	 * `gatherpress_event_archive_mode` filter so site builders can opt a
+	 * non-event post type's bare archive into upcoming/past handling
+	 * (#1611). The same filter still works against `gatherpress_event`.
+	 *
+	 * @covers ::get_event_archive_mode
+	 *
+	 * @return void
+	 */
+	public function test_get_event_archive_mode_filter_can_opt_non_event_post_type_into_upcoming(): void {
+		$instance = Setup::get_instance();
+
+		register_post_type(
+			'shindig',
+			array(
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		$received_post_type = null;
+		$pin_upcoming       = static function ( string $mode, string $post_type ) use ( &$received_post_type ) {
+			$received_post_type = $post_type;
+			return ( 'shindig' === $post_type ) ? 'upcoming' : $mode;
+		};
+		add_filter( 'gatherpress_event_archive_mode', $pin_upcoming, 10, 2 );
+
+		$this->assertSame(
+			'upcoming',
+			$instance->get_event_archive_mode( 'shindig' ),
+			'Filter must be able to opt a non-event post type into upcoming handling.'
+		);
+		$this->assertSame(
+			'shindig',
+			$received_post_type,
+			'Filter must receive the queried post type as its second argument.'
+		);
+
+		remove_filter( 'gatherpress_event_archive_mode', $pin_upcoming, 10 );
+		unregister_post_type( 'shindig' );
+	}
+
+	/**
+	 * `handle_event_archive_redirect()` routes the bare archive of a
+	 * non-event event-supporting post type through the same mode
+	 * resolver as `gatherpress_event` — but skips the page-as-archive
+	 * settings flow, which is event-specific. Without a
+	 * `gatherpress_event_archive_mode` filter the archive passes
+	 * through to the default WP query (#1611).
+	 *
+	 * @covers ::handle_event_archive_redirect
+	 *
+	 * @return void
+	 */
+	public function test_handle_event_archive_redirect_non_event_post_type_passes_through(): void {
+		global $wp_query;
+
+		$instance = Setup::get_instance();
+
+		register_post_type(
+			'shindig',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		// Mock being on the bare post-type archive of `shindig`.
+		$wp_query->is_post_type_archive = true;
+		$wp_query->set( 'post_type', 'shindig' );
+
+		$instance->handle_event_archive_redirect();
+
+		$this->assertFalse(
+			$wp_query->is_404(),
+			'Non-event archives must pass through, not 404.'
+		);
+
+		unregister_post_type( 'shindig' );
+	}
+
+	/**
+	 * `fall_back_to_archive_mode()` for a non-event post type with an
+	 * unresolved mode (`none`) leaves the global query untouched —
+	 * unlike `gatherpress_event` it must NOT 404, because admins of
+	 * other event-supporting post types haven't opted into temporal
+	 * handling at all (#1611).
+	 *
+	 * @covers ::fall_back_to_archive_mode
+	 *
+	 * @return void
+	 */
+	public function test_fall_back_to_archive_mode_does_not_404_non_event_post_types(): void {
+		global $wp_query;
+
+		$instance = Setup::get_instance();
+
+		register_post_type(
+			'shindig',
+			array(
+				'public'   => false,
+				'supports' => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		Utility::invoke_hidden_method(
+			$instance,
+			'fall_back_to_archive_mode',
+			array( $wp_query, 'shindig' )
+		);
+
+		$this->assertFalse(
+			$wp_query->is_404(),
+			'Non-event post types with no resolved mode must pass through, not 404.'
+		);
+
+		unregister_post_type( 'shindig' );
+	}
+
+	/**
 	 * Tests handle_event_archive_redirect does not interfere with feed requests.
 	 *
 	 * @covers ::handle_event_archive_redirect
@@ -1802,7 +1958,7 @@ class Test_Setup extends Base {
 		Utility::invoke_hidden_method(
 			$instance,
 			'fall_back_to_archive_mode',
-			array( $wp_query )
+			array( $wp_query, Event::POST_TYPE )
 		);
 
 		delete_option( Settings::OPTION_NAME );
@@ -1838,7 +1994,7 @@ class Test_Setup extends Base {
 		Utility::invoke_hidden_method(
 			$instance,
 			'fall_back_to_archive_mode',
-			array( $wp_query )
+			array( $wp_query, Event::POST_TYPE )
 		);
 
 		remove_filter( 'gatherpress_event_archive_mode', $mode_filter );

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -1576,17 +1576,15 @@ class Test_Setup extends Base {
 	}
 
 	/**
-	 * `get_event_archive_mode()` returns `none` for a non-event post type
-	 * by default, leaving the bare archive on WordPress's default query
-	 * path. Without a `gatherpress_event_archive_mode` filter override
-	 * there's no settings dropdown to read from, so no temporal filter
-	 * applies (#1611).
+	 * `get_event_archive_mode()` defaults to `upcoming` for every
+	 * event-supporting post type and ignores the events-only Event
+	 * Archive setting when resolving for a non-event post type (#1611).
 	 *
 	 * @covers ::get_event_archive_mode
 	 *
 	 * @return void
 	 */
-	public function test_get_event_archive_mode_defaults_to_none_for_non_event_post_type(): void {
+	public function test_get_event_archive_mode_defaults_to_upcoming_for_non_event_post_type(): void {
 		$instance = Setup::get_instance();
 
 		register_post_type(
@@ -1597,14 +1595,13 @@ class Test_Setup extends Base {
 			)
 		);
 
-		// Even with the events setting present, a non-event post type
-		// must not pick up the events dropdown's value.
+		// The events setting must not bleed into other post types.
 		update_option( Settings::OPTION_NAME, array( 'event_archive' => 'past' ) );
 
 		$this->assertSame(
-			'none',
+			'upcoming',
 			$instance->get_event_archive_mode( 'shindig' ),
-			'Non-event post types must default to `none` and ignore the events setting.'
+			'Non-event post types must default to `upcoming` and ignore the events setting.'
 		);
 
 		delete_option( Settings::OPTION_NAME );
@@ -1613,15 +1610,15 @@ class Test_Setup extends Base {
 
 	/**
 	 * `get_event_archive_mode()` passes the queried post type to the
-	 * `gatherpress_event_archive_mode` filter so site builders can opt a
-	 * non-event post type's bare archive into upcoming/past handling
-	 * (#1611). The same filter still works against `gatherpress_event`.
+	 * `gatherpress_event_archive_mode` filter so site builders can pin
+	 * a non-event post type to a different mode than the upcoming
+	 * default (#1611). The same filter works for `gatherpress_event`.
 	 *
 	 * @covers ::get_event_archive_mode
 	 *
 	 * @return void
 	 */
-	public function test_get_event_archive_mode_filter_can_opt_non_event_post_type_into_upcoming(): void {
+	public function test_get_event_archive_mode_filter_receives_post_type(): void {
 		$instance = Setup::get_instance();
 
 		register_post_type(
@@ -1633,16 +1630,16 @@ class Test_Setup extends Base {
 		);
 
 		$received_post_type = null;
-		$pin_upcoming       = static function ( string $mode, string $post_type ) use ( &$received_post_type ) {
+		$pin_past           = static function ( string $mode, string $post_type ) use ( &$received_post_type ) {
 			$received_post_type = $post_type;
-			return ( 'shindig' === $post_type ) ? 'upcoming' : $mode;
+			return ( 'shindig' === $post_type ) ? 'past' : $mode;
 		};
-		add_filter( 'gatherpress_event_archive_mode', $pin_upcoming, 10, 2 );
+		add_filter( 'gatherpress_event_archive_mode', $pin_past, 10, 2 );
 
 		$this->assertSame(
-			'upcoming',
+			'past',
 			$instance->get_event_archive_mode( 'shindig' ),
-			'Filter must be able to opt a non-event post type into upcoming handling.'
+			'Filter must be able to override the default for a non-event post type.'
 		);
 		$this->assertSame(
 			'shindig',
@@ -1650,23 +1647,22 @@ class Test_Setup extends Base {
 			'Filter must receive the queried post type as its second argument.'
 		);
 
-		remove_filter( 'gatherpress_event_archive_mode', $pin_upcoming, 10 );
+		remove_filter( 'gatherpress_event_archive_mode', $pin_past, 10 );
 		unregister_post_type( 'shindig' );
 	}
 
 	/**
 	 * `handle_event_archive_redirect()` routes the bare archive of a
 	 * non-event event-supporting post type through the same mode
-	 * resolver as `gatherpress_event` — but skips the page-as-archive
-	 * settings flow, which is event-specific. Without a
-	 * `gatherpress_event_archive_mode` filter the archive passes
-	 * through to the default WP query (#1611).
+	 * resolver as `gatherpress_event`. With the default `upcoming`
+	 * mode, the archive is re-queried with the upcoming temporal
+	 * filter applied (#1611).
 	 *
 	 * @covers ::handle_event_archive_redirect
 	 *
 	 * @return void
 	 */
-	public function test_handle_event_archive_redirect_non_event_post_type_passes_through(): void {
+	public function test_handle_event_archive_redirect_non_event_post_type_defaults_to_upcoming(): void {
 		global $wp_query;
 
 		$instance = Setup::get_instance();
@@ -1687,24 +1683,28 @@ class Test_Setup extends Base {
 
 		$this->assertFalse(
 			$wp_query->is_404(),
-			'Non-event archives must pass through, not 404.'
+			'Non-event archives must not 404 by default.'
+		);
+		$this->assertSame(
+			'upcoming',
+			$wp_query->get( Query::EVENT_QUERY_PARAM ),
+			'Non-event archives default to the upcoming temporal filter.'
 		);
 
 		unregister_post_type( 'shindig' );
 	}
 
 	/**
-	 * `fall_back_to_archive_mode()` for a non-event post type with an
-	 * unresolved mode (`none`) leaves the global query untouched —
-	 * unlike `gatherpress_event` it must NOT 404, because admins of
-	 * other event-supporting post types haven't opted into temporal
-	 * handling at all (#1611).
+	 * `fall_back_to_archive_mode()` 404s for any post type when the
+	 * resolved mode is `none` — that's an explicit admin or filter
+	 * opt-out and applies the same way to every event-supporting post
+	 * type (#1611).
 	 *
 	 * @covers ::fall_back_to_archive_mode
 	 *
 	 * @return void
 	 */
-	public function test_fall_back_to_archive_mode_does_not_404_non_event_post_types(): void {
+	public function test_fall_back_to_archive_mode_404s_when_filter_pins_none_for_non_event(): void {
 		global $wp_query;
 
 		$instance = Setup::get_instance();
@@ -1717,18 +1717,22 @@ class Test_Setup extends Base {
 			)
 		);
 
+		$pin_none = static fn(): string => 'none';
+		add_filter( 'gatherpress_event_archive_mode', $pin_none );
+
 		Utility::invoke_hidden_method(
 			$instance,
 			'fall_back_to_archive_mode',
 			array( $wp_query, 'shindig' )
 		);
 
-		$this->assertFalse(
-			$wp_query->is_404(),
-			'Non-event post types with no resolved mode must pass through, not 404.'
-		);
-
+		remove_filter( 'gatherpress_event_archive_mode', $pin_none );
 		unregister_post_type( 'shindig' );
+
+		$this->assertTrue(
+			$wp_query->is_404(),
+			'A filter pinning `none` opts the archive out and 404s, regardless of post type.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

`Event\Setup::handle_event_archive_redirect()` only handled the `gatherpress_event` post type, so the bare archive URL of any other event-supporting post type rendered with no temporal filter — past and future entries jumbled together with no upcoming/past separation.

This PR generalizes the archive flow and standardizes the default to **upcoming** for every event-supporting post type. The Event Archive setting still controls the default for `gatherpress_event`. The existing `gatherpress_event_archive_mode` filter — now receiving the queried post type as its second argument — gets the last word for any post type.

Concretely:
- `get_event_archive_mode( string $post_type = Event::POST_TYPE )` defaults to `upcoming`. `gatherpress_event` overrides that with the Event Archive setting when set; the filter then runs with both `$mode` and `$post_type`. Anything outside `upcoming` / `past` / `none` is coerced back to `upcoming`.
- `fall_back_to_archive_mode( WP_Query $wp_query, string $post_type )` re-queries with the resolved mode for any post type. `none` 404s for any post type — that's only reachable via explicit admin or filter opt-out.
- `handle_event_archive_redirect()` detects every event-supporting post type archive. The settings-page flow (events_url / upcoming_events / past_events) stays gated to `gatherpress_event` because those settings are event-specific; everything else routes straight to the mode resolver.
- URL params (`?gatherpress_event_query=upcoming|past`) already worked and continue to work.

Closes #1611

### How to test the Change

1. Activate a companion plugin that registers an event-supporting custom post type with `has_archive => true`.
2. Visit `/<your_post_type>/` — the bare archive should default to upcoming, with past entries hidden.
3. Append `?gatherpress_event_query=past` and confirm only past entries render.
4. Add a `gatherpress_event_archive_mode` filter pinning your post type to `past`, reload `/<your_post_type>/`, and confirm the default flips.
5. Visit `/event/` with the existing Event Archive setting / configured pages and confirm nothing changed.

### Changelog Entry

> Fixed - Bare post type archives of event-supporting custom post types now default to upcoming, respect `?gatherpress_event_query` URL params, and can be pinned to a different mode via the `gatherpress_event_archive_mode` filter (which now receives the queried post type).

### Credits

Props @mauteri, @carstingaxion

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.