### PR TITLE
Migrate Calendar\Template's theme-override discovery into Utility

### DIFF
--- a/docs/developer/hooks-naming-convention.md
+++ b/docs/developer/hooks-naming-convention.md
@@ -40,6 +40,7 @@ The subsystem segment names a single area of the plugin. The current set:
 | `static_map_*` | Server-side OSM tile compositor and PNG output **only**. |
 | `static_map_prewarm_*` | Prewarm cron family (batch sizes, run/sweep actions, enqueue short-circuit). |
 | `settings_*` | Admin settings UI surfaces. |
+| `template_*` | Theme-override-aware template path resolution shared across subsystems (see `Utility::locate_template()`). |
 
 When adding a hook in a subsystem that's not on this list, add the subsystem
 here in the same PR.

--- a/includes/core/classes/calendar/class-template.php
+++ b/includes/core/classes/calendar/class-template.php
@@ -86,41 +86,41 @@ class Template extends Endpoint_Type {
 	/**
 	 * Load the theme-overridable feed template from the plugin.
 	 *
-	 * This method ensures that a feed template is loaded when a request is made to
-	 * a custom feed endpoint. If the theme provides an override for the feed template,
-	 * it will be used; otherwise, the default template from the plugin is loaded. The
-	 * method ensures that WordPress does not return a 404 for custom feed URLs.
+	 * Ensures that a feed template is loaded when a request hits a custom
+	 * feed endpoint — without this `do_feed_{slug}` action callback,
+	 * WordPress would XML-404 on `/feed/{slug}` URLs.
 	 *
-	 * A call to any post types /feed/anything endpoint is handled by WordPress
-	 * prior 'Template's template_include hook would run.
-	 * Therefore WordPress will throw an xml'ed 404 error,
-	 * if nothing is hooked onto the 'do_feed_anything' action.
+	 * Resolves the template via `template_include()` (same theme → plugin
+	 * lookup the non-feed branch uses) and then runs it via
+	 * `Utility::render_template()` so the feed body is emitted. Globals
+	 * (`$wp_query`, `$post`) are already set by WordPress before
+	 * `do_feed_{slug}` fires, so the file does not need
+	 * `load_template()`'s explicit `set_global_vars()`.
 	 *
-	 * That's the reason for this method, it delivers what WordPress wants
-	 * and re-uses the parameters provided by the class.
-	 *
-	 * We expect that a endpoint, that contains the /feed/ string, only has one 'Redirect_Template' attached.
-	 * This might be wrong or short sightened, please open an issue in that case
-	 * under https://github.com/GatherPress/gatherpress/issues.
-	 *
-	 * Until then, we *just* use the first of the provided endpoint-types,
-	 * to hook into WordPress, which should be the valid template endpoint.
+	 * We expect that an endpoint containing `/feed/` only has one
+	 * `Redirect_Template` attached. If that assumption ever breaks, open an
+	 * issue at https://github.com/GatherPress/gatherpress/issues — until
+	 * then we just use the first of the provided endpoint-types.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
-	public function load_feed_template() {
-		load_template( $this->template_include() );
+	public function load_feed_template(): void {
+		$resolved = $this->template_include();
+
+		if ( ! empty( $resolved ) ) {
+			Utility::render_template( $resolved, array(), true );
+		}
 	}
 
 	/**
 	 * Filters the path of the current template before including it.
 	 *
-	 * This method checks if the theme or child theme provides a custom template for the
-	 * current endpoint. If a theme template exists, it will use that; otherwise, it will
-	 * fall back to the default template provided by the plugin. The template information
-	 * is provided by the callback set during the construction of the endpoint.
+	 * Delegates the theme → block-template → plugin fallback walk to
+	 * `Utility::locate_template()` and returns the resolved path. Falls
+	 * back to the WP-supplied default when nothing is found, so the
+	 * template loader can keep looking.
 	 *
 	 * @since 1.0.0
 	 *
@@ -129,24 +129,11 @@ class Template extends Endpoint_Type {
 	 * @return string          The path of the template to include, either from the theme or plugin.
 	 */
 	public function template_include( string $template = '' ): string {
-		$presets   = $this->get_template_presets();
-		$file_name = $presets['file_name'];
-		$dir_path  = $presets['dir_path'] ?? $this->plugin_template_dir;
+		$presets  = $this->get_template_presets();
+		$dir_path = $presets['dir_path'] ?? $this->plugin_template_dir;
+		$resolved = Utility::locate_template( $presets['file_name'], $dir_path );
 
-		// Check if the theme provides a custom template.
-		$theme_template = $this->get_template_from_theme( $file_name );
-		if ( $theme_template ) {
-			return $theme_template;
-		}
-
-		// Check if the plugin has a template file.
-		$plugin_template = $this->get_template_from_plugin( $file_name, $dir_path );
-		if ( $plugin_template ) {
-			return $plugin_template;
-		}
-
-		// Fallback to the default template.
-		return $template;
+		return $resolved ? $resolved : $template;
 	}
 
 	/**
@@ -158,56 +145,5 @@ class Template extends Endpoint_Type {
 	 */
 	protected function get_template_presets(): array {
 		return ( $this->callback )();
-	}
-
-	/**
-	 * Locate a template in the theme or child theme.
-	 *
-	 * @todo Maybe better put in the Utility class?
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $file_name The name of the template file.
-	 * @return string The path to the theme template or an empty string if not found.
-	 */
-	protected function get_template_from_theme( string $file_name ): string {
-		// locate_template() accepts a string, but locate_block_template()
-		// requires an array of candidate templates.
-		$templates = array( $file_name );
-
-		// First, search for PHP templates, which block themes can also use.
-		$template = locate_template( $templates );
-
-		// Pass the result into the block template locator and let it figure
-		// out whether block templates are supported and this template exists.
-		$template = locate_block_template(
-			$template,
-			pathinfo( $file_name, PATHINFO_FILENAME ), // Name of the file without extension.
-			$templates
-		);
-
-		return $template;
-	}
-
-	/**
-	 * Build the full path to the plugin's template file.
-	 *
-	 * @todo Maybe better put in the Utility class?
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $file_name The name of the template file.
-	 * @param string $dir_path  The directory path where the template is stored.
-	 * @return string The full path to the template file or an empty string if file not exists.
-	 */
-	protected function get_template_from_plugin( string $file_name, string $dir_path ): string {
-		// Remove the GatherPress prefix to keep template filenames simple for
-		// core templates shipped from this plugin.
-		if ( $this->plugin_template_dir === $dir_path ) {
-			$file_name = Utility::unprefix_key( $file_name );
-		}
-
-		$template = trailingslashit( $dir_path ) . $file_name;
-		return file_exists( $template ) ? $template : '';
 	}
 }

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -60,6 +60,69 @@ class Utility {
 	}
 
 	/**
+	 * Locate a theme-overridable template file.
+	 *
+	 * Walks the resolution chain used everywhere GatherPress ships an
+	 * overridable template:
+	 *
+	 * 1. `locate_template()` — classic theme / child-theme override.
+	 * 2. `locate_block_template()` — block-theme override (HTML template
+	 *    parts), keyed off the file basename minus extension.
+	 * 3. The plugin's bundled fallback under `$plugin_dir`:
+	 *    - the file name as-supplied (so a caller's custom dir can ship a
+	 *      `gatherpress_*.php` file under its prefixed name), then
+	 *    - the file name with the `gatherpress_` prefix stripped (so the
+	 *      bundled core templates live as plain `ical-download.php` on disk).
+	 *
+	 * Returns the first match, or `''` if nothing exists.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $file_name  The template file name, e.g. `gatherpress_ical-download.php`.
+	 * @param string $plugin_dir Absolute directory the plugin's bundled fallback lives in.
+	 * @return string Absolute path to the resolved template, or `''` if none exists.
+	 */
+	public static function locate_template( string $file_name, string $plugin_dir = '' ): string {
+		// `locate_template()` accepts a string, `locate_block_template()`
+		// requires an array of candidates.
+		$templates      = array( $file_name );
+		$theme_template = locate_template( $templates );
+		$theme_template = locate_block_template(
+			$theme_template,
+			pathinfo( $file_name, PATHINFO_FILENAME ),
+			$templates
+		);
+
+		if ( $theme_template ) {
+			return $theme_template;
+		}
+
+		if ( empty( $plugin_dir ) ) {
+			return '';
+		}
+
+		// Try the file name as-supplied first so a caller can ship a
+		// `gatherpress_*.php` file under its prefixed name on disk.
+		$plugin_template = trailingslashit( $plugin_dir ) . $file_name;
+		if ( file_exists( $plugin_template ) ) {
+			return $plugin_template;
+		}
+
+		// Fall back to the unprefixed name so the bundled core templates
+		// (which live on disk as plain `ical-download.php`) still resolve
+		// when callers pass the prefixed name (the convention used by
+		// `Utility::prefix_key()`-tagged template descriptors).
+		$unprefixed = self::unprefix_key( $file_name );
+		if ( $unprefixed === $file_name ) {
+			return '';
+		}
+
+		$plugin_template = trailingslashit( $plugin_dir ) . $unprefixed;
+
+		return file_exists( $plugin_template ) ? $plugin_template : '';
+	}
+
+	/**
 	 * Prefixes a key with 'gatherpress_'.
 	 *
 	 * This method adds the 'gatherpress_' prefix to the provided key and returns the modified key.

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -68,7 +68,8 @@ class Utility {
 	 * 1. `locate_template()` — classic theme / child-theme override.
 	 * 2. `locate_block_template()` — block-theme override (HTML template
 	 *    parts), keyed off the file basename minus extension.
-	 * 3. The plugin's bundled fallback under `$plugin_dir`:
+	 * 3. The caller's bundled fallback under `$fallback_dir` (which may be
+	 *    a plugin, mu-plugin, theme, or any other source):
 	 *    - the file name as-supplied (so a caller's custom dir can ship a
 	 *      `gatherpress_*.php` file under its prefixed name), then
 	 *    - the file name with the `gatherpress_` prefix stripped (so the
@@ -78,11 +79,11 @@ class Utility {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $file_name  The template file name, e.g. `gatherpress_ical-download.php`.
-	 * @param string $plugin_dir Absolute directory the plugin's bundled fallback lives in.
+	 * @param string $file_name    The template file name, e.g. `gatherpress_ical-download.php`.
+	 * @param string $fallback_dir Absolute directory the caller's bundled fallback lives in.
 	 * @return string Absolute path to the resolved template, or `''` if none exists.
 	 */
-	public static function locate_template( string $file_name, string $plugin_dir = '' ): string {
+	public static function locate_template( string $file_name, string $fallback_dir = '' ): string {
 		// `locate_template()` accepts a string, `locate_block_template()`
 		// requires an array of candidates.
 		$templates      = array( $file_name );
@@ -94,32 +95,64 @@ class Utility {
 		);
 
 		if ( $theme_template ) {
-			return $theme_template;
+			$resolved = $theme_template;
+		} elseif ( empty( $fallback_dir ) ) {
+			$resolved = '';
+		} else {
+			$resolved = self::resolve_fallback_template_path( $fallback_dir, $file_name );
 		}
 
-		if ( empty( $plugin_dir ) ) {
-			return '';
+		/**
+		 * Filters the resolved template path returned by `Utility::locate_template()`.
+		 *
+		 * Lets extension code (plugin, mu-plugin, theme, etc.) override or
+		 * replace GatherPress's default theme → block-template → fallback-dir
+		 * resolution chain — for example to point the calendar's iCal
+		 * templates at a custom directory, or to ship overridable templates
+		 * from a companion source via the same utility. Return an empty
+		 * string to signal "no template found"; callers will fall back to
+		 * their own default.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $resolved     Resolved absolute template path, or `''` if no candidate matched.
+		 * @param string $file_name    The template file name passed to `Utility::locate_template()`.
+		 * @param string $fallback_dir Directory the bundled fallback was looked up in (may be empty).
+		 */
+		return (string) apply_filters( 'gatherpress_template_path', $resolved, $file_name, $fallback_dir );
+	}
+
+	/**
+	 * Resolve a caller-bundled template path, with prefix-strip fallback.
+	 *
+	 * Tries the file name as-supplied first (so a caller can ship a
+	 * `gatherpress_*.php` file under its prefixed name on disk), then falls
+	 * back to the unprefixed name so the bundled core templates (which live
+	 * on disk as plain `ical-download.php`) still resolve when callers pass
+	 * the prefixed name (the convention used by `Utility::prefix_key()`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $fallback_dir Absolute directory the caller's bundled fallback lives in.
+	 * @param string $file_name    Template file name to check inside `$fallback_dir`.
+	 * @return string Resolved template path, or `''` if neither variant exists on disk.
+	 */
+	private static function resolve_fallback_template_path( string $fallback_dir, string $file_name ): string {
+		$fallback_template = trailingslashit( $fallback_dir ) . $file_name;
+
+		if ( file_exists( $fallback_template ) ) {
+			return $fallback_template;
 		}
 
-		// Try the file name as-supplied first so a caller can ship a
-		// `gatherpress_*.php` file under its prefixed name on disk.
-		$plugin_template = trailingslashit( $plugin_dir ) . $file_name;
-		if ( file_exists( $plugin_template ) ) {
-			return $plugin_template;
-		}
-
-		// Fall back to the unprefixed name so the bundled core templates
-		// (which live on disk as plain `ical-download.php`) still resolve
-		// when callers pass the prefixed name (the convention used by
-		// `Utility::prefix_key()`-tagged template descriptors).
 		$unprefixed = self::unprefix_key( $file_name );
+
 		if ( $unprefixed === $file_name ) {
 			return '';
 		}
 
-		$plugin_template = trailingslashit( $plugin_dir ) . $unprefixed;
+		$fallback_template = trailingslashit( $fallback_dir ) . $unprefixed;
 
-		return file_exists( $plugin_template ) ? $plugin_template : '';
+		return file_exists( $fallback_template ) ? $fallback_template : '';
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-template.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-template.php
@@ -127,8 +127,6 @@ class Test_Template extends Base {
 	 *
 	 * @covers ::template_include
 	 * @covers ::get_template_presets
-	 * @covers ::get_template_from_theme
-	 * @covers ::get_template_from_plugin
 	 *
 	 * @return void
 	 */
@@ -159,8 +157,6 @@ class Test_Template extends Base {
 	 *
 	 * @covers ::template_include
 	 * @covers ::get_template_presets
-	 * @covers ::get_template_from_theme
-	 * @covers ::get_template_from_plugin
 	 *
 	 * @return void
 	 */
@@ -190,11 +186,10 @@ class Test_Template extends Base {
 	}
 
 	/**
-	 * When `get_template_from_theme()` returns a non-empty path,
-	 * template_include short-circuits and returns it without consulting the
-	 * plugin directory. Verifying via reflection-invoked subcomponents keeps
-	 * the test independent of `locate_template()`'s theme-resolution rules,
-	 * which are difficult to set up reliably in the unit-test environment.
+	 * When a theme provides the override file, `template_include` returns the
+	 * theme path without consulting the plugin directory. Exercises the real
+	 * `locate_template()` resolution by pointing the registered stylesheet
+	 * directory at a scratch dir.
 	 *
 	 * @covers ::template_include
 	 * @covers ::get_template_presets
@@ -202,66 +197,15 @@ class Test_Template extends Base {
 	 * @return void
 	 */
 	public function test_template_include_returns_theme_template_when_present(): void {
-		$slug     = 'ical';
-		$callback = static function () {
-			return array(
-				'file_name' => 'gatherpress_ical-download.php',
-			);
-		};
-
-		$theme_template = '/path/to/theme/ical-download.php';
-
-		// Subclass that stubs the protected theme/plugin lookups so we exercise
-		// the early-return branch of template_include() without depending on
-		// the filesystem.
-		$instance                 = new class( $slug, $callback, '/nonexistent' ) extends Template {
-
-			/**
-			 * Stub return value for the overridden lookup.
-			 *
-			 * @var string
-			 */
-			public string $theme_template = '';
-
-			/**
-			 * Override that returns the stubbed theme template path.
-			 *
-			 * @param string $file_name Template file name (unused in stub).
-			 * @return string
-			 */
-			protected function get_template_from_theme( string $file_name ): string {
-				return $this->theme_template;
-			}
-		};
-		$instance->theme_template = $theme_template;
-
-		$this->assertSame(
-			$theme_template,
-			$instance->template_include( '/default/template.php' ),
-			'template_include should return the theme template when it is non-empty.'
-		);
-	}
-
-	/**
-	 * Direct coverage for `get_template_from_theme()` — exercises
-	 * locate_template + locate_block_template against a real on-disk file
-	 * placed in the registered stylesheet directory.
-	 *
-	 * @covers ::get_template_from_theme
-	 *
-	 * @return void
-	 */
-	public function test_get_template_from_theme_locates_existing_file(): void {
-		$file_name = 'gatherpress-calendar-test-' . wp_generate_password( 6, false, false ) . '.php';
+		$file_name = 'gatherpress_ical-test-' . wp_generate_password( 6, false, false ) . '.php';
 		$tmp_dir   = sys_get_temp_dir() . '/gatherpress-test-theme-' . wp_generate_password( 6, false, false );
 
 		wp_mkdir_p( $tmp_dir );
+		// Theme files live as the unprefixed name (the prefix is plugin-side).
 		$theme_path = trailingslashit( $tmp_dir ) . $file_name;
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tmp scratch dir under sys_get_temp_dir().
 		file_put_contents( $theme_path, "<?php // Test stub.\n" );
 
-		// Override the stylesheet/template paths so locate_template() looks at
-		// our scratch directory instead of the real active theme.
 		$override = static function () use ( $tmp_dir ) {
 			return $tmp_dir;
 		};
@@ -269,17 +213,15 @@ class Test_Template extends Base {
 		add_filter( 'template_directory', $override );
 
 		try {
-			$instance = new Template( 'ical', static function () {} );
-			$result   = Utility::invoke_hidden_method(
-				$instance,
-				'get_template_from_theme',
-				array( $file_name )
-			);
+			$callback = static function () use ( $file_name ) {
+				return array( 'file_name' => $file_name );
+			};
+			$instance = new Template( 'ical', $callback, '/nonexistent' );
 
 			$this->assertSame(
 				$theme_path,
-				$result,
-				'get_template_from_theme should resolve via locate_template when the file lives in the theme directory.'
+				$instance->template_include( '/default/template.php' ),
+				'template_include should return the theme template when locate_template resolves it.'
 			);
 		} finally {
 			remove_filter( 'stylesheet_directory', $override );
@@ -292,47 +234,8 @@ class Test_Template extends Base {
 	}
 
 	/**
-	 * Direct coverage for `get_template_from_plugin()` — returns the resolved
-	 * path when the file exists in the plugin's template directory, an empty
-	 * string when it does not. Also confirms the `gatherpress_` prefix is
-	 * stripped when the configured dir matches the bundled template dir.
-	 *
-	 * @covers ::get_template_from_plugin
-	 *
-	 * @return void
-	 */
-	public function test_get_template_from_plugin_resolves_and_falls_back(): void {
-		$instance = new Template( 'ical', static function () {} );
-
-		// Bundled template under the default plugin_template_dir — the
-		// `gatherpress_` prefix should be stripped before the file check.
-		$bundled = Utility::invoke_hidden_method(
-			$instance,
-			'get_template_from_plugin',
-			array( 'gatherpress_ical-download.php', Utility::get_hidden_property( $instance, 'plugin_template_dir' ) )
-		);
-		$this->assertSame(
-			sprintf( '%s/includes/templates/calendar/ical-download.php', GATHERPRESS_CORE_PATH ),
-			$bundled,
-			'Should resolve the bundled iCal template and strip the gatherpress_ prefix.'
-		);
-
-		// Non-existent file → empty string fallback.
-		$missing = Utility::invoke_hidden_method(
-			$instance,
-			'get_template_from_plugin',
-			array( 'definitely-missing.php', '/nonexistent/dir' )
-		);
-		$this->assertSame(
-			'',
-			$missing,
-			'Should return an empty string when the resolved file does not exist.'
-		);
-	}
-
-	/**
 	 * Delegates to template_include and loads the resolved template via
-	 * WordPress's `load_template()`.
+	 * `Utility::render_template()`.
 	 *
 	 * @covers ::load_feed_template
 	 *

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -58,6 +58,127 @@ class Test_Utility extends Base {
 	}
 
 	/**
+	 * Coverage for locate_template — resolves a theme override placed in the
+	 * registered stylesheet directory.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_resolves_theme_override(): void {
+		$file_name = 'gatherpress_locate-test-' . wp_generate_password( 6, false, false ) . '.php';
+		$tmp_dir   = sys_get_temp_dir() . '/gatherpress-test-theme-' . wp_generate_password( 6, false, false );
+
+		wp_mkdir_p( $tmp_dir );
+		$theme_path = trailingslashit( $tmp_dir ) . $file_name;
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tmp scratch dir under sys_get_temp_dir().
+		file_put_contents( $theme_path, "<?php // Test stub.\n" );
+
+		$override = static function () use ( $tmp_dir ) {
+			return $tmp_dir;
+		};
+		add_filter( 'stylesheet_directory', $override );
+		add_filter( 'template_directory', $override );
+
+		try {
+			$this->assertSame(
+				$theme_path,
+				Utility::locate_template( $file_name, '/nonexistent/plugin/templates' ),
+				'locate_template should return the theme override when locate_template() resolves it.'
+			);
+		} finally {
+			remove_filter( 'stylesheet_directory', $override );
+			remove_filter( 'template_directory', $override );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Tmp scratch dir.
+			unlink( $theme_path );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Tmp scratch dir.
+			rmdir( $tmp_dir );
+		}
+	}
+
+	/**
+	 * Coverage for locate_template — falls back to the plugin directory when
+	 * the theme has no override. Strips the `gatherpress_` prefix from the
+	 * passed file name before checking disk.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_resolves_plugin_fallback(): void {
+		$expected = sprintf( '%s/includes/templates/calendar/ical-download.php', GATHERPRESS_CORE_PATH );
+
+		$this->assertSame(
+			$expected,
+			Utility::locate_template(
+				'gatherpress_ical-download.php',
+				sprintf( '%s/includes/templates/calendar', GATHERPRESS_CORE_PATH )
+			),
+			'locate_template should return the bundled plugin template and strip the gatherpress_ prefix.'
+		);
+	}
+
+	/**
+	 * Coverage for locate_template — resolves an exact (already-unprefixed)
+	 * filename inside the supplied plugin directory without touching the
+	 * prefix-strip fallback.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_resolves_exact_plugin_filename(): void {
+		$tmp_template = wp_tempnam( 'gatherpress-locate-exact' );
+		$dir_path     = dirname( $tmp_template );
+		$file_name    = basename( $tmp_template );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tmp scratch file.
+		file_put_contents( $tmp_template, "<?php // Test stub.\n" );
+
+		try {
+			$this->assertSame(
+				$tmp_template,
+				Utility::locate_template( $file_name, $dir_path ),
+				'locate_template should resolve an exact plugin filename without the prefix-strip fallback.'
+			);
+		} finally {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Tmp scratch file.
+			unlink( $tmp_template );
+		}
+	}
+
+	/**
+	 * Coverage for locate_template — returns an empty string when neither the
+	 * theme nor the supplied plugin directory has the file.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_returns_empty_when_missing(): void {
+		$this->assertSame(
+			'',
+			Utility::locate_template( 'definitely-missing.php', '/nonexistent/plugin/templates' ),
+			'locate_template should return an empty string when nothing resolves.'
+		);
+	}
+
+	/**
+	 * Coverage for locate_template — returns an empty string when the theme
+	 * has no override and the caller omits the plugin directory.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_without_plugin_dir_returns_empty(): void {
+		$this->assertSame(
+			'',
+			Utility::locate_template( 'definitely-missing.php' ),
+			'locate_template should return an empty string when no plugin dir is supplied and the theme has no override.'
+		);
+	}
+
+	/**
 	 * Coverage for prefix_key method.
 	 *
 	 * @covers ::prefix_key

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -174,7 +174,7 @@ class Test_Utility extends Base {
 		$this->assertSame(
 			'',
 			Utility::locate_template( 'definitely-missing.php' ),
-			'locate_template should return an empty string when no fallback dir is supplied and no theme override exists.'
+			'locate_template should return an empty string when no fallback dir is supplied and no theme override.'
 		);
 	}
 
@@ -264,7 +264,9 @@ class Test_Utility extends Base {
 	public function test_locate_template_filter_overrides_resolved_path(): void {
 		$captured = array();
 		$callback = static function ( $resolved, $file_name, $fallback_dir ) use ( &$captured ) {
-			$captured = compact( 'resolved', 'file_name', 'fallback_dir' );
+			$captured['resolved']     = $resolved;
+			$captured['file_name']    = $file_name;
+			$captured['fallback_dir'] = $fallback_dir;
 
 			return '/filter/overrode/this.php';
 		};

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -164,18 +164,137 @@ class Test_Utility extends Base {
 
 	/**
 	 * Coverage for locate_template — returns an empty string when the theme
-	 * has no override and the caller omits the plugin directory.
+	 * has no override and the caller omits the fallback directory.
 	 *
 	 * @covers ::locate_template
 	 *
 	 * @return void
 	 */
-	public function test_locate_template_without_plugin_dir_returns_empty(): void {
+	public function test_locate_template_without_fallback_dir_returns_empty(): void {
 		$this->assertSame(
 			'',
 			Utility::locate_template( 'definitely-missing.php' ),
-			'locate_template should return an empty string when no plugin dir is supplied and the theme has no override.'
+			'locate_template should return an empty string when no fallback dir is supplied and no theme override exists.'
 		);
+	}
+
+	/**
+	 * Coverage for resolve_fallback_template_path — returns the file at its
+	 * supplied name when it exists on disk.
+	 *
+	 * @covers ::resolve_fallback_template_path
+	 *
+	 * @return void
+	 */
+	public function test_resolve_fallback_template_path_exact_match(): void {
+		$tmp_template = wp_tempnam( 'gatherpress-resolve-exact' );
+		$dir_path     = dirname( $tmp_template );
+		$file_name    = basename( $tmp_template );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Tmp scratch file.
+		file_put_contents( $tmp_template, "<?php // Test stub.\n" );
+
+		try {
+			$this->assertSame(
+				$tmp_template,
+				PMC_Utility::invoke_hidden_method(
+					new Utility(),
+					'resolve_fallback_template_path',
+					array( $dir_path, $file_name )
+				),
+				'resolve_fallback_template_path should return the file at the supplied name when it exists.'
+			);
+		} finally {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Tmp scratch file.
+			unlink( $tmp_template );
+		}
+	}
+
+	/**
+	 * Coverage for resolve_fallback_template_path — falls back to the
+	 * unprefixed file name when the prefixed name does not exist on disk.
+	 *
+	 * @covers ::resolve_fallback_template_path
+	 *
+	 * @return void
+	 */
+	public function test_resolve_fallback_template_path_strips_prefix(): void {
+		$fallback_dir = sprintf( '%s/includes/templates/calendar', GATHERPRESS_CORE_PATH );
+		$expected     = sprintf( '%s/ical-download.php', $fallback_dir );
+
+		$this->assertSame(
+			$expected,
+			PMC_Utility::invoke_hidden_method(
+				new Utility(),
+				'resolve_fallback_template_path',
+				array( $fallback_dir, 'gatherpress_ical-download.php' )
+			),
+			'resolve_fallback_template_path should fall back to the unprefixed name when the prefixed name is absent.'
+		);
+	}
+
+	/**
+	 * Coverage for resolve_fallback_template_path — returns an empty string
+	 * when neither the prefixed nor the unprefixed name resolves to a file.
+	 *
+	 * @covers ::resolve_fallback_template_path
+	 *
+	 * @return void
+	 */
+	public function test_resolve_fallback_template_path_returns_empty_when_missing(): void {
+		$this->assertSame(
+			'',
+			PMC_Utility::invoke_hidden_method(
+				new Utility(),
+				'resolve_fallback_template_path',
+				array( '/nonexistent/fallback/templates', 'definitely-missing.php' )
+			),
+			'resolve_fallback_template_path should return an empty string when neither variant exists.'
+		);
+	}
+
+	/**
+	 * Coverage for locate_template — the `gatherpress_template_path` filter
+	 * receives the resolved path along with the file name and fallback dir,
+	 * and the filter's return value wins over the default resolution.
+	 *
+	 * @covers ::locate_template
+	 *
+	 * @return void
+	 */
+	public function test_locate_template_filter_overrides_resolved_path(): void {
+		$captured = array();
+		$callback = static function ( $resolved, $file_name, $fallback_dir ) use ( &$captured ) {
+			$captured = compact( 'resolved', 'file_name', 'fallback_dir' );
+
+			return '/filter/overrode/this.php';
+		};
+
+		add_filter( 'gatherpress_template_path', $callback, 10, 3 );
+
+		try {
+			$this->assertSame(
+				'/filter/overrode/this.php',
+				Utility::locate_template( 'definitely-missing.php', '/nonexistent/fallback/templates' ),
+				'The gatherpress_template_path filter return value should win over the default resolution.'
+			);
+			$this->assertSame(
+				'',
+				$captured['resolved'],
+				'Filter should receive the unresolved empty string.'
+			);
+			$this->assertSame(
+				'definitely-missing.php',
+				$captured['file_name'],
+				'Filter should receive the requested file name.'
+			);
+			$this->assertSame(
+				'/nonexistent/fallback/templates',
+				$captured['fallback_dir'],
+				'Filter should receive the supplied fallback dir.'
+			);
+		} finally {
+			remove_filter( 'gatherpress_template_path', $callback, 10 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
`Calendar\Template` carried two private helpers — `get_template_from_theme()` and `get_template_from_plugin()` — both tagged with `@todo Maybe better put in the Utility class?`. This PR finishes that migration and adds a public extension point:

- New `Utility::locate_template( string $file_name, string $fallback_dir = '' ): string` walks the resolution chain everywhere GatherPress ships an overridable template:
  1. `locate_template()` (classic theme / child-theme override)
  2. `locate_block_template()` (block-theme override)
  3. Caller-supplied fallback directory — tries the supplied filename verbatim first, then falls back to the unprefixed variant so callers can pass the prefixed name and still resolve bundled `ical-download.php` / `ical-feed.php`.
- New `gatherpress_template_path` filter on the resolved path. The old `protected` helpers on `Calendar\Template` were theoretically subclass-overridable but had no extension point that let a third party plug in a custom subclass. The filter replaces that lost seam with a real WordPress-style hook, so companion plugins, mu-plugins, or themes can override the resolution.
- The fallback-directory argument is named `$fallback_dir` (not `plugin_dir`) — themes and mu-plugins can pass their own directory too, not just plugins.
- `Calendar\Template::template_include()` becomes a thin orchestrator that delegates to `Utility::locate_template()`.
- `Calendar\Template::load_feed_template()` swaps `load_template()` for `Utility::render_template( $path, array(), true )` — `do_feed_{slug}` has already set `$wp_query` globals by the time this fires, so the explicit `set_global_vars()` `load_template()` did is redundant here.
- Both `@todo`-tagged helpers are removed; their coverage moves to direct tests on `Utility::locate_template()` and the new private `resolve_fallback_template_path()` helper.
- `docs/developer/hooks-naming-convention.md` adds `template_*` to the subsystems table (required by the doc when a new subsystem is introduced).

Behavior is unchanged for the seven calendar endpoints (`/event/<slug>/ical`, `/outlook`, `/google-calendar`, `/yahoo-calendar`, `/feed/ical`, `/event/feed/ical`, `/venue/<slug>/feed/ical`, `/topic/<slug>/feed/ical`) and the theme-override flow (dropping `ical-download.php` into the active theme still wins over the bundled one).

Coverage stays at 100% on both touched classes: `Calendar\Template` 5/5 methods, 17/17 lines · `Utility` 22/22 methods, 214/214 lines.

Closes #1667

### How to test the Change
1. `npm run test:unit:php -- --filter 'Test_Utility|Core.Calendar.Test_Template'` — 87 tests pass.
2. On a published event: Add to Calendar block → iCal should download a valid `.ics`.
3. Hit `/feed/ical` — should serve the feed, not 404.
4. Hit `/event/<slug>/outlook/` — should download a valid `.ics`, not 404.
5. Hit `/event/<slug>/google-calendar/` — should redirect to Google Calendar, not 404.
6. Hit `/event/feed/ical/` and `/venue/<slug>/feed/ical/` — both should serve feeds.
7. Drop `ical-download.php` into the active theme's root and visit `/event/<slug>/ical/` — should serve the theme's version.
8. Drop a no-op `add_filter( 'gatherpress_template_path', fn( $path ) => '/tmp/forced-template.php' )` in a mu-plugin and confirm `template_include()` returns the forced path (use a `.php` stub that exists at that location).

### Changelog Entry
> Changed - Calendar template theme-override discovery moved into a reusable `Utility::locate_template()`; resolves the long-standing `@todo` tags on `Calendar\Template`. Adds a new `gatherpress_template_path` filter so companion plugins / themes / mu-plugins can override the resolution chain.

### Credits
Props @mauteri, @jmarx

### Checklist:
- [x] I agree to follow this project's **Code of Conduct**.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
