### PR TITLE
Add show_if field key to Settings API for conditional field visibility

### DIFF
--- a/docs/developer/settings/extending-settings.md
+++ b/docs/developer/settings/extending-settings.md
@@ -221,6 +221,52 @@ Flag fields that affect permalink structure. When these change, rewrite rules ar
 ),
 ```
 
+### show_if (conditional visibility)
+
+Show a field only when one or more controlling fields hold a specific value. Useful for "this setting only matters when that other setting is on" relationships — for example, hiding the Google Maps API Key field unless Google is the selected map provider.
+
+`show_if` is a sibling of `field`, not nested inside it. It maps controlling field keys to expected values:
+
+```php
+'google_maps_api_key' => array(
+    'labels'      => array( 'name' => __( 'Google Maps API Key', 'my-plugin' ) ),
+    'description' => __( 'Required when Google Maps is selected.', 'my-plugin' ),
+    'field'       => array(
+        'type'    => 'text',
+        'size'    => 'regular',
+        'options' => array( 'default' => '' ),
+    ),
+    'show_if'     => array(
+        'map_platform' => 'google',
+    ),
+),
+```
+
+#### Match semantics
+
+- **Scalar value** — string equality after casting. `'map_platform' => 'google'` matches when the controlling field's current value (coerced to string) equals `'google'`.
+- **Array of values** — OR within one key. `'map_platform' => array( 'google', 'mapbox' )` matches when the current value is either.
+- **Multiple keys** — AND across keys. Every entry in the `show_if` array must be satisfied for the field to be visible.
+
+```php
+'show_if' => array(
+    'map_platform'                  => array( 'google', 'mapbox' ),
+    'venue_map_default_render_mode' => 'interactive',
+),
+```
+
+#### Hidden ≠ cleared
+
+Hiding a field is purely visual — its stored value is **never** dropped just because the field is currently hidden. If a user enters a Google Maps API key, switches the platform to OSM, and saves, the key remains in the `gatherpress_settings` option. Switching back to Google reveals the field with its prior value intact.
+
+This works because (a) the field row is hidden via CSS, so the input still posts its value, and (b) the save path merges submitted input with the previously stored options — any field key not in POST keeps its existing value.
+
+#### Constraints (v1)
+
+- **Same page only.** The controlling field must live on the same settings tab as the dependent field.
+- **Single controller per key.** Each option key on a settings page renders one input; that's the input the JS will resolve.
+- **Comparisons are string-based.** Booleans and numbers are coerced to string before comparing. To match a checkbox stored as `true`, declare `'my_toggle' => 'true'`.
+
 ## Key Uniqueness
 
 All option keys must be globally unique across all tabs and sections. If two extensions register the same key, an admin error notice is displayed:

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -328,6 +328,20 @@ class Assets {
 			// Need to load block styling for some dynamic fields.
 			wp_enqueue_style( 'wp-edit-blocks' );
 
+			// Shared utility classes (`gatherpress--is-hidden`, etc.) used by
+			// settings UI like the `show_if` row visibility toggle. The handle
+			// is registered on the frontend in `block_enqueue_scripts`; re-
+			// register here so it's available on admin settings pages too.
+			$utility_asset = $this->get_asset_data( 'utility_style' );
+
+			wp_register_style(
+				'gatherpress-utility-style',
+				$this->build . 'utility_style.css',
+				$utility_asset['dependencies'],
+				$utility_asset['version']
+			);
+			wp_enqueue_style( 'gatherpress-utility-style' );
+
 			$asset = $this->get_asset_data( 'settings_style' );
 
 			wp_enqueue_style(

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -447,15 +447,107 @@ class Settings {
 					$this->render_field( (string) $option, $option_settings );
 				};
 
+				// Initial row visibility class is computed server-side from
+				// the currently saved option values so the row paints
+				// hidden (no flash of unhidden content) before settings.js
+				// has had a chance to wire up the change listeners.
+				$row_class = $this->build_row_class( $option_settings );
+
 				add_settings_field(
 					(string) $option,
 					$option_settings['labels']['name'],
 					$option_settings['callback'],
 					Utility::prefix_key( $sub_page ),
-					(string) $section
+					(string) $section,
+					array( 'class' => $row_class )
 				);
 			}
 		}
+	}
+
+	/**
+	 * Build the row class string for an option's `<tr>` wrapper.
+	 *
+	 * Every settings row gets the base `gatherpress-settings-row` hook so
+	 * the show_if JS has a stable selector to attach to. Rows whose
+	 * `show_if` condition does not currently match the saved values are
+	 * additionally tagged with the `--hidden` modifier so they paint
+	 * hidden on first render — JS toggles the modifier off if the user
+	 * later changes the controlling field to a matching value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $option_settings The option settings array.
+	 * @return string Space-separated class names for the row.
+	 */
+	protected function build_row_class( array $option_settings ): string {
+		$classes = array( 'gatherpress-settings-row' );
+
+		if ( ! empty( $option_settings['show_if'] )
+			&& ! $this->evaluate_show_if( (array) $option_settings['show_if'] )
+		) {
+			$classes[] = 'gatherpress-settings-row--hidden';
+		}
+
+		return implode( ' ', $classes );
+	}
+
+	/**
+	 * Evaluate a `show_if` condition against the current saved option values.
+	 *
+	 * Conditions are an associative array of `controlling_field => expected`.
+	 * Multiple keys are combined with AND. A value can be a scalar (equality
+	 * after string casting) or an array (membership, OR within the same key).
+	 * Comparisons cast both sides to string so checkbox booleans, select
+	 * strings, and numeric values all compare cleanly.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $conditions Map of controlling option key => expected value(s).
+	 * @return bool True when every key matches the current saved value, false otherwise.
+	 */
+	protected function evaluate_show_if( array $conditions ): bool {
+		foreach ( $conditions as $key => $expected ) {
+			$current = $this->get( (string) $key );
+
+			if ( is_array( $expected ) ) {
+				$expected = array_map( 'strval', $expected );
+
+				if ( ! in_array( (string) $current, $expected, true ) ) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if ( (string) $current !== (string) $expected ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Render a hidden marker that carries a field's `show_if` condition.
+	 *
+	 * Emitted alongside the field by `render_field()` so the settings JS
+	 * can find the row, locate the controlling input(s) by name, and toggle
+	 * the row's `--hidden` modifier on `change`. The condition is JSON-
+	 * encoded onto a `data-` attribute rather than walked into separate
+	 * attributes so multi-key AND combinations and array-of-values OR
+	 * combinations both serialize without ambiguity.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $conditions Map of controlling option key => expected value(s).
+	 * @return void
+	 */
+	protected function render_show_if_marker( array $conditions ): void {
+		printf(
+			'<input type="hidden" class="gatherpress-show-if-marker" data-show-if="%s" />',
+			esc_attr( (string) wp_json_encode( $conditions ) )
+		);
 	}
 
 	/**
@@ -695,6 +787,10 @@ class Settings {
 			$params,
 			true
 		);
+
+		if ( ! empty( $option_settings['show_if'] ) ) {
+			$this->render_show_if_marker( (array) $option_settings['show_if'] );
+		}
 
 		if ( $inherited ) {
 			if ( current_user_can( 'manage_network_options' ) ) {

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -471,9 +471,10 @@ class Settings {
 	 * Every settings row gets the base `gatherpress-settings-row` hook so
 	 * the show_if JS has a stable selector to attach to. Rows whose
 	 * `show_if` condition does not currently match the saved values are
-	 * additionally tagged with the `--hidden` modifier so they paint
-	 * hidden on first render — JS toggles the modifier off if the user
-	 * later changes the controlling field to a matching value.
+	 * additionally tagged with the shared `gatherpress--is-hidden` utility
+	 * class so they paint hidden on first render — JS toggles the utility
+	 * class off if the user later changes the controlling field to a
+	 * matching value.
 	 *
 	 * @since 1.0.0
 	 *
@@ -486,7 +487,7 @@ class Settings {
 		if ( ! empty( $option_settings['show_if'] )
 			&& ! $this->evaluate_show_if( (array) $option_settings['show_if'] )
 		) {
-			$classes[] = 'gatherpress-settings-row--hidden';
+			$classes[] = 'gatherpress--is-hidden';
 		}
 
 		return implode( ' ', $classes );

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -138,6 +138,12 @@ class Venues extends Base {
 							'type'  => 'text',
 							'size'  => 'regular',
 						),
+						// Only relevant when the Google provider is selected.
+						// Hidden via CSS rather than removed, so a previously
+						// saved key survives a temporary switch to OSM.
+						'show_if'     => array(
+							'map_platform' => 'google',
+						),
 					),
 					'venue_map_default_render_mode'  => array(
 						'labels'      => array(

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -138,9 +138,6 @@ class Venues extends Base {
 							'type'  => 'text',
 							'size'  => 'regular',
 						),
-						// Only relevant when the Google provider is selected.
-						// Hidden via CSS rather than removed, so a previously
-						// saved key survives a temporary switch to OSM.
 						'show_if'     => array(
 							'map_platform' => 'google',
 						),

--- a/src/helpers/settings-show-if.js
+++ b/src/helpers/settings-show-if.js
@@ -18,7 +18,7 @@
  * @since 1.0.0
  */
 
-const ROW_HIDDEN_CLASS = 'gatherpress-settings-row--hidden';
+const ROW_HIDDEN_CLASS = 'gatherpress--is-hidden';
 const MARKER_SELECTOR = '.gatherpress-show-if-marker';
 const NAME_TEMPLATE = ( key ) => `[name="gatherpress_settings[${ key }]"]`;
 

--- a/src/helpers/settings-show-if.js
+++ b/src/helpers/settings-show-if.js
@@ -1,0 +1,170 @@
+/**
+ * Toggle dependent settings field visibility based on the value of a
+ * controlling field — the JS half of the Settings API's `show_if` feature.
+ *
+ * Server-side (`Settings::build_row_class()`) sets the initial visibility on
+ * page load so there's no flash of unhidden content. This module wires up
+ * the runtime side: every field with a `show_if` declaration emits a hidden
+ * marker (`<input type="hidden" class="gatherpress-show-if-marker" data-show-if='{...}' />`)
+ * inside its `<td>`. For each marker we walk up to the row's `<tr>`, locate
+ * the controlling input(s) by name, attach `change` listeners, and re-toggle
+ * the `gatherpress-settings-row--hidden` modifier whenever a value changes.
+ *
+ * Hidden rows still submit their values — visibility is CSS-only, never
+ * `disabled`. The save path (`sanitize_page_settings`) additionally merges
+ * submitted input with stored values, so even if a browser somehow omits a
+ * hidden field, the previously saved value is preserved.
+ *
+ * @since 1.0.0
+ */
+
+const ROW_HIDDEN_CLASS = 'gatherpress-settings-row--hidden';
+const MARKER_SELECTOR = '.gatherpress-show-if-marker';
+const NAME_TEMPLATE = ( key ) => `[name="gatherpress_settings[${ key }]"]`;
+
+/**
+ * Read the current submittable value from a form control.
+ *
+ * Checkboxes report their checked state as a boolean — everything else
+ * (text, number, select, hidden) reports `value`. The string casts in
+ * `matches()` smooth the boolean / number / string comparison.
+ *
+ * @param {HTMLInputElement|HTMLSelectElement} el The input or select element.
+ * @return {string|boolean} The control's current value.
+ */
+function readControlValue( el ) {
+	if ( 'checkbox' === el.type ) {
+		return el.checked;
+	}
+
+	return el.value;
+}
+
+/**
+ * Test whether a current value satisfies an expected `show_if` value.
+ *
+ * Scalar expected → string equality. Array expected → membership (OR within
+ * the same key). All comparisons coerce to string so checkbox booleans,
+ * select strings, and numeric values compare cleanly.
+ *
+ * @param {string|boolean}              current  The control's current value.
+ * @param {string|number|boolean|Array} expected The expected value(s) from the show_if declaration.
+ * @return {boolean} True when the current value satisfies the expectation.
+ */
+function matches( current, expected ) {
+	if ( Array.isArray( expected ) ) {
+		return expected.map( String ).includes( String( current ) );
+	}
+
+	return String( current ) === String( expected );
+}
+
+/**
+ * Resolve the set of controlling inputs for a condition map.
+ *
+ * Returns `{ key, el }` pairs only for conditions whose controlling input
+ * actually exists on the page — missing controllers are silently dropped
+ * (the dependent stays hidden, which is the safe default for an unsatisfied
+ * condition).
+ *
+ * The select and checkbox field templates render a hidden `<input>` fallback
+ * BEFORE the real control with the same `name` (see select.php / checkbox.php
+ * — required because `disabled` controls drop out of the POST, so the hidden
+ * carries the inherited value). For repeated names PHP takes the LAST value,
+ * so we mirror that here: when multiple elements share the name, pick the
+ * last one. That naturally picks the live `<select>` / `<input type="checkbox">`
+ * over the upstream hidden fallback.
+ *
+ * @param {Object} conditions Map of controlling option key → expected value(s).
+ * @return {Array<{key: string, el: HTMLElement}>} Resolved controller pairs.
+ */
+function resolveControllers( conditions ) {
+	return Object.keys( conditions )
+		.map( ( key ) => {
+			const candidates = document.querySelectorAll( NAME_TEMPLATE( key ) );
+			return {
+				key,
+				el: 0 < candidates.length ? candidates[ candidates.length - 1 ] : null,
+			};
+		} )
+		.filter( ( entry ) => entry.el );
+}
+
+/**
+ * Wire up the show/hide behavior for one marker.
+ *
+ * Extracted so each marker's setup is testable in isolation. The marker
+ * itself stays in the DOM after wiring — it's a hidden input with no name,
+ * so it has no effect on form submission.
+ *
+ * @param {HTMLElement} marker The `.gatherpress-show-if-marker` element.
+ * @return {void}
+ */
+function wireMarker( marker ) {
+	const row = marker.closest( 'tr' );
+	if ( ! row ) {
+		return;
+	}
+
+	let conditions;
+	try {
+		conditions = JSON.parse( marker.dataset.showIf );
+	} catch {
+		// Malformed marker — leave the server-side initial visibility in place
+		// rather than guess. This branch should be unreachable in practice;
+		// the marker is produced by `wp_json_encode` server-side.
+		return;
+	}
+
+	const controllers = resolveControllers( conditions );
+
+	// If none of the controlling inputs exist on the page, the condition
+	// can never become true at runtime. Leave the row in whatever state
+	// the server-side initial render decided (hidden by default).
+	if ( 0 === controllers.length ) {
+		return;
+	}
+
+	const evaluate = () => {
+		const allMatch = controllers.every( ( { key, el } ) =>
+			matches( readControlValue( el ), conditions[ key ] )
+		);
+
+		row.classList.toggle( ROW_HIDDEN_CLASS, ! allMatch );
+	};
+
+	controllers.forEach( ( { el } ) => {
+		el.addEventListener( 'change', evaluate );
+	} );
+
+	// Re-evaluate once on init so the JS-driven state agrees with the
+	// server-side initial render. If a future change to `evaluate_show_if`
+	// diverges from `matches()` here, this catches it on page load rather
+	// than waiting for the first user interaction.
+	evaluate();
+}
+
+/**
+ * Initialize all `show_if` field dependencies on the current settings page.
+ *
+ * Idempotent — calling twice rewires the same markers but the duplicate
+ * `change` listeners are deduped by re-using the same `evaluate` closure
+ * reference per marker (a fresh closure is built on each call, so this is
+ * NOT truly safe to call twice in the same load; callers should only call
+ * once per page load).
+ *
+ * @return {void}
+ */
+export function initShowIfDependencies() {
+	document
+		.querySelectorAll( MARKER_SELECTOR )
+		.forEach( ( marker ) => wireMarker( marker ) );
+}
+
+// Exported for unit testing — not part of the public surface.
+export const __testables = {
+	matches,
+	readControlValue,
+	resolveControllers,
+	wireMarker,
+};

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -9,6 +9,7 @@ import { createRoot } from '@wordpress/element';
 import Autocomplete from '../components/Autocomplete';
 import { dateTimePreview } from '../helpers/datetime';
 import { urlRewritePreview } from '../helpers/urlrewrite';
+import { initShowIfDependencies } from '../helpers/settings-show-if';
 
 /**
  * Autocomplete Initialization
@@ -62,3 +63,13 @@ dateTimePreview();
  * @since 1.0.0
  */
 urlRewritePreview();
+
+/**
+ * Show/hide dependent settings fields based on the value of a controlling
+ * field. Driven by the `show_if` key on a field's definition; see
+ * `Settings::build_row_class()` / `render_show_if_marker()` for the
+ * server-side half of the contract.
+ *
+ * @since 1.0.0
+ */
+initShowIfDependencies();

--- a/src/settings/style.scss
+++ b/src/settings/style.scss
@@ -64,12 +64,3 @@
 		pointer-events: auto;
 	}
 }
-
-// Hidden by `show_if` field dependency — controlling input does not currently
-// match the dependent field's required value. Toggled by `settings-show-if.js`
-// on change. Hidden via display:none rather than [disabled] so the input still
-// posts its value (sanitize_page_settings also merges with stored values, so
-// the saved value is preserved either way).
-.gatherpress-settings-row--hidden {
-	display: none;
-}

--- a/src/settings/style.scss
+++ b/src/settings/style.scss
@@ -64,3 +64,12 @@
 		pointer-events: auto;
 	}
 }
+
+// Hidden by `show_if` field dependency — controlling input does not currently
+// match the dependent field's required value. Toggled by `settings-show-if.js`
+// on change. Hidden via display:none rather than [disabled] so the input still
+// posts its value (sanitize_page_settings also merges with stored values, so
+// the saved value is preserved either way).
+.gatherpress-settings-row--hidden {
+	display: none;
+}

--- a/test/unit/js/src/helpers/settings-show-if.test.js
+++ b/test/unit/js/src/helpers/settings-show-if.test.js
@@ -14,7 +14,7 @@ import {
 const { matches, readControlValue, resolveControllers, wireMarker } =
 	__testables;
 
-const HIDDEN_CLASS = 'gatherpress-settings-row--hidden';
+const HIDDEN_CLASS = 'gatherpress--is-hidden';
 
 /**
  * Build a minimal settings-table form fragment with a controlling field

--- a/test/unit/js/src/helpers/settings-show-if.test.js
+++ b/test/unit/js/src/helpers/settings-show-if.test.js
@@ -1,0 +1,402 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+
+/**
+ * Internal dependencies
+ */
+import {
+	initShowIfDependencies,
+	__testables,
+} from '@src/helpers/settings-show-if';
+
+const { matches, readControlValue, resolveControllers, wireMarker } =
+	__testables;
+
+const HIDDEN_CLASS = 'gatherpress-settings-row--hidden';
+
+/**
+ * Build a minimal settings-table form fragment with a controlling field
+ * and a dependent row carrying a show_if marker. Mirrors the markup the
+ * PHP side produces (a `<form>` containing a `<tr>` per option, each with
+ * a `<td>` holding the field plus the marker for show_if rows).
+ *
+ * @param {Object}  options                   Setup options.
+ * @param {string}  options.controllingType   The controlling input type ('select', 'text', or 'checkbox').
+ * @param {string}  options.controllingValue  The controlling input's initial value (or 'true'/'false' for checkbox).
+ * @param {Object}  options.conditions        The show_if condition map.
+ * @param {boolean} [options.initiallyHidden] Whether the dependent row starts with the hidden class.
+ * @return {Object} Refs to the inserted DOM nodes for assertions.
+ */
+function buildFixture( {
+	controllingType,
+	controllingValue,
+	conditions,
+	initiallyHidden = true,
+} ) {
+	document.body.innerHTML = `
+		<form>
+			<table>
+				<tr class="gatherpress-settings-row">
+					<td>${ renderControllingInput( controllingType, controllingValue ) }</td>
+				</tr>
+				<tr class="gatherpress-settings-row${
+	initiallyHidden ? ` ${ HIDDEN_CLASS }` : ''
+}">
+					<td>
+						<input type="text" name="gatherpress_settings[google_maps_api_key]" value="prev-key" />
+						<input type="hidden" class="gatherpress-show-if-marker"
+							data-show-if='${ JSON.stringify( conditions ) }' />
+					</td>
+				</tr>
+			</table>
+		</form>
+	`;
+
+	// Pick the LAST element matching the controlling name — production
+	// markup puts a hidden fallback BEFORE the live control (select /
+	// checkbox), so the last match is the one actually wired to events.
+	const candidates = document.querySelectorAll(
+		'[name="gatherpress_settings[map_platform]"]'
+	);
+
+	return {
+		controlling: candidates[ candidates.length - 1 ],
+		dependent: document.querySelectorAll( 'tr' )[ 1 ],
+		marker: document.querySelector( '.gatherpress-show-if-marker' ),
+	};
+}
+
+/**
+ * Helper to render a controlling input element for the fixture.
+ *
+ * Mirrors the production templates: select / checkbox render a hidden
+ * `<input>` fallback with the same `name` BEFORE the real control (see
+ * select.php / checkbox.php). The hidden fallback exists so disabled
+ * controls (which drop out of POST) still carry their inherited value.
+ * The show_if resolver must pick the LAST element with the matching name
+ * — mirroring PHP's "last value wins for repeated names" — so it lands
+ * on the live control rather than the hidden fallback.
+ *
+ * @param {string} type  'select', 'text', or 'checkbox'.
+ * @param {string} value The initial value (or 'true'/'false' for checkbox).
+ * @return {string} The HTML string for the controlling input.
+ */
+function renderControllingInput( type, value ) {
+	if ( 'select' === type ) {
+		return `
+			<input type="hidden" name="gatherpress_settings[map_platform]" value="0" />
+			<select name="gatherpress_settings[map_platform]">
+				<option value="osm"${ 'osm' === value ? ' selected' : '' }>OSM</option>
+				<option value="google"${ 'google' === value ? ' selected' : '' }>Google</option>
+				<option value="mapbox"${ 'mapbox' === value ? ' selected' : '' }>Mapbox</option>
+			</select>
+		`;
+	}
+	if ( 'checkbox' === type ) {
+		const checked = 'true' === value ? ' checked' : '';
+		const fallback = 'true' === value ? '1' : '0';
+		return `
+			<input type="hidden" name="gatherpress_settings[map_platform]" value="${ fallback }" />
+			<input type="checkbox" name="gatherpress_settings[map_platform]"${ checked } />
+		`;
+	}
+	return `<input type="text" name="gatherpress_settings[map_platform]" value="${ value }" />`;
+}
+
+describe( 'settings-show-if helper', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	describe( 'matches', () => {
+		it( 'compares scalar expected against current as strings', () => {
+			expect( matches( 'google', 'google' ) ).toBe( true );
+			expect( matches( 'osm', 'google' ) ).toBe( false );
+		} );
+
+		it( 'coerces booleans and numbers to strings for comparison', () => {
+			// Checkbox booleans round-trip through String() so a stored
+			// checkbox value can be matched against '1'/'true' as the
+			// declared expected.
+			expect( matches( true, 'true' ) ).toBe( true );
+			expect( matches( false, 'false' ) ).toBe( true );
+			expect( matches( 5, '5' ) ).toBe( true );
+		} );
+
+		it( 'returns true when current is a member of an expected array', () => {
+			expect( matches( 'google', [ 'google', 'mapbox' ] ) ).toBe( true );
+			expect( matches( 'mapbox', [ 'google', 'mapbox' ] ) ).toBe( true );
+		} );
+
+		it( 'returns false when current is not a member of an expected array', () => {
+			expect( matches( 'osm', [ 'google', 'mapbox' ] ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'readControlValue', () => {
+		it( 'returns the value attribute for non-checkbox inputs', () => {
+			const input = document.createElement( 'input' );
+			input.type = 'text';
+			input.value = 'hello';
+
+			expect( readControlValue( input ) ).toBe( 'hello' );
+		} );
+
+		it( 'returns the checked state for checkboxes', () => {
+			const input = document.createElement( 'input' );
+			input.type = 'checkbox';
+			input.checked = true;
+
+			expect( readControlValue( input ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'resolveControllers', () => {
+		it( 'resolves controllers that exist on the page', () => {
+			buildFixture( {
+				controllingType: 'select',
+				controllingValue: 'google',
+				conditions: { map_platform: 'google' },
+			} );
+
+			const resolved = resolveControllers( { map_platform: 'google' } );
+
+			expect( resolved ).toHaveLength( 1 );
+			expect( resolved[ 0 ].key ).toBe( 'map_platform' );
+			expect( resolved[ 0 ].el ).not.toBeNull();
+		} );
+
+		it( 'drops conditions whose controlling input is missing', () => {
+			buildFixture( {
+				controllingType: 'select',
+				controllingValue: 'google',
+				conditions: { map_platform: 'google' },
+			} );
+
+			const resolved = resolveControllers( {
+				map_platform: 'google',
+				nonexistent_field: 'whatever',
+			} );
+
+			expect( resolved ).toHaveLength( 1 );
+			expect( resolved[ 0 ].key ).toBe( 'map_platform' );
+		} );
+
+		it( 'picks the LAST element when multiple inputs share the name', () => {
+			// Production markup: select / checkbox fields emit a hidden
+			// fallback BEFORE the real control (same name). PHP takes the
+			// last value for repeated names, so the resolver must mirror
+			// that — otherwise change events fire on the live control while
+			// the resolver still points at the inert hidden input.
+			buildFixture( {
+				controllingType: 'select',
+				controllingValue: 'google',
+				conditions: { map_platform: 'google' },
+			} );
+
+			const resolved = resolveControllers( { map_platform: 'google' } );
+
+			expect( resolved ).toHaveLength( 1 );
+			expect( resolved[ 0 ].el.tagName ).toBe( 'SELECT' );
+		} );
+	} );
+
+	describe( 'wireMarker', () => {
+		it( 'reveals the dependent row when the condition is initially satisfied', () => {
+			const { dependent, marker } = buildFixture( {
+				controllingType: 'select',
+				controllingValue: 'google',
+				conditions: { map_platform: 'google' },
+				initiallyHidden: true,
+			} );
+
+			wireMarker( marker );
+
+			expect( dependent.classList.contains( HIDDEN_CLASS ) ).toBe( false );
+		} );
+
+		it( 'keeps the dependent row hidden when the condition is unsatisfied', () => {
+			const { dependent, marker } = buildFixture( {
+				controllingType: 'select',
+				controllingValue: 'osm',
+				conditions: { map_platform: 'google' },
+				initiallyHidden: true,
+			} );
+
+			wireMarker( marker );
+
+			expect( dependent.classList.contains( HIDDEN_CLASS ) ).toBe( true );
+		} );
+
+		it( 'toggles visibility when the controlling field changes', () => {
+			const { controlling, dependent, marker } = buildFixture( {
+				controllingType: 'select',
+				controllingValue: 'osm',
+				conditions: { map_platform: 'google' },
+				initiallyHidden: true,
+			} );
+
+			wireMarker( marker );
+			expect( dependent.classList.contains( HIDDEN_CLASS ) ).toBe( true );
+
+			controlling.value = 'google';
+			controlling.dispatchEvent( new Event( 'change' ) );
+			expect( dependent.classList.contains( HIDDEN_CLASS ) ).toBe( false );
+
+			controlling.value = 'osm';
+			controlling.dispatchEvent( new Event( 'change' ) );
+			expect( dependent.classList.contains( HIDDEN_CLASS ) ).toBe( true );
+		} );
+
+		it( 'supports an array of expected values (OR within one key)', () => {
+			const { controlling, dependent, marker } = buildFixture( {
+				controllingType: 'select',
+				controllingValue: 'mapbox',
+				conditions: { map_platform: [ 'google', 'mapbox' ] },
+				initiallyHidden: true,
+			} );
+
+			wireMarker( marker );
+			expect( dependent.classList.contains( HIDDEN_CLASS ) ).toBe( false );
+
+			controlling.value = 'google';
+			controlling.dispatchEvent( new Event( 'change' ) );
+			expect( dependent.classList.contains( HIDDEN_CLASS ) ).toBe( false );
+
+			controlling.value = 'osm';
+			controlling.dispatchEvent( new Event( 'change' ) );
+			expect( dependent.classList.contains( HIDDEN_CLASS ) ).toBe( true );
+		} );
+
+		it( 'reads checkbox controls via .checked rather than .value', () => {
+			const { controlling, dependent, marker } = buildFixture( {
+				controllingType: 'checkbox',
+				controllingValue: 'true',
+				conditions: { map_platform: 'true' },
+				initiallyHidden: true,
+			} );
+
+			wireMarker( marker );
+			expect( dependent.classList.contains( HIDDEN_CLASS ) ).toBe( false );
+
+			controlling.checked = false;
+			controlling.dispatchEvent( new Event( 'change' ) );
+			expect( dependent.classList.contains( HIDDEN_CLASS ) ).toBe( true );
+		} );
+
+		it( 'leaves the row alone when the marker has no enclosing tr', () => {
+			document.body.innerHTML = `
+				<input type="hidden" class="gatherpress-show-if-marker"
+					data-show-if='{"map_platform":"google"}' />
+			`;
+			const marker = document.querySelector(
+				'.gatherpress-show-if-marker'
+			);
+
+			// Should not throw despite the missing tr.
+			expect( () => wireMarker( marker ) ).not.toThrow();
+		} );
+
+		it( 'returns silently when the marker JSON is malformed', () => {
+			document.body.innerHTML = `
+				<table>
+					<tr class="gatherpress-settings-row ${ HIDDEN_CLASS }">
+						<td>
+							<input type="hidden" class="gatherpress-show-if-marker"
+								data-show-if='not-valid-json' />
+						</td>
+					</tr>
+				</table>
+			`;
+			const marker = document.querySelector(
+				'.gatherpress-show-if-marker'
+			);
+			const row = document.querySelector( 'tr' );
+
+			// Should not throw, and should leave the row's initial hidden
+			// state in place (defensive — the marker is produced by
+			// wp_json_encode server-side, so this branch is unreachable in
+			// practice).
+			expect( () => wireMarker( marker ) ).not.toThrow();
+			expect( row.classList.contains( HIDDEN_CLASS ) ).toBe( true );
+		} );
+
+		it( 'returns when no controllers can be resolved', () => {
+			document.body.innerHTML = `
+				<table>
+					<tr class="gatherpress-settings-row ${ HIDDEN_CLASS }">
+						<td>
+							<input type="hidden" class="gatherpress-show-if-marker"
+								data-show-if='{"missing_field":"x"}' />
+						</td>
+					</tr>
+				</table>
+			`;
+			const marker = document.querySelector(
+				'.gatherpress-show-if-marker'
+			);
+			const row = document.querySelector( 'tr' );
+
+			wireMarker( marker );
+
+			// Leaves the row in whatever state the server-side initial
+			// render set it to (here: hidden).
+			expect( row.classList.contains( HIDDEN_CLASS ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'initShowIfDependencies', () => {
+		it( 'wires every marker found on the page', () => {
+			// Two rows, both initially hidden — one whose condition matches
+			// (should become visible after init), one whose condition does not
+			// (should stay hidden).
+			document.body.innerHTML = `
+				<form>
+					<table>
+						<tr>
+							<td>
+								<select name="gatherpress_settings[map_platform]">
+									<option value="osm">OSM</option>
+									<option value="google" selected>Google</option>
+								</select>
+							</td>
+						</tr>
+						<tr id="row-google" class="${ HIDDEN_CLASS }">
+							<td>
+								<input type="hidden" class="gatherpress-show-if-marker"
+									data-show-if='{"map_platform":"google"}' />
+							</td>
+						</tr>
+						<tr id="row-osm" class="${ HIDDEN_CLASS }">
+							<td>
+								<input type="hidden" class="gatherpress-show-if-marker"
+									data-show-if='{"map_platform":"osm"}' />
+							</td>
+						</tr>
+					</table>
+				</form>
+			`;
+
+			initShowIfDependencies();
+
+			expect(
+				document
+					.getElementById( 'row-google' )
+					.classList.contains( HIDDEN_CLASS )
+			).toBe( false );
+			expect(
+				document
+					.getElementById( 'row-osm' )
+					.classList.contains( HIDDEN_CLASS )
+			).toBe( true );
+		} );
+
+		it( 'is a no-op when there are no markers on the page', () => {
+			document.body.innerHTML = '<div>no markers here</div>';
+
+			expect( () => initShowIfDependencies() ).not.toThrow();
+		} );
+	} );
+} );

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -2755,4 +2755,396 @@ class Test_Settings extends Base {
 		delete_site_option( Settings::OPTION_NAME );
 		\GatherPress\Core\Settings\Network::flush_config_cache();
 	}
+
+	/**
+	 * Build the row class string with no show_if returns the base hook class
+	 * by itself. Every row gets the base class so the show_if JS can target
+	 * rows uniformly; the `--hidden` modifier is added only when a condition
+	 * exists and isn't satisfied.
+	 *
+	 * @since 1.0.0
+	 * @covers ::build_row_class
+	 *
+	 * @return void
+	 */
+	public function test_build_row_class_without_show_if(): void {
+		$instance = Settings::get_instance();
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'build_row_class',
+			array(
+				array( 'field' => array( 'type' => 'text' ) ),
+			)
+		);
+
+		$this->assertSame( 'gatherpress-settings-row', $result );
+	}
+
+	/**
+	 * Build the row class string when the show_if condition isn't satisfied
+	 * tacks on the `--hidden` modifier so the row paints hidden on first
+	 * render. JS later toggles it off if the user changes the controlling
+	 * field to a matching value.
+	 *
+	 * @since 1.0.0
+	 * @covers ::build_row_class
+	 *
+	 * @return void
+	 */
+	public function test_build_row_class_with_unsatisfied_show_if(): void {
+		$instance = Settings::get_instance();
+
+		delete_option( Settings::OPTION_NAME );
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'osm' ) );
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'build_row_class',
+			array(
+				array(
+					'field'   => array( 'type' => 'text' ),
+					'show_if' => array( 'map_platform' => 'google' ),
+				),
+			)
+		);
+
+		$this->assertSame(
+			'gatherpress-settings-row gatherpress-settings-row--hidden',
+			$result
+		);
+
+		delete_option( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Build the row class string when the show_if condition IS satisfied
+	 * omits the `--hidden` modifier so the row paints visible on first
+	 * render — JS leaves it alone unless the controlling field later changes.
+	 *
+	 * @since 1.0.0
+	 * @covers ::build_row_class
+	 *
+	 * @return void
+	 */
+	public function test_build_row_class_with_satisfied_show_if(): void {
+		$instance = Settings::get_instance();
+
+		delete_option( Settings::OPTION_NAME );
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'google' ) );
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'build_row_class',
+			array(
+				array(
+					'field'   => array( 'type' => 'text' ),
+					'show_if' => array( 'map_platform' => 'google' ),
+				),
+			)
+		);
+
+		$this->assertSame( 'gatherpress-settings-row', $result );
+
+		delete_option( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Evaluate show_if returns true when every controlling key matches the
+	 * currently saved value. Single-value conditions use string equality.
+	 *
+	 * @since 1.0.0
+	 * @covers ::evaluate_show_if
+	 *
+	 * @return void
+	 */
+	public function test_evaluate_show_if_single_value_match(): void {
+		$instance = Settings::get_instance();
+
+		delete_option( Settings::OPTION_NAME );
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'google' ) );
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'evaluate_show_if',
+			array( array( 'map_platform' => 'google' ) )
+		);
+
+		$this->assertTrue( $result );
+
+		delete_option( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Evaluate show_if returns false when the controlling key has a value
+	 * other than the one expected.
+	 *
+	 * @since 1.0.0
+	 * @covers ::evaluate_show_if
+	 *
+	 * @return void
+	 */
+	public function test_evaluate_show_if_single_value_mismatch(): void {
+		$instance = Settings::get_instance();
+
+		delete_option( Settings::OPTION_NAME );
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'osm' ) );
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'evaluate_show_if',
+			array( array( 'map_platform' => 'google' ) )
+		);
+
+		$this->assertFalse( $result );
+
+		delete_option( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Evaluate show_if accepts an array of expected values and returns true
+	 * when the current value is a member (OR semantics within one key).
+	 *
+	 * @since 1.0.0
+	 * @covers ::evaluate_show_if
+	 *
+	 * @return void
+	 */
+	public function test_evaluate_show_if_array_of_values(): void {
+		$instance = Settings::get_instance();
+
+		delete_option( Settings::OPTION_NAME );
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'google' ) );
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'evaluate_show_if',
+			array( array( 'map_platform' => array( 'google', 'mapbox' ) ) )
+		);
+		$this->assertTrue( $result );
+
+		// Non-member current value.
+		update_option( Settings::OPTION_NAME, array( 'map_platform' => 'osm' ) );
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'evaluate_show_if',
+			array( array( 'map_platform' => array( 'google', 'mapbox' ) ) )
+		);
+		$this->assertFalse( $result );
+
+		delete_option( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Evaluate show_if combines multiple keys with AND — every key's
+	 * condition must hold for the result to be true.
+	 *
+	 * @since 1.0.0
+	 * @covers ::evaluate_show_if
+	 *
+	 * @return void
+	 */
+	public function test_evaluate_show_if_multi_key_and(): void {
+		$instance = Settings::get_instance();
+
+		delete_option( Settings::OPTION_NAME );
+		update_option(
+			Settings::OPTION_NAME,
+			array(
+				'map_platform'                  => 'google',
+				'venue_map_default_render_mode' => 'interactive',
+			)
+		);
+
+		$matching_conditions = array(
+			'map_platform'                  => 'google',
+			'venue_map_default_render_mode' => 'interactive',
+		);
+		$this->assertTrue(
+			Utility::invoke_hidden_method(
+				$instance,
+				'evaluate_show_if',
+				array( $matching_conditions )
+			)
+		);
+
+		// Flip one key out of band — overall result must drop to false.
+		$mixed_conditions = array(
+			'map_platform'                  => 'google',
+			'venue_map_default_render_mode' => 'static',
+		);
+		$this->assertFalse(
+			Utility::invoke_hidden_method(
+				$instance,
+				'evaluate_show_if',
+				array( $mixed_conditions )
+			)
+		);
+
+		delete_option( Settings::OPTION_NAME );
+	}
+
+	/**
+	 * Render field emits the show_if marker alongside the field template
+	 * when the option declares a `show_if` condition. Without this call site
+	 * exercise, the helper would be covered in isolation but the wiring
+	 * from `render_field` → `render_show_if_marker` could silently break
+	 * in a refactor.
+	 *
+	 * @since 1.0.0
+	 * @covers ::render_field
+	 *
+	 * @return void
+	 */
+	public function test_render_field_emits_show_if_marker_when_declared(): void {
+		$instance = Settings::get_instance();
+
+		ob_start();
+		$instance->render_field(
+			'google_maps_api_key',
+			array(
+				'labels'  => array( 'name' => 'Google Maps API Key' ),
+				'field'   => array(
+					'label' => 'Google Maps API key:',
+					'type'  => 'text',
+					'size'  => 'regular',
+				),
+				'show_if' => array( 'map_platform' => 'google' ),
+			)
+		);
+		$output = ob_get_clean();
+
+		// Field input itself renders.
+		$this->assertStringContainsString(
+			'name="gatherpress_settings[google_maps_api_key]"',
+			$output
+		);
+		// And the show_if marker is emitted alongside it.
+		$this->assertStringContainsString(
+			'class="gatherpress-show-if-marker"',
+			$output
+		);
+		$this->assertStringContainsString(
+			'data-show-if="{&quot;map_platform&quot;:&quot;google&quot;}"',
+			$output
+		);
+	}
+
+	/**
+	 * Render field skips the show_if marker when no condition is declared,
+	 * keeping the field output free of the JS hook for the vast majority of
+	 * fields that don't use the feature.
+	 *
+	 * @since 1.0.0
+	 * @covers ::render_field
+	 *
+	 * @return void
+	 */
+	public function test_render_field_omits_show_if_marker_by_default(): void {
+		$instance = Settings::get_instance();
+
+		ob_start();
+		$instance->render_field(
+			'plain_text_field',
+			array(
+				'labels' => array( 'name' => 'Plain Text Field' ),
+				'field'  => array(
+					'label' => 'Plain text:',
+					'type'  => 'text',
+					'size'  => 'regular',
+				),
+			)
+		);
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'gatherpress-show-if-marker',
+			$output
+		);
+	}
+
+	/**
+	 * Render show_if marker emits a hidden input carrying the condition map
+	 * as a JSON-encoded data attribute. The marker has no `name` attribute
+	 * so it never enters the POST payload — it's a JS hook, not a value.
+	 *
+	 * @since 1.0.0
+	 * @covers ::render_show_if_marker
+	 *
+	 * @return void
+	 */
+	public function test_render_show_if_marker_emits_hidden_input(): void {
+		$instance = Settings::get_instance();
+
+		ob_start();
+		Utility::invoke_hidden_method(
+			$instance,
+			'render_show_if_marker',
+			array( array( 'map_platform' => 'google' ) )
+		);
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'type="hidden"', $output );
+		$this->assertStringContainsString(
+			'class="gatherpress-show-if-marker"',
+			$output
+		);
+		$this->assertStringContainsString(
+			'data-show-if="{&quot;map_platform&quot;:&quot;google&quot;}"',
+			$output
+		);
+		$this->assertStringNotContainsString( 'name=', $output );
+	}
+
+	/**
+	 * Saving a partial input (omitting a show_if-hidden field) preserves the
+	 * field's previously stored value rather than dropping it. This is the
+	 * key guarantee behind the "hidden ≠ cleared" promise of the show_if
+	 * feature: even if the browser somehow omits the field from POST, the
+	 * sanitize_page_settings closure merges with read_stored_options() and
+	 * keeps the value in place.
+	 *
+	 * Uses a synthetic non-default value for the controlling field so the
+	 * "values matching defaults are stripped" pass doesn't interfere with
+	 * the assertion on the hidden field.
+	 *
+	 * @since 1.0.0
+	 * @covers ::sanitize_page_settings
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_page_settings_preserves_hidden_field_value(): void {
+		$instance = Settings::get_instance();
+
+		delete_option( Settings::OPTION_NAME );
+		update_option(
+			Settings::OPTION_NAME,
+			array(
+				'map_platform'        => 'google',
+				'google_maps_api_key' => 'prev-saved-key',
+			)
+		);
+
+		$callback = $instance->sanitize_page_settings(
+			array(
+				'map_platform'        => 'select',
+				'google_maps_api_key' => 'text',
+			)
+		);
+
+		// Submit only the controlling field — simulating what happens if a
+		// show_if-hidden field were somehow omitted from POST. Keep it at
+		// 'google' (the stored value) so it doesn't get stripped via the
+		// "matches default" pass and we can assert on it.
+		$result = $callback( array( 'map_platform' => 'google' ) );
+
+		$this->assertSame( 'google', $result['map_platform'] );
+		$this->assertSame(
+			'prev-saved-key',
+			$result['google_maps_api_key'],
+			'Hidden field value must survive a partial save.'
+		);
+
+		delete_option( Settings::OPTION_NAME );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -2810,7 +2810,7 @@ class Test_Settings extends Base {
 		);
 
 		$this->assertSame(
-			'gatherpress-settings-row gatherpress-settings-row--hidden',
+			'gatherpress-settings-row gatherpress--is-hidden',
 			$result
 		);
 


### PR DESCRIPTION
### Description of the Change

Adds a `show_if` field key to the Settings API so a field can declare a dependency on another field's value, and the dependent field is hidden in the admin UI when the condition isn't met.

```php
'google_maps_api_key' => array(
    'labels'  => array( 'name' => __( 'Google Maps API Key', 'gatherpress' ) ),
    'field'   => array( 'type' => 'text', 'size' => 'regular' ),
    'show_if' => array(
        'map_platform' => 'google',
    ),
),
```

Supports single-value equality, array-of-values (OR within one key), and multiple keys (AND). Hiding is CSS-only — saved values are **never** dropped just because a field is currently hidden, so switching the controlling field back reveals the dependent with its prior value intact.

Migrates the `google_maps_api_key` field as the first consumer — it now hides unless the map platform is set to Google.

Closes #1632

### How to test the Change

1. Settings → Venues. With "Selected Mapping Platform" set to **Google Maps**, the **Google Maps API Key** field is visible.
2. Switch to **OpenStreetMap** — the API Key field hides.
3. Switch back to **Google Maps** — the API Key field reappears with its previous value intact.
4. Enter a key, save, switch to OpenStreetMap, save again. Switch back to Google — the key is still saved.
5. Run `npm run test:unit:js` (820 pass, +25 new) and `npm run test:unit:php` (1365 pass, +11 new).
6. Run `npm run lint:js`, `npm run lint:css`, `npm run lint:php`, `npm run lint:phpstan` — all clean.

### Changelog Entry

> Added - Settings API `show_if` field key for conditional field visibility based on another field's value.

### Credits

Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.