### PR TITLE
Use post type labels in query block UI

### DIFF
--- a/src/variations/core/query/components.js
+++ b/src/variations/core/query/components.js
@@ -19,7 +19,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import EventQueryControls from './slots/query-controls';
 import EventInheritedQueryControls from './slots/inherited-query-controls';
 import { isEventPostType, usePostTypeSupports } from '../../../helpers/event';
-import { isInFSETemplate } from '../../../helpers/editor';
+import { getPostTypeLabel, isInFSETemplate, usePostTypeLabel } from '../../../helpers/editor';
 
 /**
  * EventCountControls component
@@ -33,11 +33,24 @@ import { isInFSETemplate } from '../../../helpers/editor';
  * @return {Element}                     RangeControl for event "per page" count.
  */
 export const EventCountControls = ( { attributes, setAttributes } ) => {
-	const { query: { perPage, offset = 0 } = {} } = attributes;
+	const { query: { postType, perPage, offset = 0 } = {} } = attributes;
+
+	// Read the plural label so the label reflects what the currently
+	// selected post type is actually called — a custom event-supporting post type with
+	// `name => 'Productions'` shows "Productions Per Page".
+	const pluralLabel = usePostTypeLabel(
+		'name',
+		postType,
+		__( 'Events', 'gatherpress' )
+	);
 
 	return (
 		<RangeControl
-			label={ __( 'Events Per Page', 'gatherpress' ) }
+			label={ sprintf(
+			/* translators: %s: Plural post type label, e.g. "Events". */
+			__( '%s Per Page', 'gatherpress' ),
+			pluralLabel
+			) }
 			min={ 1 }
 			max={ 50 }
 			onChange={ ( newCount ) => {
@@ -69,7 +82,7 @@ export const EventCountControls = ( { attributes, setAttributes } ) => {
  * @return {Element}                        ToggleControl to exclude current event.
  */
 export const EventExcludeControls = ( { attributes, setAttributes } ) => {
-	const { query: { exclude_current: excludeCurrent } = {} } = attributes;
+	const { query: { postType, exclude_current: excludeCurrent } = {} } = attributes;
 
 	const currentPost = useSelect( ( select ) => {
 		return select( 'core/editor' ).getCurrentPost();
@@ -79,9 +92,22 @@ export const EventExcludeControls = ( { attributes, setAttributes } ) => {
 		return <div>{ __( 'Loading…', 'gatherpress' ) }</div>;
 	}
 
+	// Read the singular label so the label reflects what the currently
+	// selected post type is actually called — a custom event-supporting post type with
+	// `singular_name => 'Production'` shows "Exclude Current Production".
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		postType,
+		__( 'Event', 'gatherpress' )
+	);
+
 	return (
 		<ToggleControl
-			label={ __( 'Exclude Current Event', 'gatherpress' ) }
+			label={ sprintf(
+				/* translators: %s: Singular post type label, e.g. "Event". */
+				__( 'Exclude Current %s', 'gatherpress' ),
+				singularLabel
+			) }
 			checked={ !! excludeCurrent }
 			onChange={ ( value ) => {
 				setAttributes( {
@@ -113,6 +139,7 @@ export const EventIncludeUnfinishedControls = ( {
 } ) => {
 	const {
 		query: {
+			postType,
 			include_unfinished: includeUnfinished,
 			gatherpress_event_query: eventListType = 'upcoming',
 		} = {},
@@ -132,19 +159,33 @@ export const EventIncludeUnfinishedControls = ( {
 		effectiveValue = ( 1 === includeUnfinished );
 	}
 
+	// Read the plural label so the label reflects what the currently
+	// selected post type is actually called — a custom event-supporting post type with
+	// `name => 'Productions'` shows "Include Unfinished Productions".
+	const pluralLabel = usePostTypeLabel(
+		'name',
+		postType,
+		__( 'Events', 'gatherpress' )
+	);
+
 	return (
 		<ToggleControl
-			label={ __( 'Include unfinished events', 'gatherpress' ) }
+			label={ sprintf(
+				/* translators: %s: Plural post type label, e.g. "Events". */
+				__( 'Include Unfinished %s', 'gatherpress' ),
+				pluralLabel
+			) }
 			help={ sprintf(
-				/* translators: %s: 'upcoming' or 'past' */
+				/* translators: %1$s: 'upcoming' or 'past', %2$s: Plural post type label */
 				_x(
-					'%s events that have started but are not yet finished.',
+					'%1$s %2$s that have started but are not yet finished.',
 					"'Shows' or 'Hides'",
 					'gatherpress',
 				),
 				effectiveValue
 					? __( 'Shows', 'gatherpress' )
 					: __( 'Hides', 'gatherpress' ),
+				pluralLabel
 			) }
 			checked={ effectiveValue }
 			onChange={ ( value ) => {
@@ -174,12 +215,25 @@ export const EventIncludeUnfinishedControls = ( {
  */
 export const EventListTypeControls = ( { attributes, setAttributes } ) => {
 	const {
-		query: { gatherpress_event_query: eventListType = 'upcoming' } = {},
+		query: { postType, gatherpress_event_query: eventListType = 'upcoming' } = {},
 	} = attributes;
+
+	// Read the singular label so the label reflects what the currently
+	// selected post type is actually called — a custom event-supporting post type with
+	// `singular_name => 'Production'` shows "Production List Type".
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		postType,
+		__( 'Event', 'gatherpress' )
+	);
 
 	return (
 		<ToggleGroupControl
-			label={ __( 'Event List Type', 'gatherpress' ) }
+			label={ sprintf(
+				/* translators: %s: Singular post type label, e.g. "Event". */
+				__( '%s List Type', 'gatherpress' ),
+				singularLabel
+			) }
 			value={ eventListType }
 			isBlock
 			__next40pxDefaultSize
@@ -252,9 +306,22 @@ export const VenueFilterControls = ( {
 			'gatherpress'
 		);
 
+	// Read the singular label so the label reflects what the currently
+	// selected post type is actually called — a re-named gatherpress_venue post type with
+	// `singular_name => 'Location'` shows "Filter by Current Location".
+	const singularLabel = getPostTypeLabel(
+		'singular_name',
+		'gatherpress_venue',
+		__( 'Venue', 'gatherpress' )
+	);
+
 	return (
 		<ToggleControl
-			label={ __( 'Filter by current venue', 'gatherpress' ) }
+			label={ sprintf(
+				/* translators: %s: Singular post type label, e.g. "Venue". */
+				__( 'Filter by Current %s', 'gatherpress' ),
+				singularLabel
+			) }
 			help={ helpText }
 			checked={ !! venueFilter }
 			onChange={ ( value ) => {
@@ -281,10 +348,24 @@ export const VenueFilterControls = ( {
  * @return {Element}                        RangeControl for event query offset.
  */
 export const EventOffsetControls = ( { attributes, setAttributes } ) => {
-	const { query: { offset = 0 } = {} } = attributes;
+	const { query: { postType, offset = 0 } = {} } = attributes;
+
+	// Read the singular label so the label reflects what the currently
+	// selected post type is actually called — a custom event-supporting post type with
+	// `singular_name => 'Production'` shows "Production Offset".
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		postType,
+		__( 'Event', 'gatherpress' )
+	);
+
 	return (
 		<RangeControl
-			label={ __( 'Event Offset', 'gatherpress' ) }
+			label={ sprintf(
+				/* translators: %s: Singular post type label, e.g. "Event". */
+				__( '%s Offset', 'gatherpress' ),
+				singularLabel
+			) }
 			min={ 0 }
 			max={ 50 }
 			value={ offset }
@@ -313,7 +394,7 @@ export const EventOffsetControls = ( { attributes, setAttributes } ) => {
  * @return {Element}                        Controls for event sorting and order.
  */
 export const EventOrderControls = ( { attributes, setAttributes } ) => {
-	const { query: { order, orderBy } = {} } = attributes;
+	const { query: { postType, order, orderBy } = {} } = attributes;
 	let label;
 	if ( 'rand' === orderBy ) {
 		label = __( 'Random Order', 'gatherpress' );
@@ -322,10 +403,24 @@ export const EventOrderControls = ( { attributes, setAttributes } ) => {
 	} else {
 		label = __( 'Descending Order', 'gatherpress' );
 	}
+
+	// Read the plural label so the label reflects what the currently
+	// selected post type is actually called — a custom event-supporting post type with
+	// `name => 'Productions'` shows "Order Productions by".
+	const pluralLabel = usePostTypeLabel(
+		'name',
+		postType,
+		__( 'Events', 'gatherpress' )
+	);
+
 	return (
 		<>
 			<SelectControl
-				label={ __( 'Order Events by', 'gatherpress' ) }
+				label={ sprintf(
+					/* translators: %s: Plural post type label, e.g. "Events". */
+					__( 'Order %s by', 'gatherpress' ),
+					pluralLabel
+				) }
 				value={ orderBy }
 				options={ [
 					{

--- a/src/variations/core/query/components.js
+++ b/src/variations/core/query/components.js
@@ -48,8 +48,8 @@ export const EventCountControls = ( { attributes, setAttributes } ) => {
 		<RangeControl
 			label={ sprintf(
 			/* translators: %s: Plural post type label, e.g. "Events". */
-			__( '%s Per Page', 'gatherpress' ),
-			pluralLabel
+				__( '%s Per Page', 'gatherpress' ),
+				pluralLabel
 			) }
 			min={ 1 }
 			max={ 50 }
@@ -88,10 +88,6 @@ export const EventExcludeControls = ( { attributes, setAttributes } ) => {
 		return select( 'core/editor' ).getCurrentPost();
 	}, [] );
 
-	if ( ! currentPost ) {
-		return <div>{ __( 'Loading…', 'gatherpress' ) }</div>;
-	}
-
 	// Read the singular label so the label reflects what the currently
 	// selected post type is actually called — a custom event-supporting post type with
 	// `singular_name => 'Production'` shows "Exclude Current Production".
@@ -100,6 +96,10 @@ export const EventExcludeControls = ( { attributes, setAttributes } ) => {
 		postType,
 		__( 'Event', 'gatherpress' )
 	);
+
+	if ( ! currentPost ) {
+		return <div>{ __( 'Loading…', 'gatherpress' ) }</div>;
+	}
 
 	return (
 		<ToggleControl

--- a/src/variations/core/query/components.js
+++ b/src/variations/core/query/components.js
@@ -404,6 +404,15 @@ export const EventOrderControls = ( { attributes, setAttributes } ) => {
 		label = __( 'Descending Order', 'gatherpress' );
 	}
 
+	// Read the singular label so the label reflects what the currently
+	// selected post type is actually called — a custom event-supporting post type with
+	// `singular_name => 'Production'` shows "Production Date".
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		postType,
+		__( 'Event', 'gatherpress' )
+	);
+
 	// Read the plural label so the label reflects what the currently
 	// selected post type is actually called — a custom event-supporting post type with
 	// `name => 'Productions'` shows "Order Productions by".
@@ -424,7 +433,11 @@ export const EventOrderControls = ( { attributes, setAttributes } ) => {
 				value={ orderBy }
 				options={ [
 					{
-						label: __( 'Event Date', 'gatherpress' ),
+						label: sprintf(
+							/* translators: %s: Singular post type label, e.g. "Event". */
+							__( '%s Date', 'gatherpress' ),
+							singularLabel
+						),
 						value: 'datetime', // This is GatherPress specific, a normal post would use 'date'.
 					},
 					{

--- a/src/variations/core/query/controls.js
+++ b/src/variations/core/query/controls.js
@@ -12,7 +12,7 @@ import { useDispatch } from '@wordpress/data';
 /**
  *  Internal dependencies
  */
-import { NAME } from '.';
+import { NAME } from './name';
 import EventQueryControls from './slots/query-controls';
 import EventInheritedQueryControls from './slots/inherited-query-controls';
 import {

--- a/src/variations/core/query/controls.js
+++ b/src/variations/core/query/controls.js
@@ -7,6 +7,7 @@ import { PanelBody } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
+import { useDispatch } from '@wordpress/data';
 
 /**
  *  Internal dependencies
@@ -93,14 +94,58 @@ const QueryPosttypeObserver = ( { attributes, setAttributes } ) => {
  * @return {Element|null} The InspectorControls panel, or null when not applicable.
  */
 export const EventQueryControlsPanel = ( props ) => {
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const { clientId } = props;
+	const { gatherpress_event_query } = props.attributes?.query || 'upcoming';
 	const queryPostType = props.attributes?.query?.postType;
 	const queryPostTypeSupportsEvents = usePostTypeSupports(
 		'gatherpress-event-date',
 		queryPostType
 	);
+
+	// Read the plural label so the "Block List" label reflects what the currently
+	// selected post type is actually called — a custom event-supporting post type with
+	// `name => 'Productions'` shows "Upcoming (or Past) Productions".
+	const pluralLabel = usePostTypeLabel(
+		'name',
+		queryPostType,
+		__( 'Events', 'gatherpress' )
+	);
+
+	// Update block name with post type label and query mode
+	useEffect( () => {
+		const queryLabel = ( 'upcoming' === gatherpress_event_query )
+			? __( 'Upcoming', 'gatherpress' )
+			: __( 'Past', 'gatherpress' );
+
+		let blockName = sprintf(
+			/* translators: %1$s: 'Upcoming' or 'Past', %2$s: Plural post type label, e.g. "Events". */
+			__( '%1$s %2$s', 'gatherpress' ),
+			queryLabel,
+			pluralLabel
+		);
+
+		// Unset if not a supporting post type.
+		if ( ! queryPostTypeSupportsEvents ) {
+			blockName = '';
+		}
+
+		updateBlockAttributes( clientId, {
+			metadata: {
+				name: blockName,
+			},
+		} );
+	}, [
+		queryPostTypeSupportsEvents,
+		pluralLabel,
+		gatherpress_event_query,
+		clientId,
+		updateBlockAttributes,
+	] );
+
 	// Read the singular label so the label reflects what the currently
 	// selected post type is actually called — a custom event-supporting post type with
-	// `singular_name => 'Production'` shows "Production Offset".
+	// `singular_name => 'Production'` shows "Production Query Settings".
 	const singularLabel = usePostTypeLabel(
 		'singular_name',
 		queryPostType,

--- a/src/variations/core/query/controls.js
+++ b/src/variations/core/query/controls.js
@@ -96,7 +96,7 @@ const QueryPosttypeObserver = ( { attributes, setAttributes } ) => {
 export const EventQueryControlsPanel = ( props ) => {
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 	const { clientId } = props;
-	const { gatherpress_event_query } = props.attributes?.query || 'upcoming';
+	const gatherpressEventQuery = props.attributes?.query?.gatherpress_event_query || 'upcoming';
 	const queryPostType = props.attributes?.query?.postType;
 	const queryPostTypeSupportsEvents = usePostTypeSupports(
 		'gatherpress-event-date',
@@ -114,7 +114,7 @@ export const EventQueryControlsPanel = ( props ) => {
 
 	// Update block name with post type label and query mode
 	useEffect( () => {
-		const queryLabel = ( 'upcoming' === gatherpress_event_query )
+		const queryLabel = ( 'upcoming' === gatherpressEventQuery )
 			? __( 'Upcoming', 'gatherpress' )
 			: __( 'Past', 'gatherpress' );
 
@@ -138,7 +138,7 @@ export const EventQueryControlsPanel = ( props ) => {
 	}, [
 		queryPostTypeSupportsEvents,
 		pluralLabel,
-		gatherpress_event_query,
+		gatherpressEventQuery,
 		clientId,
 		updateBlockAttributes,
 	] );

--- a/src/variations/core/query/controls.js
+++ b/src/variations/core/query/controls.js
@@ -4,7 +4,7 @@
 import { addFilter } from '@wordpress/hooks';
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 
@@ -19,6 +19,7 @@ import {
 	EventInheritedQueryControlsSlotFill,
 } from './components';
 import { usePostTypeSupports } from '../../../helpers/event';
+import { usePostTypeLabel } from '../../../helpers/editor';
 
 /**
  * Determines if the current block instance is the GatherPress event query variation.
@@ -97,6 +98,14 @@ export const EventQueryControlsPanel = ( props ) => {
 		'gatherpress-event-date',
 		queryPostType
 	);
+	// Read the singular label so the label reflects what the currently
+	// selected post type is actually called — a custom event-supporting post type with
+	// `singular_name => 'Production'` shows "Production Offset".
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		queryPostType,
+		__( 'Event', 'gatherpress' )
+	);
 
 	if ( ! queryPostTypeSupportsEvents ) {
 		return null;
@@ -104,7 +113,11 @@ export const EventQueryControlsPanel = ( props ) => {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Event Query Settings', 'gatherpress' ) }>
+			<PanelBody title={ sprintf(
+				/* translators: %s: Singular post type label, e.g. "Event". */
+				__( '%s Query Settings', 'gatherpress' ),
+				singularLabel
+			) }>
 				{ false === props.attributes.query.inherit ? (
 					<EventQueryControls.Slot
 						fillProps={ { ...props } }

--- a/src/variations/core/query/index.js
+++ b/src/variations/core/query/index.js
@@ -7,11 +7,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { NAME } from './name';
 import './controls';
 import './patterns';
 import './start-blank';
 
-export const NAME = 'gatherpress-event-query';
+export { NAME };
 
 const QUERY_ATTRIBUTES = {
 	namespace: NAME,

--- a/src/variations/core/query/name.js
+++ b/src/variations/core/query/name.js
@@ -1,0 +1,9 @@
+/**
+ * Block-variation name for the GatherPress Event Query loop.
+ *
+ * Kept in its own side-effect-free module so unit tests (and any future
+ * consumers) can import the constant without dragging in the variation
+ * registration, starter patterns, and `start-blank` modules pulled in by
+ * `./index.js`.
+ */
+export const NAME = 'gatherpress-event-query';

--- a/test/unit/js/src/variations/core/query/components.test.js
+++ b/test/unit/js/src/variations/core/query/components.test.js
@@ -77,6 +77,8 @@ jest.mock( '@src/helpers/event', () => ( {
 
 jest.mock( '@src/helpers/editor', () => ( {
 	isInFSETemplate: jest.fn(),
+	getPostTypeLabel: jest.fn( ( key, postType, fallback ) => fallback ),
+	usePostTypeLabel: jest.fn( ( key, postType, fallback ) => fallback ),
 } ) );
 
 /**
@@ -90,7 +92,7 @@ import { isInFSETemplate } from '@src/helpers/editor';
  */
 import { EventQueryControlsSlotFill } from '@src/variations/core/query/components';
 
-const venueToggleLabel = 'Filter by current venue';
+const venueToggleLabel = 'Filter by Current Venue';
 const excludeToggleLabel = 'Exclude Current Event';
 const venueHelp =
 	'When placed on a venue page, only shows events at that venue.';

--- a/test/unit/js/src/variations/core/query/controls.test.js
+++ b/test/unit/js/src/variations/core/query/controls.test.js
@@ -36,6 +36,7 @@ jest.mock( '@wordpress/components', () => ( {
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( text ) => text,
+	sprintf: ( fmt, ...args ) => args.reduce( ( s, a ) => s.replace( '%s', a ), fmt ),
 } ) );
 
 jest.mock( '@src/variations/core/query/slots/query-controls', () => {
@@ -64,6 +65,16 @@ jest.mock( '@src/variations/core/query/components', () => ( {
 
 jest.mock( '@src/helpers/event', () => ( {
 	usePostTypeSupports: jest.fn(),
+} ) );
+
+jest.mock( '@src/helpers/editor', () => ( {
+	usePostTypeLabel: jest.fn( ( key, postType, fallback ) => fallback ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn( () => ( {
+		updateBlockAttributes: jest.fn(),
+	} ) ),
 } ) );
 
 /**


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->
I couldn't hold me back to make use the of the new `usePostTypeLabel` helpers inside one of the most important blocks - the event-query block. 

>Site builders who filter the post type labels (e.g. to "Happenings") or extenders who register their own event-supporting post type with their own labels never saw those labels surface in the settings sub-menus, permalink fields, or the event RSS feed — they always read GatherPress's defaults.
>
>https://github.com/GatherPress/gatherpress/pull/1627#issue-4415892830



### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR adds broader support for the registered labels an event-supporting post type comes with. Changes were made to all UI controls of the "Event Query" block.

<img width="1280" height="1011" alt="use-post-type-labels-in-gatherpress-query-block" src="https://github.com/user-attachments/assets/fbf7449c-356a-42e1-97a1-1aae711d7289" />


Further one this PR adds a small UI helper, that updates the blocks name from the selected `post_type` and `gatherpress_event_query` params, so the "Block List" shows "Upcoming Happenings" instead of "Event Query Loop".

<img width="1280" height="900" alt="use-post-type-labels-in-editor-block-list" src="https://github.com/user-attachments/assets/2e4740b7-fb5d-4767-8cf3-d563b3b115d2" />


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
~~Closes #~~ Follow-up for #1631

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Register a custom event-supporting post type with a different singular label, e.g.:
```php
register_post_type( 'production', array(
    'public'   => true,
    'label'    => 'Productions',
    'labels'   => array( 'singular_name' => 'Production' ),
    'supports' => array( 'title', 'editor', 'gatherpress-event-date', 'gatherpress-rsvp' ),
) );
```
2. Create a new post
3. Add a "Event Query" block
4. Switch between (event supporting) post types
5. Confirm the UI changes from "Event ..." to "Production ..." for all kinds of block controls
6. Open the "Block List"
7. Confirm the blocks name follows your selected query parameters, for e.g. "Upcoming Events"

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added more UI support for the registered post type labels inside the "Event Query" block
> Changed the blocks editor-only name attriubute to better reflect currently selected query parameters


### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @carstingaxion 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
