### PR TITLE
Bump playground blueprint demo data to 0.34.0 XML

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -51,7 +51,7 @@
       "step": "importWxr",
       "file": {
         "resource": "url",
-        "url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.33.0.xml"
+        "url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.34.0.xml"
       }
     }
   ]


### PR DESCRIPTION
## Summary

- Bump the canonical Playground blueprint at `.wordpress-org/blueprints/blueprint.json` to import `GatherPress-demo-data-0.34.0.xml` instead of the 0.33.0 one.
- Pairs with [gatherpress-demo-data#57](https://github.com/GatherPress/gatherpress-demo-data/pull/57) (which adds the new XML to that repo).
- Safe to merge into develop now — the public playground link in `README.md` / `docs/playground.md` pulls the blueprint from `main`, so the new XML reference only goes live to users when develop → main lands as part of the 0.34.0 release.

## Test plan

- [ ] Confirm [gatherpress-demo-data#57](https://github.com/GatherPress/gatherpress-demo-data/pull/57) has merged before this lands so the XML is reachable.
- [ ] On a checkout of this branch, click the Playground link from the modified blueprint (e.g. `https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/GatherPress/gatherpress/update/blueprint-0.34.0-demo-data/.wordpress-org/blueprints/blueprint.json`) → events archive renders, single events show the new venue/online-event/events-list block templates with no fatal/notice.
- [ ] Grep the imported demo content for old block markup — should be zero (`gatherpress/online-event /--`, `gatherpress/venue /--`, `gatherpress/events-list`, `gatherpress_venue_information`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
