### PR TITLE
Move calendar template lookup into shared Utility

### DIFF
--- a/includes/core/classes/calendar/class-template.php
+++ b/includes/core/classes/calendar/class-template.php
@@ -110,8 +110,18 @@ class Template extends Endpoint_Type {
 	 *
 	 * @return void
 	 */
-	public function load_feed_template() {
-		load_template( $this->template_include() );
+	public function load_feed_template(): void {
+		$presets  = $this->get_template_presets();
+		$dir_path = $presets['dir_path'] ?? $this->plugin_template_dir;
+		$path     = Utility::locate_template(
+			$presets['file_name'],
+			$dir_path,
+			$this->plugin_template_dir === $dir_path
+		);
+
+		if ( $path ) {
+			Utility::render_template( $path, array(), true );
+		}
 	}
 
 	/**
@@ -129,23 +139,18 @@ class Template extends Endpoint_Type {
 	 * @return string          The path of the template to include, either from the theme or plugin.
 	 */
 	public function template_include( string $template = '' ): string {
-		$presets   = $this->get_template_presets();
-		$file_name = $presets['file_name'];
-		$dir_path  = $presets['dir_path'] ?? $this->plugin_template_dir;
+		$presets  = $this->get_template_presets();
+		$dir_path = $presets['dir_path'] ?? $this->plugin_template_dir;
+		$resolved = Utility::locate_template(
+			$presets['file_name'],
+			$dir_path,
+			$this->plugin_template_dir === $dir_path
+		);
 
-		// Check if the theme provides a custom template.
-		$theme_template = $this->get_template_from_theme( $file_name );
-		if ( $theme_template ) {
-			return $theme_template;
+		if ( $resolved ) {
+			return $resolved;
 		}
 
-		// Check if the plugin has a template file.
-		$plugin_template = $this->get_template_from_plugin( $file_name, $dir_path );
-		if ( $plugin_template ) {
-			return $plugin_template;
-		}
-
-		// Fallback to the default template.
 		return $template;
 	}
 
@@ -158,56 +163,5 @@ class Template extends Endpoint_Type {
 	 */
 	protected function get_template_presets(): array {
 		return ( $this->callback )();
-	}
-
-	/**
-	 * Locate a template in the theme or child theme.
-	 *
-	 * @todo Maybe better put in the Utility class?
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $file_name The name of the template file.
-	 * @return string The path to the theme template or an empty string if not found.
-	 */
-	protected function get_template_from_theme( string $file_name ): string {
-		// locate_template() accepts a string, but locate_block_template()
-		// requires an array of candidate templates.
-		$templates = array( $file_name );
-
-		// First, search for PHP templates, which block themes can also use.
-		$template = locate_template( $templates );
-
-		// Pass the result into the block template locator and let it figure
-		// out whether block templates are supported and this template exists.
-		$template = locate_block_template(
-			$template,
-			pathinfo( $file_name, PATHINFO_FILENAME ), // Name of the file without extension.
-			$templates
-		);
-
-		return $template;
-	}
-
-	/**
-	 * Build the full path to the plugin's template file.
-	 *
-	 * @todo Maybe better put in the Utility class?
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $file_name The name of the template file.
-	 * @param string $dir_path  The directory path where the template is stored.
-	 * @return string The full path to the template file or an empty string if file not exists.
-	 */
-	protected function get_template_from_plugin( string $file_name, string $dir_path ): string {
-		// Remove the GatherPress prefix to keep template filenames simple for
-		// core templates shipped from this plugin.
-		if ( $this->plugin_template_dir === $dir_path ) {
-			$file_name = Utility::unprefix_key( $file_name );
-		}
-
-		$template = trailingslashit( $dir_path ) . $file_name;
-		return file_exists( $template ) ? $template : '';
 	}
 }

--- a/includes/core/classes/calendar/class-template.php
+++ b/includes/core/classes/calendar/class-template.php
@@ -111,17 +111,15 @@ class Template extends Endpoint_Type {
 	 * @return void
 	 */
 	public function load_feed_template(): void {
-		$presets  = $this->get_template_presets();
-		$dir_path = $presets['dir_path'] ?? $this->plugin_template_dir;
-		$path     = Utility::locate_template(
-			$presets['file_name'],
-			$dir_path,
-			$this->plugin_template_dir === $dir_path
+		$presets = $this->get_template_presets();
+		Utility::render_template(
+			Utility::locate_template(
+				$presets['file_name'],
+				$presets['dir_path'] ?? $this->plugin_template_dir
+			),
+			array(),
+			true
 		);
-
-		if ( $path ) {
-			Utility::render_template( $path, array(), true );
-		}
 	}
 
 	/**
@@ -140,18 +138,13 @@ class Template extends Endpoint_Type {
 	 */
 	public function template_include( string $template = '' ): string {
 		$presets  = $this->get_template_presets();
-		$dir_path = $presets['dir_path'] ?? $this->plugin_template_dir;
 		$resolved = Utility::locate_template(
 			$presets['file_name'],
-			$dir_path,
-			$this->plugin_template_dir === $dir_path
+			$presets['dir_path'] ?? $this->plugin_template_dir
 		);
 
-		if ( $resolved ) {
-			return $resolved;
-		}
-
-		return $template;
+		// phpcs:ignore Universal.Operators.DisallowShortTernary.Found -- Issue #1667 orchestrator shape.
+		return $resolved ?: $template;
 	}
 
 	/**

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -68,17 +68,11 @@ class Utility {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $file_name                 Template file name (e.g. `gatherpress_ical-download.php`).
-	 * @param string $plugin_dir                Plugin directory for the bundled fallback lookup.
-	 * @param bool   $strip_gatherpress_prefix  When true, strip the `gatherpress_` prefix from
-	 *                                          `$file_name` before checking the plugin directory.
+	 * @param string $file_name  Template file name (e.g. `gatherpress_ical-download.php`).
+	 * @param string $plugin_dir Plugin directory for the bundled fallback lookup.
 	 * @return string Resolved template path, or empty string when nothing matches.
 	 */
-	public static function locate_template(
-		string $file_name,
-		string $plugin_dir = '',
-		bool $strip_gatherpress_prefix = false
-	): string {
+	public static function locate_template( string $file_name, string $plugin_dir = '' ): string {
 		// locate_template() accepts a string, but locate_block_template()
 		// requires an array of candidate templates.
 		$templates = array( $file_name );
@@ -102,12 +96,17 @@ class Utility {
 			return '';
 		}
 
-		$plugin_file_name = $file_name;
-		if ( $strip_gatherpress_prefix ) {
-			$plugin_file_name = self::unprefix_key( $file_name );
+		$plugin_template = trailingslashit( $plugin_dir ) . $file_name;
+		if ( file_exists( $plugin_template ) ) {
+			return $plugin_template;
 		}
 
-		$plugin_template = trailingslashit( $plugin_dir ) . $plugin_file_name;
+		$unprefixed_name = self::unprefix_key( $file_name );
+		if ( $unprefixed_name === $file_name ) {
+			return '';
+		}
+
+		$plugin_template = trailingslashit( $plugin_dir ) . $unprefixed_name;
 
 		return file_exists( $plugin_template ) ? $plugin_template : '';
 	}

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -92,10 +92,21 @@ class Utility {
 			return $theme_template;
 		}
 
-		if ( empty( $plugin_dir ) ) {
-			return '';
-		}
+		return ! empty( $plugin_dir )
+			? self::resolve_plugin_template( $plugin_dir, $file_name )
+			: '';
+	}
 
+	/**
+	 * Resolve a plugin-bundled template path when the theme has no override.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $plugin_dir Plugin directory for the bundled fallback lookup.
+	 * @param string $file_name  Template file name (e.g. `gatherpress_ical-download.php`).
+	 * @return string Resolved template path, or empty string when nothing matches.
+	 */
+	private static function resolve_plugin_template( string $plugin_dir, string $file_name ): string {
 		$plugin_template = trailingslashit( $plugin_dir ) . $file_name;
 		if ( file_exists( $plugin_template ) ) {
 			return $plugin_template;

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -60,6 +60,59 @@ class Utility {
 	}
 
 	/**
+	 * Locate a theme-overridable template file.
+	 *
+	 * Walks theme PHP templates, block templates, then a plugin-bundled fallback
+	 * directory in that order. Returns the resolved absolute path, or an empty
+	 * string when no candidate exists.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $file_name                 Template file name (e.g. `gatherpress_ical-download.php`).
+	 * @param string $plugin_dir                Plugin directory for the bundled fallback lookup.
+	 * @param bool   $strip_gatherpress_prefix  When true, strip the `gatherpress_` prefix from
+	 *                                          `$file_name` before checking the plugin directory.
+	 * @return string Resolved template path, or empty string when nothing matches.
+	 */
+	public static function locate_template(
+		string $file_name,
+		string $plugin_dir = '',
+		bool $strip_gatherpress_prefix = false
+	): string {
+		// locate_template() accepts a string, but locate_block_template()
+		// requires an array of candidate templates.
+		$templates = array( $file_name );
+
+		// First, search for PHP templates, which block themes can also use.
+		$theme_template = locate_template( $templates );
+
+		// Pass the result into the block template locator and let it figure
+		// out whether block templates are supported and this template exists.
+		$theme_template = locate_block_template(
+			$theme_template,
+			pathinfo( $file_name, PATHINFO_FILENAME ),
+			$templates
+		);
+
+		if ( $theme_template ) {
+			return $theme_template;
+		}
+
+		if ( empty( $plugin_dir ) ) {
+			return '';
+		}
+
+		$plugin_file_name = $file_name;
+		if ( $strip_gatherpress_prefix ) {
+			$plugin_file_name = self::unprefix_key( $file_name );
+		}
+
+		$plugin_template = trailingslashit( $plugin_dir ) . $plugin_file_name;
+
+		return file_exists( $plugin_template ) ? $plugin_template : '';
+	}
+
+	/**
 	 * Prefixes a key with 'gatherpress_'.
 	 *
 	 * This method adds the 'gatherpress_' prefix to the provided key and returns the modified key.

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-template.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-template.php
@@ -127,8 +127,6 @@ class Test_Template extends Base {
 	 *
 	 * @covers ::template_include
 	 * @covers ::get_template_presets
-	 * @covers ::get_template_from_theme
-	 * @covers ::get_template_from_plugin
 	 *
 	 * @return void
 	 */
@@ -159,8 +157,6 @@ class Test_Template extends Base {
 	 *
 	 * @covers ::template_include
 	 * @covers ::get_template_presets
-	 * @covers ::get_template_from_theme
-	 * @covers ::get_template_from_plugin
 	 *
 	 * @return void
 	 */
@@ -190,11 +186,7 @@ class Test_Template extends Base {
 	}
 
 	/**
-	 * When `get_template_from_theme()` returns a non-empty path,
-	 * template_include short-circuits and returns it without consulting the
-	 * plugin directory. Verifying via reflection-invoked subcomponents keeps
-	 * the test independent of `locate_template()`'s theme-resolution rules,
-	 * which are difficult to set up reliably in the unit-test environment.
+	 * When a theme override exists, template_include returns it before the plugin fallback.
 	 *
 	 * @covers ::template_include
 	 * @covers ::get_template_presets
@@ -202,84 +194,34 @@ class Test_Template extends Base {
 	 * @return void
 	 */
 	public function test_template_include_returns_theme_template_when_present(): void {
-		$slug     = 'ical';
-		$callback = static function () {
-			return array(
-				'file_name' => 'gatherpress_ical-download.php',
-			);
-		};
-
-		$theme_template = '/path/to/theme/ical-download.php';
-
-		// Subclass that stubs the protected theme/plugin lookups so we exercise
-		// the early-return branch of template_include() without depending on
-		// the filesystem.
-		$instance                 = new class( $slug, $callback, '/nonexistent' ) extends Template {
-
-			/**
-			 * Stub return value for the overridden lookup.
-			 *
-			 * @var string
-			 */
-			public string $theme_template = '';
-
-			/**
-			 * Override that returns the stubbed theme template path.
-			 *
-			 * @param string $file_name Template file name (unused in stub).
-			 * @return string
-			 */
-			protected function get_template_from_theme( string $file_name ): string {
-				return $this->theme_template;
-			}
-		};
-		$instance->theme_template = $theme_template;
-
-		$this->assertSame(
-			$theme_template,
-			$instance->template_include( '/default/template.php' ),
-			'template_include should return the theme template when it is non-empty.'
-		);
-	}
-
-	/**
-	 * Direct coverage for `get_template_from_theme()` — exercises
-	 * locate_template + locate_block_template against a real on-disk file
-	 * placed in the registered stylesheet directory.
-	 *
-	 * @covers ::get_template_from_theme
-	 *
-	 * @return void
-	 */
-	public function test_get_template_from_theme_locates_existing_file(): void {
-		$file_name = 'gatherpress-calendar-test-' . wp_generate_password( 6, false, false ) . '.php';
-		$tmp_dir   = sys_get_temp_dir() . '/gatherpress-test-theme-' . wp_generate_password( 6, false, false );
+		$file_name = 'gatherpress-theme-override-' . wp_generate_password( 6, false, false ) . '.php';
+		$tmp_dir   = sys_get_temp_dir() . '/gatherpress-template-theme-' . wp_generate_password( 6, false, false );
 
 		wp_mkdir_p( $tmp_dir );
 		$theme_path = trailingslashit( $tmp_dir ) . $file_name;
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tmp scratch dir under sys_get_temp_dir().
 		file_put_contents( $theme_path, "<?php // Test stub.\n" );
 
-		// Override the stylesheet/template paths so locate_template() looks at
-		// our scratch directory instead of the real active theme.
 		$override = static function () use ( $tmp_dir ) {
 			return $tmp_dir;
 		};
 		add_filter( 'stylesheet_directory', $override );
 		add_filter( 'template_directory', $override );
 
-		try {
-			$instance = new Template( 'ical', static function () {} );
-			$result   = Utility::invoke_hidden_method(
-				$instance,
-				'get_template_from_theme',
-				array( $file_name )
+		$slug     = 'ical';
+		$callback = static function () use ( $file_name ) {
+			return array(
+				'file_name' => $file_name,
 			);
+		};
+
+		try {
+			$instance = new Template( $slug, $callback );
 
 			$this->assertSame(
 				$theme_path,
-				$result,
-				'get_template_from_theme should resolve via locate_template when the file lives in the theme directory.'
+				$instance->template_include( '/default/template.php' ),
+				'template_include should return the theme template when it is non-empty.'
 			);
 		} finally {
 			remove_filter( 'stylesheet_directory', $override );
@@ -292,47 +234,7 @@ class Test_Template extends Base {
 	}
 
 	/**
-	 * Direct coverage for `get_template_from_plugin()` — returns the resolved
-	 * path when the file exists in the plugin's template directory, an empty
-	 * string when it does not. Also confirms the `gatherpress_` prefix is
-	 * stripped when the configured dir matches the bundled template dir.
-	 *
-	 * @covers ::get_template_from_plugin
-	 *
-	 * @return void
-	 */
-	public function test_get_template_from_plugin_resolves_and_falls_back(): void {
-		$instance = new Template( 'ical', static function () {} );
-
-		// Bundled template under the default plugin_template_dir — the
-		// `gatherpress_` prefix should be stripped before the file check.
-		$bundled = Utility::invoke_hidden_method(
-			$instance,
-			'get_template_from_plugin',
-			array( 'gatherpress_ical-download.php', Utility::get_hidden_property( $instance, 'plugin_template_dir' ) )
-		);
-		$this->assertSame(
-			sprintf( '%s/includes/templates/calendar/ical-download.php', GATHERPRESS_CORE_PATH ),
-			$bundled,
-			'Should resolve the bundled iCal template and strip the gatherpress_ prefix.'
-		);
-
-		// Non-existent file → empty string fallback.
-		$missing = Utility::invoke_hidden_method(
-			$instance,
-			'get_template_from_plugin',
-			array( 'definitely-missing.php', '/nonexistent/dir' )
-		);
-		$this->assertSame(
-			'',
-			$missing,
-			'Should return an empty string when the resolved file does not exist.'
-		);
-	}
-
-	/**
-	 * Delegates to template_include and loads the resolved template via
-	 * WordPress's `load_template()`.
+	 * Delegates to Utility::locate_template and renders the resolved feed template.
 	 *
 	 * @covers ::load_feed_template
 	 *
@@ -341,7 +243,7 @@ class Test_Template extends Base {
 	public function test_load_feed_template_loads_resolved_template(): void {
 		$tmp_template = wp_tempnam( 'calendar-test-load-feed' );
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tmp scratch file.
-		file_put_contents( $tmp_template, "<?php // Test stub.\n" );
+		file_put_contents( $tmp_template, "<?php echo 'feed-template-loaded';\n" );
 
 		$slug     = 'ical';
 		$dir_path = dirname( $tmp_template );
@@ -355,16 +257,19 @@ class Test_Template extends Base {
 
 		$instance = new Template( $slug, $callback, $dir_path );
 
-		// Pure smoke test — load_feed_template returns void; we just verify
-		// that resolving the template and loading it does not error.
-		$instance->load_feed_template();
+		$output = \PMC\Unit_Test\Utility::buffer_and_return(
+			static function () use ( $instance ) {
+				$instance->load_feed_template();
+			}
+		);
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Tmp scratch file.
 		unlink( $tmp_template );
 
-		$this->assertTrue(
-			true,
-			'load_feed_template should resolve the template path and load it without error.'
+		$this->assertStringContainsString(
+			'feed-template-loaded',
+			$output,
+			'load_feed_template should render the resolved template via Utility::render_template().'
 		);
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -73,6 +73,21 @@ class Test_Utility extends Base {
 	}
 
 	/**
+	 * Returns an empty string when no theme match exists and no plugin directory is given.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_returns_empty_when_plugin_dir_is_empty(): void {
+		$this->assertSame(
+			'',
+			Utility::locate_template( 'gatherpress-definitely-missing.php', '' ),
+			'Should return an empty string when the plugin fallback directory is empty.'
+		);
+	}
+
+	/**
 	 * Resolves a template file placed in the active theme directory.
 	 *
 	 * @covers ::locate_template
@@ -160,6 +175,73 @@ class Test_Utility extends Base {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Tmp scratch file.
 			unlink( $tmp_template );
 		}
+	}
+
+	/**
+	 * Returns an exact plugin template match from the bundled directory.
+	 *
+	 * @covers ::resolve_plugin_template
+	 *
+	 * @return void
+	 */
+	public function test_resolve_plugin_template_returns_exact_match(): void {
+		$tmp_template = wp_tempnam( 'gatherpress-resolve-plugin' );
+		$dir_path     = dirname( $tmp_template );
+		$file_name    = basename( $tmp_template );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tmp scratch file.
+		file_put_contents( $tmp_template, "<?php // Test stub.\n" );
+
+		try {
+			$result = PMC_Utility::invoke_hidden_method(
+				new Utility(),
+				'resolve_plugin_template',
+				array( $dir_path, $file_name )
+			);
+
+			$this->assertSame( $tmp_template, $result );
+		} finally {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Tmp scratch file.
+			unlink( $tmp_template );
+		}
+	}
+
+	/**
+	 * Strips the gatherpress_ prefix when resolving a bundled plugin template.
+	 *
+	 * @covers ::resolve_plugin_template
+	 *
+	 * @return void
+	 */
+	public function test_resolve_plugin_template_strips_gatherpress_prefix(): void {
+		$plugin_dir = sprintf( '%s/includes/templates/calendar', GATHERPRESS_CORE_PATH );
+
+		$result = PMC_Utility::invoke_hidden_method(
+			new Utility(),
+			'resolve_plugin_template',
+			array( $plugin_dir, 'gatherpress_ical-download.php' )
+		);
+
+		$this->assertSame(
+			sprintf( '%s/ical-download.php', $plugin_dir ),
+			$result
+		);
+	}
+
+	/**
+	 * Returns an empty string when no bundled plugin template exists.
+	 *
+	 * @covers ::resolve_plugin_template
+	 *
+	 * @return void
+	 */
+	public function test_resolve_plugin_template_returns_empty_when_missing(): void {
+		$result = PMC_Utility::invoke_hidden_method(
+			new Utility(),
+			'resolve_plugin_template',
+			array( '/nonexistent/plugin/templates', 'gatherpress-definitely-missing.php' )
+		);
+
+		$this->assertSame( '', $result );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -58,6 +58,112 @@ class Test_Utility extends Base {
 	}
 
 	/**
+	 * Returns an empty string when no theme, block, or plugin template exists.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_returns_empty_when_nothing_matches(): void {
+		$this->assertSame(
+			'',
+			Utility::locate_template( 'gatherpress-definitely-missing.php', '/nonexistent/plugin/templates' ),
+			'Should return an empty string when no candidate template exists.'
+		);
+	}
+
+	/**
+	 * Resolves a template file placed in the active theme directory.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_finds_theme_override(): void {
+		$file_name = 'gatherpress-locate-test-' . wp_generate_password( 6, false, false ) . '.php';
+		$tmp_dir   = sys_get_temp_dir() . '/gatherpress-locate-theme-' . wp_generate_password( 6, false, false );
+
+		wp_mkdir_p( $tmp_dir );
+		$theme_path = trailingslashit( $tmp_dir ) . $file_name;
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tmp scratch dir under sys_get_temp_dir().
+		file_put_contents( $theme_path, "<?php // Test stub.\n" );
+
+		$override = static function () use ( $tmp_dir ) {
+			return $tmp_dir;
+		};
+		add_filter( 'stylesheet_directory', $override );
+		add_filter( 'template_directory', $override );
+
+		try {
+			$result = Utility::locate_template( $file_name, '/nonexistent/plugin/templates' );
+
+			$this->assertSame(
+				$theme_path,
+				$result,
+				'Theme override should win over the plugin fallback directory.'
+			);
+		} finally {
+			remove_filter( 'stylesheet_directory', $override );
+			remove_filter( 'template_directory', $override );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Tmp scratch dir.
+			unlink( $theme_path );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Tmp scratch dir.
+			rmdir( $tmp_dir );
+		}
+	}
+
+	/**
+	 * Falls back to the bundled plugin template and strips the gatherpress_ prefix.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_resolves_plugin_fallback_with_prefix_strip(): void {
+		$plugin_dir = sprintf( '%s/includes/templates/calendar', GATHERPRESS_CORE_PATH );
+
+		$result = Utility::locate_template(
+			'gatherpress_ical-download.php',
+			$plugin_dir,
+			true
+		);
+
+		$this->assertSame(
+			sprintf( '%s/ical-download.php', $plugin_dir ),
+			$result,
+			'Should resolve the bundled iCal template and strip the gatherpress_ prefix.'
+		);
+	}
+
+	/**
+	 * Skips prefix stripping when the caller opts out of the bundled-dir convention.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_plugin_fallback_without_prefix_strip(): void {
+		$tmp_template = wp_tempnam( 'gatherpress-locate-plugin' );
+		$dir_path     = dirname( $tmp_template );
+		$file_name    = basename( $tmp_template );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tmp scratch file.
+		file_put_contents( $tmp_template, "<?php // Test stub.\n" );
+
+		try {
+			$result = Utility::locate_template( $file_name, $dir_path, false );
+
+			$this->assertSame(
+				$tmp_template,
+				$result,
+				'Should resolve an exact plugin filename when prefix stripping is disabled.'
+			);
+		} finally {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Tmp scratch file.
+			unlink( $tmp_template );
+		}
+	}
+
+	/**
 	 * Coverage for prefix_key method.
 	 *
 	 * @covers ::prefix_key

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -124,8 +124,7 @@ class Test_Utility extends Base {
 
 		$result = Utility::locate_template(
 			'gatherpress_ical-download.php',
-			$plugin_dir,
-			true
+			$plugin_dir
 		);
 
 		$this->assertSame(
@@ -136,13 +135,13 @@ class Test_Utility extends Base {
 	}
 
 	/**
-	 * Skips prefix stripping when the caller opts out of the bundled-dir convention.
+	 * Resolves a plugin template when the filename has no gatherpress_ prefix.
 	 *
 	 * @covers ::locate_template
 	 *
 	 * @return void
 	 */
-	public function test_locate_template_plugin_fallback_without_prefix_strip(): void {
+	public function test_locate_template_plugin_fallback_exact_filename(): void {
 		$tmp_template = wp_tempnam( 'gatherpress-locate-plugin' );
 		$dir_path     = dirname( $tmp_template );
 		$file_name    = basename( $tmp_template );
@@ -150,12 +149,12 @@ class Test_Utility extends Base {
 		file_put_contents( $tmp_template, "<?php // Test stub.\n" );
 
 		try {
-			$result = Utility::locate_template( $file_name, $dir_path, false );
+			$result = Utility::locate_template( $file_name, $dir_path );
 
 			$this->assertSame(
 				$tmp_template,
 				$result,
-				'Should resolve an exact plugin filename when prefix stripping is disabled.'
+				'Should resolve an exact plugin filename when no prefix stripping is needed.'
 			);
 		} finally {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Tmp scratch file.


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change
Calendar template lookup lived only on `Calendar\Template`; this moves it into shared Utility so theme overrides and plugin fallbacks work the same way everywhere else. Behavior is unchanged — calendar links, ICS downloads, and feeds should all work as before. Verified with lint, unit tests, Add to calendar on a published event, and /feed/ical downloading a valid feed.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #1667 

### How to test the Change
- On a published event, use Add to calendar(the block)->  iCal should download a valid .ics.
- Hit /feed/ical -> should download a feed, not 404.
- Hit /event/{slug}/outlook/ -> should download a valid .ics, not 404.
- Hit /event/{slug}/google-calendar/ -> should redirect to Google Calendar, not 404.
- Hit /event/feed/ical/ -> should download a feed, not 404.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Existing functionality


### Credits
Props @jmarx 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
