### PR TITLE
Bump "Tested up to" to WordPress 7.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === GatherPress ===
 Contributors: mauteri, patricia70, hrmervin, jmarx75, stephenerdelyi, carstenbach, jordanpak, mahimadave, tusharaddweb, pkbhatt, dd32, kofimokome, richsalvucci
 Tags: events, event, meetup, community
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 0.34.0-alpha.2
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change
Bumps the `Tested up to` header in `readme.txt` from 6.9 to 7.0 after smoke-testing the plugin against the WordPress 7.0 release candidate.

Closes #1429

### How to test the Change
1. Open `readme.txt` and confirm line 4 reads `Tested up to: 7.0`.
2. Activate the plugin on a WordPress 7.0 RC site and verify no regressions in core event/RSVP/venue flows.

### Changelog Entry
> Changed - Bump "Tested up to" to WordPress 7.0.

### Credits
Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.