### PR TITLE
Use core/editor for isEditorPanelOpened (deprecated on core/edit-post in WP 6.5)

### DIFF
--- a/src/panels/event-settings/index.js
+++ b/src/panels/event-settings/index.js
@@ -134,14 +134,14 @@ registerPlugin( 'gatherpress-event-settings', {
  * @return {void}
  */
 domReady( () => {
-	const selectEditPost = select( 'core/edit-post' );
+	const selectEditor = select( 'core/editor' );
 	const dispatchEditor = dispatch( 'core/editor' );
 
-	if ( ! selectEditPost || ! dispatchEditor ) {
+	if ( ! selectEditor || ! dispatchEditor ) {
 		return;
 	}
 
-	const isEventSettingsPanelOpen = selectEditPost.isEditorPanelOpened(
+	const isEventSettingsPanelOpen = selectEditor.isEditorPanelOpened(
 		'gatherpress-event-settings/gatherpress-event-settings',
 	);
 


### PR DESCRIPTION
### Description of the Change
Switches the event-settings panel auto-open in `src/panels/event-settings/index.js` from `select('core/edit-post').isEditorPanelOpened` to `select('core/editor').isEditorPanelOpened`, which is the non-deprecated equivalent (deprecated on `core/edit-post` since WordPress 6.5). The variable is renamed from `selectEditPost` to `selectEditor` to match. `core/editor` is available in both the post editor and the site editor, so the existing guard still works.

Closes #1644

### How to test the Change
1. Run `npm start` (dev build — production builds strip deprecation warnings).
2. Open any post/event in the block editor.
3. Open DevTools, switch the Console context to the editor iframe, ensure the "Warnings" level filter is enabled.
4. Confirm the `select( 'core/edit-post' ).isEditorPanelOpened is deprecated` message no longer appears.
5. Confirm the Event Settings panel still auto-opens on an event edit screen as before.

### Changelog Entry
> Fixed - Stop calling the deprecated `select('core/edit-post').isEditorPanelOpened`; use `select('core/editor').isEditorPanelOpened` instead.

### Credits
Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.