### PR TITLE
Lock down GITHUB_TOKEN permissions across CI workflows

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -12,6 +12,10 @@ on:
     - 'package.*'
     - '*.js'
     - '*.php'
+
+permissions:
+  contents: read
+
 jobs:
   phpcs:
     name: PHP Coding Standards

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,6 +14,10 @@ on:
     - 'test/e2e/**'
     - '*.php'
     - '*.js'
+
+permissions:
+  contents: read
+
 jobs:
   playwright:
     name: Playwright Tests

--- a/.github/workflows/general-linting.yml
+++ b/.github/workflows/general-linting.yml
@@ -11,6 +11,9 @@ on:
     - '*.md'
     - 'package.json'
 
+permissions:
+  contents: read
+
 jobs:
   mdlinting:
     name: Markdown

--- a/.github/workflows/jest-tests.yml
+++ b/.github/workflows/jest-tests.yml
@@ -10,6 +10,10 @@ on:
     - 'test/unit/js**'
     - '*.js'
     - 'package.*'
+
+permissions:
+  contents: read
+
 jobs:
   test-js:
     name: Jest Tests

--- a/.github/workflows/phpmd-tests.yml
+++ b/.github/workflows/phpmd-tests.yml
@@ -9,6 +9,10 @@ on:
     - 'includes/**'
     - 'phpmd.xml'
     - 'composer.*'
+
+permissions:
+  contents: read
+
 jobs:
   test-phpmd:
     name: PHP Mess Detector

--- a/.github/workflows/phpstan-tests.yml
+++ b/.github/workflows/phpstan-tests.yml
@@ -11,6 +11,10 @@ on:
     # - '*.php'
     - 'phpstan.neon.dist'
     - 'composer.*'
+
+permissions:
+  contents: read
+
 jobs:
   test-phpstan:
     name: PHPStan for WordPress

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -11,6 +11,10 @@ on:
     - '*.php'
     - 'phpunit.xml.dist'
     - 'composer.*'
+
+permissions:
+  contents: read
+
 jobs:
   test-php:
     name: ${{ matrix.php_versions }} on ${{ matrix.os }}

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -36,6 +36,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   zip:
@@ -115,6 +118,9 @@ jobs:
     name: Comment with playground link
     needs: zip  # Ensure this runs after zip job.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -24,6 +24,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-coverage:
     name: Check Test Coverage on Changed Files

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,6 +5,9 @@ on:
       - develop
       - main
 
+permissions:
+  contents: read
+
 jobs:
   sonarcloud:
     name: 'PHPUnit and Jest Tests'

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -7,6 +7,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   typos:
     name: Spell Check with Typos

--- a/.github/workflows/wordpress-org-deploy.yml
+++ b/.github/workflows/wordpress-org-deploy.yml
@@ -3,7 +3,10 @@ name: Deploy to WordPress.org Repository
 on:
   release:
     types: [published]
-    
+
+permissions:
+  contents: write
+
 jobs:
   deploy_to_wp_repository:
     name: Deploy to WP.org

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -13,6 +13,9 @@ on: # rebuild any PRs and main branch changes
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   wp-org-plugin-guidelines:
     runs-on: ubuntu-latest

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
@@ -157,17 +157,20 @@ class Test_Rsvp extends Base {
 			. 'visibility class.'
 		);
 		$this->assertStringContainsString(
-			'<div class="gatherpress--is-hidden" data-rsvp-status="no_status"><p class="wp-block-paragraph">No status content</p></div>',
+			'<div class="gatherpress--is-hidden" data-rsvp-status="no_status">'
+			. '<p class="wp-block-paragraph">No status content</p></div>',
 			$result,
 			'The transform_block_content method should mark content for the no_status status as not visible.'
 		);
 		$this->assertStringContainsString(
-			'<div class="gatherpress--is-hidden" data-rsvp-status="waiting_list"><p class="wp-block-paragraph">Waiting List content</p></div>',
+			'<div class="gatherpress--is-hidden" data-rsvp-status="waiting_list">'
+			. '<p class="wp-block-paragraph">Waiting List content</p></div>',
 			$result,
 			'The transform_block_content method should mark content for the waiting_list status as not visible.'
 		);
 		$this->assertStringContainsString(
-			'<div class="gatherpress--is-hidden" data-rsvp-status="not_attending"><p class="wp-block-paragraph">Not Attending content</p></div>',
+			'<div class="gatherpress--is-hidden" data-rsvp-status="not_attending">'
+			. '<p class="wp-block-paragraph">Not Attending content</p></div>',
 			$result,
 			'The transform_block_content method should mark content for the not_attending status as not visible.'
 		);

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
@@ -151,23 +151,23 @@ class Test_Rsvp extends Base {
 			'The transform_block_content method should correctly mark the active RSVP status as attending.'
 		);
 		$this->assertStringContainsString(
-			'<div class="" data-rsvp-status="attending"><p>Attending content</p></div>',
+			'<div class="" data-rsvp-status="attending"><p class="wp-block-paragraph">Attending content</p></div>',
 			$result,
 			'The transform_block_content method should display content for the attending status without a '
 			. 'visibility class.'
 		);
 		$this->assertStringContainsString(
-			'<div class="gatherpress--is-hidden" data-rsvp-status="no_status"><p>No status content</p></div>',
+			'<div class="gatherpress--is-hidden" data-rsvp-status="no_status"><p class="wp-block-paragraph">No status content</p></div>',
 			$result,
 			'The transform_block_content method should mark content for the no_status status as not visible.'
 		);
 		$this->assertStringContainsString(
-			'<div class="gatherpress--is-hidden" data-rsvp-status="waiting_list"><p>Waiting List content</p></div>',
+			'<div class="gatherpress--is-hidden" data-rsvp-status="waiting_list"><p class="wp-block-paragraph">Waiting List content</p></div>',
 			$result,
 			'The transform_block_content method should mark content for the waiting_list status as not visible.'
 		);
 		$this->assertStringContainsString(
-			'<div class="gatherpress--is-hidden" data-rsvp-status="not_attending"><p>Not Attending content</p></div>',
+			'<div class="gatherpress--is-hidden" data-rsvp-status="not_attending"><p class="wp-block-paragraph">Not Attending content</p></div>',
 			$result,
 			'The transform_block_content method should mark content for the not_attending status as not visible.'
 		);
@@ -230,7 +230,7 @@ class Test_Rsvp extends Base {
 		$result        = $instance->transform_block_content( $block_content, $block );
 
 		$this->assertStringContainsString(
-			'<p>Past content</p>',
+			'<p class="wp-block-paragraph">Past content</p>',
 			$result,
 			'The transform_block_content method should include the "past" status content for a past event.'
 		);


### PR DESCRIPTION
### Description of the Change
Adds explicit `permissions:` blocks to the 13 workflows that were running with the default GITHUB_TOKEN scope, closing 18 `actions/missing-workflow-permissions` code scanning alerts. Each workflow gets the minimum it needs: read-only for CI/lint, `pull-requests: write` for the two workflows that post PR comments (`pr-coverage`, `playground-preview` comment job), and `contents: write` for the wp.org release deploy that uploads release assets.

### How to test the Change
1. Open this PR and confirm the affected workflows still run successfully on push/PR events.
2. Confirm `pr-coverage` still posts its coverage comment and `playground-preview` still posts its preview link comment.
3. Verify the GitHub code scanning tab shows the 18 `actions/missing-workflow-permissions` alerts resolved.

### Changelog Entry
> Security - Lock down GITHUB_TOKEN permissions across CI workflows.

### Credits
Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.