### PR TITLE
Add site health test for pretty permalink detection

### DIFF
--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -68,6 +68,7 @@ class Setup {
 		Import::get_instance();
 		Rsvp\Setup::get_instance();
 		Settings::get_instance();
+		Site_Health::get_instance();
 		Shadow_Source::get_instance();
 		Topic::get_instance();
 		User::get_instance();

--- a/includes/core/classes/class-site-health.php
+++ b/includes/core/classes/class-site-health.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Site Health checks for GatherPress.
+ *
+ * Registers WordPress Site Health tests that surface configuration issues
+ * affecting GatherPress features.
+ *
+ * @package GatherPress\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Core;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Traits\Singleton;
+
+/**
+ * Class Site_Health.
+ *
+ * Manages GatherPress Site Health tests.
+ *
+ * @since 1.0.0
+ */
+class Site_Health {
+
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Site Health test identifier for the pretty permalinks check.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public const PRETTY_PERMALINKS_TEST = 'gatherpress_pretty_permalinks';
+
+	/**
+	 * Class constructor.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Set up hooks for Site Health tests.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks(): void {
+		add_filter( 'site_status_tests', array( $this, 'register_site_status_tests' ) );
+	}
+
+	/**
+	 * Register GatherPress direct Site Health tests.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, array<string, array<string, mixed>>> $tests Existing Site Health tests.
+	 * @return array<string, array<string, array<string, mixed>>> Updated Site Health tests.
+	 */
+	public function register_site_status_tests( array $tests ): array {
+		$tests['direct'][ self::PRETTY_PERMALINKS_TEST ] = array(
+			'label' => __( 'GatherPress pretty permalinks', 'gatherpress' ),
+			'test'  => array( $this, 'test_pretty_permalinks' ),
+		);
+
+		return $tests;
+	}
+
+	/**
+	 * Site Health test for WordPress pretty permalinks.
+	 *
+	 * GatherPress rewrite rules for event and venue URLs, feeds, and calendar
+	 * endpoints require a permalink structure other than Plain.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, mixed> Site Health test result.
+	 */
+	public function test_pretty_permalinks(): array {
+		$result = array(
+			'label'       => __( 'Pretty permalinks are enabled', 'gatherpress' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'GatherPress', 'gatherpress' ),
+				'color' => 'green',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				esc_html__(
+					'Pretty permalinks are enabled, so GatherPress event and venue URLs and feeds work correctly.',
+					'gatherpress'
+				)
+			),
+			'actions'     => '',
+			'test'        => self::PRETTY_PERMALINKS_TEST,
+		);
+
+		if ( empty( get_option( 'permalink_structure' ) ) ) {
+			$result['status']         = 'recommended';
+			$result['label']          = __( 'Pretty permalinks are not enabled', 'gatherpress' );
+			$result['badge']['color'] = 'orange';
+			$result['description']    = sprintf(
+				'<p>%s</p>',
+				esc_html__(
+					'GatherPress needs pretty permalinks for events and venues. Plain permalinks may cause 404 errors.',
+					'gatherpress'
+				)
+			);
+			$result['actions']        = sprintf(
+				'<p><a href="%s">%s</a></p>',
+				esc_url( admin_url( 'options-permalink.php' ) ),
+				esc_html__( 'Change permalink settings', 'gatherpress' )
+			);
+		}
+
+		return $result;
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/class-test-site-health.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-site-health.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Class handles unit tests for GatherPress\Core\Site_Health.
+ *
+ * @package GatherPress\Tests\Core
+ * @since 1.0.0
+ */
+
+namespace GatherPress\Tests\Core;
+
+use GatherPress\Core\Site_Health;
+use GatherPress\Tests\Base;
+
+/**
+ * Class Test_Site_Health.
+ *
+ * @coversDefaultClass \GatherPress\Core\Site_Health
+ */
+class Test_Site_Health extends Base {
+
+	/**
+	 * Test instance of Site_Health.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var Site_Health
+	 */
+	protected Site_Health $instance;
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->instance = Site_Health::get_instance();
+	}
+
+	/**
+	 * Coverage for setup_hooks.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @covers ::__construct
+	 * @covers ::setup_hooks
+	 *
+	 * @return void
+	 */
+	public function test_setup_hooks(): void {
+		$hooks = array(
+			array(
+				'type'     => 'filter',
+				'name'     => 'site_status_tests',
+				'priority' => 10,
+				'callback' => array( $this->instance, 'register_site_status_tests' ),
+			),
+		);
+
+		$this->assert_hooks( $hooks, $this->instance );
+	}
+
+	/**
+	 * Registers the pretty permalinks direct Site Health test.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @covers ::register_site_status_tests
+	 *
+	 * @return void
+	 */
+	public function test_register_site_status_tests(): void {
+		$tests = $this->instance->register_site_status_tests(
+			array(
+				'direct' => array(),
+				'async'  => array(),
+			)
+		);
+
+		$this->assertArrayHasKey( Site_Health::PRETTY_PERMALINKS_TEST, $tests['direct'] );
+		$this->assertSame(
+			array( $this->instance, 'test_pretty_permalinks' ),
+			$tests['direct'][ Site_Health::PRETTY_PERMALINKS_TEST ]['test']
+		);
+	}
+
+	/**
+	 * Returns a good result when pretty permalinks are enabled.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @covers ::test_pretty_permalinks
+	 *
+	 * @return void
+	 */
+	public function test_pretty_permalinks_returns_good_when_structure_is_set(): void {
+		add_filter(
+			'pre_option_permalink_structure',
+			static function (): string {
+				return '/%postname%/';
+			}
+		);
+
+		$result = $this->instance->test_pretty_permalinks();
+
+		remove_all_filters( 'pre_option_permalink_structure' );
+
+		$this->assertSame( 'good', $result['status'] );
+		$this->assertSame( Site_Health::PRETTY_PERMALINKS_TEST, $result['test'] );
+		$this->assertSame( '', $result['actions'] );
+	}
+
+	/**
+	 * Returns a recommended result when permalinks are Plain.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @covers ::test_pretty_permalinks
+	 *
+	 * @return void
+	 */
+	public function test_pretty_permalinks_returns_recommended_when_plain(): void {
+		add_filter(
+			'pre_option_permalink_structure',
+			static function (): string {
+				return '';
+			}
+		);
+
+		$result = $this->instance->test_pretty_permalinks();
+
+		remove_all_filters( 'pre_option_permalink_structure' );
+
+		$this->assertSame( 'recommended', $result['status'] );
+		$this->assertStringContainsString(
+			admin_url( 'options-permalink.php' ),
+			$result['actions']
+		);
+	}
+}


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
Add site status health check for pretty permalinks

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1348 

### How to test the Change
Settings -> Permalinks -> set to Plain -> save
Tools -> Site Health -> Recommended tab -> look for GatherPress pretty permalinks
Switch to Post name (or anything non-Plain) -> item should move to Good

### Changelog Entry
> Added - New feature

### Credits
<!-- Please list any and all contributors on this PR so that they can be properly credited within this project. -->
Props @jmarx

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
