### PR TITLE
Memoize resolved post-type labels to short-circuit useSelect re-runs

### DIFF
--- a/src/helpers/editor.js
+++ b/src/helpers/editor.js
@@ -10,6 +10,59 @@ import { store as coreStore } from '@wordpress/core-data';
 import { isPostTypeSupporting } from './event';
 
 /**
+ * Module-level cache of resolved post-type labels, keyed by
+ * `<postType>::<labelKey>`. Post-type labels are set during
+ * `register_post_type()` and don't change at runtime, so once we've
+ * resolved a non-fallback label we serve it from the cache for the rest
+ * of the editor session.
+ *
+ * This doesn't change how often `usePostTypeLabel`'s selector runs —
+ * `useSelect` re-invokes the selector on every dispatch to the stores it
+ * subscribes to (`core/editor`, `core`), which is many times during
+ * editor init (REST resolutions for post types, taxonomies, etc.). With
+ * the cache the selector body is a Map lookup instead of two store
+ * reads. See issue #1646.
+ *
+ * Exported only for tests; production callers should go through
+ * `getPostTypeLabel` / `usePostTypeLabel`.
+ *
+ * @ignore
+ */
+export const __postTypeLabelCache = new Map();
+
+/**
+ * Look up `<postType>::<labelKey>` in the module cache without performing
+ * any store reads. Callers must have already resolved a truthy `postType`
+ * (both `getPostTypeLabel` and `usePostTypeLabel` short-circuit to the
+ * fallback before this is invoked when no post type is available).
+ *
+ * @param {string} postType Post type slug.
+ * @param {string} key      Label key.
+ * @return {string|undefined} The cached label, or `undefined` if absent.
+ */
+function getCachedLabel( postType, key ) {
+	return __postTypeLabelCache.get( `${ postType }::${ key }` );
+}
+
+/**
+ * Cache a non-empty resolved label.
+ *
+ * No-op for empty / falsy labels so the cache only ever serves real values
+ * — a missed lookup still falls through to the live store read on the next
+ * call so we pick up the label as soon as `core` finishes resolving it.
+ *
+ * @param {string} postType Post type slug.
+ * @param {string} key      Label key.
+ * @param {string} label    Resolved label string.
+ * @return {void}
+ */
+function rememberLabel( postType, key, label ) {
+	if ( label ) {
+		__postTypeLabelCache.set( `${ postType }::${ key }`, label );
+	}
+}
+
+/**
  * Resolve a single label from a post type's registered labels.
  *
  * JS counterpart to `Utility::post_type_label()` — wraps `getPostType()` so
@@ -39,7 +92,13 @@ export function getPostTypeLabel( key, postType = null, fallback = '' ) {
 		return fallback;
 	}
 
+	const cached = getCachedLabel( typeToCheck, key );
+	if ( cached !== undefined ) {
+		return cached;
+	}
+
 	const label = select( 'core' ).getPostType( typeToCheck )?.labels?.[ key ];
+	rememberLabel( typeToCheck, key, label );
 
 	return label || fallback;
 }
@@ -53,6 +112,14 @@ export function getPostTypeLabel( key, postType = null, fallback = '' ) {
  * hook subscribes via `useSelect` so the component re-renders the moment
  * the labels become known — which is the difference between a variation
  * permanently titled "Event" and one that picks up the registered label.
+ *
+ * The selector body re-runs on every dispatch to the subscribed stores —
+ * that's how `useSelect` works, and `core` dispatches many times during
+ * editor init (REST resolutions for post types, taxonomies, settings).
+ * Once a label has resolved, subsequent selector invocations short-circuit
+ * to the module-level `__postTypeLabelCache` so each re-run is an O(1)
+ * Map lookup rather than two store reads (issue #1646). React still only
+ * re-renders the component when the resolved string actually changes.
  *
  * @since 1.0.0
  *
@@ -71,8 +138,14 @@ export function usePostTypeLabel( key, postType = null, fallback = '' ) {
 				return fallback;
 			}
 
+			const cached = getCachedLabel( typeToCheck, key );
+			if ( cached !== undefined ) {
+				return cached;
+			}
+
 			const label = wpSelect( 'core' ).getPostType( typeToCheck )
 				?.labels?.[ key ];
+			rememberLabel( typeToCheck, key, label );
 
 			return label || fallback;
 		},

--- a/test/unit/js/src/helpers/editor.test.js
+++ b/test/unit/js/src/helpers/editor.test.js
@@ -24,6 +24,7 @@ jest.mock( '@wordpress/core-data', () => ( {
  * Internal dependencies
  */
 import {
+	__postTypeLabelCache,
 	enableSave,
 	getCurrentContextualPostId,
 	getEditorDocument,
@@ -580,6 +581,14 @@ describe( 'Editor helper functions', () => {
 	}
 
 	describe( 'getPostTypeLabel', () => {
+		beforeEach( () => {
+			// Clear the module-level label cache so each test starts from a
+			// clean slate — without this, an earlier test that resolves
+			// `gatherpress_event::name` would short-circuit later tests that
+			// mock a different label for the same key.
+			__postTypeLabelCache.clear();
+		} );
+
 		it( 'returns the resolved label for the given key and post type', () => {
 			select.mockImplementation( ( store ) => {
 				if ( 'core' === store ) {
@@ -650,9 +659,76 @@ describe( 'Editor helper functions', () => {
 
 			expect( getPostTypeLabel( 'name' ) ).toBe( '' );
 		} );
+
+		it( 'serves the cached label without re-reading from the core store (issue #1646)', () => {
+			const getPostType = jest.fn( mockGetPostTypeWithLabels );
+			select.mockImplementation( ( store ) => {
+				if ( 'core' === store ) {
+					return { getPostType };
+				}
+				return {};
+			} );
+
+			expect( getPostTypeLabel( 'name', 'gatherpress_event' ) ).toBe( 'Events' );
+			expect( getPostTypeLabel( 'name', 'gatherpress_event' ) ).toBe( 'Events' );
+			expect( getPostTypeLabel( 'name', 'gatherpress_event' ) ).toBe( 'Events' );
+
+			expect( getPostType ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not cache a fallback so the next call can pick up a later resolution', () => {
+			let resolved = false;
+			select.mockImplementation( ( store ) => {
+				if ( 'core' === store ) {
+					return {
+						getPostType: ( slug ) => {
+							if ( ! resolved ) {
+								return undefined;
+							}
+							return mockGetPostTypeWithLabels( slug );
+						},
+					};
+				}
+				return {};
+			} );
+
+			expect(
+				getPostTypeLabel( 'name', 'gatherpress_event', 'Default' )
+			).toBe( 'Default' );
+			expect( __postTypeLabelCache.has( 'gatherpress_event::name' ) ).toBe( false );
+
+			resolved = true;
+
+			expect(
+				getPostTypeLabel( 'name', 'gatherpress_event', 'Default' )
+			).toBe( 'Events' );
+			expect( __postTypeLabelCache.get( 'gatherpress_event::name' ) ).toBe( 'Events' );
+		} );
+
+		it( 'shares the cache with usePostTypeLabel (one resolves, the other hits)', () => {
+			const getPostType = jest.fn( mockGetPostTypeWithLabels );
+			select.mockImplementation( ( store ) => {
+				if ( 'core' === store ) {
+					return { getPostType };
+				}
+				return {};
+			} );
+
+			// usePostTypeLabel populates the cache first.
+			expect( usePostTypeLabel( 'singular_name', 'gatherpress_event' ) ).toBe( 'Event' );
+			expect( getPostType ).toHaveBeenCalledTimes( 1 );
+
+			// getPostTypeLabel for the same key/post type hits the shared cache.
+			expect( getPostTypeLabel( 'singular_name', 'gatherpress_event' ) ).toBe( 'Event' );
+			expect( getPostType ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
 	describe( 'usePostTypeLabel', () => {
+		beforeEach( () => {
+			__postTypeLabelCache.clear();
+		} );
+
 		it( 'returns the resolved label for the given key and post type', () => {
 			select.mockImplementation( ( store ) => {
 				if ( 'core' === store ) {
@@ -758,6 +834,61 @@ describe( 'Editor helper functions', () => {
 			expect(
 				usePostTypeLabel( 'name', 'gatherpress_event', 'Default' )
 			).toBe( 'Events' );
+		} );
+
+		it( 'serves the cached label without re-reading from the core store (issue #1646)', () => {
+			// First call populates the cache from the live store, subsequent
+			// calls hit the cache and never invoke `select('core').getPostType`
+			// again — that's the optimization that keeps the per-call work
+			// O(1) even though `useSelect` invokes the selector body many
+			// times during editor init.
+			const getPostType = jest.fn( mockGetPostTypeWithLabels );
+			select.mockImplementation( ( store ) => {
+				if ( 'core' === store ) {
+					return { getPostType };
+				}
+				return {};
+			} );
+
+			expect( usePostTypeLabel( 'name', 'gatherpress_event' ) ).toBe( 'Events' );
+			expect( usePostTypeLabel( 'name', 'gatherpress_event' ) ).toBe( 'Events' );
+			expect( usePostTypeLabel( 'name', 'gatherpress_event' ) ).toBe( 'Events' );
+
+			expect( getPostType ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not cache a fallback so the next call can pick up a later resolution', () => {
+			// Falsy labels are not cached so callers don't get stuck on the
+			// fallback when the core store hydrates the post type after the
+			// first render.
+			let resolved = false;
+			select.mockImplementation( ( store ) => {
+				if ( 'core' === store ) {
+					return {
+						getPostType: ( slug ) => {
+							if ( ! resolved ) {
+								return undefined;
+							}
+							return mockGetPostTypeWithLabels( slug );
+						},
+					};
+				}
+				return {};
+			} );
+
+			expect(
+				usePostTypeLabel( 'name', 'gatherpress_event', 'Default' )
+			).toBe( 'Default' );
+
+			expect( __postTypeLabelCache.has( 'gatherpress_event::name' ) ).toBe( false );
+
+			resolved = true;
+
+			expect(
+				usePostTypeLabel( 'name', 'gatherpress_event', 'Default' )
+			).toBe( 'Events' );
+
+			expect( __postTypeLabelCache.get( 'gatherpress_event::name' ) ).toBe( 'Events' );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Description of the Change
Adds a module-level `__postTypeLabelCache` (`Map`) in `src/helpers/editor.js` and threads it through both `getPostTypeLabel` and `usePostTypeLabel`. Post-type labels are set during `register_post_type()` and don't change at runtime, so once we've resolved a non-fallback label for a `<postType>::<key>` pair we serve it from the cache for the rest of the editor session. `useSelect` still invokes the selector body on every dispatch to its subscribed stores (that's by design — and `core` dispatches many times during editor init for REST resolutions), but the body is now an `O(1)` `Map` lookup instead of two store reads. Falsy labels are intentionally not cached so the late-resolution case (selector first runs before `core` has hydrated the post type) still falls through to the live store read on the next selector tick and picks up the real label as soon as it lands. Verified in the editor: out of 141 selector invocations on a single post-edit page load, only 6 ended up hitting the live store (one initial miss per `<postType>::<key>` pair, plus a couple of late-hydration retries for `gatherpress_event`); the remaining 135 were cache hits.

Closes #1646

### How to test the Change
1. `npm run build` and open `/wp-admin/post.php?post=<id>&action=edit` for any post.
2. Confirm the Event Settings panel title and the Event Query block's labels render correctly (`Events`, `Event`, etc.). Custom event-supporting post types should surface their own `singular_name` / `name` labels in those same UIs.
3. Optional verification of the optimization: temporarily add `console.log` lines inside `usePostTypeLabel`'s cache-hit and live-read branches, rebuild, reload the editor, and observe a small handful of MISSes followed by HITs for the rest of the session.
4. `npm run test:unit:js` — `editor.test.js` passes with 100% statements / branches / functions / lines on `src/helpers/editor.js`.

### Changelog Entry
> Fixed - Memoize resolved post-type labels so `usePostTypeLabel` / `getPostTypeLabel` short-circuit to an O(1) Map lookup after first resolution.

### Credits
Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.