### PR TITLE
Invalidate caches on RSVP token redemption and bypass page cache for magic-link URLs

### DIFF
--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -551,6 +551,22 @@ class Setup {
 	 * Validates the RSVP token from the URL parameter and automatically
 	 * approves the corresponding comment if the token is valid.
 	 *
+	 * Whenever the `?gatherpress_rsvp_token=…` query var is present we
+	 * also queue `nocache_headers()` onto WP's `send_headers` action so
+	 * any host-level page cache (WP Rocket, W3TC, Nginx FastCGI,
+	 * Cloudflare when configured to honor origin Cache-Control) treats
+	 * the URL as per-user and never stores it. The token acts as a
+	 * magic link — the same URL keeps authenticating the same person on
+	 * every reload — so caching it shared would either leak one user's
+	 * authenticated view to another, or serve a stale render that
+	 * doesn't reflect their RSVP (see #1626). We deferred this to
+	 * `send_headers` rather than calling `nocache_headers()` inline so
+	 * the headers fire at the right moment in the response lifecycle
+	 * (when `headers_sent()` is still false), regardless of any output
+	 * the handler might have triggered. The deferral runs regardless of
+	 * whether the token actually validates, so an expired or wrong-hash
+	 * token also stays out of the page cache.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
@@ -558,8 +574,11 @@ class Setup {
 	public function handle_rsvp_token(): void {
 		$rsvp_token = Token::from_url_parameter();
 
-		if ( $rsvp_token ) {
-			$rsvp_token->approve_comment();
+		if ( ! $rsvp_token ) {
+			return;
 		}
+
+		add_action( 'send_headers', 'nocache_headers' );
+		$rsvp_token->approve_comment();
 	}
 }

--- a/includes/core/classes/rsvp/class-token.php
+++ b/includes/core/classes/rsvp/class-token.php
@@ -154,6 +154,22 @@ class Token {
 	 * on marginal inputs, and there's no reason to give them a repeat
 	 * opportunity once the comment is already approved.
 	 *
+	 * After a successful status flip we invalidate two layers of cache so
+	 * the page rendered in the same request — and on any subsequent
+	 * anonymous visit to the canonical event URL — reflects the new RSVP:
+	 *
+	 *   1. `Rsvp::CACHE_KEY` in `GATHERPRESS_CACHE_GROUP` — the
+	 *      per-event response cache that `Rsvp::responses()` reads.
+	 *      Without this, the rsvp / rsvp-response blocks still pull the
+	 *      pre-approval list on the very same page render that follows
+	 *      token redemption (see #1626).
+	 *   2. `clean_post_cache()` — bumps WP's lastpostmodified and fires
+	 *      the `clean_post_cache` action that page-cache plugins
+	 *      (WP Rocket, W3TC, etc.) listen to for purging the canonical
+	 *      permalink's cached HTML. Without this, anonymous visitors
+	 *      hitting the cached event page after someone redeems a token
+	 *      keep seeing the stale rendered RSVP list.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
@@ -168,6 +184,16 @@ class Token {
 		}
 
 		wp_set_comment_status( (int) $this->comment->comment_ID, 'approve' );
+
+		$post_id = (int) $this->comment->comment_post_ID;
+
+		if ( $post_id ) {
+			wp_cache_delete(
+				sprintf( Rsvp::CACHE_KEY, $post_id ),
+				GATHERPRESS_CACHE_GROUP
+			);
+			clean_post_cache( $post_id );
+		}
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-setup.php
@@ -478,6 +478,92 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * Whenever the token query var is present the handler must queue
+	 * `nocache_headers()` onto WP's `send_headers` action so the magic-
+	 * link URL is treated as per-user by any host-level page cache.
+	 * Without this, an aggressive page cache either leaks one user's
+	 * authenticated view to another or pins a stale RSVP-list render to
+	 * the URL (#1626). The deferred dispatch is what makes this
+	 * observable in tests — `nocache_headers()` called inline early-
+	 * returns under `headers_sent()`, which is always true in the
+	 * PHPUnit runner.
+	 *
+	 * @covers ::handle_rsvp_token
+	 *
+	 * @return void
+	 */
+	public function test_handle_rsvp_token_defers_nocache_headers(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+
+		$comment_id = $this->factory->comment->create(
+			array(
+				'comment_post_ID'      => $post_id,
+				'comment_type'         => Rsvp::COMMENT_TYPE,
+				'comment_author_email' => 'test@example.com',
+				'comment_approved'     => 0,
+			)
+		);
+
+		$token = new Token( $comment_id );
+		$token->generate_token();
+		$token_string = sprintf( '%d_%s', $comment_id, $token->get_token() );
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, $type, $var_name ) use ( $token_string ) {
+				if ( INPUT_GET === $type && Token::NAME === $var_name ) {
+					return $token_string;
+				}
+				return null;
+			},
+			10,
+			3
+		);
+
+		// Ensure baseline: no nocache_headers wiring before the call.
+		remove_action( 'send_headers', 'nocache_headers' );
+
+		Setup::get_instance()->handle_rsvp_token();
+
+		$has_action = has_action( 'send_headers', 'nocache_headers' );
+
+		remove_action( 'send_headers', 'nocache_headers' );
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+
+		$this->assertNotFalse(
+			$has_action,
+			'`send_headers` must be wired to `nocache_headers` on every token-bearing request.'
+		);
+	}
+
+	/**
+	 * Without a token in the URL the handler must NOT queue no-cache
+	 * headers — otherwise every page request would become uncacheable,
+	 * defeating the host's page cache for the vast majority of traffic.
+	 *
+	 * @covers ::handle_rsvp_token
+	 *
+	 * @return void
+	 */
+	public function test_handle_rsvp_token_skips_nocache_headers_when_token_absent(): void {
+		// Ensure baseline: no nocache_headers wiring before the call.
+		remove_action( 'send_headers', 'nocache_headers' );
+
+		Setup::get_instance()->handle_rsvp_token();
+
+		$has_action = has_action( 'send_headers', 'nocache_headers' );
+
+		$this->assertFalse(
+			$has_action,
+			'`send_headers` must not be wired to `nocache_headers` on requests that carry no RSVP token.'
+		);
+	}
+
+	/**
 	 * Coverage for adjust_comments_number with non-event post.
 	 *
 	 * @covers ::adjust_comments_number

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-token.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-token.php
@@ -390,6 +390,142 @@ class Test_Token extends Base {
 	}
 
 	/**
+	 * After flipping a comment from pending to approved, approve_comment()
+	 * must invalidate the GatherPress per-event RSVP cache. Without this,
+	 * the rsvp / rsvp-response blocks still render the pre-approval list
+	 * on the very same request that redeems the token (see #1626).
+	 *
+	 * @covers ::approve_comment
+	 *
+	 * @return void
+	 */
+	public function test_approve_comment_invalidates_gatherpress_rsvp_cache(): void {
+		$post = $this->mock->post(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		)->get();
+
+		$comment_id = $this->factory->comment->create(
+			array(
+				'comment_post_ID'  => $post->ID,
+				'comment_type'     => Rsvp::COMMENT_TYPE,
+				'comment_approved' => '0',
+			)
+		);
+
+		// Seed the per-event cache so we can confirm it gets deleted.
+		$cache_key = sprintf( Rsvp::CACHE_KEY, $post->ID );
+		wp_cache_set( $cache_key, 'stale-payload', GATHERPRESS_CACHE_GROUP );
+		$this->assertSame(
+			'stale-payload',
+			wp_cache_get( $cache_key, GATHERPRESS_CACHE_GROUP )
+		);
+
+		$token = new Token( $comment_id );
+		$token->approve_comment();
+
+		$this->assertFalse(
+			wp_cache_get( $cache_key, GATHERPRESS_CACHE_GROUP ),
+			'Per-event RSVP cache must be deleted after a successful token redemption.'
+		);
+	}
+
+	/**
+	 * After flipping a comment from pending to approved, approve_comment()
+	 * must call `clean_post_cache()` so page-cache plugins listening on
+	 * that action purge the canonical event permalink — and so WP's own
+	 * post cache reflects the new RSVP for subsequent reads.
+	 *
+	 * @covers ::approve_comment
+	 *
+	 * @return void
+	 */
+	public function test_approve_comment_calls_clean_post_cache(): void {
+		$post = $this->mock->post(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		)->get();
+
+		$comment_id = $this->factory->comment->create(
+			array(
+				'comment_post_ID'  => $post->ID,
+				'comment_type'     => Rsvp::COMMENT_TYPE,
+				'comment_approved' => '0',
+			)
+		);
+
+		$purged_ids = array();
+		$spy        = static function ( $purged_post_id ) use ( &$purged_ids ): void {
+			$purged_ids[] = (int) $purged_post_id;
+		};
+		add_action( 'clean_post_cache', $spy );
+
+		$token = new Token( $comment_id );
+		$token->approve_comment();
+
+		remove_action( 'clean_post_cache', $spy );
+
+		$this->assertContains(
+			(int) $post->ID,
+			$purged_ids,
+			'clean_post_cache must fire for the event post when a token approves an RSVP.'
+		);
+	}
+
+	/**
+	 * The already-approved fast path must NOT re-invalidate caches. Token
+	 * URLs are sticky; the user revisits the same URL on every reload, so
+	 * a hot path that re-purges caches on every visit would defeat the
+	 * purpose of caching entirely.
+	 *
+	 * @covers ::approve_comment
+	 *
+	 * @return void
+	 */
+	public function test_approve_comment_skips_cache_invalidation_when_already_approved(): void {
+		$post = $this->mock->post(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		)->get();
+
+		$comment_id = $this->factory->comment->create(
+			array(
+				'comment_post_ID'  => $post->ID,
+				'comment_type'     => Rsvp::COMMENT_TYPE,
+				'comment_approved' => '1',
+			)
+		);
+
+		$cache_key = sprintf( Rsvp::CACHE_KEY, $post->ID );
+		wp_cache_set( $cache_key, 'still-fresh', GATHERPRESS_CACHE_GROUP );
+
+		$purged_ids = array();
+		$spy        = static function ( $purged_post_id ) use ( &$purged_ids ): void {
+			$purged_ids[] = (int) $purged_post_id;
+		};
+		add_action( 'clean_post_cache', $spy );
+
+		$token = new Token( $comment_id );
+		$token->approve_comment();
+
+		remove_action( 'clean_post_cache', $spy );
+
+		$this->assertSame(
+			'still-fresh',
+			wp_cache_get( $cache_key, GATHERPRESS_CACHE_GROUP ),
+			'Per-event RSVP cache must NOT be invalidated when the comment was already approved.'
+		);
+		$this->assertNotContains(
+			(int) $post->ID,
+			$purged_ids,
+			'clean_post_cache must NOT fire when the comment was already approved.'
+		);
+	}
+
+	/**
 	 * Coverage for get_comment method.
 	 *
 	 * @covers ::get_comment


### PR DESCRIPTION
### Description of the Change

When a user clicks an RSVP token link from a confirmation email, the RSVP was being recorded server-side but the page they landed on still showed them as not attending. Two cache layers were not being invalidated on the token-redemption path:

1. **GatherPress per-event RSVP cache** — `Rsvp::responses()` reads from `gatherpress_rsvp_%d` in `GATHERPRESS_CACHE_GROUP`. The non-token REST path clears this inside `Rsvp::save()`, but the token path went straight to `wp_set_comment_status()` and bypassed it. Fixed by calling `wp_cache_delete()` for that key inside `Token::approve_comment()` after a successful status flip.
2. **WordPress post cache + page-cache plugins** — `clean_post_cache( $comment_post_id )` was never called, so neither WP's own post cache nor third-party page-cache plugins (WP Rocket, W3TC, etc., which listen to the `clean_post_cache` action) knew to purge. Fixed by calling it on the same successful path.

Both invalidations are skipped on the already-approved fast path so reloads of the sticky magic-link URL don't thrash caches on every request.

Separately, `Setup::handle_rsvp_token()` now wires `nocache_headers` onto `send_headers` whenever the token query var is present, so host-level page caches treat the magic-link URL as per-user and never store it. The deferred dispatch (instead of an inline `nocache_headers()` call) ensures the headers actually fire when WP sends them.

Closes #1626

### How to test the Change

1. RSVP to an event as a guest (no account) so a confirmation email is generated.
2. Click the token link in the email.
3. The event page should immediately reflect your RSVP — without requiring a hard refresh or waiting for a cache to expire.
4. Reload the same URL — RSVP state is still correct, no extra DB writes (the already-approved fast path runs).
5. Confirm `Cache-Control: no-cache` and friends are on the response for token URLs (DevTools → Network → response headers).
6. Run `npm run test:unit:php` — 1372 pass (+7 new).

### Changelog Entry

> Fixed - RSVP token magic-link URL now invalidates the event's RSVP cache and post cache on redemption, and signals page-cache layers to treat the URL as per-user, so users see their RSVP reflected immediately instead of a stale cached render.

### Credits

Props @mauteri, @carstingaxion

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.