### PR TITLE
Authenticate composer with GITHUB_TOKEN in dist-archive install steps

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -50,6 +50,8 @@ jobs:
           tools: wp-cli
 
       - name: Install dist-archive-command
+        env:
+          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
         run: wp package install wp-cli/dist-archive-command:^2
 
       - name: Setup Node

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -32,6 +32,8 @@ jobs:
           tools: wp-cli
 
       - name: Install dist-archive-command
+        env:
+          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
         run: wp package install wp-cli/dist-archive-command:^2
 
       - name: Setup Node


### PR DESCRIPTION
### Description of the Change
The `Install dist-archive-command` step in two CI workflows runs `wp package install wp-cli/dist-archive-command:^2`, which invokes composer under the hood. Without a `COMPOSER_AUTH` token, composer hits GitHub's anonymous API as the shared runner IP and gets blocked by the 60 requests/hour rate-limit, causing intermittent CI failures.

This PR adds a `COMPOSER_AUTH` env block to both steps so composer authenticates with the workflow's `secrets.GITHUB_TOKEN` (5000 requests/hour). The token is always available on `pull_request` events, including community fork PRs (forced read-only scope, which is sufficient for fetching public package metadata).

Affected workflows:
- `.github/workflows/wordpress-org-plugin-guidelines.yml`
- `.github/workflows/playground-preview.yml`

Closes #1670

### How to test the Change
1. Open this PR and watch the `WordPress.org plugin directory guidelines` and `Playground Preview` workflows run.
2. The `Install dist-archive-command` step should complete without hitting `API rate limit exceeded` from `api.github.com`.
3. Re-run the workflows a few times to confirm consistency.

### Changelog Entry
> Fixed - Authenticate composer with `GITHUB_TOKEN` in the `Install dist-archive-command` CI step to avoid GitHub anonymous API rate-limit failures.

### Credits
Props @mauteri

### Checklist:
- [x] I agree to follow this project's **Code of Conduct**.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.