### PR TITLE
Refactor Calendar\Setup::alternate_links() into orchestrator + helpers

### DIFF
--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -304,8 +304,28 @@ class Setup {
 		if ( ! current_theme_supports( 'automatic-feed-links' ) ) {
 			return;
 		}
+		$args  = $this->alternate_link_label_args();
+		$links = array_merge(
+			$this->collect_sitewide_alternate_link( $args ),
+			$this->collect_post_type_archive_alternate_links( $args ),
+			$this->collect_contextual_alternate_links( $args )
+		);
+		$this->render_alternate_links( $links );
+	}
 
-		$args = array(
+	/**
+	 * Build the localized label args used to format alternate-link titles.
+	 *
+	 * Returns the site title, the locale-specific separator (defaults to
+	 * `&raquo;`), and the four `sprintf()` templates the link builders
+	 * consume: `singletitle`, `feedtitle`, `posttypetitle`, `taxtitle`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array{blogtitle:string,separator:string,singletitle:string,feedtitle:string,posttypetitle:string,taxtitle:string}
+	 */
+	protected function alternate_link_label_args(): array {
+		return array(
 			'blogtitle'     => get_bloginfo( 'name' ),
 			/* translators: Separator between site name and feed type in feed links. */
 			'separator'     => _x( '&raquo;', 'feed link separator', 'gatherpress' ),
@@ -318,35 +338,60 @@ class Setup {
 			/* translators: 1: Site name, 2: Separator (raquo), 3: Term name, 4: Taxonomy singular name. */
 			'taxtitle'      => __( '📅 %1$s %2$s %3$s %4$s iCal Feed', 'gatherpress' ),
 		);
+	}
 
-		$alternate_links = array();
-
-		$alternate_links[] = array(
-			'url'  => get_feed_link( self::ICAL_SLUG ),
-			'attr' => sprintf(
-				$args['feedtitle'],
-				$args['blogtitle'],
-				$args['separator']
+	/**
+	 * Build the single sitewide `<link rel="alternate">` entry.
+	 *
+	 * Always emitted on every request that reaches `alternate_links()`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $args Label args from `alternate_link_label_args()`.
+	 * @return array<int,array{url:string,attr:string}> One-element list.
+	 */
+	protected function collect_sitewide_alternate_link( array $args ): array {
+		return array(
+			array(
+				'url'  => get_feed_link( self::ICAL_SLUG ),
+				'attr' => sprintf(
+					$args['feedtitle'],
+					$args['blogtitle'],
+					$args['separator']
+				),
 			),
 		);
+	}
+
+	/**
+	 * Build one `<link rel="alternate">` entry per event-supporting post-type archive.
+	 *
+	 * Reads the archive title straight off the post type object instead of via
+	 * `post_type_archive_title()` — that function early-returns outside an
+	 * `is_post_type_archive()` context, which is exactly the case here when
+	 * this hook fires on a non-archive page. Invoking the
+	 * `post_type_archive_title` filter directly from plugin code also trips
+	 * WordPress.NamingConventions.PrefixAllGlobals because it's a core hook
+	 * not owned by GatherPress.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $args Label args from `alternate_link_label_args()`.
+	 * @return array<int,array{url:string,attr:string}> One entry per event-supporting post type.
+	 */
+	protected function collect_post_type_archive_alternate_links( array $args ): array {
+		$links = array();
 
 		foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $post_type ) {
-			// Read the archive title straight off the post type object instead
-			// of via `post_type_archive_title()` — that function early-returns
-			// outside an `is_post_type_archive()` context, which is exactly the
-			// case here when this hook fires on a non-archive page. Invoking
-			// the `post_type_archive_title` filter directly from plugin code
-			// also trips WordPress.NamingConventions.PrefixAllGlobals because
-			// it's a core hook not owned by GatherPress.
 			$post_type_object = get_post_type_object( $post_type );
 			// The fallback to the bare slug only fires when `get_post_type_object()`
-			// returns null — structurally unreachable here because the outer loop
+			// returns null — structurally unreachable here because the loop
 			// iterates `get_post_types_by_support()`, which only yields registered
 			// post types. Defensive code that needs no test invocation.
-			$archive_title     = $post_type_object instanceof WP_Post_Type
+			$archive_title = $post_type_object instanceof WP_Post_Type
 				? $post_type_object->labels->name
 				: $post_type; // @codeCoverageIgnore
-			$alternate_links[] = array(
+			$links[]       = array(
 				'url'  => get_post_type_archive_feed_link(
 					$post_type,
 					self::ICAL_SLUG
@@ -360,10 +405,56 @@ class Setup {
 			);
 		}
 
-		if ( is_singular() && post_type_supports( get_queried_object()->post_type, 'gatherpress-event-date' ) ) {
-			$calendar = new Calendar( get_queried_object()->ID );
+		return $links;
+	}
 
-			$alternate_links[] = array(
+	/**
+	 * Dispatch the contextual `<link rel="alternate">` entries for the current request.
+	 *
+	 * Returns the per-request additions on top of the always-on sitewide and
+	 * per-post-type-archive entries. Dispatches on the queried object:
+	 * singular event, singular tax-like shadow-source post, or taxonomy
+	 * archive. Returns an empty list for any other context.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $args Label args from `alternate_link_label_args()`.
+	 * @return array<int,array{url:string,attr:string}>
+	 */
+	protected function collect_contextual_alternate_links( array $args ): array {
+		$queried = get_queried_object();
+
+		if ( is_singular() && post_type_supports( $queried->post_type, 'gatherpress-event-date' ) ) {
+			return $this->collect_singular_event_alternate_links( $queried, $args );
+		}
+
+		if ( is_singular() && $this->is_tax_like_type_for_event_supporting_types( $queried->post_type ) ) {
+			return $this->collect_singular_tax_like_alternate_links( $queried, $args );
+		}
+
+		if ( is_tax() && $this->has_post_type_for_taxonomy( $queried->taxonomy ) ) {
+			return $this->collect_tax_archive_alternate_links( $queried, $args );
+		}
+
+		return array();
+	}
+
+	/**
+	 * Build the alternate-link entries for a singular event request.
+	 *
+	 * Always emits the single-event iCal download link; appends one entry
+	 * per related taxonomy term via `collect_event_term_alternate_links()`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Post $event The queried event post.
+	 * @param array   $args  Label args from `alternate_link_label_args()`.
+	 * @return array<int,array{url:string,attr:string}>
+	 */
+	protected function collect_singular_event_alternate_links( WP_Post $event, array $args ): array {
+		$calendar = new Calendar( $event->ID );
+		$links    = array(
+			array(
 				'url'  => $calendar->get_ical_url(),
 				'attr' => sprintf(
 					$args['singletitle'],
@@ -371,103 +462,157 @@ class Setup {
 					$args['separator'],
 					the_title_attribute( array( 'echo' => false ) )
 				),
-			);
+			),
+		);
 
-			// Get all terms associated with the current event-post.
-			$terms = get_terms(
-				array(
-					'taxonomy'   => get_object_taxonomies( get_queried_object() ),
-					'object_ids' => get_queried_object()->ID,
-				)
-			);
-			// Loop over terms and generate the ical feed links for the <head>.
-			array_walk(
-				$terms,
-				function ( WP_Term $term ) use ( $args, &$alternate_links ) {
-					$tax           = get_taxonomy( $term->taxonomy );
-					$shadow_source = Shadow_Source::get_instance();
+		return array_merge( $links, $this->collect_event_term_alternate_links( $event, $args ) );
+	}
 
-					// For the venue taxonomy, we want to link to the feed of the associated venue post,
-					// not the term archive feed, so we need to resolve the venue post from the term first
-					// and then get the feed link for that post.
-					if ( $shadow_source->is_shadow_term_slug( $term->taxonomy ) ) {
-
-						// Strip out all 'non-default' shadow terms like 'Online-Event',
-						// which does not start with a "_".
-						if ( $shadow_source->is_shadow_term_slug( $term->slug ) ) {
-							$post = $shadow_source->get_post_from_term_slug(
-								$term->slug,
-								ltrim( $term->taxonomy, '_' )
-							);
-							// Feels weird to use a *_comments_* function here, but it delivers clean results
-							// in the form of "domain.tld/event/my-sample-event/feed/ical/".
-							$href = get_post_comments_feed_link( $post->ID, self::ICAL_SLUG );
-						}
-
-						// For non-shadow taxonomies, we can link to the term archive feed as usual.
-					} else {
-						$href = get_term_feed_link(
-							$term->term_id,
-							$term->taxonomy,
-							self::ICAL_SLUG
-						);
-					}
-
-					// Can be empty for Online-Events.
-					if ( ! empty( $href ) ) {
-						$alternate_links[] = array(
-							'url'  => $href,
-							'attr' => sprintf(
-								$args['taxtitle'],
-								$args['blogtitle'],
-								$args['separator'],
-								$term->name,
-								$tax->labels->singular_name
-							),
-						);
-					}
-				}
-			);
-		} elseif (
-			is_singular()
-			&& $this->is_tax_like_type_for_event_supporting_types( get_queried_object()->post_type )
-		) {
-			// Feels weird to use a *_comments_* function here, but it delivers clean results
-			// in the form of "domain.tld/venue/my-sample-venue/feed/ical/".
-			$alternate_links[] = array(
-				'url'  => get_post_comments_feed_link(
-					get_queried_object()->ID,
-					self::ICAL_SLUG
-				),
+	/**
+	 * Build the alternate-link entries for a singular tax-like shadow-source request.
+	 *
+	 * Feels weird to use a `*_comments_*` function here, but it delivers
+	 * clean results in the form of `domain.tld/venue/my-sample-venue/feed/ical/`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Post $post The queried shadow-source post (e.g. a venue).
+	 * @param array   $args Label args from `alternate_link_label_args()`.
+	 * @return array<int,array{url:string,attr:string}>
+	 */
+	protected function collect_singular_tax_like_alternate_links( WP_Post $post, array $args ): array {
+		return array(
+			array(
+				'url'  => get_post_comments_feed_link( $post->ID, self::ICAL_SLUG ),
 				'attr' => sprintf(
 					$args['singletitle'],
 					$args['blogtitle'],
 					$args['separator'],
 					the_title_attribute( array( 'echo' => false ) )
 				),
-			);
-		} elseif ( is_tax() && $this->has_post_type_for_taxonomy( get_queried_object()->taxonomy ) ) {
-			$tax = get_taxonomy( get_queried_object()->taxonomy );
+			),
+		);
+	}
 
-			$alternate_links[] = array(
-				'url'  => get_term_feed_link(
-					get_queried_object()->term_id,
-					get_queried_object()->taxonomy,
-					self::ICAL_SLUG
-				),
+	/**
+	 * Build the alternate-link entries for an event-bearing taxonomy archive.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Term $term The queried taxonomy term.
+	 * @param array   $args Label args from `alternate_link_label_args()`.
+	 * @return array<int,array{url:string,attr:string}>
+	 */
+	protected function collect_tax_archive_alternate_links( WP_Term $term, array $args ): array {
+		$tax = get_taxonomy( $term->taxonomy );
+
+		return array(
+			array(
+				'url'  => get_term_feed_link( $term->term_id, $term->taxonomy, self::ICAL_SLUG ),
 				'attr' => sprintf(
 					$args['taxtitle'],
 					$args['blogtitle'],
 					$args['separator'],
-					get_queried_object()->name,
+					$term->name,
 					$tax->labels->singular_name
 				),
-			);
+			),
+		);
+	}
+
+	/**
+	 * Walk the queried event's related terms into alternate-link entries.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Post $event The queried event post.
+	 * @param array   $args  Label args from `alternate_link_label_args()`.
+	 * @return array<int,array{url:string,attr:string}>
+	 */
+	protected function collect_event_term_alternate_links( WP_Post $event, array $args ): array {
+		$terms = get_terms(
+			array(
+				'taxonomy'   => get_object_taxonomies( $event ),
+				'object_ids' => $event->ID,
+			)
+		);
+
+		$links = array();
+
+		foreach ( $terms as $term ) {
+			$links = array_merge( $links, $this->collect_term_alternate_link( $term, $args ) );
 		}
 
-		// Render tags into <head/>.
+		return $links;
+	}
+
+	/**
+	 * Resolve a single related term into zero or one alternate-link entries.
+	 *
+	 * For shadow-source taxonomies the link points at the associated post's
+	 * comments-feed URL (so `gatherpress_venue` resolves to the venue
+	 * post's feed, not the term archive feed). Sentinel shadow terms like
+	 * `online-event` — slugs that don't start with `_` — are skipped because
+	 * they have no backing post. For regular taxonomies the term archive
+	 * feed link is used directly.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Term $term Term attached to the queried event.
+	 * @param array   $args Label args from `alternate_link_label_args()`.
+	 * @return array<int,array{url:string,attr:string}> Empty for sentinel terms; otherwise one entry.
+	 */
+	protected function collect_term_alternate_link( WP_Term $term, array $args ): array {
+		$shadow_source = Shadow_Source::get_instance();
+		$href          = '';
+
+		if ( $shadow_source->is_shadow_term_slug( $term->taxonomy ) ) {
+			// Skip sentinel shadow terms like `online-event` whose slug does
+			// not start with `_` — no backing post means no feed to link to.
+			if ( $shadow_source->is_shadow_term_slug( $term->slug ) ) {
+				$post = $shadow_source->get_post_from_term_slug(
+					$term->slug,
+					ltrim( $term->taxonomy, '_' )
+				);
+				// Feels weird to use a *_comments_* function here, but it delivers clean results
+				// in the form of "domain.tld/event/my-sample-event/feed/ical/".
+				$href = get_post_comments_feed_link( $post->ID, self::ICAL_SLUG );
+			}
+		} else {
+			$href = get_term_feed_link( $term->term_id, $term->taxonomy, self::ICAL_SLUG );
+		}
+
+		if ( empty( $href ) ) {
+			return array();
+		}
+
+		$tax = get_taxonomy( $term->taxonomy );
+
+		return array(
+			array(
+				'url'  => $href,
+				'attr' => sprintf(
+					$args['taxtitle'],
+					$args['blogtitle'],
+					$args['separator'],
+					$term->name,
+					$tax->labels->singular_name
+				),
+			),
+		);
+	}
+
+	/**
+	 * Render the collected alternate-link entries into `<head>`.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<int,array{url:string,attr:string}> $links Entries to render.
+	 * @return void
+	 */
+	protected function render_alternate_links( array $links ): void {
 		array_walk(
-			$alternate_links,
+			$links,
 			function ( $link ) {
 				printf(
 					'<link rel="alternate" type="%s" title="%s" href="%s" />' . "\n",

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -845,4 +845,479 @@ class Test_Setup extends Base {
 			'page is not a tax-like shadow source for events.'
 		);
 	}
+
+	/**
+	 * Coverage for alternate_link_label_args — returns the six expected keys
+	 * and a non-empty site title.
+	 *
+	 * @covers ::alternate_link_label_args
+	 *
+	 * @return void
+	 */
+	public function test_alternate_link_label_args_shape(): void {
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+
+		$this->assertIsArray( $args, 'alternate_link_label_args should return an array.' );
+		foreach ( array( 'blogtitle', 'separator', 'singletitle', 'feedtitle', 'posttypetitle', 'taxtitle' ) as $key ) {
+			$this->assertArrayHasKey( $key, $args, sprintf( 'Label args should contain "%s".', $key ) );
+		}
+		$this->assertNotEmpty( $args['blogtitle'], 'blogtitle should be populated from get_bloginfo().' );
+		$this->assertStringContainsString(
+			'iCal Download',
+			$args['singletitle'],
+			'singletitle template should mention iCal Download.'
+		);
+		$this->assertStringContainsString(
+			'iCal Feed',
+			$args['feedtitle'],
+			'feedtitle template should mention iCal Feed.'
+		);
+	}
+
+	/**
+	 * Coverage for collect_sitewide_alternate_link — returns a one-element list
+	 * with the sitewide feed URL and the formatted attr label.
+	 *
+	 * @covers ::collect_sitewide_alternate_link
+	 *
+	 * @return void
+	 */
+	public function test_collect_sitewide_alternate_link_returns_single_entry(): void {
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method( $instance, 'collect_sitewide_alternate_link', array( $args ) );
+
+		$this->assertCount( 1, $links, 'Sitewide collector should emit exactly one entry.' );
+		$this->assertArrayHasKey( 'url', $links[0], 'Entry should have a url key.' );
+		$this->assertArrayHasKey( 'attr', $links[0], 'Entry should have an attr key.' );
+		$this->assertStringContainsString(
+			'iCal Feed',
+			$links[0]['attr'],
+			'Sitewide attr should be formatted with the feedtitle template.'
+		);
+	}
+
+	/**
+	 * Coverage for collect_post_type_archive_alternate_links — emits one entry
+	 * per event-supporting post type.
+	 *
+	 * @covers ::collect_post_type_archive_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_post_type_archive_alternate_links_one_per_post_type(): void {
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method(
+			$instance,
+			'collect_post_type_archive_alternate_links',
+			array( $args )
+		);
+
+		$this->assertSameSize(
+			get_post_types_by_support( 'gatherpress-event-date' ),
+			$links,
+			'Should emit exactly one entry per event-supporting post type.'
+		);
+		foreach ( $links as $link ) {
+			$this->assertArrayHasKey( 'url', $link );
+			$this->assertArrayHasKey( 'attr', $link );
+			$this->assertStringContainsString(
+				'iCal Feed',
+				$link['attr'],
+				'Post-type archive attr should be formatted with the posttypetitle template.'
+			);
+		}
+	}
+
+	/**
+	 * Coverage for collect_contextual_alternate_links — returns the singular-event
+	 * branch when on an event permalink.
+	 *
+	 * @covers ::collect_contextual_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_contextual_alternate_links_on_singular_event(): void {
+		$event_id = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+		$this->go_to( get_permalink( $event_id ) );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method( $instance, 'collect_contextual_alternate_links', array( $args ) );
+
+		$this->assertNotEmpty( $links, 'Singular event should produce contextual links.' );
+		$this->assertStringContainsString(
+			'iCal Download',
+			$links[0]['attr'],
+			'First contextual link on an event should be the iCal Download.'
+		);
+	}
+
+	/**
+	 * Coverage for collect_contextual_alternate_links — returns the
+	 * singular-tax-like branch when on a venue permalink.
+	 *
+	 * @covers ::collect_contextual_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_contextual_alternate_links_on_singular_tax_like(): void {
+		$venue_id = $this->mock->post(
+			array(
+				'post_type'  => Venue::POST_TYPE,
+				'post_title' => 'Venue C',
+				'post_name'  => 'venue-c',
+			)
+		)->get()->ID;
+		$this->go_to( get_permalink( $venue_id ) );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method( $instance, 'collect_contextual_alternate_links', array( $args ) );
+
+		$this->assertCount( 1, $links, 'Singular venue dispatch should produce exactly one entry.' );
+		$this->assertStringContainsString(
+			'iCal Download',
+			$links[0]['attr'],
+			'Singular venue dispatch should emit the iCal Download entry.'
+		);
+	}
+
+	/**
+	 * Coverage for collect_contextual_alternate_links — returns the
+	 * tax-archive branch when on an event-bearing taxonomy archive.
+	 *
+	 * @covers ::collect_contextual_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_contextual_alternate_links_on_taxonomy_archive(): void {
+		$term_id  = $this->factory->term->create(
+			array( 'taxonomy' => 'gatherpress_topic' )
+		);
+		$wp_query = $GLOBALS['wp_query'];
+		$wp_query->init();
+		$wp_query->is_tax            = true;
+		$wp_query->queried_object    = get_term( $term_id, 'gatherpress_topic' );
+		$wp_query->queried_object_id = $term_id;
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method( $instance, 'collect_contextual_alternate_links', array( $args ) );
+
+		$this->assertCount( 1, $links, 'Tax archive dispatch should produce exactly one entry.' );
+		$this->assertStringContainsString(
+			'iCal Feed',
+			$links[0]['attr'],
+			'Tax archive dispatch should emit a taxtitle-formatted entry.'
+		);
+	}
+
+	/**
+	 * Coverage for collect_contextual_alternate_links — returns an empty list
+	 * for a request that does not match any of the dispatch arms.
+	 *
+	 * @covers ::collect_contextual_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_contextual_alternate_links_falls_through_to_empty(): void {
+		$this->go_to( home_url( '/' ) );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method( $instance, 'collect_contextual_alternate_links', array( $args ) );
+
+		$this->assertSame( array(), $links, 'Home request should produce no contextual links.' );
+	}
+
+	/**
+	 * Coverage for collect_singular_event_alternate_links — emits the single
+	 * download entry plus the per-term entries.
+	 *
+	 * @covers ::collect_singular_event_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_singular_event_alternate_links_includes_download_and_terms(): void {
+		$event_id = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+		$topic_id = $this->factory->term->create(
+			array( 'taxonomy' => 'gatherpress_topic' )
+		);
+		wp_set_post_terms( $event_id, array( $topic_id ), 'gatherpress_topic' );
+
+		$this->go_to( get_permalink( $event_id ) );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method(
+			$instance,
+			'collect_singular_event_alternate_links',
+			array( get_queried_object(), $args )
+		);
+
+		$this->assertNotEmpty( $links, 'Singular event collector should return at least the download entry.' );
+		$this->assertStringContainsString(
+			'iCal Download',
+			$links[0]['attr'],
+			'First entry should be the single-event iCal download.'
+		);
+		$this->assertGreaterThanOrEqual(
+			2,
+			count( $links ),
+			'Event tagged with a topic should produce at least one term entry in addition to the download.'
+		);
+	}
+
+	/**
+	 * Coverage for collect_singular_tax_like_alternate_links — emits the venue
+	 * comments-feed download link.
+	 *
+	 * @covers ::collect_singular_tax_like_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_singular_tax_like_alternate_links_emits_download_entry(): void {
+		$venue_id = $this->mock->post(
+			array(
+				'post_type'  => Venue::POST_TYPE,
+				'post_title' => 'Venue Y',
+				'post_name'  => 'venue-y',
+			)
+		)->get()->ID;
+		$this->go_to( get_permalink( $venue_id ) );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method(
+			$instance,
+			'collect_singular_tax_like_alternate_links',
+			array( get_queried_object(), $args )
+		);
+
+		$this->assertCount( 1, $links, 'Tax-like singular collector should emit exactly one entry.' );
+		$this->assertStringContainsString(
+			'iCal Download',
+			$links[0]['attr'],
+			'Tax-like singular attr should be formatted with the singletitle template.'
+		);
+		$this->assertSame(
+			get_post_comments_feed_link( $venue_id, Setup::ICAL_SLUG ),
+			$links[0]['url'],
+			'Tax-like singular url should resolve to the venue post comments feed link.'
+		);
+	}
+
+	/**
+	 * Coverage for collect_tax_archive_alternate_links — emits the term archive
+	 * feed link.
+	 *
+	 * @covers ::collect_tax_archive_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_tax_archive_alternate_links_emits_term_feed_entry(): void {
+		$term_id = $this->factory->term->create(
+			array( 'taxonomy' => 'gatherpress_topic' )
+		);
+		$term    = get_term( $term_id, 'gatherpress_topic' );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method(
+			$instance,
+			'collect_tax_archive_alternate_links',
+			array( $term, $args )
+		);
+
+		$this->assertCount( 1, $links, 'Tax archive collector should emit exactly one entry.' );
+		$this->assertStringContainsString(
+			'iCal Feed',
+			$links[0]['attr'],
+			'Tax archive attr should be formatted with the taxtitle template.'
+		);
+		$this->assertNotEmpty( $links[0]['url'], 'Tax archive entry should have a non-empty url.' );
+	}
+
+	/**
+	 * Coverage for collect_event_term_alternate_links — walks the event's
+	 * related terms and returns one entry per resolvable term.
+	 *
+	 * @covers ::collect_event_term_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_event_term_alternate_links_walks_terms(): void {
+		$event_id = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+		$topic_id = $this->factory->term->create(
+			array( 'taxonomy' => 'gatherpress_topic' )
+		);
+		wp_set_post_terms( $event_id, array( $topic_id ), 'gatherpress_topic' );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method(
+			$instance,
+			'collect_event_term_alternate_links',
+			array( get_post( $event_id ), $args )
+		);
+
+		$this->assertNotEmpty( $links, 'Event with a topic term should produce at least one term entry.' );
+		$this->assertStringContainsString(
+			'iCal Feed',
+			$links[0]['attr'],
+			'Term entry attr should be formatted with the taxtitle template.'
+		);
+	}
+
+	/**
+	 * Coverage for collect_term_alternate_link — returns a single entry for a
+	 * regular taxonomy term.
+	 *
+	 * @covers ::collect_term_alternate_link
+	 *
+	 * @return void
+	 */
+	public function test_collect_term_alternate_link_regular_taxonomy(): void {
+		$term_id = $this->factory->term->create(
+			array( 'taxonomy' => 'gatherpress_topic' )
+		);
+		$term    = get_term( $term_id, 'gatherpress_topic' );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$entry    = Utility::invoke_hidden_method(
+			$instance,
+			'collect_term_alternate_link',
+			array( $term, $args )
+		);
+
+		$this->assertCount( 1, $entry, 'Regular taxonomy term should produce one entry.' );
+		$this->assertNotEmpty( $entry[0]['url'], 'Regular term entry should have a non-empty url.' );
+		$this->assertStringContainsString(
+			'iCal Feed',
+			$entry[0]['attr'],
+			'Regular term attr should be formatted with the taxtitle template.'
+		);
+	}
+
+	/**
+	 * Coverage for collect_term_alternate_link — returns an empty list for a
+	 * sentinel shadow term like `online-event` whose slug does not start with `_`.
+	 *
+	 * @covers ::collect_term_alternate_link
+	 *
+	 * @return void
+	 */
+	public function test_collect_term_alternate_link_sentinel_shadow_returns_empty(): void {
+		$result = wp_insert_term(
+			'Online Event',
+			Venue::TAXONOMY,
+			array( 'slug' => 'online-event' )
+		);
+		$term   = get_term( (int) $result['term_id'], Venue::TAXONOMY );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$entry    = Utility::invoke_hidden_method(
+			$instance,
+			'collect_term_alternate_link',
+			array( $term, $args )
+		);
+
+		$this->assertSame(
+			array(),
+			$entry,
+			'Sentinel shadow term (slug without leading underscore) should produce no entry.'
+		);
+	}
+
+	/**
+	 * Coverage for collect_term_alternate_link — returns a single entry for a
+	 * resolvable shadow term (slug starts with `_` and has a backing post).
+	 *
+	 * @covers ::collect_term_alternate_link
+	 *
+	 * @return void
+	 */
+	public function test_collect_term_alternate_link_shadow_with_backing_post(): void {
+		$venue_id = $this->mock->post(
+			array(
+				'post_type'  => Venue::POST_TYPE,
+				'post_title' => 'Venue Z',
+				'post_name'  => 'venue-z',
+			)
+		)->get()->ID;
+		$term     = get_term_by( 'slug', '_venue-z', Venue::TAXONOMY );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$entry    = Utility::invoke_hidden_method(
+			$instance,
+			'collect_term_alternate_link',
+			array( $term, $args )
+		);
+
+		$this->assertCount( 1, $entry, 'Resolvable shadow term should produce one entry.' );
+		$this->assertSame(
+			get_post_comments_feed_link( $venue_id, Setup::ICAL_SLUG ),
+			$entry[0]['url'],
+			'Shadow term url should resolve to the backing venue post comments feed link.'
+		);
+	}
+
+	/**
+	 * Coverage for render_alternate_links — prints one `<link>` tag per entry
+	 * with proper escaping.
+	 *
+	 * @covers ::render_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_render_alternate_links_prints_link_tags(): void {
+		$instance = Setup::get_instance();
+		$links    = array(
+			array(
+				'url'  => 'https://example.org/feed/ical/',
+				'attr' => 'Example iCal Feed',
+			),
+			array(
+				'url'  => 'https://example.org/event/sample/feed/ical/',
+				'attr' => 'Example iCal Download',
+			),
+		);
+
+		ob_start();
+		Utility::invoke_hidden_method( $instance, 'render_alternate_links', array( $links ) );
+		$out = ob_get_clean();
+
+		$this->assertSame(
+			2,
+			substr_count( $out, '<link rel="alternate"' ),
+			'Should emit exactly one <link> tag per entry.'
+		);
+		$this->assertStringContainsString(
+			'type="text/calendar"',
+			$out,
+			'Should set the calendar MIME type on each tag.'
+		);
+		$this->assertStringContainsString(
+			'Example iCal Feed',
+			$out,
+			'Should include the first entry attr label.'
+		);
+		$this->assertStringContainsString(
+			'Example iCal Download',
+			$out,
+			'Should include the second entry attr label.'
+		);
+	}
 }


### PR DESCRIPTION
### Description of the Change
`Calendar\Setup::alternate_links()` was a 178-line method with deeply nested conditionals that built every `<link rel="alternate" type="text/calendar">` tag for `<head>`. This PR slims it down to a 12-line orchestrator and extracts the four collection branches into named helpers:

- `alternate_link_label_args()` — localized label dictionary
- `collect_sitewide_alternate_link()` — always-on sitewide feed entry
- `collect_post_type_archive_alternate_links()` — one entry per event-supporting post type
- `collect_contextual_alternate_links()` — request-type dispatcher
- `collect_singular_event_alternate_links()` — singular event branch (download + term walk)
- `collect_singular_tax_like_alternate_links()` — singular venue / shadow-source branch
- `collect_tax_archive_alternate_links()` — taxonomy archive branch
- `collect_event_term_alternate_links()` — term walker for the event's related taxonomies
- `collect_term_alternate_link()` — single-term resolver (shadow vs regular vs sentinel)
- `render_alternate_links()` — `<head>` print loop

Each helper returns an `array<array{url:string,attr:string}>` so the orchestrator becomes a straight `array_merge()` of branch outputs before rendering. The shadow-vs-regular split inside `collect_term_alternate_link()` is now isolated and unit-testable on its own.

No behavior change — `<head>` output stays byte-identical for a regular post, an event with venue + topic, an event with the `online-event` sentinel term, a singular venue, and a topic taxonomy archive.

Closes #1666

### How to test the Change
1. `npm run test:unit:php -- --filter 'Core.Calendar.Test_Setup'` — all 43 tests pass.
2. Coverage on `GatherPress\Core\Calendar\Setup`: 100% methods (30/30), 100% lines (273/273).
3. Manual smoke (via Lando or wp-env): visit a regular post, an event detail page, a venue detail page, and a topic taxonomy archive; inspect `<head>` and confirm each emits the expected `<link rel="alternate" type="text/calendar" ...>` tags as before.

### Changelog Entry
> Changed - Refactored `Calendar\Setup::alternate_links()` into a thin orchestrator with extracted per-branch helpers; no public behavior change.

### Credits
Props @mauteri

### Checklist:
- [x] I agree to follow this project's **Code of Conduct**.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.