### PR TITLE
Move gatherpress-utility-style enqueue onto enqueue_block_assets so it reaches the editor iframe

### DIFF
--- a/docs/developer/blocks/README.md
+++ b/docs/developer/blocks/README.md
@@ -6,3 +6,5 @@
 3. [Slots & fills in GatherPress Admin UI](./slot-fills/)
 4. [Pattern pickers](./pattern-pickers.md)
     - JS filters for adding starter patterns to GatherPress blocks (RSVP Response and others)
+5. [Sharing the GatherPress utility stylesheet with your own blocks](./sharing-utility-styles.md)
+    - Opt a companion plugin's block prefix into GatherPress's shared utility CSS so blocks can reuse helpers like `gatherpress--is-hidden` without duplicating the stylesheet.

--- a/docs/developer/blocks/sharing-utility-styles.md
+++ b/docs/developer/blocks/sharing-utility-styles.md
@@ -1,0 +1,79 @@
+# Sharing the GatherPress utility stylesheet with your own blocks
+
+GatherPress ships a small shared utility stylesheet (`gatherpress-utility-style`,
+sourced from `build/utility_style.css`) used by GatherPress's own blocks for
+things like the `gatherpress--is-hidden` visibility helper that drives RSVP
+status switching, tooltip variables, and other primitives shared across the
+block library.
+
+On the frontend, GatherPress only enqueues the utility stylesheet when a block
+whose name starts with `gatherpress/` is actually rendered, so pages without
+any GatherPress block don't pay for the CSS.
+
+Companion plugins and themes can opt their own blocks into the same coverage
+by adding their block-name prefix to the
+`gatherpress_asset_utility_style_block_prefixes` filter.
+
+## When to use this filter
+
+Use this filter when your block:
+
+- Renders markup that relies on classes defined in `utility_style.css` (e.g.
+  `gatherpress--is-hidden`), and
+- You'd rather inherit the host plugin's CSS than maintain your own copy that
+  could drift if GatherPress changes a class name.
+
+If your block doesn't use any of those classes, you don't need this filter —
+WordPress will load only the styles your own block registers.
+
+## How it works
+
+GatherPress always handles the `gatherpress/` prefix itself. The filter is
+purely additive: whatever array you return is merged with `gatherpress/`
+before the prefix match runs, so you cannot accidentally break GatherPress's
+own blocks by replacing the array — you can only add to it.
+
+## Example
+
+A companion plugin that ships blocks under the `gatherpress-awesome/`
+namespace can opt them all in with one filter callback:
+
+```php
+add_filter(
+    'gatherpress_asset_utility_style_block_prefixes',
+    static function ( array $prefixes ): array {
+        $prefixes[] = 'gatherpress-awesome/';
+        return $prefixes;
+    }
+);
+```
+
+After this runs, any block whose `blockName` begins with `gatherpress-awesome/`
+will cause `gatherpress-utility-style` to be enqueued on the page when that
+block is rendered, alongside GatherPress's own blocks.
+
+You can add multiple prefixes at once:
+
+```php
+add_filter(
+    'gatherpress_asset_utility_style_block_prefixes',
+    static function ( array $prefixes ): array {
+        $prefixes[] = 'gatherpress-awesome/';
+        $prefixes[] = 'gatherpress-productions/';
+        return $prefixes;
+    }
+);
+```
+
+## Caveats
+
+- The filter is matched as a **prefix** (via `str_starts_with`). Pass the
+  trailing slash (`my-plugin/`) so it doesn't accidentally match unrelated
+  namespaces like `my-plugin-extra/`.
+- The utility stylesheet is registered under the handle
+  `gatherpress-utility-style`. If you need it loaded in a non-block context
+  (e.g. a settings screen of your own), enqueue it directly by handle.
+- Frontend enqueue is gated on `render_block` for prefixes returned by the
+  filter. Blocks rendered exclusively client-side (without ever hitting
+  PHP `render_block`) won't trigger the enqueue — fall back to enqueuing
+  the handle yourself in that case.

--- a/docs/developer/hooks-naming-convention.md
+++ b/docs/developer/hooks-naming-convention.md
@@ -29,6 +29,7 @@ The subsystem segment names a single area of the plugin. The current set:
 
 | Subsystem | Covers |
 |---|---|
+| `asset_*` | Stylesheet/script registration, enqueue gating, and block-asset coverage shared with companion plugins. |
 | `event_*` | Event lifecycle, queries, feed output. |
 | `venue_*` | Venue post type resolution, structured-address sync. |
 | `rsvp_*` | RSVP storage (comment-based), attendee management, comment-query coexistence. |

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -92,7 +92,7 @@ class Assets {
 	 */
 	protected function setup_hooks(): void {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-		add_action( 'enqueue_block_assets', array( $this, 'block_enqueue_scripts' ) );
+		add_action( 'enqueue_block_assets', array( $this, 'register_block_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'editor_enqueue_scripts' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_variation_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_aql_integration' ) );
@@ -179,19 +179,30 @@ class Assets {
 	}
 
 	/**
-	 * Enqueue necessary frontend styles and scripts.
+	 * Register the shared utility stylesheet and enqueue it in the block editor.
 	 *
-	 * This method is responsible for enqueuing essential frontend styles and scripts
-	 * required for the proper functioning of the plugin on the frontend.
+	 * Hooked on `enqueue_block_assets`, which fires in two contexts with
+	 * different responsibilities:
+	 *
+	 * - Frontend: registers the `gatherpress-utility-style` handle so other
+	 *   code paths can enqueue it by name. The actual frontend enqueue is
+	 *   delegated to `maybe_enqueue_styles()` on the `render_block` filter,
+	 *   which only fires the enqueue when a `gatherpress/*` block is being
+	 *   rendered — so frontends that don't use a gatherpress block don't
+	 *   load the CSS.
+	 *
+	 * - Block editor: also enqueues unconditionally so the stylesheet lands
+	 *   inside the editor canvas iframe. `enqueue_block_assets` is the
+	 *   documented hook for iframe-bound styles; `enqueue_block_editor_assets`
+	 *   only reaches the wrapper UI, and a late, `render_block`-driven enqueue
+	 *   during dynamic-block rendering trips the "stylesheet was added to the
+	 *   iframe incorrectly" warning in newer WordPress (issue #1645).
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
-	public function block_enqueue_scripts(): void {
-		// @todo remove once new blocks are completed.
-		wp_enqueue_style( 'dashicons' );
-
+	public function register_block_assets(): void {
 		$asset = $this->get_asset_data( 'utility_style' );
 
 		wp_register_style(
@@ -200,6 +211,10 @@ class Assets {
 			$asset['dependencies'],
 			$asset['version']
 		);
+
+		if ( is_admin() ) {
+			wp_enqueue_style( 'gatherpress-utility-style' );
+		}
 	}
 
 	/**
@@ -330,7 +345,7 @@ class Assets {
 
 			// Shared utility classes (`gatherpress--is-hidden`, etc.) used by
 			// settings UI like the `show_if` row visibility toggle. The handle
-			// is registered on the frontend in `block_enqueue_scripts`; re-
+			// is registered on the frontend in `register_block_assets`; re-
 			// register here so it's available on admin settings pages too.
 			$utility_asset = $this->get_asset_data( 'utility_style' );
 
@@ -400,7 +415,11 @@ class Assets {
 			true
 		);
 
-		wp_enqueue_style( 'gatherpress-utility-style' );
+		// `gatherpress-utility-style` is enqueued from `register_block_assets`
+		// (on `enqueue_block_assets`) so it reaches the editor canvas iframe.
+		// Enqueuing it here on `enqueue_block_editor_assets` only loaded it in
+		// the wrapper UI and triggered an "added to the iframe incorrectly"
+		// warning in newer WordPress.
 
 		wp_set_script_translations( 'gatherpress-editor', 'gatherpress' );
 	}

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -227,8 +227,31 @@ class Assets {
 	 * @return string The block content.
 	 */
 	public function maybe_enqueue_styles( string $block_content, array $block ): string {
-		if ( isset( $block['blockName'] ) && str_contains( $block['blockName'], 'gatherpress/' ) ) {
-			wp_enqueue_style( 'gatherpress-utility-style' );
+		if ( ! isset( $block['blockName'] ) ) {
+			return $block_content;
+		}
+
+		/**
+		 * Filters additional block-name prefixes whose blocks should
+		 * auto-enqueue the GatherPress utility stylesheet.
+		 *
+		 * Companion plugins and themes can use this filter to share the
+		 * utility CSS with their own blocks (e.g. `gatherpress-awesome/`).
+		 * The `gatherpress/` prefix is appended after this filter runs and
+		 * cannot be removed through it.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string[] $prefixes Additional block-name prefixes to match.
+		 */
+		$prefixes   = (array) apply_filters( 'gatherpress_asset_utility_style_block_prefixes', array() );
+		$prefixes[] = 'gatherpress/';
+
+		foreach ( $prefixes as $prefix ) {
+			if ( str_starts_with( $block['blockName'], (string) $prefix ) ) {
+				wp_enqueue_style( 'gatherpress-utility-style' );
+				break;
+			}
 		}
 
 		return $block_content;

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -430,6 +430,70 @@ class Test_Assets extends Base {
 	}
 
 	/**
+	 * Coverage for maybe_enqueue_styles with a third-party prefix added via the
+	 * `gatherpress_asset_utility_style_block_prefixes` filter.
+	 *
+	 * @covers ::maybe_enqueue_styles
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_styles_filter_adds_extra_prefix(): void {
+		$instance = Assets::get_instance();
+
+		$instance->register_block_assets();
+		wp_dequeue_style( 'gatherpress-utility-style' );
+
+		$callback = static function (): array {
+			return array( 'gatherpress-awesome/' );
+		};
+		add_filter( 'gatherpress_asset_utility_style_block_prefixes', $callback );
+
+		$block_content = '<div>Test</div>';
+		$block         = array( 'blockName' => 'gatherpress-awesome/showcase' );
+
+		$instance->maybe_enqueue_styles( $block_content, $block );
+
+		remove_filter( 'gatherpress_asset_utility_style_block_prefixes', $callback );
+
+		$this->assertTrue(
+			wp_style_is( 'gatherpress-utility-style', 'enqueued' ),
+			'Failed to assert gatherpress-utility-style is enqueued for a filter-added prefix.'
+		);
+	}
+
+	/**
+	 * `gatherpress/` is appended after the filter runs, so a filter that omits
+	 * (or replaces) the array still leaves GatherPress's own blocks covered.
+	 *
+	 * @covers ::maybe_enqueue_styles
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_styles_filter_cannot_remove_gatherpress_prefix(): void {
+		$instance = Assets::get_instance();
+
+		$instance->register_block_assets();
+		wp_dequeue_style( 'gatherpress-utility-style' );
+
+		$callback = static function (): array {
+			return array();
+		};
+		add_filter( 'gatherpress_asset_utility_style_block_prefixes', $callback );
+
+		$block_content = '<div>Test</div>';
+		$block         = array( 'blockName' => 'gatherpress/event-date' );
+
+		$instance->maybe_enqueue_styles( $block_content, $block );
+
+		remove_filter( 'gatherpress_asset_utility_style_block_prefixes', $callback );
+
+		$this->assertTrue(
+			wp_style_is( 'gatherpress-utility-style', 'enqueued' ),
+			'Failed to assert gatherpress-utility-style is still enqueued for gatherpress/ blocks when the filter returns an empty array.'
+		);
+	}
+
+	/**
 	 * Coverage for editor_enqueue_scripts method.
 	 *
 	 * @covers ::editor_enqueue_scripts

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -489,7 +489,8 @@ class Test_Assets extends Base {
 
 		$this->assertTrue(
 			wp_style_is( 'gatherpress-utility-style', 'enqueued' ),
-			'Failed to assert gatherpress-utility-style is still enqueued for gatherpress/ blocks when the filter returns an empty array.'
+			'Failed to assert gatherpress-utility-style is still enqueued for gatherpress/ blocks '
+			. 'when the filter returns an empty array.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -41,7 +41,7 @@ class Test_Assets extends Base {
 				'type'     => 'action',
 				'name'     => 'enqueue_block_assets',
 				'priority' => 10,
-				'callback' => array( $instance, 'block_enqueue_scripts' ),
+				'callback' => array( $instance, 'register_block_assets' ),
 			),
 			array(
 				'type'     => 'action',
@@ -231,17 +231,51 @@ class Test_Assets extends Base {
 
 
 	/**
-	 * Coverage for block_enqueue_scripts.
+	 * Coverage for register_block_assets.
 	 *
-	 * @covers ::block_enqueue_scripts
+	 * Registers `gatherpress-utility-style` in every context and additionally
+	 * enqueues it in the block editor (where `is_admin()` is true) so the
+	 * stylesheet lands inside the editor canvas iframe via the
+	 * `enqueue_block_assets` hook.
+	 *
+	 * @covers ::register_block_assets
 	 *
 	 * @return void
 	 */
-	public function test_block_enqueue_scripts(): void {
+	public function test_register_block_assets(): void {
 		$instance = Assets::get_instance();
-		$instance->block_enqueue_scripts();
 
-		$this->assertTrue( wp_style_is( 'dashicons', 'enqueued' ) );
+		// Frontend context: style registered but not enqueued (the per-block
+		// `maybe_enqueue_styles` filter handles conditional frontend loading).
+		set_current_screen( 'front' );
+		wp_dequeue_style( 'gatherpress-utility-style' );
+
+		$instance->register_block_assets();
+
+		$this->assertTrue(
+			wp_style_is( 'gatherpress-utility-style', 'registered' ),
+			'Failed to assert gatherpress-utility-style is registered on frontend.'
+		);
+		$this->assertFalse(
+			wp_style_is( 'gatherpress-utility-style', 'enqueued' ),
+			'Failed to assert gatherpress-utility-style is not enqueued on frontend.'
+		);
+
+		// Admin / block-editor context: style is also enqueued so it reaches
+		// the editor canvas iframe (issue #1645).
+		set_current_screen( 'post.php' );
+		wp_dequeue_style( 'gatherpress-utility-style' );
+
+		$instance->register_block_assets();
+
+		$this->assertTrue(
+			wp_style_is( 'gatherpress-utility-style', 'enqueued' ),
+			'Failed to assert gatherpress-utility-style is enqueued in the block editor.'
+		);
+
+		// Reset for downstream tests.
+		set_current_screen( 'front' );
+		wp_dequeue_style( 'gatherpress-utility-style' );
 	}
 
 	/**
@@ -304,7 +338,7 @@ class Test_Assets extends Base {
 		$instance = Assets::get_instance();
 
 		// First register the utility style.
-		$instance->block_enqueue_scripts();
+		$instance->register_block_assets();
 
 		$block_content = '<div class="wp-block-gatherpress-event-date">Test</div>';
 		$block         = array(
@@ -340,7 +374,7 @@ class Test_Assets extends Base {
 		$instance = Assets::get_instance();
 
 		// First register the utility style.
-		$instance->block_enqueue_scripts();
+		$instance->register_block_assets();
 
 		// Dequeue if it was enqueued by previous test.
 		wp_dequeue_style( 'gatherpress-utility-style' );
@@ -374,7 +408,7 @@ class Test_Assets extends Base {
 		$instance = Assets::get_instance();
 
 		// First register the utility style.
-		$instance->block_enqueue_scripts();
+		$instance->register_block_assets();
 
 		// Dequeue if it was enqueued by previous test.
 		wp_dequeue_style( 'gatherpress-utility-style' );
@@ -405,8 +439,12 @@ class Test_Assets extends Base {
 	public function test_editor_enqueue_scripts(): void {
 		$instance = Assets::get_instance();
 
-		// First register the utility style.
-		$instance->block_enqueue_scripts();
+		// First register the utility style. The utility-style enqueue itself
+		// moved into register_block_assets() so it loads on the
+		// `enqueue_block_assets` hook and reaches the editor canvas iframe
+		// (issue #1645); editor_enqueue_scripts() now only enqueues the
+		// editor script.
+		$instance->register_block_assets();
 
 		$this->assertFalse(
 			wp_script_is( 'gatherpress-editor', 'enqueued' ),
@@ -418,10 +456,6 @@ class Test_Assets extends Base {
 		$this->assertTrue(
 			wp_script_is( 'gatherpress-editor', 'enqueued' ),
 			'Failed to assert gatherpress-editor is enqueued.'
-		);
-		$this->assertTrue(
-			wp_style_is( 'gatherpress-utility-style', 'enqueued' ),
-			'Failed to assert gatherpress-utility-style is enqueued in editor.'
 		);
 	}
 
@@ -756,7 +790,7 @@ class Test_Assets extends Base {
 		$instance = Assets::get_instance();
 
 		// First register the utility style.
-		$instance->block_enqueue_scripts();
+		$instance->register_block_assets();
 
 		// Dequeue if it was enqueued by previous test.
 		wp_dequeue_style( 'gatherpress-utility-style' );
@@ -781,7 +815,7 @@ class Test_Assets extends Base {
 		$instance = Assets::get_instance();
 
 		// First register the utility style.
-		$instance->block_enqueue_scripts();
+		$instance->register_block_assets();
 
 		// Call enqueue_tooltip_assets twice - second call should return early.
 		Utility::invoke_hidden_method( $instance, 'enqueue_tooltip_assets' );
@@ -912,7 +946,7 @@ class Test_Assets extends Base {
 		$instance = Assets::get_instance();
 
 		// First register the utility style.
-		$instance->block_enqueue_scripts();
+		$instance->register_block_assets();
 
 		// Dequeue if it was enqueued by previous test.
 		wp_dequeue_style( 'gatherpress-utility-style' );


### PR DESCRIPTION
### Description of the Change

Moves the `gatherpress-utility-style` enqueue from `editor_enqueue_scripts()` (hooked on `enqueue_block_editor_assets`, which only reaches the editor's wrapper UI) into `register_block_assets()` (formerly `block_enqueue_scripts()`, hooked on `enqueue_block_assets`), gated on `is_admin()`. `enqueue_block_assets` is the documented hook for stylesheets that need to land inside the editor canvas iframe; the prior late, `render_block`-driven enqueue during dynamic-block rendering was what triggered WordPress's "stylesheet was added to the iframe incorrectly" warning. Frontend behavior is unchanged — `register_block_assets()` still registers the handle so the per-block `maybe_enqueue_styles()` filter can enqueue it on `render_block` only when a matching block is actually rendered. Also drops the stale `wp_enqueue_style( 'dashicons' )` call (carried a `// @todo remove once new blocks are completed` comment that's now obsolete), renames `block_enqueue_scripts` → `register_block_assets` to match what the method actually does, rewrites the docblock to explain the dual FE-register-only / editor-also-enqueue responsibility, and updates the assets tests for both code paths.

Adds a new `gatherpress_asset_utility_style_block_prefixes` filter so companion plugins and themes can opt their own block-name prefixes into the shared utility CSS (e.g. `gatherpress-awesome/`). The filter is purely additive — `gatherpress/` is appended after the filter runs and cannot be removed through it, so an extender can broaden coverage but not break GatherPress's own blocks. The prefix match is tightened from `str_contains` to `str_starts_with` while in there. Adds an `asset_*` row to the subsystems table in `docs/developer/hooks-naming-convention.md` (matches the existing `gatherpress_asset_critical` filter that wasn't previously listed) and a new `docs/developer/blocks/sharing-utility-styles.md` extender guide (linked from `docs/developer/blocks/README.md`).

Closes #1645

### How to test the Change

1. `npm run start` (dev build — production builds strip the WP iframe warning).
2. Open a post with an Event Query block (or any gatherpress block).
3. Open DevTools, switch the Console context to the editor iframe, ensure the **Warnings** level filter is on.
4. Confirm the "gatherpress-utility-style-css was added to the iframe incorrectly" warning no longer appears.
5. View the source of a frontend page that does **not** render any gatherpress block and confirm `utility_style.css` is not loaded; view a frontend page that does render one and confirm it is.
6. Drop a small test plugin / mu-plugin that calls `add_filter( 'gatherpress_asset_utility_style_block_prefixes', fn( \$p ) => array_merge( \$p, array( 'test-ns/' ) ) );`, render a block with name `test-ns/something` on a page, and confirm the utility CSS is enqueued there too.
7. `npm run test:unit:php` — `Test_Assets` passes (covers both the iframe enqueue path and the two new filter cases).

### Changelog Entry

> Fixed - Stop the "gatherpress-utility-style-css was added to the iframe incorrectly" editor warning by moving the utility-style enqueue onto `enqueue_block_assets`; also drop the stale dashicons enqueue.
> Added - `gatherpress_asset_utility_style_block_prefixes` filter for sharing the GatherPress utility stylesheet with companion-plugin block namespaces.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.