### PR TITLE
Use registered post type labels for more GatherPress UI strings

### DIFF
--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -20,6 +20,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp\Query as Rsvp_Query;
 use GatherPress\Core\Rsvp\Rsvp;
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Utility;
 use GatherPress\Core\Venue\Setup as Venue_Setup;
 use WP_Query;
 
@@ -629,7 +630,11 @@ class Admin_List {
 			 */
 			'datetime' => apply_filters(
 				'gatherpress_event_datetime_label',
-				__( 'Event date &amp; time', 'gatherpress' ),
+				sprintf(
+					/* translators: %s: Singular post type label, e.g. "Event". */
+					__( '%s date &amp; time', 'gatherpress' ),
+					Utility::post_type_label( 'singular_name', $post_type )
+				),
 				$post_type
 			),
 		);

--- a/includes/core/classes/rsvp/class-form.php
+++ b/includes/core/classes/rsvp/class-form.php
@@ -183,9 +183,22 @@ class Form {
 		// Check if event has passed - prevent RSVPs to past events.
 		$event = new Event( $post_id );
 		if ( $event->has_event_past() ) {
+			$singular = Utility::post_type_label( 'singular_name', (string) get_post_type( $post_id ) );
 			wp_die(
-				esc_html__( 'Registration for this event is now closed.', 'gatherpress' ),
-				esc_html__( 'Event Has Passed', 'gatherpress' ),
+				esc_html(
+					sprintf(
+						/* translators: %s: Singular post type label, e.g. "event". */
+						__( 'Registration for this %s is now closed.', 'gatherpress' ),
+						strtolower( $singular )
+					)
+				),
+				esc_html(
+					sprintf(
+						/* translators: %s: Singular post type label, e.g. "Event". */
+						__( '%s Has Passed', 'gatherpress' ),
+						$singular
+					)
+				),
 				400
 			);
 		}

--- a/includes/templates/admin/emails/event-email.php
+++ b/includes/templates/admin/emails/event-email.php
@@ -15,6 +15,8 @@
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Event;
+use GatherPress\Core\Utility;
+use GatherPress\Core\Venue;
 
 if ( ! isset( $event_id, $message ) ) {
 	return;
@@ -45,7 +47,13 @@ $gatherpress_venue       = $gatherpress_event->get_venue_information()['name'];
 				'full',
 				false,
 				array(
-					'alt'   => esc_attr__( 'Event Image', 'gatherpress' ),
+					'alt'   => esc_attr(
+						sprintf(
+							/* translators: %s: Singular post type label, e.g. "Event". */
+							__( '%s Image', 'gatherpress' ),
+							Utility::post_type_label( 'singular_name', (string) get_post_type( $event_id ) )
+						)
+					),
 					'style' => 'max-width: 100%;',
 				)
 			);
@@ -67,8 +75,12 @@ $gatherpress_venue       = $gatherpress_event->get_venue_information()['name'];
 		<?php if ( ! empty( $gatherpress_venue ) ) : ?>
 			<p style="text-align: center;">
 				<?php
-				/* translators: %s: gatherpress_event gatherpress_venue name. */
-				printf( esc_html__( 'Venue: %s', 'gatherpress' ), wp_kses_post( $gatherpress_venue ) );
+				printf(
+					/* translators: 1: Singular post type label (e.g. "Venue"), 2: Venue name. */
+					esc_html__( '%1$s: %2$s', 'gatherpress' ),
+					esc_html( Utility::post_type_label( 'singular_name', Venue::POST_TYPE ) ),
+					wp_kses_post( $gatherpress_venue )
+				);
 				?>
 			</p>
 		<?php endif; ?>

--- a/includes/templates/admin/rsvp/list-table.php
+++ b/includes/templates/admin/rsvp/list-table.php
@@ -9,6 +9,7 @@ defined( 'ABSPATH' ) || exit;
 
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Utility;
 
 if ( ! isset( $rsvp_table, $search_term, $status, $event ) ) {
 	return;
@@ -44,7 +45,13 @@ $rsvp_table->prepare_items();
 		printf(
 			'<a href="%1$s" class="comments-view-item-link">%2$s</a>',
 			esc_url( get_permalink( $gatherpress_post_id ) ),
-			esc_html__( 'View Event', 'gatherpress' )
+			esc_html(
+				sprintf(
+					/* translators: %s: Singular post type label, e.g. "Event". */
+					__( 'View %s', 'gatherpress' ),
+					Utility::post_type_label( 'singular_name', (string) get_post_type( $gatherpress_post_id ) )
+				)
+			)
 		);
 	}
 	?>


### PR DESCRIPTION
### Description of the Change

Continuing the work merged in the previous PR for #1612. Migrates a few more PHP-side hardcoded "Event"/"Venue" strings to read from the registered post type labels via `Utility::post_type_label()`, so site builders who filter labels (or extenders who declare their own event-supporting post type) see those labels instead of GatherPress defaults.

Migrations:
- `Event\Admin_List` — admin list "Event date & time" column header. Uses the queried post type's singular label. The existing `gatherpress_event_datetime_label` filter still has the last word.
- `Rsvp\Form` — `wp_die` "Event Has Passed" title and body when an attempted RSVP lands on a past event. Both reflect the actual queried post type's singular label.
- `templates/admin/emails/event-email.php` — featured image alt text and the "Venue: %s" prefix.
- `templates/admin/rsvp/list-table.php` — "View Event" link text.

Out of scope (intentionally — see issue thread for context): block titles, JS-side strings (need a JS-side mirror of the helper, separate PR), and the genuinely heterogeneous RSVP list-table column header.

### How to test the Change

1. Filter `gatherpress_event` labels via `post_type_labels_gatherpress_event` to rename `singular_name` to e.g. "Happening".
2. Open the events admin list — the "Event date & time" column header now reads "Happening date & time".
3. Try to RSVP to a past event from the frontend — the wp_die page reads "Happening Has Passed" / "Registration for this happening is now closed."
4. Send an event email (or render the template) — the image alt and any venue prefix follow the registered labels.
5. Visit the admin RSVP list table for a single event — the "View Happening" link reflects the post type label.

### Changelog Entry

> Changed - Several admin and email UI strings now read from each post type's registered labels instead of hardcoded "Event"/"Venue" copy.

### Credits

Props @mauteri, @carstingaxion

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.