### PR TITLE
Add __next40pxDefaultSize to all SelectControl instances (WP 6.8 size opt-in)

### DIFF
--- a/src/blocks/dropdown/edit.js
+++ b/src/blocks/dropdown/edit.js
@@ -365,6 +365,7 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 						/>
 						{ actAsSelect && (
 							<SelectControl
+								__next40pxDefaultSize
 								label={ __(
 									'Default Selected Item',
 									'gatherpress',

--- a/src/blocks/form-field/edit.js
+++ b/src/blocks/form-field/edit.js
@@ -140,6 +140,7 @@ export default function Edit( { attributes, setAttributes } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Field Settings', 'gatherpress' ) }>
 					<SelectControl
+						__next40pxDefaultSize
 						label={ __( 'Field Type', 'gatherpress' ) }
 						value={ fieldType }
 						options={ [

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -52,6 +52,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 			<InspectorControls>
 				<PanelBody title={ __( 'Icon Settings', 'gatherpress' ) }>
 					<SelectControl
+						__next40pxDefaultSize
 						label={ __( 'Icon', 'gatherpress' ) }
 						value={ icon }
 						options={ ICON_OPTIONS }

--- a/src/blocks/rsvp-count/edit.js
+++ b/src/blocks/rsvp-count/edit.js
@@ -170,6 +170,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 					title={ __( 'RSVP Count Settings', 'gatherpress' ) }
 				>
 					<SelectControl
+						__next40pxDefaultSize
 						label={ __( 'RSVP Status', 'gatherpress' ) }
 						value={ status }
 						options={ statusOptions }

--- a/src/blocks/rsvp-form/edit.js
+++ b/src/blocks/rsvp-form/edit.js
@@ -310,6 +310,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 			<InspectorControls>
 				<PanelBody title={ __( 'Preview Settings', 'gatherpress' ) }>
 					<SelectControl
+						__next40pxDefaultSize
 						label={ __( 'Form State Preview', 'gatherpress' ) }
 						help={ __(
 							'Preview how blocks appear in different form states. This setting is not saved.',

--- a/src/blocks/rsvp-form/index.js
+++ b/src/blocks/rsvp-form/index.js
@@ -117,6 +117,7 @@ const withFormVisibilityControls = createHigherOrderComponent( ( BlockEdit ) => 
 				<BlockEdit { ...props } />
 				<InspectorAdvancedControls>
 					<SelectControl
+						__next40pxDefaultSize
 						label={ __( 'On Successful Submission', 'gatherpress' ) }
 						help={ __(
 							'Control visibility when the RSVP form is successfully submitted.',
@@ -140,6 +141,7 @@ const withFormVisibilityControls = createHigherOrderComponent( ( BlockEdit ) => 
 						onChange={ ( value ) => updateVisibility( 'onSuccess', value ) }
 					/>
 					<SelectControl
+						__next40pxDefaultSize
 						label={ __( 'When Event Has Passed', 'gatherpress' ) }
 						help={ __(
 							'Control visibility when the event end time has passed.',

--- a/src/blocks/rsvp-response/rsvp-manager.js
+++ b/src/blocks/rsvp-response/rsvp-manager.js
@@ -135,6 +135,7 @@ const RsvpManager = ( { defaultStatus, setDefaultStatus } ) => {
 	return (
 		<>
 			<SelectControl
+				__next40pxDefaultSize
 				label={ __( 'RSVP Status', 'gatherpress' ) }
 				value={ defaultStatus }
 				options={ [

--- a/src/blocks/rsvp/edit.js
+++ b/src/blocks/rsvp/edit.js
@@ -441,6 +441,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 								) }
 							</p>
 							<SelectControl
+								__next40pxDefaultSize
 								label={ __( 'Edit Block Status', 'gatherpress' ) }
 								value={ selectedStatus }
 								options={ [

--- a/src/blocks/venue-detail/edit.js
+++ b/src/blocks/venue-detail/edit.js
@@ -105,6 +105,7 @@ const Edit = ( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Field settings', 'gatherpress' ) }>
 					<SelectControl
+						__next40pxDefaultSize
 						label={ __( 'Field type', 'gatherpress' ) }
 						value={ fieldType }
 						options={ [

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -591,6 +591,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 			<InspectorControls>
 				<PanelBody>
 					<SelectControl
+						__next40pxDefaultSize
 						label={ __( 'Render mode', 'gatherpress' ) }
 						value={ renderMode }
 						options={ [
@@ -618,6 +619,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 					/>
 					{ showMapTypeControl && (
 						<SelectControl
+							__next40pxDefaultSize
 							label={ __( 'Map type', 'gatherpress' ) }
 							value={ type }
 							options={ googleMapTypeSelectOptions }
@@ -697,6 +699,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 						panelId={ clientId }
 					>
 						<SelectControl
+							__next40pxDefaultSize
 							label={ __( 'Aspect ratio', 'gatherpress' ) }
 							value={ isCustomAspectRatio ? 'custom' : aspectRatio }
 							options={ ASPECT_RATIO_PRESETS }
@@ -749,6 +752,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 							panelId={ clientId }
 						>
 							<SelectControl
+								__next40pxDefaultSize
 								label={ __( 'Scale', 'gatherpress' ) }
 								value={ scale ?? siteScaleDefault }
 								options={ SCALE_OPTIONS.map( ( value ) => ( {
@@ -789,6 +793,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 									} }
 								>
 									<SelectControl
+										__next40pxDefaultSize
 										label={ __( 'Link to', 'gatherpress' ) }
 										value={
 											linkDestination ||

--- a/src/components/Duration.js
+++ b/src/components/Duration.js
@@ -36,6 +36,7 @@ const Duration = () => {
 	const { setDateTimeEnd, setDuration } = dispatch( 'gatherpress/datetime' );
 	return (
 		<SelectControl
+			__next40pxDefaultSize
 			label={ __( 'Duration', 'gatherpress' ) }
 			value={
 				durationOptions().some( ( option ) => option.value === duration )

--- a/src/components/Timezone.js
+++ b/src/components/Timezone.js
@@ -39,6 +39,7 @@ const Timezone = () => {
 	return (
 		<PanelRow>
 			<SelectControl
+				__next40pxDefaultSize
 				label={ __( 'Time Zone', 'gatherpress' ) }
 				value={ maybeConvertUtcOffsetForSelect( timezone ) }
 				onChange={ ( value ) => {

--- a/src/components/VenueSelector.js
+++ b/src/components/VenueSelector.js
@@ -109,6 +109,7 @@ const VenueSelector = () => {
 	return (
 		<PanelRow>
 			<SelectControl
+				__next40pxDefaultSize
 				label={ __( 'Venue Selector', 'gatherpress' ) }
 				value={ venue }
 				onChange={ ( value ) => {

--- a/src/variations/core/query/components.js
+++ b/src/variations/core/query/components.js
@@ -425,6 +425,7 @@ export const EventOrderControls = ( { attributes, setAttributes } ) => {
 	return (
 		<>
 			<SelectControl
+				__next40pxDefaultSize
 				label={ sprintf(
 					/* translators: %s: Plural post type label, e.g. "Events". */
 					__( 'Order %s by', 'gatherpress' ),


### PR DESCRIPTION
### Description of the Change
Adds the `__next40pxDefaultSize` opt-in prop to every `<SelectControl>` instance across GatherPress's block edits and shared editor components (19 call sites in 14 files). `@wordpress/components` deprecated the 36px default height in WP 6.8 and is moving every form control to 40px in a future release; setting the prop both silences the deprecation warning the editor was emitting on every render and bumps each control to its post-6.8 default size, which aligns visually with the other 40px controls already in the editor sidebar (the `ToggleGroupControl` instances that were migrated earlier). The prop is a no-op on `@wordpress/components` versions that don't recognize it, so no minimum-WP bump is required.

Closes #1656

### How to test the Change
1. `npm run start` (dev build — production strips the deprecation warning).
2. Open any post that renders a GatherPress block with a `SelectControl` (an event post is the easiest — the Event Settings sidebar's **Duration** and **Time Zone** dropdowns both render through this path; an Event Query block surfaces the variation's order/type dropdown).
3. Open DevTools, switch the Console context to the editor iframe, ensure **Warnings** are enabled.
4. Confirm the `36px default size for wp.components.SelectControl is deprecated since version 6.8` warning no longer appears.
5. Confirm each `SelectControl` renders at 40px tall (a hair taller than before, lined up with the neighboring `ToggleGroupControl`s).

### Changelog Entry
> Fixed - Set `__next40pxDefaultSize` on every `SelectControl` to silence the WP 6.8 36px-default deprecation warning and adopt the new 40px control size.

### Credits
Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.