### PR TITLE
Split privileged PR workflows to remove untrusted-checkout and cache-poisoning exposure

### DIFF
--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -168,9 +168,11 @@ function createPlaygroundLinks( blueprint, prText) {
  *
  * @param {object} github - An authenticated GitHub API instance.
  * @param {object} context - The context of the event.
+ * @param {number} [prNumberOverride] - Explicit PR number; required when called from a workflow_run
+ *   context where context.payload.pull_request is not present.
  */
-async function createPreviewLinksComment(github, context) {
-	const prNumber       = context.payload.pull_request.number;
+async function createPreviewLinksComment(github, context, prNumberOverride) {
+	const prNumber       = prNumberOverride ?? context.payload.pull_request.number;
 	const zipArtifactUrl = createBlueprintUrl(context.repo, prNumber);  // URL to the built plugin artifact
 	const prText         = `for PR#${prNumber}`;  // Descriptive text for the PR
 

--- a/.github/scripts/pr-coverage-comment/index.js
+++ b/.github/scripts/pr-coverage-comment/index.js
@@ -61,9 +61,11 @@ function formatCoverageComment(phpOutput, jsOutput, phpStatus, jsStatus) {
  * @param {string} jsOutput  JavaScript coverage check output.
  * @param {string} phpStatus PHP coverage check status ('success' or 'failure').
  * @param {string} jsStatus  JavaScript coverage check status ('success' or 'failure').
+ * @param {number} [prNumberOverride] Explicit PR number; required when called from a workflow_run
+ *   context where context.payload.pull_request is not present.
  */
-async function createCoverageComment(github, context, phpOutput, jsOutput, phpStatus, jsStatus) {
-	const prNumber = context.payload.pull_request.number;
+async function createCoverageComment(github, context, phpOutput, jsOutput, phpStatus, jsStatus, prNumberOverride) {
+	const prNumber = prNumberOverride ?? context.payload.pull_request.number;
 
 	const repoData = {
 		owner: context.repo.owner,

--- a/.github/workflows/playground-preview-comment.yml
+++ b/.github/workflows/playground-preview-comment.yml
@@ -1,0 +1,58 @@
+name: Playground Preview Comment
+
+# Privileged companion to the `Playground Preview` workflow.
+#
+# Triggered when the build workflow finishes, downloads its artifact, and posts
+# the PR comment with playground links. Because this runs via workflow_run, it
+# executes from the base repo's default branch — never from PR-controlled code
+# — even though it has `pull-requests: write` to post the comment.
+
+on:
+  workflow_run:
+    workflows: ['Playground Preview']
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+
+  comment:
+    name: Comment with playground link
+    # Only post for successful PR runs. Skips push/scheduled invocations of
+    # the upstream workflow (none today, but defensive) and failed builds.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Download build artifact from upstream workflow
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.event.repository.name }}-pr
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number from artifact
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      # Check out the base repo at the default branch (trusted code) so the
+      # github-script step below can require .github/scripts/playground-preview
+      # from the merged base, never from the PR.
+      - name: Checkout base repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Add Preview Links comment
+        uses: actions/github-script@v7
+        env:
+          PHP_VERSIONS: '["8.4","8.2","7.4"]'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const createPreviewLinks = require('.github/scripts/playground-preview');
+            await createPreviewLinks(github, context, ${{ steps.pr.outputs.number }});

--- a/.github/workflows/playground-preview-comment.yml
+++ b/.github/workflows/playground-preview-comment.yml
@@ -51,8 +51,9 @@ jobs:
         uses: actions/github-script@v7
         env:
           PHP_VERSIONS: '["8.4","8.2","7.4"]'
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const createPreviewLinks = require('.github/scripts/playground-preview');
-            await createPreviewLinks(github, context, ${{ steps.pr.outputs.number }});
+            await createPreviewLinks(github, context, Number(process.env.PR_NUMBER));

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -3,25 +3,20 @@
 # The plugin-proxy.php does a check against exact this workflow name.
 name: Playground Preview
 
-# Inspired by, but not based on https://github.com/WordPress/gutenberg/blob/b89fb7b6eaf619bde0269e2a7fbf6245822f6cbf/.github/workflows/build-plugin-zip.yml#L153
+# Why pull_request (not pull_request_target)?
+#
+# This workflow checks out and builds PR code (npm ci, npm run build) which is
+# fundamentally untrusted. Running that on pull_request_target gives the PR's
+# build scripts access to the base repo's GITHUB_TOKEN — a supply-chain attack
+# surface (CodeQL flagged this as actions/untrusted-checkout/critical).
+#
+# The companion workflow `Playground Preview Comment` consumes this run's
+# artifact via workflow_run, runs in the privileged base-repo context with
+# `pull-requests: write`, and posts the preview-links PR comment — without ever
+# executing PR code.
 
 on:
-  # What and Why pull_request_target?
-  # https://github.com/GatherPress/gatherpress/pull/666#issuecomment-2143088443
-  #
-  # The GitHub Actions built in environment variables and Context
-  # of pull_request_target event are different from those of pull_request event.
-  #
-  # For example, the following environment variables and context are different.
-  #
-  # - event_name, GITHUB_EVENT_NAME
-  # - ref, GITHUB_REF
-  # - sha, GITHUB_SHA
-  # - ref_name, GITHUB_REF_NAME
-  #
-  # @source https://dev.to/suzukishunsuke/secure-github-actions-by-pullrequesttarget-641#modify-workflows-for-pullrequesttarget
-
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
     paths:
     - 'build/**'
@@ -31,9 +26,7 @@ on:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-  # The concurrency group contains the workflow name and the branch name for pull requests
-  # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 permissions:
@@ -46,19 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # To checkout the merged commit with actions/checkout on pull_request_target event,
-      # you need to get the pull request by GitHub API
-      # and set the merge commit hash to actions/checkout input ref.
-      #
-      # @source https://dev.to/suzukishunsuke/secure-github-actions-by-pullrequesttarget-641#checkout-merge-commits
-      - uses: suzuki-shunsuke/get-pr-action@v0.1.0
-        id: pr
-
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.pr.outputs.merge_commit_sha }}
-          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -74,33 +56,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          # Enable built-in functionality for caching and restoring dependencies, which is disabled by default.
-          # The actions/setup-node uses actions/cache under the hood.
-          # https://github.com/actions/setup-node#caching-global-packages-data
+          # The built-in setup-node cache (keyed by package-lock.json hash) is
+          # safe for untrusted PR code; the prior manual actions/cache restore
+          # of ./node_modules was flagged as poisonable and is intentionally
+          # removed.
           cache: 'npm'
 
-      # Restoring the short lived node_modules cache
-      # to be used across all workflows running on the last commit.
-      # https://github.com/actions/cache/blob/main/caching-strategies.md#creating-a-short-lived-cache
-      - uses: actions/cache/restore@v4
-        id: node_modules-cache
-        with:
-          path: |
-            ./node_modules
-          key: ${{ runner.os }}-node_modules-${{ steps.pr.outputs.merge_commit_sha }}-${{ hashFiles('package-lock.json') }}
-
       - name: NPM install
-        if: steps.node_modules-cache.outputs.cache-hit != 'true'
         run: npm ci
-
-      # Creating a short lived node_modules cache
-      - uses: actions/cache/save@v4
-        if: steps.node_modules-cache.outputs.cache-hit != 'true'
-        continue-on-error: true
-        with:
-          path: |
-            ./node_modules
-          key: ${{ steps.node_modules-cache.outputs.cache-primary-key }}
 
       - name: Build plugin
         # - [Incorrect version number used when creating zip archive · Issue #92 · wp-cli/dist-archive-command](https://github.com/wp-cli/dist-archive-command/issues/92)
@@ -108,31 +71,13 @@ jobs:
           npm run build
           wp dist-archive . ./${{ github.event.repository.name }}.zip
 
+      - name: Save PR number for downstream comment workflow
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.repository.name }}-pr
-          path: ./${{ github.event.repository.name }}.zip
-
-  comment:
-    name: Comment with playground link
-    needs: zip  # Ensure this runs after zip job.
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Add Preview Links comment
-        id: comment-on-pr
-        uses: actions/github-script@v7
-        env:
-          PHP_VERSIONS: '["8.4","8.2","7.4"]'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const createPreviewLinks = require('.github/scripts/playground-preview');
-            createPreviewLinks(github, context);
+          path: |
+            ./${{ github.event.repository.name }}.zip
+            pr-number.txt

--- a/.github/workflows/pr-coverage-comment.yml
+++ b/.github/workflows/pr-coverage-comment.yml
@@ -1,0 +1,87 @@
+name: PR Coverage Comment
+
+# Privileged companion to the `PR Coverage Check` workflow.
+#
+# Triggered when the upstream coverage run finishes (success or failure),
+# downloads its artifact, and posts the coverage PR comment. Because this runs
+# via workflow_run, it executes from the base repo's default branch — never
+# from PR-controlled code — even though it has `pull-requests: write` to post
+# the comment.
+
+on:
+  workflow_run:
+    workflows: ['PR Coverage Check']
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+
+  comment:
+    name: Post coverage comment on PR
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Download coverage artifact from upstream workflow
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-coverage-results
+          # Drop the artifact in a sibling directory so the base-repo checkout
+          # below doesn't overwrite it.
+          path: ./artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata from artifact
+        id: meta
+        run: |
+          echo "pr_number=$(cat ./artifact/pr-number.txt)" >> "$GITHUB_OUTPUT"
+          echo "php_status=$(cat ./artifact/php-status.txt)" >> "$GITHUB_OUTPUT"
+          echo "js_status=$(cat ./artifact/js-status.txt)" >> "$GITHUB_OUTPUT"
+
+      # Check out the base repo at the default branch (trusted code) so the
+      # github-script step below can require .github/scripts/pr-coverage-comment
+      # from the merged base, never from the PR.
+      - name: Checkout base repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Post coverage comment
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          PHP_STATUS: ${{ steps.meta.outputs.php_status }}
+          JS_STATUS: ${{ steps.meta.outputs.js_status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const createCoverageComment = require('.github/scripts/pr-coverage-comment');
+
+            let phpOutput;
+            try {
+              phpOutput = fs.readFileSync('./artifact/php-coverage-output.txt', 'utf8');
+            } catch {
+              phpOutput = 'PHP coverage check did not run.';
+            }
+
+            let jsOutput;
+            try {
+              jsOutput = fs.readFileSync('./artifact/js-coverage-output.txt', 'utf8');
+            } catch {
+              jsOutput = 'JavaScript coverage check did not run.';
+            }
+
+            await createCoverageComment(
+              github,
+              context,
+              phpOutput,
+              jsOutput,
+              process.env.PHP_STATUS,
+              process.env.JS_STATUS,
+              Number(process.env.PR_NUMBER)
+            );

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -1,7 +1,20 @@
 name: PR Coverage Check
 
+# Why pull_request (not pull_request_target)?
+#
+# This workflow checks out and executes PR code (composer install, npm install,
+# npm run build, the PHPUnit/Jest suites). Running that on pull_request_target
+# would give the PR's build/test scripts access to the base repo's
+# pull-requests:write token — a supply-chain attack surface (CodeQL flagged
+# this as actions/untrusted-checkout/critical).
+#
+# The companion workflow `PR Coverage Comment` consumes this run's artifact
+# via workflow_run, runs in the privileged base-repo context with
+# `pull-requests: write`, and posts the coverage PR comment — without ever
+# executing PR code.
+
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - develop
       - main
@@ -26,7 +39,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   check-coverage:
@@ -34,14 +46,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get PR merge commit
-        uses: suzuki-shunsuke/get-pr-action@v0.1.0
-        id: pr
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.pr.outputs.merge_commit_sha }}
           fetch-depth: 0  # Fetch all history for all branches and tags.
 
       - name: Setup PHP
@@ -104,41 +111,29 @@ jobs:
           GITHUB_BASE_REF: ${{ github.base_ref }}
         continue-on-error: true  # Continue to show all results before failing
 
-      - name: Post coverage comment on PR
+      - name: Save PR metadata for downstream comment workflow
         if: always()
-        uses: actions/github-script@v7
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr-number.txt
+          echo "${{ steps.php-coverage.outcome }}" > php-status.txt
+          echo "${{ steps.js-coverage.outcome }}" > js-status.txt
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const createCoverageComment = require('.github/scripts/pr-coverage-comment');
-
-            // Read coverage output files.
-            let phpOutput = '';
-            let jsOutput = '';
-
-            try {
-              phpOutput = fs.readFileSync('php-coverage-output.txt', 'utf8');
-            } catch (e) {
-              phpOutput = 'PHP coverage check did not run.';
-            }
-
-            try {
-              jsOutput = fs.readFileSync('js-coverage-output.txt', 'utf8');
-            } catch (e) {
-              jsOutput = 'JavaScript coverage check did not run.';
-            }
-
-            // Get the status of each coverage check.
-            const phpStatus = '${{ steps.php-coverage.outcome }}';
-            const jsStatus = '${{ steps.js-coverage.outcome }}';
-
-            await createCoverageComment(github, context, phpOutput, jsOutput, phpStatus, jsStatus);
+          name: pr-coverage-results
+          path: |
+            php-coverage-output.txt
+            js-coverage-output.txt
+            pr-number.txt
+            php-status.txt
+            js-status.txt
 
       - name: Fail if coverage checks failed
         if: steps.php-coverage.outcome == 'failure' || steps.js-coverage.outcome == 'failure'
         run: |
-          echo "❌ One or more coverage checks failed. See the PR comment for details."
+          echo "One or more coverage checks failed. See the PR comment for details."
           exit 1
 
       - name: Stop WordPress environment


### PR DESCRIPTION
### Description of the Change
Splits `Playground Preview` and `PR Coverage Check` from single `pull_request_target` workflows into a pair each: a low-privilege `pull_request` build/test workflow (no secrets, runs PR code) that uploads an artifact, plus a `workflow_run` companion (`Playground Preview Comment`, `PR Coverage Comment`) that downloads the artifact, checks out the base repo's default branch (trusted code), and posts the PR comment with `pull-requests: write`. The PR comment scripts now accept an explicit PR number argument since `context.payload.pull_request` is not present in a `workflow_run` context. The manual `actions/cache` restore/save of `./node_modules` in the playground build is dropped in favor of setup-node's safe built-in npm cache. Closes the remaining critical `actions/untrusted-checkout` and high `actions/cache-poisoning` code-scanning alerts.

### How to test the Change
1. After merge to `develop`, open a throwaway PR that touches any of the watched paths.
2. Confirm `Playground Preview` runs on the PR and uploads the `gatherpress-pr` artifact; `Playground Preview Comment` then fires and posts the preview-links comment.
3. Confirm `PR Coverage Check` runs and uploads `pr-coverage-results`; `PR Coverage Comment` fires and posts the coverage report comment.
4. Verify GitHub code scanning shows the `actions/untrusted-checkout/critical` and `actions/cache-poisoning/*` alerts on these two workflows resolved.

### Changelog Entry
> Security - Split privileged PR workflows so untrusted PR code no longer runs with `pull-requests: write` and no longer poisons shared caches.

### Credits
Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.