### PR TITLE
Remove dead RichText onSplit prop on dropdown-item (silences WP 6.4 deprecation)

### DIFF
--- a/src/blocks/dropdown-item/edit.js
+++ b/src/blocks/dropdown-item/edit.js
@@ -108,13 +108,6 @@ const Edit = ( { attributes, setAttributes, clientId, insertBlocksAfter } ) => {
 				} }
 				placeholder={ __( 'Item Text…', 'gatherpress' ) }
 				allowedFormats={ [ 'core/link' ] }
-				onSplit={ ( before, after ) => {
-					const newBlock = createBlock( 'gatherpress/dropdown-item', {
-						text: after,
-					} );
-					insertBlocksAfter( [ newBlock ] );
-					setAttributes( { text: before } );
-				} }
 				onKeyDown={ ( event ) => {
 					if ( 'Enter' === event.key ) {
 						event.preventDefault();


### PR DESCRIPTION
### Description of the Change
Removes the `onSplit={ ... }` callback from the `<RichText>` in `src/blocks/dropdown-item/edit.js`. WordPress 6.4 deprecated `RichText`'s `onSplit` prop in favor of declaring `"supports": { "splitting": true }` in `block.json`, and the warning was firing on every editor render that loaded a Dropdown Item block.

The callback was already dead code at runtime: the block's `onKeyDown` handler (added in Dec '24) intercepts Enter, calls `event.preventDefault()`, and inserts a new empty `gatherpress/dropdown-item` after the current one. `preventDefault()` blocks the newline character that would otherwise be inserted into the contenteditable, and RichText's `onSplit` path is triggered by detecting a newline in its value — so with the keydown override in place, `onSplit` was never invoked. Removing the prop silences the deprecation warning without changing runtime behavior.

We intentionally did **not** adopt the `block.json` `splitting` support flag here, because that would replace the current "Enter inserts an empty new item" UX with core's "Enter splits the current item's text at the cursor" UX — a deliberate behavior change that was previously chosen against. The Backspace-to-delete-empty-item handling in the same `onKeyDown` is also preserved.

Closes #1657

### How to test the Change
1. `npm run start` (dev build — production builds strip deprecation warnings).
2. Open a post with a Dropdown block that contains at least one Dropdown Item.
3. Open DevTools, switch the Console context to the editor iframe, ensure **Warnings** are enabled.
4. Confirm the `wp.blockEditor.RichText onSplit prop is deprecated since version 6.4` warning no longer appears.
5. With focus inside a Dropdown Item's text, press **Enter** — a new empty Dropdown Item is inserted after the current one (unchanged behavior).
6. With focus inside an empty Dropdown Item, press **Backspace** — the item is removed and focus returns to the end of the previous item (unchanged behavior).

### Changelog Entry
> Fixed - Remove the deprecated `RichText` `onSplit` prop from the Dropdown Item block to silence the WP 6.4 deprecation warning; Enter/Backspace behavior is unchanged.

### Credits
Props @mauteri

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.