### PR TITLE
Use registered post type labels for GatherPress UI strings

### DIFF
--- a/docs/developer/post-type-supports/README.md
+++ b/docs/developer/post-type-supports/README.md
@@ -74,6 +74,24 @@ addFilter(
 );
 ```
 
+#### Surfacing your own labels in GatherPress UI
+
+GatherPress's settings sub-menus and a handful of admin UI strings now pull from each post type's registered labels rather than hardcoded "Event"/"Venue" copy. Whatever label you register your custom event-supporting post type with — `singular_name`, `name`, etc. — is what shows up.
+
+```php
+register_post_type( 'my_custom_event', array(
+    'labels'   => array(
+        'name'          => __( 'Happenings', 'my-plugin' ),
+        'singular_name' => __( 'Happening', 'my-plugin' ),
+    ),
+    'supports' => array( 'title', 'editor', 'gatherpress-event-date' ),
+) );
+```
+
+If you'd rather rename the labels of GatherPress's own `gatherpress_event` (or `gatherpress_venue`), use WordPress's `post_type_labels_<post_type>` filter — the labels propagate to the same UI surfaces.
+
+When writing your own admin UI on top of GatherPress, read labels through `Utility::post_type_label( $key, $post_type )`. It wraps `get_post_type_object()` and returns an empty string when the post type isn't registered (or the label key isn't set), so call sites don't have to defend against either.
+
 #### Bare archive temporal handling
 
 The bare post-type archive URL (e.g. `/my_custom_event/`) defaults to **upcoming** for every event-supporting post type, so past entries don't appear alongside future ones in the same list. Two knobs override that default:

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -15,8 +15,10 @@ namespace GatherPress\Core;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Settings;
+use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Utility;
+use GatherPress\Core\Venue;
 use WP_Query;
 
 /**
@@ -163,8 +165,9 @@ class Feed {
 		// Add venue information.
 		if ( $venue && ! empty( $venue['name'] ) ) {
 			$event_info[] = sprintf(
-				/* translators: %s: Venue name */
-				__( 'Venue: %s', 'gatherpress' ),
+				/* translators: 1: Singular post type label (e.g. "Venue"), 2: Venue name. */
+				__( '%1$s: %2$s', 'gatherpress' ),
+				Utility::post_type_label( 'singular_name', Venue::POST_TYPE ),
 				$venue['name']
 			);
 		}
@@ -212,8 +215,9 @@ class Feed {
 		// Add venue information.
 		if ( $venue && ! empty( $venue['name'] ) ) {
 			$event_info[] = sprintf(
-				/* translators: %s: Venue name */
-				__( 'Venue: %s', 'gatherpress' ),
+				/* translators: 1: Singular post type label (e.g. "Venue"), 2: Venue name. */
+				__( '%1$s: %2$s', 'gatherpress' ),
+				Utility::post_type_label( 'singular_name', Venue::POST_TYPE ),
 				$venue['name']
 			);
 		}

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -92,6 +92,33 @@ class Utility {
 	}
 
 	/**
+	 * Resolve a single label from a post type's registered labels.
+	 *
+	 * Wraps `get_post_type_object()` so call sites don't have to defend
+	 * against unregistered post types or missing label keys. Lets UI
+	 * strings reflect whatever a site builder filtered the labels to,
+	 * and lets extenders' event-supporting post types surface their own
+	 * labels instead of GatherPress's defaults (#1612).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key       Label key to read (e.g. `singular_name`,
+	 *                          `name`, `add_new_item`).
+	 * @param string $post_type Post type slug to read the label from.
+	 * @return string The resolved label, or empty string when the post
+	 *                type isn't registered or the key isn't set.
+	 */
+	public static function post_type_label( string $key, string $post_type ): string {
+		$object = get_post_type_object( $post_type );
+
+		if ( ! $object || empty( $object->labels->$key ) ) {
+			return '';
+		}
+
+		return (string) $object->labels->$key;
+	}
+
+	/**
 	 * Convert a snake_case string to camelCase.
 	 *
 	 * Expects standard snake_case input (lowercase words separated by single underscores).

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -53,9 +53,9 @@ class Events extends Base {
 	 * @return string The localized name for the events settings page.
 	 */
 	protected function get_name(): string {
-		// Read the registered plural label so a site that filters
-		// `gatherpress_event` to "Happenings" sees that everywhere the
-		// Events settings sub-menu surfaces (#1612).
+		// Read the registered plural label so the settings sub-menu
+		// reflects whatever the site has filtered the post type's
+		// labels to (#1612).
 		return Utility::post_type_label( 'name', Event::POST_TYPE );
 	}
 
@@ -138,7 +138,11 @@ class Events extends Base {
 				),
 			),
 			'event_display' => array(
-				'name'        => __( 'Event Display', 'gatherpress' ),
+				'name'        => sprintf(
+					/* translators: %s: Singular post type label, e.g. "Event". */
+					__( '%s Display', 'gatherpress' ),
+					Utility::post_type_label( 'singular_name', Event::POST_TYPE )
+				),
 				'description' => __(
 					'Configure how events are displayed on your site.',
 					'gatherpress'
@@ -171,7 +175,11 @@ class Events extends Base {
 				'options'     => array(
 					'event_archive'   => array(
 						'labels'      => array(
-							'name' => __( 'Event Archive', 'gatherpress' ),
+							'name' => sprintf(
+								/* translators: %s: Singular post type label, e.g. "Event". */
+								__( '%s Archive', 'gatherpress' ),
+								Utility::post_type_label( 'singular_name', Event::POST_TYPE )
+							),
 						),
 						'description' => __(
 							'What the events archive URL displays when no custom page is assigned.',
@@ -232,7 +240,11 @@ class Events extends Base {
 							'type'    => 'text',
 							'rewrite' => true,
 							'options' => array(
-								'label'   => __( 'Permalink base of Events.', 'gatherpress' ),
+								'label'   => sprintf(
+									/* translators: %s: Plural post type label, e.g. "Events". */
+									__( 'Permalink base of %s.', 'gatherpress' ),
+									Utility::post_type_label( 'name', Event::POST_TYPE )
+								),
 								'default' => Setup::get_localized_post_type_slug(),
 							),
 							'preview' => array(

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -14,9 +14,11 @@ namespace GatherPress\Core\Settings;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Event;
 use GatherPress\Core\Event\Setup;
 use GatherPress\Core\Topic;
+use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Utility;
 
 /**
  * Class Events.
@@ -51,7 +53,10 @@ class Events extends Base {
 	 * @return string The localized name for the events settings page.
 	 */
 	protected function get_name(): string {
-		return __( 'Events', 'gatherpress' );
+		// Read the registered plural label so a site that filters
+		// `gatherpress_event` to "Happenings" sees that everywhere the
+		// Events settings sub-menu surfaces (#1612).
+		return Utility::post_type_label( 'name', Event::POST_TYPE );
 	}
 
 	/**
@@ -221,7 +226,7 @@ class Events extends Base {
 				'options'     => array(
 					'events_url' => array(
 						'labels' => array(
-							'name' => __( 'Events', 'gatherpress' ),
+							'name' => Utility::post_type_label( 'name', Event::POST_TYPE ),
 						),
 						'field'  => array(
 							'type'    => 'text',

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -16,6 +16,8 @@ namespace GatherPress\Core\Settings;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Utility;
+use GatherPress\Core\Venue;
 use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Setup;
 
@@ -52,7 +54,10 @@ class Venues extends Base {
 	 * @return string The localized name for the venues settings page.
 	 */
 	protected function get_name(): string {
-		return __( 'Venues', 'gatherpress' );
+		// Read the registered plural label so a site that filters
+		// `gatherpress_venue` to "Locations" sees that everywhere the
+		// Venues settings sub-menu surfaces (#1612).
+		return Utility::post_type_label( 'name', Venue::POST_TYPE );
 	}
 
 	/**
@@ -262,7 +267,7 @@ class Venues extends Base {
 				'options'     => array(
 					'venues_url' => array(
 						'labels' => array(
-							'name' => __( 'Venues', 'gatherpress' ),
+							'name' => Utility::post_type_label( 'name', Venue::POST_TYPE ),
 						),
 						'field'  => array(
 							'type'    => 'text',

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -54,9 +54,9 @@ class Venues extends Base {
 	 * @return string The localized name for the venues settings page.
 	 */
 	protected function get_name(): string {
-		// Read the registered plural label so a site that filters
-		// `gatherpress_venue` to "Locations" sees that everywhere the
-		// Venues settings sub-menu surfaces (#1612).
+		// Read the registered plural label so the settings sub-menu
+		// reflects whatever the site has filtered the post type's
+		// labels to (#1612).
 		return Utility::post_type_label( 'name', Venue::POST_TYPE );
 	}
 
@@ -273,7 +273,11 @@ class Venues extends Base {
 							'type'    => 'text',
 							'rewrite' => true,
 							'options' => array(
-								'label'   => __( 'Permalink base of Venues.', 'gatherpress' ),
+								'label'   => sprintf(
+									/* translators: %s: Plural post type label, e.g. "Venues". */
+									__( 'Permalink base of %s.', 'gatherpress' ),
+									Utility::post_type_label( 'name', Venue::POST_TYPE )
+								),
 								'default' => Setup::get_instance()->get_localized_post_type_slug(),
 							),
 							'preview' => array(

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -89,6 +89,74 @@ class Test_Utility extends Base {
 	}
 
 	/**
+	 * `Utility::post_type_label()` reads a single label off a registered
+	 * post type so admin UI strings reflect whatever a site builder
+	 * filtered the labels to (#1612).
+	 *
+	 * @covers ::post_type_label
+	 *
+	 * @return void
+	 */
+	public function test_post_type_label_returns_registered_label(): void {
+		register_post_type(
+			'shindig',
+			array(
+				'public' => false,
+				'labels' => array(
+					'name'          => 'Shindigs',
+					'singular_name' => 'Shindig',
+					'add_new_item'  => 'Add New Shindig',
+				),
+			)
+		);
+
+		$this->assertSame( 'Shindigs', Utility::post_type_label( 'name', 'shindig' ) );
+		$this->assertSame( 'Shindig', Utility::post_type_label( 'singular_name', 'shindig' ) );
+		$this->assertSame( 'Add New Shindig', Utility::post_type_label( 'add_new_item', 'shindig' ) );
+
+		unregister_post_type( 'shindig' );
+	}
+
+	/**
+	 * `Utility::post_type_label()` returns an empty string for an
+	 * unregistered post type rather than warning. Lets call sites fall
+	 * back gracefully when the post type isn't (or isn't yet)
+	 * registered.
+	 *
+	 * @covers ::post_type_label
+	 *
+	 * @return void
+	 */
+	public function test_post_type_label_unregistered_post_type_returns_empty_string(): void {
+		$this->assertSame( '', Utility::post_type_label( 'name', 'definitely_not_a_post_type' ) );
+	}
+
+	/**
+	 * `Utility::post_type_label()` returns an empty string when the
+	 * label key isn't set on the post type, instead of triggering a
+	 * notice on the missing dynamic property.
+	 *
+	 * @covers ::post_type_label
+	 *
+	 * @return void
+	 */
+	public function test_post_type_label_missing_key_returns_empty_string(): void {
+		register_post_type(
+			'shindig',
+			array(
+				'public' => false,
+				'labels' => array(
+					'name' => 'Shindigs',
+				),
+			)
+		);
+
+		$this->assertSame( '', Utility::post_type_label( 'no_such_label_key', 'shindig' ) );
+
+		unregister_post_type( 'shindig' );
+	}
+
+	/**
 	 * Coverage for snake_to_camel method.
 	 *
 	 * @covers ::snake_to_camel


### PR DESCRIPTION
### Description of the Change

A handful of GatherPress UI strings hardcoded "Event" / "Events" / "Venue" / "Venues" via `__()` calls. Site builders who filter the post type labels (e.g. to "Happenings") or extenders who register their own event-supporting post type with their own labels never saw those labels surface in the settings sub-menus, permalink fields, or the event RSS feed — they always read GatherPress's defaults.

This PR adds `Utility::post_type_label( $key, $post_type )` — a thin wrapper over `get_post_type_object()` that returns a single label and falls back to an empty string when the post type isn't registered or the key isn't set. Then migrates the tractable hand-maintained call sites to use it.

Migrations:
- `Settings\Events::get_name()` (Events sub-menu)
- `Settings\Events` "Event Display" panel name
- `Settings\Events` "Event Archive" field label
- `Settings\Events` events_url permalink label + help text
- `Settings\Venues::get_name()` (Venues sub-menu)
- `Settings\Venues` venues_url permalink label + help text
- `Feed` "Venue: %s" prefix in the event RSS excerpt

Out of scope (intentionally — these need design discussion or live in different layers): block titles ("Event Query Loop"), the RSVP list table column header, and JS-side block keywords.

### How to test the Change

1. Filter `gatherpress_event` labels via WordPress's `post_type_labels_gatherpress_event` filter, e.g. rename `name` to "Happenings" and `singular_name` to "Happening".
2. Visit the GatherPress settings → confirm the sub-menu shows "Happenings", the panel reads "Happening Display", the "Permalink base of Happenings." help text matches.
3. Hit any event RSS feed (`/event/feed/`) for an event with a venue → confirm the venue prefix matches the registered venue singular label.
4. Register a custom event-supporting post type with your own labels and confirm `Utility::post_type_label( 'singular_name', 'your_post_type' )` returns the registered label.

### Changelog Entry

> Changed - GatherPress settings sub-menu labels, permalink field labels, and the event RSS feed venue prefix now read from each post type's registered labels instead of hardcoded "Event"/"Venue" strings, so filtered or extender-provided labels surface in the UI.

### Credits

Props @mauteri, @carstingaxion

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.