### PR TITLE
Normalize docblocks to canonical AGENTS.md format

### DIFF
--- a/includes/core/classes/blocks/class-dropdown.php
+++ b/includes/core/classes/blocks/class-dropdown.php
@@ -102,6 +102,7 @@ class Dropdown {
 	 *
 	 * @param string $block_content The original block content.
 	 * @param array  $block         The parsed block data containing block attributes.
+	 *
 	 * @return string The modified block content with inline styles.
 	 */
 	public function generate_block_styles( string $block_content, array $block ): string {
@@ -184,6 +185,7 @@ class Dropdown {
 	 *
 	 * @param string $block_content The original block content.
 	 * @param array  $block         The parsed block data.
+	 *
 	 * @return string The modified block content with select mode attributes.
 	 */
 	public function apply_select_mode_attributes( string $block_content, array $block ): string {

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -107,6 +107,7 @@ class Event_Query {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type that was just registered.
+	 *
 	 * @return void
 	 */
 	public function maybe_register_event_date_rest_hooks( string $post_type ): void {
@@ -137,6 +138,7 @@ class Event_Query {
 	 *
 	 * @param string|null $pre_render   The pre-rendered content. Default null.
 	 * @param array       $parsed_block The block being rendered.
+	 *
 	 * @return string|null The pre-rendered content. Default null.
 	 */
 	public function pre_render_block( ?string $pre_render, array $parsed_block ): ?string {
@@ -201,6 +203,7 @@ class Event_Query {
 	 * @since 0.33.0
 	 *
 	 * @param array $attributes Event Query block attributes.
+	 *
 	 * @return int[] Array of post IDs to exclude.
 	 */
 	protected function get_exclude_ids( array $attributes ): array {
@@ -221,6 +224,7 @@ class Event_Query {
 	 *
 	 * @param array    $query Array containing parameters for <code>WP_Query</code> as parsed by the block context.
 	 * @param WP_Block $block Block instance.
+	 *
 	 * @return array Array containing parameters for <code>WP_Query</code> as parsed by the block context.
 	 */
 	public function query_loop_block_query_vars( array $query, WP_Block $block ): array {
@@ -294,6 +298,7 @@ class Event_Query {
 	 *
 	 * @param array           $args    Array of arguments for WP_Query.
 	 * @param WP_REST_Request $request The REST API request object.
+	 *
 	 * @return array Array of arguments for WP_Query.
 	 */
 	public function rest_query( array $args, WP_REST_Request $request ): array {
@@ -368,6 +373,7 @@ class Event_Query {
 	 * @see https://developer.wordpress.org/reference/classes/wp_rest_posts_controller/get_collection_params/
 	 *
 	 * @param array $query_params JSON Schema-formatted collection parameters.
+	 *
 	 * @return array JSON Schema-formatted collection parameters.
 	 */
 	public function rest_collection_params( array $query_params ): array {
@@ -415,6 +421,7 @@ class Event_Query {
 	 *
 	 * @param array $query_args  The query arguments being built.
 	 * @param array $block_query The block's query attributes.
+	 *
 	 * @return array Modified query arguments.
 	 */
 	public function aql_query_vars( array $query_args, array $block_query ): array {

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -186,6 +186,7 @@ class Rsvp_Form {
 	 *
 	 * @param string $block_content The rendered block content.
 	 * @param array  $block         The block instance array.
+	 *
 	 * @return string The modified block content or empty string if block should be hidden.
 	 */
 	public function apply_visibility_attribute( string $block_content, array $block ): string {
@@ -255,6 +256,7 @@ class Rsvp_Form {
 	 * @since 0.33.0
 	 *
 	 * @param array $block The block instance array.
+	 *
 	 * @return int|null The post ID or null if not found.
 	 */
 	private function get_post_id_from_context( array $block ): ?int {
@@ -279,6 +281,7 @@ class Rsvp_Form {
 	 *
 	 * @param string $html       The form HTML content.
 	 * @param bool   $is_success Whether the form was successfully submitted.
+	 *
 	 * @return string The modified HTML with appropriate visibility.
 	 */
 	private function handle_form_visibility( string $html, bool $is_success ): string {
@@ -314,6 +317,7 @@ class Rsvp_Form {
 	 * @param string                $visibility_rule The visibility rule as a JSON object.
 	 * @param bool                  $is_success      Whether the form was successfully submitted.
 	 * @param bool                  $is_past         Whether the event has passed.
+	 *
 	 * @return void
 	 */
 	private function apply_visibility_rule(
@@ -355,6 +359,7 @@ class Rsvp_Form {
 	 * @param string $visibility_rule The visibility rule as a JSON object.
 	 * @param bool   $is_success      Whether the form was successfully submitted.
 	 * @param bool   $is_past         Whether the event has passed.
+	 *
 	 * @return bool|null True to show, false to hide, null for no change (always visible).
 	 */
 	private function determine_visibility( string $visibility_rule, bool $is_success, bool $is_past ): ?bool {
@@ -396,6 +401,7 @@ class Rsvp_Form {
 	 * @since 0.33.0
 	 *
 	 * @param int $post_id The post ID being saved.
+	 *
 	 * @return void
 	 */
 	public function save_form_schema( int $post_id ): void {
@@ -437,6 +443,7 @@ class Rsvp_Form {
 	 * @since 0.33.0
 	 *
 	 * @param array $blocks Array of parsed blocks.
+	 *
 	 * @return array Array of form schemas keyed by form ID.
 	 */
 	private function extract_form_schemas_from_blocks( array $blocks ): array {
@@ -478,6 +485,7 @@ class Rsvp_Form {
 	 * @since 0.33.0
 	 *
 	 * @param array $inner_blocks Array of inner blocks.
+	 *
 	 * @return array Array of form field configurations.
 	 */
 	private function extract_form_fields_from_inner_blocks( array $inner_blocks ): array {
@@ -537,6 +545,7 @@ class Rsvp_Form {
 	 *
 	 * @param int   $post_id The post ID.
 	 * @param array $block   The current block being rendered.
+	 *
 	 * @return string The form schema ID (e.g., 'form_0', 'form_2').
 	 */
 	private function get_form_schema_id( int $post_id, array $block ): string {
@@ -562,6 +571,7 @@ class Rsvp_Form {
 	 * @param array $blocks       Array of parsed blocks.
 	 * @param array $target_block The block we're looking for.
 	 * @param int   $base_index   Base index for nested blocks.
+	 *
 	 * @return int The index of the form block.
 	 */
 	private function find_form_index_in_blocks( array $blocks, array $target_block, int $base_index = 0 ): int {
@@ -600,6 +610,7 @@ class Rsvp_Form {
 	 *
 	 * @param array $block1 First block to compare.
 	 * @param array $block2 Second block to compare.
+	 *
 	 * @return bool True if blocks match.
 	 */
 	private function blocks_match( array $block1, array $block2 ): bool {
@@ -633,6 +644,7 @@ class Rsvp_Form {
 	 * @since 0.33.0
 	 *
 	 * @param int $comment_id The comment ID of the RSVP.
+	 *
 	 * @return void
 	 */
 	public function process_custom_fields_for_form( int $comment_id ): void {
@@ -688,6 +700,7 @@ class Rsvp_Form {
 	 *
 	 * @param mixed $value  The field value to sanitize.
 	 * @param array $config The field configuration from the schema.
+	 *
 	 * @return mixed|false The sanitized value, or false if sanitization fails.
 	 */
 	public function sanitize_custom_field_value( $value, array $config ) {
@@ -749,6 +762,7 @@ class Rsvp_Form {
 	 *
 	 * @param string $block_content The block content.
 	 * @param array  $block         The block data.
+	 *
 	 * @return string The processed block content.
 	 */
 	public function process_form_field_attributes( string $block_content, array $block ): string {

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -323,6 +323,7 @@ class Rsvp {
 	 * @since 0.33.0
 	 *
 	 * @param string $block_content The block content to modify.
+	 *
 	 * @return string The modified block content with form field callbacks applied.
 	 */
 	public function apply_guests_input_interactivity( string $block_content ): string {
@@ -344,6 +345,7 @@ class Rsvp {
 	 *
 	 * @param string $block_content The form field block content.
 	 * @param array  $block         The block data including attributes.
+	 *
 	 * @return string The modified block content or empty string if field should be hidden.
 	 */
 	public function handle_rsvp_form_fields( string $block_content, array $block ): string {

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -281,6 +281,7 @@ class Calendar {
 	 * @since 0.34.0
 	 *
 	 * @param string $text The raw text to escape.
+	 *
 	 * @return string The escaped text suitable for a TEXT-typed iCal property.
 	 */
 	private function escape_ical_text( string $text ): string {
@@ -299,6 +300,7 @@ class Calendar {
 	 *
 	 * @param string      $endpoint_slug The visible suffix appended to the post permalink.
 	 * @param string|null $query_var     Optional query var; falls back to `Setup::QUERY_VAR`.
+	 *
 	 * @return string|false              URL of the event's endpoint, or false when the post can't be resolved.
 	 */
 	protected function get_endpoint_url( string $endpoint_slug, ?string $query_var = null ) {
@@ -364,6 +366,7 @@ class Calendar {
 		 *
 		 * @param string   $endpoint_url The full calendar URL.
 		 * @param \WP_Post $post         The corresponding event post.
+		 *
 		 * @return string                The filtered calendar URL.
 		 */
 		$endpoint_url = sanitize_url(
@@ -395,6 +398,7 @@ class Calendar {
 	 * @since 0.34.0
 	 *
 	 * @param string $text The string to be escaped.
+	 *
 	 * @return string The escaped string.
 	 */
 	private function fold_ical_text( string $text ): string {

--- a/includes/core/classes/calendar/class-endpoint-type.php
+++ b/includes/core/classes/calendar/class-endpoint-type.php
@@ -83,6 +83,7 @@ abstract class Endpoint_Type {
 	 * @since 0.34.0
 	 *
 	 * @param Endpoint|null $endpoint Class for custom rewrite endpoints and their query handling in GatherPress.
+	 *
 	 * @return void
 	 */
 	abstract public function activate( ?Endpoint $endpoint = null ): void;
@@ -98,6 +99,7 @@ abstract class Endpoint_Type {
 	 * @since 0.34.0
 	 *
 	 * @param  string $entity The class name of the entity to check against (e.g., 'Redirect' or 'Template').
+	 *
 	 * @return bool                  True if the `$type` is an instance of the `$entity` class, false otherwise.
 	 */
 	public function is_of_class( string $entity ): bool {
@@ -115,6 +117,7 @@ abstract class Endpoint_Type {
 	 * @since 0.34.0
 	 *
 	 * @param  string $entity The class name of the entity to check (e.g., 'Redirect' or 'Template').
+	 *
 	 * @return bool           True if the `$entity` is a valid endpoint class, false otherwise.
 	 */
 	private static function is_in_class( string $entity ): bool {

--- a/includes/core/classes/calendar/class-endpoint.php
+++ b/includes/core/classes/calendar/class-endpoint.php
@@ -225,6 +225,7 @@ class Endpoint {
 	 *
 	 * @param  string $reg_ex_pattern The regular expression pattern for matching the custom endpoint URL structure.
 	 * @param  string $rewrite_url    The URL structure for handling matched requests via query vars.
+	 *
 	 * @return void
 	 */
 	private function maybe_flush_rewrite_rules( string $reg_ex_pattern, string $rewrite_url ): void {
@@ -250,6 +251,7 @@ class Endpoint {
 	 * @param string $type_name   The name of the post type or taxonomy to validate.
 	 * @param array  $types       Array of endpoint types to register (redirects/templates).
 	 * @param string $object_type The type of object ('post' or 'taxonomy').
+	 *
 	 * @return bool               Returns true if registration is valid, false otherwise.
 	 */
 	private function is_valid_registration( string $type_name, array $types, string $object_type ): bool {
@@ -325,6 +327,7 @@ class Endpoint {
 	 * @since 0.34.0
 	 *
 	 * @param string[] $public_query_vars The array of allowed query variable names.
+	 *
 	 * @return string[]                   The updated array of allowed query variable names.
 	 */
 	public function allow_query_vars( array $public_query_vars ): array {

--- a/includes/core/classes/calendar/class-redirect.php
+++ b/includes/core/classes/calendar/class-redirect.php
@@ -53,6 +53,7 @@ class Redirect extends Endpoint_Type {
 	 * @since 0.34.0
 	 *
 	 * @param Endpoint|null $endpoint Class for custom rewrite endpoints and their query handling in GatherPress.
+	 *
 	 * @return void
 	 */
 	public function activate( ?Endpoint $endpoint = null ): void {
@@ -83,6 +84,7 @@ class Redirect extends Endpoint_Type {
 	 * @since 0.34.0
 	 *
 	 * @param string[] $hosts An array of allowed host names.
+	 *
 	 * @return string[]       The updated array of allowed host names, including the redirect target.
 	 */
 	public function allowed_redirect_hosts( array $hosts ): array {

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -348,6 +348,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param array $args Label args from `alternate_link_label_args()`.
+	 *
 	 * @return array<int,array{url:string,attr:string}> One-element list.
 	 */
 	protected function collect_sitewide_alternate_link( array $args ): array {
@@ -377,6 +378,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param array $args Label args from `alternate_link_label_args()`.
+	 *
 	 * @return array<int,array{url:string,attr:string}> One entry per event-supporting post type.
 	 */
 	protected function collect_post_type_archive_alternate_links( array $args ): array {
@@ -419,6 +421,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param array $args Label args from `alternate_link_label_args()`.
+	 *
 	 * @return array<int,array{url:string,attr:string}>
 	 */
 	protected function collect_contextual_alternate_links( array $args ): array {
@@ -449,6 +452,7 @@ class Setup {
 	 *
 	 * @param WP_Post $event The queried event post.
 	 * @param array   $args  Label args from `alternate_link_label_args()`.
+	 *
 	 * @return array<int,array{url:string,attr:string}>
 	 */
 	protected function collect_singular_event_alternate_links( WP_Post $event, array $args ): array {
@@ -478,6 +482,7 @@ class Setup {
 	 *
 	 * @param WP_Post $post The queried shadow-source post (e.g. a venue).
 	 * @param array   $args Label args from `alternate_link_label_args()`.
+	 *
 	 * @return array<int,array{url:string,attr:string}>
 	 */
 	protected function collect_singular_tax_like_alternate_links( WP_Post $post, array $args ): array {
@@ -501,6 +506,7 @@ class Setup {
 	 *
 	 * @param WP_Term $term The queried taxonomy term.
 	 * @param array   $args Label args from `alternate_link_label_args()`.
+	 *
 	 * @return array<int,array{url:string,attr:string}>
 	 */
 	protected function collect_tax_archive_alternate_links( WP_Term $term, array $args ): array {
@@ -527,6 +533,7 @@ class Setup {
 	 *
 	 * @param WP_Post $event The queried event post.
 	 * @param array   $args  Label args from `alternate_link_label_args()`.
+	 *
 	 * @return array<int,array{url:string,attr:string}>
 	 */
 	protected function collect_event_term_alternate_links( WP_Post $event, array $args ): array {
@@ -560,6 +567,7 @@ class Setup {
 	 *
 	 * @param WP_Term $term Term attached to the queried event.
 	 * @param array   $args Label args from `alternate_link_label_args()`.
+	 *
 	 * @return array<int,array{url:string,attr:string}> Empty for sentinel terms; otherwise one entry.
 	 */
 	protected function collect_term_alternate_link( WP_Term $term, array $args ): array {
@@ -608,6 +616,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param array<int,array{url:string,attr:string}> $links Entries to render.
+	 *
 	 * @return void
 	 */
 	protected function render_alternate_links( array $links ): void {
@@ -634,6 +643,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param string $calendar_data The events to be included in the iCal file.
+	 *
 	 * @return string               The complete iCal data wrapped in the VCALENDAR format.
 	 */
 	public function get_ical_wrap( string $calendar_data ): string {
@@ -769,6 +779,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param string $filename Generated name of the file.
+	 *
 	 * @return void
 	 */
 	public function send_ics_headers( string $filename ): void {

--- a/includes/core/classes/calendar/class-template.php
+++ b/includes/core/classes/calendar/class-template.php
@@ -68,6 +68,7 @@ class Template extends Endpoint_Type {
 	 * @since 0.34.0
 	 *
 	 * @param Endpoint|null $endpoint Class for custom rewrite endpoints and their query handling in GatherPress.
+	 *
 	 * @return void
 	 */
 	public function activate( ?Endpoint $endpoint = null ): void {

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -584,7 +584,6 @@ class Assets {
 
 	/**
 	 * Register a new script and sets translated strings for the script.
-
 	 *
 	 * @since 0.33.0
 	 *

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -224,6 +224,7 @@ class Assets {
 	 *
 	 * @param string $block_content The block content.
 	 * @param array  $block         The block settings.
+	 *
 	 * @return string The block content.
 	 */
 	public function maybe_enqueue_styles( string $block_content, array $block ): string {
@@ -263,6 +264,7 @@ class Assets {
 	 * @since 0.34.0
 	 *
 	 * @param string $block_content The block content.
+	 *
 	 * @return string The block content.
 	 */
 	public function maybe_enqueue_tooltip_assets( string $block_content ): string {
@@ -317,6 +319,7 @@ class Assets {
 	 * @since 0.27.0
 	 *
 	 * @param string $hook The name of the current admin page.
+	 *
 	 * @return void
 	 */
 	public function admin_enqueue_scripts( string $hook ): void {
@@ -582,6 +585,7 @@ class Assets {
 	/**
 	 * Register a new script and sets translated strings for the script.
 
+	 *
 	 * @since 0.33.0
 	 *
 	 * @param string $folder_name Slug of the block to register scripts and translations for.

--- a/includes/core/classes/class-autoloader.php
+++ b/includes/core/classes/class-autoloader.php
@@ -41,6 +41,7 @@ class Autoloader {
 				 * namespaces and their corresponding paths can be registered.
 				 *
 				 * @param array $registered_autoloaders An associative array of namespaces and their paths.
+				 *
 				 * @return array Modified array of namespaces and their paths.
 				 * @since 0.27.0
 				 *

--- a/includes/core/classes/class-coexistence-guard.php
+++ b/includes/core/classes/class-coexistence-guard.php
@@ -71,6 +71,7 @@ class Coexistence_Guard {
 	 *                          folder named `<slug>` (canonical) or `<slug>-*` (siblings).
 	 * @param string $name      Display name, e.g. `GatherPress Alpha`.
 	 * @param string $main_file Absolute path to the companion's main plugin file.
+	 *
 	 * @return void
 	 */
 	public function register( string $slug, string $name, string $main_file ): void {
@@ -95,6 +96,7 @@ class Coexistence_Guard {
 	 * @since 0.34.0
 	 *
 	 * @param string $slug Plugin folder slug.
+	 *
 	 * @return string[] Plugin basenames matching the slug pattern.
 	 */
 	public function find_duplicates( string $slug ): array {
@@ -156,6 +158,7 @@ class Coexistence_Guard {
 	 *
 	 * @param string $slug Plugin folder slug.
 	 * @param string $name Plugin display name.
+	 *
 	 * @return void
 	 */
 	public function refuse_on_duplicates( string $slug, string $name ): void {

--- a/includes/core/classes/class-export.php
+++ b/includes/core/classes/class-export.php
@@ -89,6 +89,7 @@ class Export extends Migrate {
 	 * @since 0.30.0
 	 *
 	 * @param  WP_Post $post  The Post object (passed by reference).
+	 *
 	 * @return void
 	 */
 	public function prepare( WP_Post $post ): void {
@@ -120,6 +121,7 @@ class Export extends Migrate {
 	 * @param  bool   $skip     Whether to skip the current post meta. Default false.
 	 * @param  string $meta_key Current meta key.
 	 * @param  object $meta     Current meta object.
+	 *
 	 * @return bool             Whether to skip the current post meta. Default false.
 	 */
 	public function extend( bool $skip, string $meta_key, object $meta ): bool {
@@ -150,6 +152,7 @@ class Export extends Migrate {
 	 * @since 0.30.0
 	 *
 	 * @param  WP_Post $post Current 'gatherpress_event' post being exported.
+	 *
 	 * @return void
 	 */
 	public function run( WP_Post $post ): void {
@@ -201,6 +204,7 @@ class Export extends Migrate {
 	 * @since 0.30.0
 	 *
 	 * @param  WP_Post $post Current 'gatherpress_event' post being exported.
+	 *
 	 * @return string        Serialized JSON string with all date, time & timezone data of the current $post.
 	 */
 	public function datetimes_callback( WP_Post $post ): string {

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -81,6 +81,7 @@ class Feed {
 	 * @since 0.33.0
 	 *
 	 * @param WP_Query $query The WP_Query instance.
+	 *
 	 * @return void
 	 */
 	public function handle_events_feed_query( WP_Query $query ): void {
@@ -126,6 +127,7 @@ class Feed {
 	 * @since 0.33.0
 	 *
 	 * @param Event $event The event object.
+	 *
 	 * @return array Array of event information strings.
 	 */
 	private function get_event_datetime_info( Event $event ): array {
@@ -149,6 +151,7 @@ class Feed {
 	 * @since 0.33.0
 	 *
 	 * @param string $excerpt The current excerpt.
+	 *
 	 * @return string The customized excerpt.
 	 */
 	public function get_default_event_excerpt( string $excerpt ): string {
@@ -199,6 +202,7 @@ class Feed {
 	 * @since 0.33.0
 	 *
 	 * @param string $content The current content.
+	 *
 	 * @return string The customized content.
 	 */
 	public function get_default_event_content( string $content ): string {
@@ -248,6 +252,7 @@ class Feed {
 	 * @since 0.33.0
 	 *
 	 * @param string $excerpt The current excerpt.
+	 *
 	 * @return string The customized excerpt.
 	 */
 	public function apply_event_excerpt( string $excerpt ): string {
@@ -290,6 +295,7 @@ class Feed {
 	 * @since 0.33.0
 	 *
 	 * @param string $content The current content.
+	 *
 	 * @return string The customized content.
 	 */
 	public function apply_event_content( string $content ): string {
@@ -332,6 +338,7 @@ class Feed {
 	 * @since 0.33.0
 	 *
 	 * @param string $feed_link The feed link URL.
+	 *
 	 * @return string The modified feed link URL.
 	 */
 	public function modify_feed_link_for_past_events( $feed_link ): string {

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -186,6 +186,7 @@ class Geocoding {
 	 * @param int    $meta_id  Meta row ID. Unused (signature requirement).
 	 * @param int    $post_id  Post ID the meta belongs to.
 	 * @param string $meta_key Meta key being added/updated.
+	 *
 	 * @return void
 	 *
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) -- $meta_id is required
@@ -324,6 +325,7 @@ class Geocoding {
 	 * @since 0.34.0
 	 *
 	 * @param int $post_id Venue post ID.
+	 *
 	 * @return void
 	 */
 	public function async_geocode_venue( int $post_id ): void {
@@ -397,6 +399,7 @@ class Geocoding {
 	 * @since 0.34.0
 	 *
 	 * @param array $settings The block editor settings array.
+	 *
 	 * @return array The modified settings.
 	 */
 	public function add_editor_settings( array $settings ): array {
@@ -579,6 +582,7 @@ class Geocoding {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request The REST request object.
+	 *
 	 * @return WP_REST_Response|WP_Error Response with coordinates or error.
 	 */
 	public function geocode_address( WP_REST_Request $request ) {
@@ -630,6 +634,7 @@ class Geocoding {
 	 * @since 0.34.0
 	 *
 	 * @param string $address Address string to resolve.
+	 *
 	 * @return array{
 	 *     latitude: string,
 	 *     longitude: string,
@@ -768,6 +773,7 @@ class Geocoding {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request The REST request object.
+	 *
 	 * @return WP_REST_Response|WP_Error Suggestions or error.
 	 */
 	public function search_addresses( WP_REST_Request $request ) {
@@ -874,6 +880,7 @@ class Geocoding {
 	 * @param mixed  $data      Decoded JSON body. Treated as "no results"
 	 *                          when not an array or missing `features`.
 	 * @param string $cache_key Transient key for the cached suggestions.
+	 *
 	 * @return WP_REST_Response The response with a `suggestions` array (possibly empty).
 	 */
 	private function build_search_suggestions_response( $data, string $cache_key ): WP_REST_Response {
@@ -958,6 +965,7 @@ class Geocoding {
 	 * @since 0.34.0
 	 *
 	 * @param array $properties Photon `properties` object.
+	 *
 	 * @return array{
 	 *     house_number: string,
 	 *     street: string,
@@ -1002,6 +1010,7 @@ class Geocoding {
 	 * @since 0.34.0
 	 *
 	 * @param array $properties Photon `properties` object.
+	 *
 	 * @return string Non-empty label or empty string.
 	 */
 	private function format_photon_feature_label( array $properties ): string {
@@ -1064,6 +1073,7 @@ class Geocoding {
 	 * @param string $body    Raw response body.
 	 * @param mixed  $decoded Result of json_decode (null when decode failed).
 	 * @param string $context Short label identifying the caller ('geocode_address', 'search_addresses').
+	 *
 	 * @return void
 	 */
 	private function maybe_log_json_decode_failure( string $body, $decoded, string $context ): void {

--- a/includes/core/classes/class-import.php
+++ b/includes/core/classes/class-import.php
@@ -78,6 +78,7 @@ class Import extends Migrate {
 	 * @see https://github.com/WordPress/wordpress-importer/blob/71bdd41a2aa2c6a0967995ee48021037b39a1097/src/class-wp-import.php#L631
 	 *
 	 * @param  array $post_data_raw The result of 'wp_import_post_data_raw'.
+	 *
 	 * @return array                Returns the unchanged result of 'wp_import_post_data_raw'.
 	 */
 	public function prepare( array $post_data_raw ): array {
@@ -99,6 +100,7 @@ class Import extends Migrate {
 	 * Checks if the currently imported post is of type 'gatherpress_event'.
 	 *
 	 * @param  array $post_data_raw The result of 'wp_import_post_data_raw'.
+	 *
 	 * @return bool                 True, when the currently imported post is of type 'gatherpress_event',
 	 *                              false otherwise.
 	 */
@@ -134,6 +136,7 @@ class Import extends Migrate {
 	 * @param  int       $object_id  ID of the object metadata is for.
 	 * @param  string    $meta_key   Metadata key.
 	 * @param  mixed     $meta_value Metadata value. Must be serializable if non-scalar.
+	 *
 	 * @return null|bool             Returning a non-null value will effectively short-circuit the saving
 	 *                               of 'normal' meta data.
 	 *
@@ -175,6 +178,7 @@ class Import extends Migrate {
 	 *
 	 * @param  int   $post_id   ID of the object metadata is for.
 	 * @param  mixed $data      Metadata value. Must be serializable if non-scalar.
+	 *
 	 * @return void
 	 */
 	public function datetimes_callback( int $post_id, $data ): void {

--- a/includes/core/classes/class-migrate.php
+++ b/includes/core/classes/class-migrate.php
@@ -80,6 +80,7 @@ class Migrate {
 		 * @since 0.34.0
 		 *
 		 * @param  array $pseudopostmetas List of data-names and their respective export- and import-callbacks.
+		 *
 		 * @return array
 		 */
 		return (array) apply_filters( 'gatherpress_pseudo_post_metas', $this->pseudopostmetas );

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -161,6 +161,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param array $settings The block editor settings array.
+	 *
 	 * @return array The modified block editor settings array.
 	 */
 	public function add_editor_settings( array $settings ): array {
@@ -422,6 +423,7 @@ class Settings {
 	 *
 	 * @param string $sub_page Sub-page slug used to scope WP's settings API.
 	 * @param array  $sections Sections array from the sub-page settings.
+	 *
 	 * @return void
 	 */
 	protected function register_sub_page_sections( string $sub_page, array $sections ): void {
@@ -479,6 +481,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param array $option_settings The option settings array.
+	 *
 	 * @return string Space-separated class names for the row.
 	 */
 	protected function build_row_class( array $option_settings ): string {
@@ -505,6 +508,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param array $conditions Map of controlling option key => expected value(s).
+	 *
 	 * @return bool True when every key matches the current saved value, false otherwise.
 	 */
 	protected function evaluate_show_if( array $conditions ): bool {
@@ -542,6 +546,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param array $conditions Map of controlling option key => expected value(s).
+	 *
 	 * @return void
 	 */
 	protected function render_show_if_marker( array $conditions ): void {
@@ -560,6 +565,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param array $sub_pages The sub-pages array from get_sub_pages().
+	 *
 	 * @return array Flat map of option_key => field_type.
 	 */
 	protected function build_field_type_map( array $sub_pages ): array {
@@ -682,6 +688,7 @@ class Settings {
 	 * sanitized data as a JSON string.
 	 *
 	 * @param string $json_string The JSON string to sanitize.
+	 *
 	 * @return string Sanitized JSON string or empty array '[]' if invalid.
 	 *
 	 * @since 0.33.0
@@ -731,6 +738,7 @@ class Settings {
 	 *
 	 * @param string $option          The unique option key for the field.
 	 * @param array  $option_settings The option settings including field config.
+	 *
 	 * @return void
 	 */
 	public function render_field( string $option, array $option_settings ): void {
@@ -831,6 +839,7 @@ class Settings {
 	 *
 	 * @param string $option The unique name of the option to set.
 	 * @param mixed  $value  The value to set.
+	 *
 	 * @return void
 	 */
 	public function set( string $option, $value ): void {
@@ -858,6 +867,7 @@ class Settings {
 	 * @since 0.27.0
 	 *
 	 * @param string $option The unique name of the option to retrieve.
+	 *
 	 * @return mixed The value of the option or its default value.
 	 */
 	public function get( string $option ) {
@@ -892,6 +902,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param string $option The option key to check.
+	 *
 	 * @return bool
 	 */
 	public function is_option_inherited( string $option ): bool {
@@ -939,6 +950,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param string $option The unique name of the option to retrieve the default value for.
+	 *
 	 * @return mixed The default value of the option or an empty string if not defined.
 	 */
 	public function get_flat_default( string $option ) {
@@ -994,6 +1006,7 @@ class Settings {
 	 * @since 0.27.0
 	 *
 	 * @param string $option Option of the setting field.
+	 *
 	 * @return string The generated name attribute for the setting field.
 	 */
 	public function get_name_field( string $option ): string {
@@ -1045,6 +1058,7 @@ class Settings {
 	 *
 	 * @param array $first  The first sub-page to compare by priority.
 	 * @param array $second The second sub-page to compare by priority.
+	 *
 	 * @return int Returns a negative number if the first sub-page has a lower priority,
 	 *             a positive number if the second sub-page has a lower priority,
 	 *             or 0 if their priorities are equal.
@@ -1087,6 +1101,7 @@ class Settings {
 	 * @since 0.27.0
 	 *
 	 * @param string $submenu The name of the sub menu page.
+	 *
 	 * @return string The selected submenu name, either the provided one or 'general'.
 	 */
 	public function select_menu( $submenu ): string {
@@ -1115,6 +1130,7 @@ class Settings {
 	 *
 	 * @param mixed $old_value The old option value.
 	 * @param mixed $new_value The new option value.
+	 *
 	 * @return void
 	 */
 	public function maybe_flush_rewrite_rules( $old_value, $new_value ): void {
@@ -1192,6 +1208,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param string $scope Storage scope: 'blog' or 'network'.
+	 *
 	 * @return array
 	 */
 	protected function read_stored_options( string $scope ): array {
@@ -1209,6 +1226,7 @@ class Settings {
 	 *
 	 * @param string $scope   Storage scope: 'blog' or 'network'.
 	 * @param array  $options Options array to persist.
+	 *
 	 * @return void
 	 */
 	protected function write_stored_options( string $scope, array $options ): void {
@@ -1226,6 +1244,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param string $scope Storage scope: 'blog' or 'network'.
+	 *
 	 * @return void
 	 */
 	protected function delete_stored_options( string $scope ): void {
@@ -1247,6 +1266,7 @@ class Settings {
 	 *
 	 * @param array  $data  The parsed import data.
 	 * @param string $scope Storage scope: 'blog' (default) or 'network'.
+	 *
 	 * @return array Validation result with 'valid', 'changes', 'unknown', and 'warnings' keys.
 	 */
 	public function validate_import( array $data, string $scope = 'blog' ): array {
@@ -1306,6 +1326,7 @@ class Settings {
 	 * @param array  $data  The parsed import data.
 	 * @param string $mode  Import mode: 'merge' or 'replace'.
 	 * @param string $scope Storage scope: 'blog' (default) or 'network'.
+	 *
 	 * @return array Result with 'success', 'imported', 'skipped', and 'warnings' keys.
 	 */
 	public function import_settings( array $data, string $mode = 'merge', string $scope = 'blog' ): array {

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -126,6 +126,7 @@ class Setup {
 	 * @since 0.27.0
 	 *
 	 * @param array $actions An array of existing action links.
+	 *
 	 * @return array An updated array of action links, including the 'Settings' link.
 	 */
 	public function filter_plugin_action_links( array $actions ): array {
@@ -158,6 +159,7 @@ class Setup {
 	 * @global wpdb $wpdb WordPress database abstraction object.
 	 *
 	 * @param bool $network_wide Whether the plugin is being activated network-wide.
+	 *
 	 * @return void
 	 */
 	public function activate_gatherpress_plugin( bool $network_wide ): void {
@@ -305,6 +307,7 @@ class Setup {
 	 * @since 0.27.0
 	 *
 	 * @param array $classes Existing body classes.
+	 *
 	 * @return array An updated array of body classes.
 	 */
 	public function add_gatherpress_body_classes( array $classes ): array {
@@ -323,6 +326,7 @@ class Setup {
 	 * @since 0.27.0
 	 *
 	 * @param array $block_categories Array of registered block categories.
+	 *
 	 * @return array An updated array of block categories.
 	 */
 	public function register_gatherpress_block_category( array $block_categories ): array {
@@ -429,6 +433,7 @@ class Setup {
 	 * @since 0.27.0
 	 *
 	 * @param array $tables An array of names of the site tables to be dropped.
+	 *
 	 * @return array An updated array of table names to be deleted during site deletion.
 	 */
 	public function on_site_delete( array $tables ): array {
@@ -542,6 +547,7 @@ class Setup {
 	 *
 	 * @param bool   $is_protected Whether the meta key is protected.
 	 * @param string $meta_key     The meta key being checked.
+	 *
 	 * @return bool True if the meta key should be protected, false otherwise.
 	 */
 	public function protect_gatherpress_meta( bool $is_protected, string $meta_key ): bool {

--- a/includes/core/classes/class-shadow-source.php
+++ b/includes/core/classes/class-shadow-source.php
@@ -85,6 +85,7 @@ class Shadow_Source {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type that was just registered.
+	 *
 	 * @return void
 	 */
 	public function maybe_register_post_type_hooks( string $post_type ): void {
@@ -140,6 +141,7 @@ class Shadow_Source {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type that owns this shadow taxonomy.
+	 *
 	 * @return array<string, mixed>
 	 */
 	protected function get_taxonomy_args( string $post_type ): array {
@@ -191,6 +193,7 @@ class Shadow_Source {
 	 * @param int     $post_id Post ID of the saved post.
 	 * @param WP_Post $post    The saved post object.
 	 * @param bool    $update  Whether this is an existing post being updated.
+	 *
 	 * @return void
 	 */
 	public function add_term( int $post_id, WP_Post $post, bool $update ): void {
@@ -237,6 +240,7 @@ class Shadow_Source {
 	 * @param int     $post_id     Post ID of the updated post.
 	 * @param WP_Post $post_after  Post object after the save operation.
 	 * @param WP_Post $post_before Post object before the save operation.
+	 *
 	 * @return void
 	 */
 	public function maybe_update_term_slug( int $post_id, WP_Post $post_after, WP_Post $post_before ): void {
@@ -291,6 +295,7 @@ class Shadow_Source {
 	 * @since 0.34.0
 	 *
 	 * @param int $post_id Post ID of the post being deleted.
+	 *
 	 * @return void
 	 */
 	public function delete_term( int $post_id ): void {
@@ -327,6 +332,7 @@ class Shadow_Source {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The shadow-source post type slug.
+	 *
 	 * @return string The taxonomy slug for the given post type.
 	 */
 	public function get_taxonomy( string $post_type ): string {
@@ -343,6 +349,7 @@ class Shadow_Source {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_name The post_name (e.g. `my-venue`).
+	 *
 	 * @return string The taxonomy term slug (e.g. `_my-venue`).
 	 */
 	public function term_slug_from_post_name( string $post_name ): string {
@@ -362,6 +369,7 @@ class Shadow_Source {
 	 * @since 0.34.0
 	 *
 	 * @param string $slug The term slug to test.
+	 *
 	 * @return bool
 	 */
 	public function is_shadow_term_slug( string $slug ): bool {
@@ -379,6 +387,7 @@ class Shadow_Source {
 	 *
 	 * @param string $slug      The shadow taxonomy term slug (e.g. `_my-venue`).
 	 * @param string $post_type The shadow-source post type to search.
+	 *
 	 * @return WP_Post|null The matching post, or null.
 	 */
 	public function get_post_from_term_slug( string $slug, string $post_type ): ?WP_Post {

--- a/includes/core/classes/class-site-health.php
+++ b/includes/core/classes/class-site-health.php
@@ -65,6 +65,7 @@ class Site_Health {
 	 * @since 0.34.0
 	 *
 	 * @param array<string, array<string, array<string, mixed>>> $tests Existing Site Health tests.
+	 *
 	 * @return array<string, array<string, array<string, mixed>>> Updated Site Health tests.
 	 */
 	public function register_site_status_tests( array $tests ): array {

--- a/includes/core/classes/class-user.php
+++ b/includes/core/classes/class-user.php
@@ -153,6 +153,7 @@ class User {
 	 * @since 0.33.0
 	 *
 	 * @param int $user_id The user ID to check.
+	 *
 	 * @return bool True if the user has opted in, false otherwise.
 	 */
 	public function has_event_updates_opt_in( int $user_id ): bool {

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -36,6 +36,7 @@ class Utility {
 	 * @param string $path      The path to the template file.
 	 * @param array  $variables An array of variables to pass to the template.
 	 * @param bool   $output    Whether to echo the template (true) or return it (false).
+	 *
 	 * @return string The rendered template as a string.
 	 */
 	public static function render_template( string $path, array $variables = array(), bool $output = false ): string {
@@ -81,6 +82,7 @@ class Utility {
 	 *
 	 * @param string $file_name    The template file name, e.g. `gatherpress_ical-download.php`.
 	 * @param string $fallback_dir Absolute directory the caller's bundled fallback lives in.
+	 *
 	 * @return string Absolute path to the resolved template, or `''` if none exists.
 	 */
 	public static function locate_template( string $file_name, string $fallback_dir = '' ): string {
@@ -135,6 +137,7 @@ class Utility {
 	 *
 	 * @param string $fallback_dir Absolute directory the caller's bundled fallback lives in.
 	 * @param string $file_name    Template file name to check inside `$fallback_dir`.
+	 *
 	 * @return string Resolved template path, or `''` if neither variant exists on disk.
 	 */
 	private static function resolve_fallback_template_path( string $fallback_dir, string $file_name ): string {
@@ -163,6 +166,7 @@ class Utility {
 	 * @since 0.27.0
 	 *
 	 * @param string $key The key to which the prefix will be added.
+	 *
 	 * @return string The key with the 'gatherpress_' prefix.
 	 */
 	public static function prefix_key( string $key ): string {
@@ -181,6 +185,7 @@ class Utility {
 	 * @since 0.27.0
 	 *
 	 * @param string $key The key from which the prefix will be removed.
+	 *
 	 * @return string The key with the 'gatherpress_' prefix removed.
 	 */
 	public static function unprefix_key( string $key ): string {
@@ -201,6 +206,7 @@ class Utility {
 	 * @param string $key       Label key to read (e.g. `singular_name`,
 	 *                          `name`, `add_new_item`).
 	 * @param string $post_type Post type slug to read the label from.
+	 *
 	 * @return string The resolved label, or empty string when the post
 	 *                type isn't registered or the key isn't set.
 	 */
@@ -223,6 +229,7 @@ class Utility {
 	 * @since 0.34.0
 	 *
 	 * @param string $key The snake_case string to convert.
+	 *
 	 * @return string The converted camelCase string.
 	 */
 	public static function snake_to_camel( string $key ): string {
@@ -253,6 +260,7 @@ class Utility {
 	 * @param string $meta_key  The meta key being accessed. Unused.
 	 * @param int    $object_id The post ID the meta belongs to.
 	 * @param int    $user_id   The user ID attempting the edit.
+	 *
 	 * @return bool True if the user can edit the post, false otherwise.
 	 */
 	public static function can_edit_post_meta(
@@ -424,6 +432,7 @@ class Utility {
 	 * @since 0.29.0
 	 *
 	 * @param string $timezone The UTC offset to convert, e.g., "+05:30" or "-08:00".
+	 *
 	 * @return string The converted timezone format, e.g., "+0530" or "-0800".
 	 */
 	public static function maybe_convert_utc_offset( string $timezone ): string {
@@ -483,6 +492,7 @@ class Utility {
 	 * @since 0.34.0
 	 *
 	 * @param float $offset Decimal-hour offset from UTC.
+	 *
 	 * @return string PHP-valid timezone identifier.
 	 */
 	public static function offset_to_timezone_string( float $offset ): string {
@@ -511,6 +521,7 @@ class Utility {
 	 * @since 0.34.0
 	 *
 	 * @param string $timezone Raw timezone string.
+	 *
 	 * @return string
 	 */
 	public static function normalize_timezone_string( string $timezone ): string {
@@ -558,6 +569,7 @@ class Utility {
 	 * @since 0.33.0
 	 *
 	 * @param int $post_id Optional. The Post ID of the event. Defaults to 0.
+	 *
 	 * @return string The login URL for the event.
 	 */
 	public static function get_login_url( int $post_id = 0 ): string {
@@ -575,6 +587,7 @@ class Utility {
 	 * @since 0.33.0
 	 *
 	 * @param int $post_id Optional. The Post ID of the event. Defaults to 0.
+	 *
 	 * @return string The registration URL for the event, or an empty string if user registration is disabled.
 	 */
 	public static function get_registration_url( int $post_id = 0 ): string {
@@ -766,6 +779,7 @@ class Utility {
 	 * @since 0.34.0
 	 *
 	 * @param array $blocks A parsed block, typically including `blockName` and `innerBlocks`.
+	 *
 	 * @return array An array of block names found within the provided block structure.
 	 */
 	public static function get_block_names( array $blocks ): array {

--- a/includes/core/classes/class-validate.php
+++ b/includes/core/classes/class-validate.php
@@ -34,6 +34,7 @@ class Validate {
 	 * @since 0.31.0
 	 *
 	 * @param string $param An RSVP status to validate.
+	 *
 	 * @return bool True if the parameter is a valid RSVP status, false otherwise.
 	 */
 	public static function rsvp_status( $param ): bool {
@@ -57,6 +58,7 @@ class Validate {
 	 * @since 0.31.0
 	 *
 	 * @param int|string $param A Post ID to validate.
+	 *
 	 * @return bool True if the parameter is a valid Event Post ID, false otherwise.
 	 */
 	public static function event_post_id( $param ): bool {
@@ -74,6 +76,7 @@ class Validate {
 	 * @since 0.33.0
 	 *
 	 * @param int|string $param The value to validate.
+	 *
 	 * @return bool True if the parameter is a valid positive numeric value, false otherwise.
 	 */
 	public static function positive_number( $param ): bool {
@@ -91,6 +94,7 @@ class Validate {
 	 * @since 0.33.0
 	 *
 	 * @param int|string $param The value to validate.
+	 *
 	 * @return bool True if the parameter is a valid non-negative numeric value, false otherwise.
 	 */
 	public static function non_negative_number( $param ): bool {
@@ -114,6 +118,7 @@ class Validate {
 	 * @since 0.34.0
 	 *
 	 * @param mixed $param The value to validate.
+	 *
 	 * @return bool True if the parameter is a numeric value within ±180, false otherwise.
 	 */
 	public static function coordinate( $param ): bool {
@@ -137,6 +142,7 @@ class Validate {
 	 * @since 0.33.0
 	 *
 	 * @param mixed $value The value to validate.
+	 *
 	 * @return bool True if the value is valid, false otherwise.
 	 */
 	public static function boolean( $value ): bool {
@@ -151,6 +157,7 @@ class Validate {
 	 * @since 0.31.0
 	 *
 	 * @param mixed $param An array of email recipients.
+	 *
 	 * @return bool True if the parameter is a valid array of email recipients, false otherwise.
 	 */
 	public static function send( $param ): bool {
@@ -180,6 +187,7 @@ class Validate {
 	 * @since 0.31.0
 	 *
 	 * @param string $param The event list type to validate.
+	 *
 	 * @return bool True if the parameter is a valid event list type, false otherwise.
 	 */
 	public static function event_list_type( string $param ): bool {
@@ -194,6 +202,7 @@ class Validate {
 	 * @since 0.31.0
 	 *
 	 * @param string $param The datetime string to validate.
+	 *
 	 * @return bool True if the parameter is a valid datetime string, false otherwise.
 	 */
 	public static function datetime( string $param ): bool {
@@ -208,6 +217,7 @@ class Validate {
 	 * @since 0.31.0
 	 *
 	 * @param string $param The timezone identifier to validate.
+	 *
 	 * @return bool True if the parameter is a valid timezone identifier, false otherwise.
 	 */
 	public static function timezone( string $param ): bool {
@@ -228,6 +238,7 @@ class Validate {
 	 * @since 0.33.0
 	 *
 	 * @param string $param The JSON string representing block data.
+	 *
 	 * @return bool True if the block data is valid, false otherwise.
 	 */
 	public static function block_data( string $param ): bool {

--- a/includes/core/classes/commands/class-settings-cli.php
+++ b/includes/core/classes/commands/class-settings-cli.php
@@ -45,6 +45,7 @@ class Settings_Cli extends WP_CLI {
 	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
+	 *
 	 * @return void
 	 *
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -120,6 +121,7 @@ class Settings_Cli extends WP_CLI {
 	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
+	 *
 	 * @return void
 	 */
 	public function import( array $args = array(), array $assoc_args = array() ): void {

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -82,6 +82,7 @@ class Admin_List {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type that was just registered.
+	 *
 	 * @return void
 	 */
 	public function maybe_register_post_type_hooks( string $post_type ): void {
@@ -125,6 +126,7 @@ class Admin_List {
 	 * @since 0.34.0
 	 *
 	 * @param array $columns An array of sortable columns.
+	 *
 	 * @return array An updated array of sortable columns.
 	 */
 	public function sortable_columns( array $columns ): array {
@@ -252,6 +254,7 @@ class Admin_List {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The event post type to count.
+	 *
 	 * @return array<string, int> Associative array with 'upcoming' and 'past' counts.
 	 */
 	protected function get_event_counts( string $post_type = Event::POST_TYPE ): array {
@@ -342,6 +345,7 @@ class Admin_List {
 	 * @since 0.34.0
 	 *
 	 * @param WP_Query $query The WP_Query instance.
+	 *
 	 * @return void
 	 */
 	public function handle_rsvp_sorting( $query ): void {
@@ -381,6 +385,7 @@ class Admin_List {
 	 * @param string                 $column    The column name to match against the orderby query var.
 	 * @param array<string,callable> $filters   Map of WordPress filter hook => callback to register.
 	 * @param string                 $order_key The query var key used to store the validated sort order.
+	 *
 	 * @return void
 	 */
 	private function handle_column_sorting( WP_Query $query, string $column, array $filters, string $order_key ): void {
@@ -419,6 +424,7 @@ class Admin_List {
 	 * @since 0.34.0
 	 *
 	 * @param string $join The JOIN clause of the query.
+	 *
 	 * @return string Modified JOIN clause.
 	 */
 	public function rsvp_sorting_join_paged( string $join ): string {
@@ -446,6 +452,7 @@ class Admin_List {
 	 * @since 0.34.0
 	 *
 	 * @param string $groupby The GROUP BY clause of the query.
+	 *
 	 * @return string Modified GROUP BY clause.
 	 */
 	public function sorting_groupby_post_id( string $groupby ): string {
@@ -487,6 +494,7 @@ class Admin_List {
 	 *
 	 * @param string $column  The name of the column to display.
 	 * @param int    $post_id The current post ID.
+	 *
 	 * @return void
 	 *
 	 * @throws Exception If initializing Event or Rsvp object fails, due to invalid post ID or database issues.
@@ -579,6 +587,7 @@ class Admin_List {
 	 * @since 0.34.0
 	 *
 	 * @param array $columns An associative array of column headings.
+	 *
 	 * @return array An updated array of column headings, including the custom columns.
 	 */
 	public function set_custom_columns( array $columns ): array {
@@ -668,6 +677,7 @@ class Admin_List {
 	 * @since 0.34.0
 	 *
 	 * @param array $columns An array of column names.
+	 *
 	 * @return array The modified array of column names without the comments column.
 	 */
 	public function remove_comments_column( array $columns ): array {

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -347,6 +347,7 @@ class Event {
 	 * @since 0.34.0
 	 *
 	 * @param string $format Optional. PHP date format. Default is 'D, M j, Y, g:i a T'.
+	 *
 	 * @return string The formatted start datetime of the event.
 	 *
 	 * @throws Exception If there is an issue formatting the start datetime.
@@ -403,6 +404,7 @@ class Event {
 	 * @param string $format Optional. The PHP date format in which to format the datetime. Default is 'D, F j, g:ia T'.
 	 * @param string $which  Optional. Datetime field in event table to format ('start' or 'end'). Default is 'start'.
 	 * @param bool   $local  Optional. Whether to format the date in local time (true) or GMT (false). Default is true.
+	 *
 	 * @return string The formatted datetime value.
 	 *
 	 * @throws Exception If there is an issue while formatting the datetime value.
@@ -509,6 +511,7 @@ class Event {
 	 *
 	 * @param string       $date     The date to be converted.
 	 * @param DateTimeZone $timezone The time zone to use for date conversion.
+	 *
 	 * @return string The converted date in GMT (UTC) time zone in 'Y-m-d H:i:s' format.
 	 */
 	protected function get_gmt_datetime( string $date, DateTimeZone $timezone ): string {

--- a/includes/core/classes/event/class-meta.php
+++ b/includes/core/classes/event/class-meta.php
@@ -82,6 +82,7 @@ class Meta {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type that was just registered.
+	 *
 	 * @return void
 	 */
 	public function register( string $post_type ): void {
@@ -101,6 +102,7 @@ class Meta {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type to register against.
+	 *
 	 * @return void
 	 */
 	protected function register_event_date_meta( string $post_type ): void {
@@ -255,6 +257,7 @@ class Meta {
 	 *
 	 * @param stdClass        $prepared_post An object representing a single post prepared for inserting or updating.
 	 * @param WP_REST_Request $request       Request object.
+	 *
 	 * @return stdClass The prepared post object.
 	 */
 	public function filter_readonly_meta( stdClass $prepared_post, WP_REST_Request $request ): stdClass {

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -80,6 +80,7 @@ class Query {
 	 * @since 0.34.0
 	 *
 	 * @param int $number Maximum number of upcoming events to retrieve.
+	 *
 	 * @return WP_Query A WordPress query object containing the list of upcoming events.
 	 */
 	public function get_upcoming_events( int $number = 5 ): WP_Query {
@@ -94,6 +95,7 @@ class Query {
 	 * @since 0.34.0
 	 *
 	 * @param int $number Maximum number of past events to retrieve.
+	 *
 	 * @return WP_Query A WordPress query object containing the list of past events.
 	 */
 	public function get_past_events( int $number = 5 ): WP_Query {
@@ -113,6 +115,7 @@ class Query {
 	 * @param int    $number          Maximum number of events to retrieve.
 	 * @param array  $topics          Array of topic slugs for additional filtering.
 	 * @param array  $venues          Array of venue slugs for additional filtering.
+	 *
 	 * @return WP_Query A WordPress query object containing the list of events.
 	 */
 	public function get_events_list(
@@ -171,6 +174,7 @@ class Query {
 	 * @since 0.34.0
 	 *
 	 * @param WP_Query $query An instance of WP_Query representing the event query.
+	 *
 	 * @return void
 	 */
 	public function prepare_event_query_before_execution( WP_Query $query ): void {
@@ -300,6 +304,7 @@ class Query {
 	 *
 	 * @param array    $query_pieces An array containing pieces of the SQL query.
 	 * @param WP_Query $query        The WP_Query instance (passed by reference).
+	 *
 	 * @return array The modified SQL query pieces with adjusted sorting criteria for upcoming events.
 	 */
 	public function adjust_sorting_for_upcoming_events( array $query_pieces, WP_Query $query ): array {
@@ -326,6 +331,7 @@ class Query {
 	 *
 	 * @param array    $query_pieces An array containing pieces of the SQL query.
 	 * @param WP_Query $query        The WP_Query instance (passed by reference).
+	 *
 	 * @return array The modified SQL query pieces with adjusted sorting criteria for past events.
 	 */
 	public function adjust_sorting_for_past_events( array $query_pieces, WP_Query $query ): array {
@@ -353,6 +359,7 @@ class Query {
 	 *
 	 * @param array    $query_pieces An array containing pieces of the SQL query.
 	 * @param WP_Query $wp_query     The WP_Query instance (passed by reference).
+	 *
 	 * @return array The modified SQL query pieces with adjusted sorting criteria.
 	 */
 	public function adjust_admin_event_sorting( array $query_pieces, WP_Query $wp_query ): array {
@@ -426,6 +433,7 @@ class Query {
 	 *                                  (Default: 'DESC').
 	 * @param string[]|string $order_by List or singular string of ORDERBY statement(s) (Default: ['datetime']).
 	 * @param bool            $inclusive Whether to include currently running events in the query (Default: true).
+	 *
 	 * @return array An array containing adjusted SQL clauses for the Event query.
 	 */
 	public function adjust_event_sql(
@@ -513,6 +521,7 @@ class Query {
 	 * @since 0.34.0
 	 *
 	 * @param array $venues Array of venue slugs to filter by.
+	 *
 	 * @return array WP_Query compatible tax_query array.
 	 */
 	private function build_venue_tax_query( array $venues ): array {

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -415,6 +415,7 @@ class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request Contains data from the request.
+	 *
 	 * @return WP_REST_Response The response indicating the success of the email scheduling process.
 	 */
 	public function email( WP_REST_Request $request ): WP_REST_Response {
@@ -442,6 +443,7 @@ class Rest_Api {
 	 * @param int    $post_id Post ID.
 	 * @param array  $send    Members to send the email to.
 	 * @param string $message Optional message to include in the email.
+	 *
 	 * @return void
 	 */
 	public function handle_email_send_action( int $post_id, array $send, string $message ): void {
@@ -460,6 +462,7 @@ class Rest_Api {
 	 * @param int    $post_id Post ID.
 	 * @param array  $send    Members to send the email to.
 	 * @param string $message Optional message to include in the email.
+	 *
 	 * @return bool True if emails were successfully sent, false otherwise.
 	 */
 	public function send_emails( int $post_id, array $send, string $message ): bool {
@@ -494,6 +497,7 @@ class Rest_Api {
 	 * @param int     $post_id      Event post ID.
 	 * @param string  $message      Optional editor-supplied message body.
 	 * @param WP_User $current_user Originating editor (restored after locale/user switch).
+	 *
 	 * @return void
 	 */
 	protected function send_event_email_to_recipient(
@@ -573,6 +577,7 @@ class Rest_Api {
 	 *
 	 * @param array $send    An array specifying who to send emails to.
 	 * @param int   $post_id The Event Post ID.
+	 *
 	 * @return array An array containing unified recipient data for both users and non-users.
 	 */
 	public function get_recipients( array $send, int $post_id ): array {
@@ -645,6 +650,7 @@ class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param object $comment RSVP comment row from `Rsvp_Query::get_rsvps()`.
+	 *
 	 * @return array|null Recipient row, or null when no email is on file.
 	 */
 	protected function build_comment_recipient( $comment ): ?array {
@@ -685,6 +691,7 @@ class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request Contains data from the REST API request.
+	 *
 	 * @return WP_REST_Response The REST API response containing an array of event data.
 	 *
 	 * @throws Exception If there is an issue while retrieving the list of events.
@@ -764,6 +771,7 @@ class Rest_Api {
 	 *
 	 * @param int $number     The actual number.
 	 * @param int $max_number The maximum number allowed.
+	 *
 	 * @return int The sanitized number, ensuring it does not exceed the maximum limit.
 	 */
 	protected function max_number( int $number, int $max_number ): int {
@@ -784,6 +792,7 @@ class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request Contains data from the request.
+	 *
 	 * @return WP_REST_Response An instance of WP_REST_Response containing the response data.
 	 */
 	public function update_rsvp( WP_REST_Request $request ): WP_REST_Response {
@@ -934,6 +943,7 @@ class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request The REST API request object.
+	 *
 	 * @return WP_REST_Response The response indicating success or failure.
 	 */
 	public function handle_rsvp_form_submission( WP_REST_Request $request ): WP_REST_Response {
@@ -1032,6 +1042,7 @@ class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request REST API request object containing post_id parameter.
+	 *
 	 * @return WP_REST_Response Response containing success status and RSVP data.
 	 */
 	public function rsvp_responses( WP_REST_Request $request ): WP_REST_Response {
@@ -1073,6 +1084,7 @@ class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Response $response The response object containing event data.
+	 *
 	 * @return WP_REST_Response The response object with enhanced event data.
 	 */
 	public function prepare_event_data( WP_REST_Response $response ): WP_REST_Response {

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -434,6 +434,7 @@ class Setup {
 	 *
 	 * @param WP_Query $wp_query  The global query, mutated in place.
 	 * @param string   $post_type The event-supporting post type being archived.
+	 *
 	 * @return void
 	 */
 	protected function fall_back_to_archive_mode( WP_Query $wp_query, string $post_type ): void {
@@ -485,6 +486,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type Post type to resolve the mode for. Defaults to the standard event post type.
+	 *
 	 * @return string One of `upcoming`, `past`, or `none`.
 	 */
 	public function get_event_archive_mode( string $post_type = Event::POST_TYPE ): string {
@@ -526,6 +528,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param int $post_id The ID of the post for which the waiting list should be checked.
+	 *
 	 * @return void
 	 */
 	public function check_waiting_list( int $post_id ): void {
@@ -547,6 +550,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param int $post_id An event post ID.
+	 *
 	 * @return void
 	 */
 	public function delete_event( int $post_id ): void {
@@ -580,6 +584,7 @@ class Setup {
 	 * @param string       $the_date The formatted date.
 	 * @param string       $format   PHP date format.
 	 * @param WP_Post|null $post     The post object.
+	 *
 	 * @return string The event date as a formatted string.
 	 *
 	 * @throws Exception If initializing the Event object fails or event data cannot be retrieved.
@@ -623,6 +628,7 @@ class Setup {
 	 * @param string   $block_content The block content.
 	 * @param array    $block         The full block, including name and attributes.
 	 * @param WP_Block $instance      The block instance.
+	 *
 	 * @return string The filtered block content with event datetime.
 	 *
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) -- $block is required by the render_block filter signature.
@@ -673,6 +679,7 @@ class Setup {
 	 *
 	 * @param array   $post_states An array of post display states.
 	 * @param WP_Post $post        The current post object.
+	 *
 	 * @return array An updated array of post display states with custom labels if applicable.
 	 */
 	public function set_event_archive_labels( array $post_states, WP_Post $post ): array {

--- a/includes/core/classes/rsvp/class-form.php
+++ b/includes/core/classes/rsvp/class-form.php
@@ -146,6 +146,7 @@ class Form {
 	 * @since 0.34.0
 	 *
 	 * @param array $comment_data The comment data array.
+	 *
 	 * @return array Modified comment data array.
 	 */
 	public function preprocess_rsvp_comment( array $comment_data ): array {
@@ -243,6 +244,7 @@ class Form {
 	 * @since 0.34.0
 	 *
 	 * @param int $comment_id The comment ID.
+	 *
 	 * @return void
 	 */
 	public function handle_rsvp_comment_post( int $comment_id ): void {
@@ -294,6 +296,7 @@ class Form {
 	 *
 	 * @param string     $location The original redirect location.
 	 * @param WP_Comment $comment  The comment object.
+	 *
 	 * @return string The modified redirect location.
 	 */
 	public function handle_rsvp_comment_redirect( string $location, WP_Comment $comment ): string {
@@ -332,6 +335,7 @@ class Form {
 	 * @since 0.34.0
 	 *
 	 * @param array $data RSVP submission data containing post_id, author, email, and optional fields.
+	 *
 	 * @return array{success: bool, message: string, comment_id: int, error_code?: int} Processing result.
 	 */
 	public function process_rsvp( array $data ): array {
@@ -384,6 +388,7 @@ class Form {
 	 *
 	 * @param int    $post_id The event post ID.
 	 * @param string $email   The email address to check.
+	 *
 	 * @return bool True if a duplicate RSVP exists, false otherwise.
 	 */
 	public function has_duplicate_rsvp( int $post_id, string $email ): bool {
@@ -429,6 +434,7 @@ class Form {
 	 * @param int    $post_id The event post ID.
 	 * @param string $author  The author name.
 	 * @param string $email   The email address.
+	 *
 	 * @return array Comment data array for wp_insert_comment().
 	 */
 	private function prepare_comment_data( int $post_id, string $author, string $email ): array {
@@ -492,6 +498,7 @@ class Form {
 	 *
 	 * @param int   $comment_id The comment ID.
 	 * @param array $data       Submission data containing field values.
+	 *
 	 * @return void
 	 */
 	public function process_fields( int $comment_id, array $data ): void {
@@ -509,6 +516,7 @@ class Form {
 	 *
 	 * @param int   $comment_id The comment ID.
 	 * @param array $data       Submission data containing meta field values.
+	 *
 	 * @return void
 	 */
 	private function process_meta_fields( int $comment_id, array $data ): void {
@@ -559,6 +567,7 @@ class Form {
 	 *
 	 * @param int   $comment_id The comment ID.
 	 * @param array $data       Submission data containing custom field values.
+	 *
 	 * @return void
 	 */
 	private function process_custom_fields( int $comment_id, array $data ): void {
@@ -624,6 +633,7 @@ class Form {
 	 *
 	 * @param int|false $comment_id_result The result from wp_insert_comment (comment ID or false).
 	 * @param array     $data              RSVP submission data.
+	 *
 	 * @return array{success: bool, message: string, comment_id: int, error_code?: int} Processing result.
 	 */
 	private function handle_rsvp_creation( $comment_id_result, array $data ): array {

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -722,6 +722,7 @@ class List_Table extends WP_List_Table {
 	 *
 	 * @param string $status_key The status key to check.
 	 * @param string $current    The currently active status.
+	 *
 	 * @return string The class attribute string or empty string.
 	 */
 	private function get_current_class_attr( string $status_key, string $current ): string {

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -86,6 +86,7 @@ class Query {
 	 *
 	 * @param array            $clauses       The clauses for the query.
 	 * @param WP_Comment_Query $comment_query Current instance of WP_Comment_Query (passed by reference).
+	 *
 	 * @return array Modified query clauses.
 	 */
 	public function taxonomy_query( array $clauses, WP_Comment_Query $comment_query ): array {
@@ -111,6 +112,7 @@ class Query {
 	 * @since 0.34.0
 	 *
 	 * @param array $args Arguments for retrieving RSVPs.
+	 *
 	 * @return mixed Array of RSVP comments or integer count when count parameter is true.
 	 */
 	public function get_rsvps( array $args ) {
@@ -141,6 +143,7 @@ class Query {
 	 * @since 0.34.0
 	 *
 	 * @param array $args Arguments for retrieving the RSVP.
+	 *
 	 * @return WP_Comment|null The RSVP comment or null if not found.
 	 */
 	public function get_rsvp( array $args ): ?WP_Comment {
@@ -205,6 +208,7 @@ class Query {
 	 *
 	 * @param int        $id      The comment ID.
 	 * @param WP_Comment $comment The comment object.
+	 *
 	 * @return void
 	 *
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -236,6 +240,7 @@ class Query {
 	 * @since 0.34.0
 	 *
 	 * @param WP_Comment_Query $query Current instance of WP_Comment_Query (passed by reference).
+	 *
 	 * @return void
 	 */
 	public function exclude_rsvp_from_comment_query( WP_Comment_Query $query ) {

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -722,6 +722,7 @@ class Rsvp {
 	 *
 	 * @param array $first  The first response to compare in the sort.
 	 * @param array $second The second response to compare in the sort.
+	 *
 	 * @return int An integer indicating the sorting order:
 	 *             -1 if $first should come before $second,
 	 *              0 if they have the same sorting order,
@@ -753,6 +754,7 @@ class Rsvp {
 	 *
 	 * @param array $first  First response to compare in the sort.
 	 * @param array $second Second response to compare in the sort.
+	 *
 	 * @return int Returns a negative number if the first response's timestamp is earlier,
 	 *             a positive number if the second response's timestamp is earlier,
 	 *             or 0 if both are equal.

--- a/includes/core/classes/rsvp/class-token.php
+++ b/includes/core/classes/rsvp/class-token.php
@@ -324,6 +324,7 @@ class Token {
 	 * @since 0.34.0
 	 *
 	 * @param string|null $token_string Token in format "commentId_token".
+	 *
 	 * @return self|null Instance if valid, null otherwise.
 	 */
 	public static function from_token_string( ?string $token_string ): ?self {
@@ -352,6 +353,7 @@ class Token {
 	 * @since 0.34.0
 	 *
 	 * @param string|null $token_string Raw token string in format "commentId_token".
+	 *
 	 * @return array Array with 'comment_id' and 'token' keys, or empty array if invalid.
 	 */
 	public static function parse_token_string( ?string $token_string ): array {

--- a/includes/core/classes/settings/class-base.php
+++ b/includes/core/classes/settings/class-base.php
@@ -150,6 +150,7 @@ abstract class Base {
 	 * @since 0.27.0
 	 *
 	 * @param array $sub_pages An array of sub-pages for GatherPress.
+	 *
 	 * @return array Modified array with the sub-page added.
 	 */
 	public function set_sub_page( array $sub_pages ): array {
@@ -167,6 +168,7 @@ abstract class Base {
 	 * @since 0.27.0
 	 *
 	 * @param string $property The name of the property to retrieve.
+	 *
 	 * @return mixed|null The value of the property or null if it doesn't exist.
 	 */
 	public function get( string $property ) {

--- a/includes/core/classes/settings/class-credits.php
+++ b/includes/core/classes/settings/class-credits.php
@@ -95,6 +95,7 @@ class Credits extends Base {
 	 * @since 0.27.0
 	 *
 	 * @param string $page The current settings page slug.
+	 *
 	 * @return void
 	 */
 	public function settings_section( string $page ): void {

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -297,6 +297,7 @@ class Network {
 	 * @since 0.34.0
 	 *
 	 * @param mixed $pre The pre-filter value (false when not short-circuited).
+	 *
 	 * @return mixed
 	 */
 	public function route_read_to_site_option( $pre ) {
@@ -360,6 +361,7 @@ class Network {
 	 * @since 0.34.0
 	 *
 	 * @param array $sub_pages Available sub-pages keyed by slug.
+	 *
 	 * @return string
 	 */
 	protected function get_current_tab( array $sub_pages ): string {
@@ -469,6 +471,7 @@ class Network {
 	 * @since 0.34.0
 	 *
 	 * @param array $sub_pages Sub-pages from Settings::get_sub_pages().
+	 *
 	 * @return array<string, string>
 	 */
 	protected function build_field_type_map( array $sub_pages ): array {
@@ -500,6 +503,7 @@ class Network {
 	 * @since 0.34.0
 	 *
 	 * @param string $tab The tab slug to return to.
+	 *
 	 * @return void
 	 */
 	protected function redirect_to_tab( string $tab ): void {
@@ -526,6 +530,7 @@ class Network {
 	 * @since 0.34.0
 	 *
 	 * @param mixed $input Raw input array.
+	 *
 	 * @return array
 	 */
 	public function sanitize( $input ): array {

--- a/includes/core/classes/settings/class-roles.php
+++ b/includes/core/classes/settings/class-roles.php
@@ -121,6 +121,7 @@ class Roles extends Base {
 	 * @since 0.34.0
 	 *
 	 * @param int $user_id User ID.
+	 *
 	 * @return string The role of the user, or 'Member' if no matching role is found.
 	 */
 	public function get_user_role( int $user_id ): string {

--- a/includes/core/classes/settings/class-tools.php
+++ b/includes/core/classes/settings/class-tools.php
@@ -86,6 +86,7 @@ class Tools extends Base {
 	 * @since 0.34.0
 	 *
 	 * @param string $page The current settings page slug.
+	 *
 	 * @return void
 	 */
 	public function settings_section( string $page ): void {
@@ -148,6 +149,7 @@ class Tools extends Base {
 	 * @since 0.34.0
 	 *
 	 * @param string $scope 'network' or 'blog'.
+	 *
 	 * @return string
 	 */
 	protected function capability_for_scope( string $scope ): string {

--- a/includes/core/classes/venue/class-meta.php
+++ b/includes/core/classes/venue/class-meta.php
@@ -132,6 +132,7 @@ class Meta {
 	 * @since 0.34.0
 	 *
 	 * @param mixed $value The submitted value.
+	 *
 	 * @return string Normalized coordinate string, or '' for invalid / unset input.
 	 */
 	public function sanitize_coordinate( $value ): string {
@@ -151,6 +152,7 @@ class Meta {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type that was just registered.
+	 *
 	 * @return void
 	 */
 	public function register( string $post_type ): void {
@@ -172,6 +174,7 @@ class Meta {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type to register against.
+	 *
 	 * @return void
 	 */
 	protected function register_venue_information_meta( string $post_type ): void {
@@ -298,6 +301,7 @@ class Meta {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type to register against.
+	 *
 	 * @return void
 	 */
 	protected function register_venue_map_meta( string $post_type ): void {
@@ -346,6 +350,7 @@ class Meta {
 	 *
 	 * @param stdClass        $prepared_post An object representing a single post prepared for inserting or updating.
 	 * @param WP_REST_Request $request       Request object.
+	 *
 	 * @return stdClass The prepared post object.
 	 */
 	public function filter_readonly_meta( stdClass $prepared_post, WP_REST_Request $request ): stdClass {

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -120,6 +120,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type that was just registered.
+	 *
 	 * @return void
 	 */
 	public function maybe_link_shadow_source_support( string $post_type ): void {
@@ -140,6 +141,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param array $settings The block editor settings array.
+	 *
 	 * @return array The modified block editor settings array.
 	 */
 	public function add_editor_settings( array $settings ): array {
@@ -361,6 +363,7 @@ class Setup {
 	 * @param int     $post_id Post ID of the venue post.
 	 * @param WP_Post $post    The venue post object.
 	 * @param bool    $update  True when updating an existing post, false on initial insert.
+	 *
 	 * @return void
 	 */
 	public function maybe_apply_venue_template( int $post_id, WP_Post $post, bool $update ): void {
@@ -423,6 +426,7 @@ class Setup {
 	 *
 	 * @param int    $post_id   The post ID for which to retrieve venue information.
 	 * @param string $post_type The post type of the provided post ID.
+	 *
 	 * @return array An array containing venue-related information.
 	 */
 	public function get_venue_meta( int $post_id, string $post_type ): array {
@@ -470,6 +474,7 @@ class Setup {
 	 *
 	 * @param string $slug            The venue taxonomy term slug (e.g. `_my-venue`).
 	 * @param string $event_post_type Optional event post-type context.
+	 *
 	 * @return WP_Post|null The matching venue post, or null.
 	 */
 	public function get_venue_post_from_term_slug( string $slug, string $event_post_type = '' ): ?WP_Post {
@@ -490,6 +495,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param int $event_post_id The event post ID.
+	 *
 	 * @return WP_Post|null The linked venue post, or null.
 	 */
 	public function get_venue_post_from_event_post_id( int $event_post_id ): ?WP_Post {
@@ -529,6 +535,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param string $slug The term slug to test.
+	 *
 	 * @return bool
 	 */
 	public function is_venue_term_slug( string $slug ): bool {
@@ -545,6 +552,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param string $event_post_type The event post type.
+	 *
 	 * @return string The venue taxonomy slug.
 	 */
 	public function taxonomy_for_event_post_type( string $event_post_type = '' ): string {
@@ -561,6 +569,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_name The venue post's post_name (e.g. `my-venue`).
+	 *
 	 * @return string The taxonomy term slug (e.g. `_my-venue`).
 	 */
 	public function term_slug_from_post_name( string $post_name ): string {
@@ -577,6 +586,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param string $venue_post_type The venue post type slug. Defaults to the built-in venue post type.
+	 *
 	 * @return string The taxonomy slug for the given venue post type.
 	 */
 	public function get_taxonomy( string $venue_post_type = '' ): string {
@@ -604,6 +614,7 @@ class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param string $event_post_type The event post type requesting a venue post type.
+	 *
 	 * @return string The venue post type slug.
 	 */
 	public function get_venue_post_type( string $event_post_type = '' ): string {

--- a/includes/core/classes/venue/map/class-manager.php
+++ b/includes/core/classes/venue/map/class-manager.php
@@ -115,7 +115,7 @@ class Manager {
 					esc_html__( 'A venue map provider is already registered for slug "%s".', 'gatherpress' ),
 					esc_html( $slug )
 				),
-				'1.0.0'
+				'0.34.0'
 			);
 			return;
 		}
@@ -204,7 +204,7 @@ class Manager {
 					esc_html__( 'No venue map provider registered for slug "%s"; falling back to OSM.', 'gatherpress' ),
 					esc_html( $slug )
 				),
-				'1.0.0'
+				'0.34.0'
 			);
 		}
 

--- a/includes/core/classes/venue/map/class-manager.php
+++ b/includes/core/classes/venue/map/class-manager.php
@@ -97,6 +97,7 @@ class Manager {
 	 * @since 0.34.0
 	 *
 	 * @param Map_Provider $provider Provider instance.
+	 *
 	 * @return void
 	 */
 	public function register( Map_Provider $provider ): void {
@@ -128,6 +129,7 @@ class Manager {
 	 * @since 0.34.0
 	 *
 	 * @param string $slug Provider slug.
+	 *
 	 * @return bool
 	 */
 	public function is_registered( string $slug ): bool {
@@ -140,6 +142,7 @@ class Manager {
 	 * @since 0.34.0
 	 *
 	 * @param string $slug Provider slug.
+	 *
 	 * @return Map_Provider|null
 	 */
 	public function get( string $slug ): ?Map_Provider {

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -321,6 +321,7 @@ class Map {
 	 *
 	 * @param array|mixed $old_value Previous settings option value.
 	 * @param array|mixed $new_value New settings option value.
+	 *
 	 * @return void
 	 */
 	public function maybe_handle_settings_change( $old_value, $new_value ): void {
@@ -442,6 +443,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param array $metadata Parsed `block.json` metadata for the block being registered.
+	 *
 	 * @return array The metadata array, potentially with updated attribute defaults.
 	 */
 	public function apply_block_attribute_defaults( array $metadata ): array {
@@ -539,6 +541,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param string $post_type The post type that was just registered.
+	 *
 	 * @return void
 	 */
 	public function maybe_register_delete_hook( string $post_type ): void {
@@ -563,6 +566,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param int $post_id The post ID being saved.
+	 *
 	 * @return void
 	 */
 	public function maybe_generate( int $post_id ): void {
@@ -628,6 +632,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param int $post_id The venue post ID.
+	 *
 	 * @return void
 	 */
 	public function delete_stored_image( int $post_id ): void {
@@ -661,6 +666,7 @@ class Map {
 	 * @param int|null $extra_width        Optional extra width (0 = auto).
 	 * @param int|null $extra_height       Optional extra height (0 = auto).
 	 * @param string   $extra_aspect_ratio Optional aspect ratio hint for the extra combo.
+	 *
 	 * @return ProviderDescriptorMap
 	 */
 	public function regenerate(
@@ -759,6 +765,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request The REST request.
+	 *
 	 * @return WP_REST_Response
 	 */
 	public function rest_regenerate( WP_REST_Request $request ): WP_REST_Response {
@@ -844,6 +851,7 @@ class Map {
 	 * @param int|null $width        Desired pixel width (0/null = auto).
 	 * @param int|null $height       Desired pixel height (0/null = auto).
 	 * @param string   $aspect_ratio Aspect-ratio hint used to derive any auto dimension.
+	 *
 	 * @return array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
 	public function get_descriptor_for_post(
@@ -937,6 +945,7 @@ class Map {
 	 * @param int|null $width        Desired pixel width (0/null = auto).
 	 * @param int|null $height       Desired pixel height (0/null = auto).
 	 * @param string   $aspect_ratio Aspect-ratio hint used to derive any auto dimension.
+	 *
 	 * @return string Static map URL, or '' when unavailable.
 	 */
 	public function get_url_for_post(
@@ -972,6 +981,7 @@ class Map {
 	 * @param int    $width        Pixel width (0 = auto).
 	 * @param int    $height       Pixel height (0 = auto).
 	 * @param string $aspect_ratio Aspect-ratio string (e.g. "16/9").
+	 *
 	 * @return array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
 	public function warm( int $post_id, int $zoom, int $width, int $height, string $aspect_ratio = '' ): ?array {
@@ -1013,6 +1023,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param int $post_id The venue post ID.
+	 *
 	 * @return array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
 	public function get_stored_descriptor( int $post_id ): ?array {
@@ -1047,6 +1058,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param int $post_id The venue post ID.
+	 *
 	 * @return ProviderDescriptorMap
 	 */
 	public function get_all_descriptors( int $post_id ): array {
@@ -1122,6 +1134,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param int $post_id Venue post ID.
+	 *
 	 * @return array<int, array{zoom: int, width: int, height: int}>
 	 */
 	public function get_cached_combos( int $post_id ): array {
@@ -1158,6 +1171,7 @@ class Map {
 	 * @param int $zoom   Zoom level.
 	 * @param int $width  Pixel width.
 	 * @param int $height Pixel height.
+	 *
 	 * @return string
 	 */
 	protected function combo_key( int $zoom, int $width, int $height ): string {
@@ -1180,6 +1194,7 @@ class Map {
 	 * @param int   $zoom    Zoom level to render at.
 	 * @param int   $width   Pixel width of the PNG.
 	 * @param int   $height  Pixel height of the PNG.
+	 *
 	 * @return array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
 	protected function ensure_descriptor_for_combo(
@@ -1352,6 +1367,7 @@ class Map {
 	 * @param int    $width    Output width.
 	 * @param int    $height   Output height.
 	 * @param string $provider Provider slug (e.g. `osm`).
+	 *
 	 * @return string MD5 hex digest.
 	 */
 	public function hash_for( array $info, int $zoom, int $width, int $height, string $provider ): string {
@@ -1393,6 +1409,7 @@ class Map {
 	 * @param int    $height   Output height (at density 1).
 	 * @param string $provider Provider slug (e.g. `osm`).
 	 * @param int    $density  Pixel-density multiplier. 1 = standard, 2 = retina.
+	 *
 	 * @return string Full public URL for the PNG.
 	 */
 	protected function build_image_url(
@@ -1429,6 +1446,7 @@ class Map {
 	 * @param string $provider Provider slug (e.g. `osm`) — namespaces the file
 	 *                         so OSM and Google PNG files can coexist on disk.
 	 * @param int    $density  Pixel-density multiplier. 1 = standard, 2 = retina.
+	 *
 	 * @return string Filename including the `.png` extension.
 	 */
 	protected function filename_for(
@@ -1476,6 +1494,7 @@ class Map {
 	 * @param int              $height   Output height (at density 1).
 	 * @param int              $density  Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @param string           $provider Provider slug.
+	 *
 	 * @return string|null Public URL of the saved file, or null on failure.
 	 */
 	public function save_image(
@@ -1518,6 +1537,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param mixed $raw Raw coordinate from venue information.
+	 *
 	 * @return float|null
 	 */
 	protected function parse_coord( $raw ): ?float {
@@ -1588,6 +1608,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param int $zoom Raw zoom value.
+	 *
 	 * @return int
 	 */
 	protected function clamp_zoom( int $zoom ): int {
@@ -1600,6 +1621,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param int $height Raw height value.
+	 *
 	 * @return int
 	 */
 	protected function clamp_height( int $height ): int {
@@ -1612,6 +1634,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param int $width Raw width value.
+	 *
 	 * @return int
 	 */
 	protected function clamp_width( int $width ): int {
@@ -1628,6 +1651,7 @@ class Map {
 	 * @since 0.34.0
 	 *
 	 * @param string $ratio Raw aspect-ratio string.
+	 *
 	 * @return float|null
 	 */
 	protected function parse_aspect_ratio( string $ratio ): ?float {
@@ -1664,6 +1688,7 @@ class Map {
 	 * @param int    $width   Block width (0 = auto).
 	 * @param int    $height  Block height (0 = auto).
 	 * @param string $ratio   Aspect-ratio string (e.g. "16/9").
+	 *
 	 * @return array{width: int, height: int}
 	 */
 	protected function resolve_dimensions( int $width, int $height, string $ratio ): array {

--- a/includes/core/classes/venue/map/class-prewarm.php
+++ b/includes/core/classes/venue/map/class-prewarm.php
@@ -212,6 +212,7 @@ class Prewarm {
 	 *
 	 * @param int     $post_id Post ID that just saved.
 	 * @param WP_Post $post    Post object.
+	 *
 	 * @return void
 	 */
 	public function on_post_saved( int $post_id, WP_Post $post ): void {
@@ -273,6 +274,7 @@ class Prewarm {
 	 * @param int    $width        Pixel width (0 = auto).
 	 * @param int    $height       Pixel height (0 = auto).
 	 * @param string $aspect_ratio Aspect-ratio string.
+	 *
 	 * @return void
 	 */
 	public function process_warm_job( int $post_id, int $zoom, int $width, int $height, string $aspect_ratio ): void {
@@ -285,6 +287,7 @@ class Prewarm {
 	 * @since 0.34.0
 	 *
 	 * @param int $venue_post_id Venue post ID.
+	 *
 	 * @return void
 	 */
 	protected function enqueue_for_venue( int $venue_post_id ): void {
@@ -299,6 +302,7 @@ class Prewarm {
 	 * @since 0.34.0
 	 *
 	 * @param array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}> $combos Combo list.
+	 *
 	 * @return void
 	 */
 	protected function enqueue_for_all_venues( array $combos ): void {
@@ -364,6 +368,7 @@ class Prewarm {
 	 *
 	 * @param int                                                      $venue_post_id Venue post ID.
 	 * @param array{zoom:int,width:int,height:int,aspect_ratio:string} $combo         Combo to warm.
+	 *
 	 * @return void
 	 */
 	protected function enqueue_warm_job( int $venue_post_id, array $combo ): void {
@@ -484,6 +489,7 @@ class Prewarm {
 	 * @since 0.34.0
 	 *
 	 * @param string[] $post_types Post types declaring `gatherpress-venue` support.
+	 *
 	 * @return array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}>
 	 */
 	protected function collect_combos_from_venue_posts( array $post_types ): array {
@@ -538,6 +544,7 @@ class Prewarm {
 	 * @since 0.34.0
 	 *
 	 * @param string $content Block markup (post_content / template content).
+	 *
 	 * @return array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}>
 	 */
 	protected function collect_combos_from_content( string $content ): array {
@@ -556,6 +563,7 @@ class Prewarm {
 	 * @since 0.34.0
 	 *
 	 * @param array<int, array<string, mixed>> $blocks Parsed blocks.
+	 *
 	 * @return array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}>
 	 */
 	protected function walk_blocks_for_combos( array $blocks ): array {
@@ -584,6 +592,7 @@ class Prewarm {
 	 * @since 0.34.0
 	 *
 	 * @param array<string, mixed> $attrs Block attributes.
+	 *
 	 * @return array{zoom:int,width:int,height:int,aspect_ratio:string}
 	 */
 	protected function extract_block_combo( array $attrs ): array {
@@ -605,6 +614,7 @@ class Prewarm {
 	 * @since 0.34.0
 	 *
 	 * @param array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}> $combos Combo list.
+	 *
 	 * @return array<int, array{zoom:int,width:int,height:int,aspect_ratio:string}>
 	 */
 	protected function dedupe_combos( array $combos ): array {

--- a/includes/core/classes/venue/map/provider/class-base.php
+++ b/includes/core/classes/venue/map/provider/class-base.php
@@ -79,6 +79,7 @@ abstract class Base {
 	 * @param int   $width     Logical pixel width (at density 1).
 	 * @param int   $height    Logical pixel height (at density 1).
 	 * @param int   $density   Pixel-density multiplier. 1 = standard, 2 = retina.
+	 *
 	 * @return GdImage|resource|null Finished image, or null on failure.
 	 */
 	abstract public function render(
@@ -116,6 +117,7 @@ abstract class Base {
 	 * @since 0.34.0
 	 *
 	 * @param string $map_type Map type slug — one of `roadmap`, `satellite`, `hybrid`, `terrain`.
+	 *
 	 * @return bool
 	 */
 	public function supports_map_type( string $map_type ): bool {

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -103,6 +103,7 @@ class OSM extends Base {
 	 * @param int   $width     Logical pixel width (at density 1).
 	 * @param int   $height    Logical pixel height (at density 1).
 	 * @param int   $density   Pixel-density multiplier. 1 = standard, 2 = retina.
+	 *
 	 * @return GdImage|resource|null Finished image, or null on failure.
 	 */
 	public function render(
@@ -209,6 +210,7 @@ class OSM extends Base {
 	 * @param int              $left_pixel World-pixel x-offset of the canvas top-left.
 	 * @param int              $top_pixel  World-pixel y-offset of the canvas top-left.
 	 * @param string           $tiles      URL template (`{z}/{x}/{y}` placeholders).
+	 *
 	 * @return void
 	 */
 	private function paint_tile(
@@ -278,6 +280,7 @@ class OSM extends Base {
 	 * @since 0.34.0
 	 *
 	 * @param string $bytes Raw PNG bytes from `fetch_tile()`.
+	 *
 	 * @return GdImage|resource|false Decoded image, or false when the bytes don't decode.
 	 */
 	protected function decode_tile( string $bytes ) {
@@ -301,6 +304,7 @@ class OSM extends Base {
 	 * @param int    $x     Tile x coordinate.
 	 * @param int    $y     Tile y coordinate.
 	 * @param string $tiles Tile URL template containing `{z}`, `{x}`, `{y}`.
+	 *
 	 * @return string|null PNG bytes, or null on failure.
 	 */
 	public function fetch_tile( int $zoom, int $x, int $y, string $tiles ): ?string {
@@ -342,6 +346,7 @@ class OSM extends Base {
 	 * @param int              $x      Pixel X position (marker center).
 	 * @param int              $y      Pixel Y position (marker center).
 	 * @param float            $scale  Multiplier applied to the marker radii.
+	 *
 	 * @return void
 	 */
 	public function stamp_marker( $canvas, int $x, int $y, float $scale = 1.0 ): void {
@@ -386,6 +391,7 @@ class OSM extends Base {
 	 *
 	 * @param float $lng  Longitude in degrees.
 	 * @param int   $zoom Zoom level.
+	 *
 	 * @return float
 	 */
 	protected function lng_to_world_pixel( float $lng, int $zoom ): float {
@@ -399,6 +405,7 @@ class OSM extends Base {
 	 *
 	 * @param float $lat  Latitude in degrees.
 	 * @param int   $zoom Zoom level.
+	 *
 	 * @return float
 	 */
 	protected function lat_to_world_pixel( float $lat, int $zoom ): float {

--- a/src/blocks/dropdown-item/edit.js
+++ b/src/blocks/dropdown-item/edit.js
@@ -19,6 +19,7 @@ import { dispatch, select } from '@wordpress/data';
  * @param {Function} props.setAttributes     Function to update attributes.
  * @param {string}   props.clientId          Unique ID of the block.
  * @param {Function} props.insertBlocksAfter Function to insert blocks after this block.
+ *
  * @return {JSX.Element} The rendered edit component.
  */
 const Edit = ( { attributes, setAttributes, clientId, insertBlocksAfter } ) => {

--- a/src/blocks/dropdown-item/save.js
+++ b/src/blocks/dropdown-item/save.js
@@ -8,6 +8,7 @@ import { useBlockProps, RichText } from '@wordpress/block-editor';
  *
  * @param {Object} props            Block properties.
  * @param {Object} props.attributes Block attributes.
+ *
  * @return {JSX.Element} The rendered save component.
  */
 const Save = ( { attributes } ) => {

--- a/src/blocks/dropdown/helpers.js
+++ b/src/blocks/dropdown/helpers.js
@@ -13,6 +13,7 @@ import { useSelect } from '@wordpress/data';
  * @since 0.33.0
  *
  * @param {string} clientId The unique identifier for the block instance.
+ *
  * @return {boolean} True if the block or any of its children are selected, false otherwise.
  */
 export function useIsBlockOrDescendantSelected( clientId ) {

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -55,6 +55,7 @@ import { isInFSETemplate } from '../../helpers/editor';
  * @param {string} endFormat
  * @param {string} separator
  * @param {string} showTimezone
+ *
  * @return {string} Displayed date.
  */
 const displayDateTime = (
@@ -149,6 +150,7 @@ const displayDateTime = (
  * @param {string}  toggleType    - Which date to toggle: 'start' or 'end'.
  * @param {boolean} showStartTime - Whether start time is currently shown.
  * @param {boolean} showEndTime   - Whether end time is currently shown.
+ *
  * @return {string} New display type value.
  */
 const calculateDisplayType = ( toggleType, showStartTime, showEndTime ) => {

--- a/src/blocks/form-field/edit.js
+++ b/src/blocks/form-field/edit.js
@@ -31,6 +31,7 @@ import FieldValue from './helpers';
  * @param {Object}   props               The block props.
  * @param {Object}   props.attributes    The block attributes.
  * @param {Function} props.setAttributes Function to set block attributes.
+ *
  * @return {JSX.Element} The edit component.
  */
 export default function Edit( { attributes, setAttributes } ) {
@@ -56,6 +57,7 @@ export default function Edit( { attributes, setAttributes } ) {
 	 * Generate field name from label.
 	 *
 	 * @param {string} labelValue The label value to convert.
+	 *
 	 * @return {string} The generated field name.
 	 */
 	const generateFieldName = ( labelValue ) => {
@@ -72,6 +74,7 @@ export default function Edit( { attributes, setAttributes } ) {
 	 * Get the default autocomplete value based on field type.
 	 *
 	 * @param {string} value - The field type.
+	 *
 	 * @return {string} The default autocomplete value.
 	 */
 	const getDefaultAutocomplete = ( value ) => {

--- a/src/blocks/form-field/helpers.js
+++ b/src/blocks/form-field/helpers.js
@@ -13,6 +13,7 @@ import {
  *
  * @param {string} fieldType  - The type of field (text, checkbox, etc.)
  * @param {Object} attributes - Block attributes
+ *
  * @return {Object} Style object for the input
  */
 export const getInputStyles = ( fieldType, attributes ) => {
@@ -100,6 +101,7 @@ export const getInputStyles = ( fieldType, attributes ) => {
  * Get label styles based on attributes.
  *
  * @param {Object} attributes - Block attributes
+ *
  * @return {Object} Style object for the label
  */
 export const getLabelStyles = ( attributes ) => {
@@ -120,6 +122,7 @@ export const getLabelStyles = ( attributes ) => {
  * Get label wrapper styles based on attributes.
  *
  * @param {Object} attributes - Block attributes
+ *
  * @return {Object} Style object for the label wrapper
  */
 export const getLabelWrapperStyles = ( attributes ) => {
@@ -142,6 +145,7 @@ export const getLabelWrapperStyles = ( attributes ) => {
  * Get option styles (for radio buttons) based on attributes.
  *
  * @param {Object} attributes - Block attributes
+ *
  * @return {Object} Style object for the options
  */
 export const getOptionStyles = ( attributes ) => {
@@ -172,6 +176,7 @@ export const getOptionStyles = ( attributes ) => {
  * @param {string}  fieldType    - The type of field
  * @param {Object}  blockProps   - Block props from useBlockProps
  * @param {boolean} inlineLayout - Whether to use side-by-side layout
+ *
  * @return {string} CSS classes for the wrapper
  */
 export const getWrapperClasses = (
@@ -199,6 +204,7 @@ export const getWrapperClasses = (
  * @param {string}   props.fieldType     - The type of form field.
  * @param {Object}   props.attributes    - Block attributes object.
  * @param {Function} props.setAttributes - Function to update block attributes.
+ *
  * @return {JSX.Element|null} The field value control component or null.
  */
 export default function FieldValue( { fieldType, attributes, setAttributes } ) {

--- a/src/blocks/form-field/panels/checkbox-field-panels.js
+++ b/src/blocks/form-field/panels/checkbox-field-panels.js
@@ -11,6 +11,7 @@ import { BaseControl, PanelBody, RangeControl } from '@wordpress/components';
  * @param {Object}   props               - Component props.
  * @param {Object}   props.attributes    - Block attributes object.
  * @param {Function} props.setAttributes - Function to update block attributes.
+ *
  * @return {JSX.Element} The checkbox field styling panels.
  */
 export default function CheckboxFieldPanels( { attributes, setAttributes } ) {

--- a/src/blocks/form-field/panels/default-field-panels.js
+++ b/src/blocks/form-field/panels/default-field-panels.js
@@ -16,6 +16,7 @@ import {
  * @param {Object}   props               - Component props.
  * @param {Object}   props.attributes    - Block attributes object.
  * @param {Function} props.setAttributes - Function to update block attributes.
+ *
  * @return {JSX.Element} The default field styling panels.
  */
 export default function DefaultFieldPanels( { attributes, setAttributes } ) {

--- a/src/blocks/form-field/panels/radio-field-panels.js
+++ b/src/blocks/form-field/panels/radio-field-panels.js
@@ -25,6 +25,7 @@ import {
  * @param {Object}   props               - Component props.
  * @param {Object}   props.attributes    - Block attributes object.
  * @param {Function} props.setAttributes - Function to update block attributes.
+ *
  * @return {JSX.Element} The radio field styling and options panels.
  */
 export default function RadioFieldPanels( { attributes, setAttributes } ) {

--- a/src/blocks/form-field/types/checkbox.js
+++ b/src/blocks/form-field/types/checkbox.js
@@ -22,6 +22,7 @@ import {
  * @param {Function} props.setAttributes     - Function to update block attributes.
  * @param {Object}   props.blockProps        - WordPress block wrapper properties.
  * @param {Function} props.generateFieldName - Function to generate field name from label.
+ *
  * @return {JSX.Element} The checkbox field component.
  */
 export default function CheckboxField( {

--- a/src/blocks/form-field/types/default.js
+++ b/src/blocks/form-field/types/default.js
@@ -22,6 +22,7 @@ import {
  * @param {Function} props.setAttributes     - Function to update block attributes.
  * @param {Object}   props.blockProps        - WordPress block wrapper properties.
  * @param {Function} props.generateFieldName - Function to generate field name from label.
+ *
  * @return {JSX.Element} The default input field component.
  */
 export default function DefaultField( {

--- a/src/blocks/form-field/types/hidden.js
+++ b/src/blocks/form-field/types/hidden.js
@@ -14,6 +14,7 @@ import { getWrapperClasses } from '../helpers';
  * @param {Object} props            - Component props.
  * @param {Object} props.attributes - Block attributes object.
  * @param {Object} props.blockProps - WordPress block wrapper properties.
+ *
  * @return {JSX.Element} The hidden field component with visual placeholder.
  */
 export default function HiddenField( { attributes, blockProps } ) {

--- a/src/blocks/form-field/types/radio.js
+++ b/src/blocks/form-field/types/radio.js
@@ -27,6 +27,7 @@ import {
  * @param {Function} props.setAttributes     - Function to update block attributes.
  * @param {Object}   props.blockProps        - WordPress block wrapper properties.
  * @param {Function} props.generateFieldName - Function to generate field name from label.
+ *
  * @return {JSX.Element} The radio button group field component.
  */
 export default function RadioField( {

--- a/src/blocks/form-field/types/textarea.js
+++ b/src/blocks/form-field/types/textarea.js
@@ -22,6 +22,7 @@ import {
  * @param {Function} props.setAttributes     - Function to update block attributes.
  * @param {Object}   props.blockProps        - WordPress block wrapper properties.
  * @param {Function} props.generateFieldName - Function to generate field name from label.
+ *
  * @return {JSX.Element} The textarea field component.
  */
 export default function TextareaField( {

--- a/src/blocks/rsvp-count/edit.js
+++ b/src/blocks/rsvp-count/edit.js
@@ -20,6 +20,7 @@ import { getFromSettings } from '../../helpers/editor-settings';
  * Fetch RSVP responses from the API.
  *
  * @param {number} postId The post ID for which to fetch RSVP responses.
+ *
  * @return {Promise<Object>} The RSVP responses data.
  */
 async function fetchRsvpResponses( postId ) {

--- a/src/blocks/rsvp-form/edit.js
+++ b/src/blocks/rsvp-form/edit.js
@@ -35,6 +35,7 @@ import { shouldHideBlock } from './visibility';
  * tuple tree into instantiated block objects, ready for `replaceInnerBlocks`.
  *
  * @param {Array} template Tuples in `[ blockName, attributes, innerBlocks ]` form.
+ *
  * @return {Array} Created block instances.
  */
 function templateToBlocks( template ) {
@@ -162,6 +163,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 	 * Apply conditional visibility class to form fields based on event settings.
 	 *
 	 * @param {Array} blocks Array of blocks to process.
+	 *
 	 * @return {Array} Processed blocks with conditional classes applied.
 	 */
 	const applyFormFieldVisibility = useCallback( ( blocks ) => {
@@ -211,6 +213,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 	 * Recursively collect visibility styles from blocks with metadata.
 	 *
 	 * @param {Array} blocks The blocks array.
+	 *
 	 * @return {Array} Array of CSS rules.
 	 */
 	const collectVisibilityStyles = useCallback( ( blocks ) => {

--- a/src/blocks/rsvp-form/index.js
+++ b/src/blocks/rsvp-form/index.js
@@ -21,6 +21,7 @@ import metadata from './block.json';
  * Stores visibility settings on each block's metadata.gatherpressRsvpFormVisibility attribute.
  *
  * @param {Function} BlockEdit Original BlockEdit component.
+ *
  * @return {Function} Wrapped BlockEdit component.
  */
 const withFormVisibilityControls = createHigherOrderComponent( ( BlockEdit ) => {
@@ -200,6 +201,7 @@ registerBlockType( metadata, {
  * @param {boolean|Array} canInsert    Whether the block can be inserted.
  * @param {Object}        blockType    The block type being checked.
  * @param {string}        rootClientId The client ID of the parent block.
+ *
  * @return {boolean} Whether the block can be inserted.
  */
 function preventNestedRsvpFormInsertion( canInsert, blockType, rootClientId ) {

--- a/src/blocks/rsvp-form/visibility.js
+++ b/src/blocks/rsvp-form/visibility.js
@@ -21,6 +21,7 @@
  * @param {string} visibility.onSuccess Show/hide on form success ('show'|'hide'|'').
  * @param {string} visibility.whenPast  Show/hide when event has passed ('show'|'hide'|'').
  * @param {string} formState            Current form state ('default'|'success'|'past').
+ *
  * @return {boolean} True if block should be hidden, false if it should be shown.
  */
 export const shouldHideBlock = ( visibility, formState ) => {

--- a/src/blocks/rsvp-response/edit.js
+++ b/src/blocks/rsvp-response/edit.js
@@ -41,6 +41,7 @@ import { EVENT_REST_API } from '../../helpers/namespace';
  * tuple tree into instantiated block objects, ready for `replaceInnerBlocks`.
  *
  * @param {Array} template Tuples in `[ blockName, attributes, innerBlocks ]` form.
+ *
  * @return {Array} Created block instances.
  */
 function templateToBlocks( template ) {
@@ -117,6 +118,7 @@ const PATTERNS = applyFilters( 'gatherpress.rsvpResponsePatterns', [
  * Fetch RSVP responses from the API.
  *
  * @param {number} postId The post ID for which to fetch RSVP responses.
+ *
  * @return {Promise<Object>} The RSVP responses data.
  */
 async function fetchRsvpResponses( postId ) {

--- a/src/blocks/rsvp/edit.js
+++ b/src/blocks/rsvp/edit.js
@@ -107,6 +107,7 @@ const DEFAULT_STATUS_TEMPLATES = applyFilters(
  * Helper function to convert a template to blocks.
  *
  * @param {Array} template The block template structure.
+ *
  * @return {Array} Array of blocks created from the template.
  */
 function templateToBlocks( template ) {
@@ -244,6 +245,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 	 * Apply conditional visibility class to form fields based on event settings.
 	 *
 	 * @param {Array} blocks Array of blocks to process.
+	 *
 	 * @return {Array} Processed blocks with conditional classes applied.
 	 */
 	const applyFormFieldVisibility = useCallback( ( blocks ) => {

--- a/src/blocks/venue-detail/edit.js
+++ b/src/blocks/venue-detail/edit.js
@@ -25,6 +25,7 @@ import { AddressField, PhoneField, UrlField, TextField } from './fields';
  * @param {Object}   props.context           - Block context.
  * @param {string}   props.clientId          - Block client ID.
  * @param {Function} props.insertBlocksAfter - Function to insert blocks after this block.
+ *
  * @return {JSX.Element} The rendered React component.
  */
 const Edit = ( {

--- a/src/blocks/venue-detail/fields/address-field.js
+++ b/src/blocks/venue-detail/fields/address-field.js
@@ -7,6 +7,7 @@ import AddressAutocompleteField from '../../../components/AddressAutocompleteFie
  * Address field for venue details in the block editor (textarea + Popover).
  *
  * @param {Object} props - Passed through to AddressAutocompleteField (block variant).
+ *
  * @return {JSX.Element} Field.
  */
 export default function AddressField( props ) {

--- a/src/blocks/venue-detail/fields/phone-field.js
+++ b/src/blocks/venue-detail/fields/phone-field.js
@@ -17,6 +17,7 @@ import { RichText } from '@wordpress/block-editor';
  * @param {string}   props.placeholder - Placeholder text.
  * @param {Function} props.onKeyDown   - Keyboard event handler.
  * @param {boolean}  props.disabled    - Whether the field is disabled.
+ *
  * @return {JSX.Element} The rendered phone field.
  */
 const PhoneField = ( {

--- a/src/blocks/venue-detail/fields/text-field.js
+++ b/src/blocks/venue-detail/fields/text-field.js
@@ -16,6 +16,7 @@ import { RichText } from '@wordpress/block-editor';
  * @param {string}   props.placeholder - Placeholder text.
  * @param {Function} props.onKeyDown   - Keyboard event handler.
  * @param {boolean}  props.disabled    - Whether the field is disabled.
+ *
  * @return {JSX.Element} The rendered text field.
  */
 const TextField = ( { value, onChange, placeholder, onKeyDown, disabled } ) => {

--- a/src/blocks/venue-detail/fields/url-field.js
+++ b/src/blocks/venue-detail/fields/url-field.js
@@ -34,6 +34,7 @@ import { cleanUrlForDisplay } from '../helpers';
  * @param {boolean}  props.cleanUrl      - Whether to display cleaned URL.
  * @param {Function} props.setAttributes - Function to update block attributes.
  * @param {boolean}  props.disabled      - Whether the field is disabled.
+ *
  * @return {JSX.Element} The rendered URL field.
  */
 const UrlField = ( {

--- a/src/blocks/venue-detail/helpers.js
+++ b/src/blocks/venue-detail/helpers.js
@@ -29,6 +29,7 @@ export const VENUE_FIELDS = [
  * @since 0.34.0
  *
  * @param {string} url The URL to clean.
+ *
  * @return {string} The cleaned URL for display.
  */
 export function cleanUrlForDisplay( url ) {
@@ -47,6 +48,7 @@ export function cleanUrlForDisplay( url ) {
  * @since 0.34.0
  *
  * @param {string} fieldType The field type (address, phone, url).
+ *
  * @return {string} The corresponding meta key, or empty string if not found.
  */
 export function getMetaKey( fieldType ) {

--- a/src/blocks/venue-detail/hooks/use-block-insertion.js
+++ b/src/blocks/venue-detail/hooks/use-block-insertion.js
@@ -17,6 +17,7 @@ import { useCallback } from '@wordpress/element';
  *
  * @param {string}   clientId          - The block's client ID.
  * @param {Function} insertBlocksAfter - Function to insert blocks after this block.
+ *
  * @return {Object} Block insertion handlers.
  */
 export function useBlockInsertion( clientId, insertBlocksAfter ) {

--- a/src/blocks/venue-detail/hooks/use-geocoding.js
+++ b/src/blocks/venue-detail/hooks/use-geocoding.js
@@ -32,6 +32,7 @@ import { geocodeAddress } from '../../../helpers/geocoding';
  * @param {string}   fieldValue       - The current field value.
  * @param {Function} updateVenueField - Function to update venue meta fields.
  * @param {boolean}  [enabled=true]   - When false, the hook skips firing geocode requests. Callers pass false in contexts where another component (e.g. the VenueInformation sidebar panel) already geocodes the same address, to avoid double requests.
+ *
  * @return {Object} Geocoding state and handlers.
  */
 export function useGeocoding( fieldType, fieldValue, updateVenueField, enabled = true ) {

--- a/src/blocks/venue-detail/hooks/use-venue-data.js
+++ b/src/blocks/venue-detail/hooks/use-venue-data.js
@@ -23,6 +23,7 @@ import { getMetaKey } from '../helpers';
  *
  * @param {Object} context   - Block context containing postId.
  * @param {string} fieldType - The type of field (address, phone, url, text).
+ *
  * @return {Object} Venue data and update functions.
  */
 export function useVenueData( context, fieldType ) {

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -94,6 +94,7 @@ const LINK_DESTINATION_CUSTOM = 'custom';
  * @param {string} latitude    Venue latitude.
  * @param {string} longitude   Venue longitude.
  * @param {number} zoom        Desired zoom level.
+ *
  * @return {string} Computed href, or '' when the preset doesn't apply.
  */
 const buildExternalMapUrl = ( destination, latitude, longitude, zoom ) => {

--- a/src/blocks/venue-map/helpers.js
+++ b/src/blocks/venue-map/helpers.js
@@ -31,6 +31,7 @@ import { REST_NAMESPACE } from '../../helpers/namespace';
  * @param {boolean} props.disabled      When true, the button is disabled regardless of internal state.
  * @param {string}  [props.label]       Override the default "Regenerate map" label.
  * @param {string}  [props.variant]     Underlying Button variant (e.g. 'primary', 'secondary', 'link').
+ *
  * @return {JSX.Element} The button.
  */
 export const RegenerateMapButton = ( {
@@ -184,6 +185,7 @@ export const RegenerateMapButton = ( {
  * @param {Object} descriptors Provider-keyed descriptor map: `{ osm: { combo_key: { url, ... } } }`.
  * @param {string} comboKey    Combo key in the form `{zoom}x{width}x{height}`.
  * @param {string} activeSlug  Slug of the currently active provider (e.g. `'osm'`).
+ *
  * @return {Object|undefined} Descriptor object, or undefined when no provider has one.
  */
 export const pickDescriptorForCombo = ( descriptors, comboKey, activeSlug ) => {
@@ -215,6 +217,7 @@ export const pickDescriptorForCombo = ( descriptors, comboKey, activeSlug ) => {
  * @since 0.34.0
  *
  * @param {string} ratio Raw aspect-ratio string.
+ *
  * @return {number|null} Parsed ratio, or null if the input is invalid.
  */
 export const parseAspectRatio = ( ratio ) => {
@@ -248,6 +251,7 @@ export const parseAspectRatio = ( ratio ) => {
  * @param {number} args.height        Raw height (0 = auto).
  * @param {string} args.aspectRatio   Aspect-ratio string.
  * @param {number} args.defaultHeight Fallback height for the both-auto case.
+ *
  * @return {{width: number, height: number}} Concrete pixel dimensions.
  */
 export const resolveDimensions = ( {
@@ -308,6 +312,7 @@ export const MAX_POLLS = 20;
  * @param {boolean} args.active        Whether polling should run (typically `showStaticPlaceholder` gated on coords).
  * @param {number}  args.venuePostId   Venue post ID.
  * @param {string}  args.venuePostType Venue post type slug.
+ *
  * @return {void}
  */
 export const usePlaceholderPolling = ( {

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -36,6 +36,7 @@ import { TEMPLATE_WITH_TITLE, TEMPLATE_WITHOUT_TITLE } from './templates/venue-d
  * tuple tree into instantiated block objects, ready for `replaceInnerBlocks`.
  *
  * @param {Array} template Tuples in `[ blockName, attributes, innerBlocks ]` form.
+ *
  * @return {Array} Created block instances.
  */
 function templateToBlocks( template ) {
@@ -286,6 +287,7 @@ const Edit = ( props ) => {
 	 *                                   "Venue Details with Title" and
 	 *                                   "Venue Details" patterns.
 	 * @param {string|null} hostPostType Post type of the post being edited.
+	 *
 	 * @return {Array} Patterns shown in the picker modal, in display order.
 	 *
 	 * @example

--- a/src/blocks/venue/helpers.js
+++ b/src/blocks/venue/helpers.js
@@ -13,6 +13,7 @@
  * @since 0.34.0
  *
  * @param {Array} terms Array of venue term objects.
+ *
  * @return {string} Mode: 'in-person', 'online', or 'hybrid'.
  */
 export function calculateMode( terms ) {
@@ -43,6 +44,7 @@ export function calculateMode( terms ) {
  * @param {string} newMode            New mode to switch to ('in-person', 'online', or 'hybrid').
  * @param {number} onlineEventTermId  The term ID for the 'online-event' term.
  * @param {number} currentVenueTermId Current venue term ID (excluding online-event).
+ *
  * @return {Array} Array of taxonomy term IDs to assign.
  */
 export function getNewTaxonomyIds( newMode, onlineEventTermId, currentVenueTermId ) {

--- a/src/components/AddressAutocompleteField/use-address-field-anti-autofill.js
+++ b/src/components/AddressAutocompleteField/use-address-field-anti-autofill.js
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
 /**
  * @param {string} value    - Current value.
  * @param {Object} inputRef - Ref to the input or textarea DOM node.
+ *
  * @return {Object} suppressNativeAutofill, unlockAddressInput.
  */
 export function useAddressFieldAntiAutofill( value, inputRef ) {

--- a/src/components/GoogleMap.js
+++ b/src/components/GoogleMap.js
@@ -83,6 +83,7 @@ const LEGACY_EMBED_LETTER_BY_SLUG = GOOGLE_MAP_TYPE_DEFINITIONS.reduce(
  * @see https://developers.google.com/maps/documentation/embed/embedding-map#view_mode
  *
  * @param {string} type Map type slug from the block.
+ *
  * @return {'roadmap'|'satellite'} Coercion for interactive iframe: hybrid→satellite, terrain→roadmap.
  */
 export function toMapsEmbedApiMapType( type ) {
@@ -106,6 +107,7 @@ const GOOGLE_LEGACY_EMBED_BASE = 'https://maps.google.com/maps';
  * @param {number} params.zoom      Zoom level.
  * @param {string} params.type      Map type slug from the block.
  * @param {string} params.apiKey    API key or empty string.
+ *
  * @return {string} Iframe URL.
  */
 export function getGoogleMapEmbedSrc( {

--- a/src/components/PatternPicker/index.js
+++ b/src/components/PatternPicker/index.js
@@ -45,6 +45,7 @@ import PatternChooserModal from './modal';
  * @param {boolean}    [props.showStartBlank]  Whether to render the secondary Start blank button. Defaults to true.
  * @param {Function}   props.onPick            Called with the picked pattern object.
  * @param {Function}   [props.onStartBlank]    Called when the user clicks Start blank. Required when `showStartBlank` is true.
+ *
  * @return {JSX.Element} The placeholder + (conditionally) modal UI.
  */
 const PatternPicker = ( {

--- a/src/components/PatternPicker/modal.js
+++ b/src/components/PatternPicker/modal.js
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
  * into instantiated block objects that `<BlockPreview>` can render.
  *
  * @param {Array} template Tuples in `[ blockName, attributes, innerBlocks ]` form.
+ *
  * @return {Array} Created block instances.
  */
 function templateToBlocks( template ) {
@@ -35,6 +36,7 @@ function templateToBlocks( template ) {
  * @param {string}   [props.title]  Modal heading. Defaults to "Choose a pattern".
  * @param {Function} props.onPick   Called with the picked pattern object.
  * @param {Function} props.onClose  Called when the modal is dismissed without a pick.
+ *
  * @return {JSX.Element} The modal UI.
  */
 const PatternChooserModal = ( { patterns, title, onPick, onClose } ) => {

--- a/src/components/VenueForm.js
+++ b/src/components/VenueForm.js
@@ -159,6 +159,7 @@ function CreateVenueForm( { search, ...props } ) {
 	 * Validates the venue title.
 	 *
 	 * @param {string} value - The title value to validate.
+	 *
 	 * @return {string} Error message if validation fails, empty string if valid.
 	 */
 	const validateTitle = ( value ) => {
@@ -236,6 +237,7 @@ function CreateVenueForm( { search, ...props } ) {
 	 * @param {string} newAddress - The address of the new venue.
 	 * @param {string} latitude   - Latitude coordinate (from geocoding).
 	 * @param {string} longitude  - Longitude coordinate (from geocoding).
+	 *
 	 * @return {Promise<Object>} A promise that resolves to the newly created venue post.
 	 */
 	const createNewVenuePost = async (

--- a/src/components/VenueNavigator.js
+++ b/src/components/VenueNavigator.js
@@ -20,6 +20,7 @@ import { getCurrentContextualPostId } from '../helpers/editor';
 /**
  *
  * @param {Object} props Properties of the 'gatherpress/venue'-block.
+ *
  * @return {Component} A Navigator component to be rendered.
  */
 export default function VenueNavigator( props = null ) {

--- a/src/formats/tooltip/helpers.js
+++ b/src/formats/tooltip/helpers.js
@@ -7,6 +7,7 @@ import { DEFAULT_COLORS } from './constants';
  * Get tooltip attributes from the active format.
  *
  * @param {Object} activeFormat The active format object.
+ *
  * @return {Object} Object containing tooltip, textColor, and bgColor.
  */
 export function getTooltipAttributes( activeFormat ) {

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -660,6 +660,7 @@ export function validateDateTimeEnd( dateTimeEnd, setDateTimeStart = null ) {
  * @since 0.27.0
  *
  * @param {string} format - The PHP date format to be converted.
+ *
  * @return {string} The equivalent Moment.js date format.
  */
 export function convertPHPToMomentFormat( format ) {
@@ -794,6 +795,7 @@ export const phpNonTimeFormatChars = [
  * @since 0.27.0
  *
  * @param {string} format - The PHP datetime format.
+ *
  * @return {string} The PHP time-only format.
  */
 export function removeNonTimePHPFormatChars( format ) {

--- a/src/helpers/editor-settings.js
+++ b/src/helpers/editor-settings.js
@@ -15,6 +15,7 @@ import { select } from '@wordpress/data';
  * @since 0.34.0
  *
  * @param {string} key - The camelCase setting key (e.g., 'dateFormat', 'mapPlatform').
+ *
  * @return {*} The setting value, or undefined if not available.
  */
 export function getFromSettings( key ) {
@@ -35,6 +36,7 @@ export function getFromSettings( key ) {
  * @since 0.34.0
  *
  * @param {string} key - The camelCase config key (e.g., 'pluginUrl', 'siteTimezone').
+ *
  * @return {*} The config value, or undefined if not available.
  */
 export function getFromConfig( key ) {

--- a/src/helpers/editor.js
+++ b/src/helpers/editor.js
@@ -38,6 +38,7 @@ export const __postTypeLabelCache = new Map();
  *
  * @param {string} postType Post type slug.
  * @param {string} key      Label key.
+ *
  * @return {string|undefined} The cached label, or `undefined` if absent.
  */
 function getCachedLabel( postType, key ) {
@@ -54,6 +55,7 @@ function getCachedLabel( postType, key ) {
  * @param {string} postType Post type slug.
  * @param {string} key      Label key.
  * @param {string} label    Resolved label string.
+ *
  * @return {void}
  */
 function rememberLabel( postType, key, label ) {
@@ -82,6 +84,7 @@ function rememberLabel( postType, key, label ) {
  * @param {string}      key      Label key to read (e.g. `singular_name`, `name`, `add_new_item`).
  * @param {string|null} postType Optional post type slug. Falls back to the editor post type.
  * @param {string}      fallback Optional fallback returned when the label can't be resolved.
+ *
  * @return {string} The resolved label, or the fallback when unresolvable.
  */
 export function getPostTypeLabel( key, postType = null, fallback = '' ) {
@@ -126,6 +129,7 @@ export function getPostTypeLabel( key, postType = null, fallback = '' ) {
  * @param {string}      key      Label key to read.
  * @param {string|null} postType Optional post type slug. Falls back to the editor post type.
  * @param {string}      fallback Optional fallback returned when the label can't be resolved.
+ *
  * @return {string} The resolved label, or the fallback when unresolvable.
  */
 export function usePostTypeLabel( key, postType = null, fallback = '' ) {
@@ -179,6 +183,7 @@ export function enableSave() {
  * @since 0.33.0
  *
  * @param {number|null} postId Optional. A specific post ID to return instead of detecting the current one. Defaults to null.
+ *
  * @return {number|null}                 The post ID, or null if it cannot be determined.
  */
 export function getCurrentContextualPostId( postId = null ) {
@@ -252,6 +257,7 @@ export function isInFSETemplate() {
  * @param {string}  [options.support]               Deprecated. Legacy fallback when `hasSupport` is omitted —
  *                                                  prefer `hasSupport` so the supports gate stays reactive.
  * @param {boolean} [options.hasData=false]         Whether the block has its specific data.
+ *
  * @return {boolean} True if the block should be fully visible, false if it should be dimmed.
  */
 export function hasValidBlockContext( {

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -38,6 +38,7 @@ export const DISABLED_FIELD_OPACITY = 0.3;
  *
  * @param {string}      support  The post type support to check (e.g. 'gatherpress-event-date').
  * @param {string|null} postType Optional post type to check. If not provided, checks current editor post type.
+ *
  * @return {boolean} True if the post type has the given support, false otherwise.
  */
 export function isPostTypeSupporting( support, postType = null ) {
@@ -67,6 +68,7 @@ export function isPostTypeSupporting( support, postType = null ) {
  *
  * @param {string}      support  The post type support to check.
  * @param {string|null} postType Optional post type to check. Falls back to the editor post type.
+ *
  * @return {boolean} True if the resolved post type has the given support, false otherwise.
  */
 export function usePostTypeSupports( support, postType = null ) {
@@ -92,6 +94,7 @@ export function usePostTypeSupports( support, postType = null ) {
  * @since 0.27.0
  *
  * @param {string|null} postType Optional post type to check. If not provided, checks current editor post type.
+ *
  * @return {boolean} True if the post type supports event_date, false otherwise.
  */
 export function isEventPostType( postType = null ) {
@@ -108,6 +111,7 @@ export function isEventPostType( postType = null ) {
  * @since 0.27.0
  *
  * @param {string|null} postType Optional post type to check. If not provided, checks current editor post type.
+ *
  * @return {boolean} True if the post type supports RSVP, false otherwise.
  */
 export function isRsvpPostType( postType = null ) {
@@ -132,6 +136,7 @@ export function isRsvpPostType( postType = null ) {
  *
  * @param {Function} selectFunc WordPress data `select` function.
  * @param {number}   postId     Post ID to resolve.
+ *
  * @return {Object|null} The post entity if found in any event-supporting post
  *                       type; null when the registry isn't loaded yet, when
  *                       no event-supporting type owns the ID, or when the
@@ -194,6 +199,7 @@ export function findEventPostById( selectFunc, postId ) {
  *
  * @param {Function} selectFunc WordPress data `select` callback.
  * @param {string}   slug       Post type slug to check.
+ *
  * @return {boolean} True when the post type declares event-date support.
  */
 const isEventSupportingType = ( selectFunc, slug ) =>
@@ -212,6 +218,7 @@ const isEventSupportingType = ( selectFunc, slug ) =>
  * @param {Function} selectFunc      WordPress data `select` callback.
  * @param {string}   currentPostType Current editor post type.
  * @param {string}   postType        Optional hinted post type.
+ *
  * @return {string|null} The post type slug to look up with, or null.
  */
 const resolveLookupType = ( selectFunc, currentPostType, postType ) => {
@@ -237,6 +244,7 @@ const resolveLookupType = ( selectFunc, currentPostType, postType ) => {
  * @param {Function}    selectFunc WordPress data `select` callback.
  * @param {number}      postId     Post ID to verify.
  * @param {string|null} postType   Optional explicit post type hint.
+ *
  * @return {boolean} True when postId resolves to a valid event.
  */
 const verifyPostIdIsValidEvent = ( selectFunc, postId, postType ) => {
@@ -396,6 +404,7 @@ export function hasEventPastNotice() {
  * @since 0.27.0
  *
  * @param {number|null} postId Optional post ID override to check.
+ *
  * @return {boolean} True if the event has the online-event term, false otherwise.
  */
 export function hasOnlineEventTerm( postId = null ) {
@@ -504,6 +513,7 @@ export function isOpenRsvpEnabled( enableOpenRsvp ) {
  * @param {Object}      selectFunc WordPress data select function.
  * @param {number|null} postId     Post ID from context or null.
  * @param {Object}      attributes Block attributes (may contain explicit postId override).
+ *
  * @return {Object} Object containing maxGuestLimit, enableRsvp, and enableAnonymousRsvp.
  */
 export function getEventMeta( selectFunc, postId, attributes ) {

--- a/src/helpers/geocoding.js
+++ b/src/helpers/geocoding.js
@@ -107,6 +107,7 @@ function setGeocodeCacheEntry( key, value ) {
  * Retrieves a cached geocode result, marking it as recently used.
  *
  * @param {string} key Trimmed address key.
+ *
  * @return {Object|undefined} Cached record if present.
  */
 function getGeocodeCacheEntry( key ) {
@@ -167,6 +168,7 @@ export function primeGeocodeCache( address, latitude, longitude ) {
  * @since 0.34.0
  *
  * @param {string} address The full address to geocode.
+ *
  * @return {Promise<Object>} Promise resolving to { latitude, longitude, error }.
  *                           On success: { latitude: string, longitude: string, error: null }
  *                           On error: { latitude: '', longitude: '', error: string }
@@ -259,6 +261,7 @@ export async function geocodeAddress( address ) {
  * @param {string}      query            Partial address input.
  * @param {Object}      [options]        Request options.
  * @param {AbortSignal} [options.signal] Signal used to abort the request when a newer one supersedes it.
+ *
  * @return {Promise<Array<{ label: string, latitude: string, longitude: string }>>} Suggestion rows.
  */
 export async function fetchAddressSuggestions( query, { signal } = {} ) {

--- a/src/helpers/globals.js
+++ b/src/helpers/globals.js
@@ -25,6 +25,7 @@
  * @since 0.27.0
  *
  * @param {string} html Raw HTML string.
+ *
  * @return {string} The HTML with `<script>` elements and `on*` attributes removed.
  */
 export function stripScriptsAndEventHandlers( html ) {
@@ -60,6 +61,7 @@ export function stripScriptsAndEventHandlers( html ) {
  * @since 0.27.0
  *
  * @param {string} snakeCaseString The snake_case string to be converted.
+ *
  * @return {string} The converted string in camelCase format.
  *
  * @example
@@ -83,6 +85,7 @@ export function toCamelCase( snakeCaseString ) {
  * @since 0.27.0
  *
  * @param {string} name The parameter name to retrieve.
+ *
  * @return {string|null} The parameter value or null if not found.
  */
 export function getUrlParam( name ) {

--- a/src/helpers/settings-show-if.js
+++ b/src/helpers/settings-show-if.js
@@ -30,6 +30,7 @@ const NAME_TEMPLATE = ( key ) => `[name="gatherpress_settings[${ key }]"]`;
  * `matches()` smooth the boolean / number / string comparison.
  *
  * @param {HTMLInputElement|HTMLSelectElement} el The input or select element.
+ *
  * @return {string|boolean} The control's current value.
  */
 function readControlValue( el ) {
@@ -49,6 +50,7 @@ function readControlValue( el ) {
  *
  * @param {string|boolean}              current  The control's current value.
  * @param {string|number|boolean|Array} expected The expected value(s) from the show_if declaration.
+ *
  * @return {boolean} True when the current value satisfies the expectation.
  */
 function matches( current, expected ) {
@@ -76,6 +78,7 @@ function matches( current, expected ) {
  * over the upstream hidden fallback.
  *
  * @param {Object} conditions Map of controlling option key → expected value(s).
+ *
  * @return {Array<{key: string, el: HTMLElement}>} Resolved controller pairs.
  */
 function resolveControllers( conditions ) {
@@ -98,6 +101,7 @@ function resolveControllers( conditions ) {
  * so it has no effect on form submission.
  *
  * @param {HTMLElement} marker The `.gatherpress-show-if-marker` element.
+ *
  * @return {void}
  */
 function wireMarker( marker ) {

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -29,6 +29,7 @@ const DEFAULT_VENUE_POST_TYPE = 'gatherpress_venue';
  * @since 0.27.0
  *
  * @param {string} [venuePostType='gatherpress_venue'] The venue post type slug.
+ *
  * @return {string} The taxonomy slug for the given venue post type.
  */
 export function getVenueTaxonomy( venuePostType = DEFAULT_VENUE_POST_TYPE ) {
@@ -45,6 +46,7 @@ export function getVenueTaxonomy( venuePostType = DEFAULT_VENUE_POST_TYPE ) {
  * @since 0.27.0
  *
  * @param {string} [eventPostType=''] The event post type slug to look up.
+ *
  * @return {string} The venue post type slug for the given event post type.
  */
 export function getVenuePostType( eventPostType = '' ) {
@@ -83,6 +85,7 @@ export function isVenuePostType() {
  *
  * @param {number|null} termId        The ID of the '_gatherpress_venue' term. If null, no post is retrieved.
  * @param {string}      venuePostType The post type to query for the venue post. Defaults to 'gatherpress_venue'.
+ *
  * @return {Object[]|Array}           An array of matching venue post objects, or an empty array if none is found.
  */
 export function useVenuePostFromTermId( termId, venuePostType = DEFAULT_VENUE_POST_TYPE ) {
@@ -128,6 +131,7 @@ export function useVenuePostFromTermId( termId, venuePostType = DEFAULT_VENUE_PO
  *
  * @param {number|null} postId        The ID of the venue post. Defaults to null, in which case no term is retrieved.
  * @param {string}      venuePostType The venue post type slug. Defaults to 'gatherpress_venue'.
+ *
  * @return {Object[]|Array}           An array of matching term objects, or an empty array if no matching term is found.
  */
 export function useVenueTermFromPostId( postId = null, venuePostType = DEFAULT_VENUE_POST_TYPE ) {
@@ -179,6 +183,7 @@ export function useVenueTermFromPostId( postId = null, venuePostType = DEFAULT_V
  *
  * @param {number} eventId  The ID of the event post.
  * @param {string} postType The post type of the event (defaults to the current editor post type).
+ *
  * @return {Object|null} The related venue post object, or null if none is found.
  */
 export function GetVenuePostFromEventId( eventId, postType = null ) {
@@ -348,6 +353,7 @@ export function useVenueOptions(
  * @param {string}      venueTaxonomy Taxonomy slug (e.g. '_gatherpress_venue').
  * @param {number|null} postId        The event post whose terms should be fetched.
  * @param {boolean}     skip          When true, skip all lookups and return undefined.
+ *
  * @return {number[]|undefined} Array of term IDs, or undefined when not yet resolved.
  */
 export function useVenueTaxonomyIds( venueTaxonomy, postId, skip = false ) {
@@ -439,6 +445,7 @@ export function usePopularVenues( limit = 3, venuePostType = DEFAULT_VENUE_POST_
  *
  * @param {Function} selectFunc WordPress data `select` function.
  * @param {number}   postId     Post ID to resolve.
+ *
  * @return {Object|null} The post entity if found in any venue-supporting post
  *                       type; null when the registry isn't loaded yet, when
  *                       no venue-supporting type owns the ID, or when the

--- a/src/integrations/aql/index.js
+++ b/src/integrations/aql/index.js
@@ -24,6 +24,7 @@ import { usePostTypeSupports } from '../../helpers/event';
  * @param {Object}   props
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Function to update block attributes.
+ *
  * @return {null} Renders nothing.
  */
 const AQLEventDefaults = ( { attributes, setAttributes } ) => {
@@ -62,6 +63,7 @@ const AQLEventDefaults = ( { attributes, setAttributes } ) => {
  *
  * @param {Object}   props           Block edit props plus BlockEdit injection.
  * @param {Function} props.BlockEdit The wrapped block's BlockEdit component.
+ *
  * @return {JSX.Element} Edit output augmented with event controls when applicable.
  */
 const AQLBlockEdit = ( { BlockEdit, ...props } ) => {
@@ -103,6 +105,7 @@ const AQLBlockEdit = ( { BlockEdit, ...props } ) => {
  * "Advanced Query Settings" panel.
  *
  * @param {Function} BlockEdit The block's edit component.
+ *
  * @return {Function} Enhanced edit component.
  */
 const withAQLEventControls = ( BlockEdit ) => ( props ) => {

--- a/src/supports/block-guard.js
+++ b/src/supports/block-guard.js
@@ -21,6 +21,7 @@ const blockGuardListeners = new Map();
  * Custom hook to manage shared block guard state.
  *
  * @param {string} blockName - The name of the block type.
+ *
  * @return {Array} Array containing [isEnabled, setIsEnabled] similar to useState.
  */
 function useSharedBlockGuardState( blockName ) {
@@ -221,6 +222,7 @@ function removeDragListeners( handler ) {
  * Create a drop handler for the given clientId.
  *
  * @param {string} clientId - The block's client ID.
+ *
  * @return {Function} Drop handler function.
  */
 function createDropHandler( clientId ) {
@@ -242,6 +244,7 @@ function createDropHandler( clientId ) {
  *
  * @param {string}  clientId            - The block's client ID.
  * @param {boolean} isBlockGuardEnabled - Whether guard is enabled.
+ *
  * @return {Object|null} Object with expander element or null if not found.
  */
 function applyListViewGuardForBlock( clientId, isBlockGuardEnabled ) {
@@ -370,6 +373,7 @@ function applyBlockGuard( clientId, name, stateKey, isBlockGuardEnabled ) {
  *
  * @param {string} name     - The block type name.
  * @param {string} clientId - The current block's client ID.
+ *
  * @return {string} Unique state key for this block's context.
  */
 function generateBlockGuardStateKey( name, clientId ) {
@@ -421,6 +425,7 @@ function generateBlockGuardStateKey( name, clientId ) {
  *
  * @param {Function} BlockEdit - The original BlockEdit component.
  * @param            props
+ *
  * @return {Function} Enhanced BlockEdit component with BlockGuard functionality.
  *
  * @example

--- a/src/supports/post-date-override.js
+++ b/src/supports/post-date-override.js
@@ -27,6 +27,7 @@ import { __ } from '@wordpress/i18n';
  * @param {string} dateTimeStart - Event start datetime.
  * @param {string} dateTimeEnd   - Event end datetime.
  * @param {string} timezone      - Event timezone.
+ *
  * @return {string} Formatted display datetime.
  */
 const formatEventDateTime = ( dateTimeStart, dateTimeEnd, timezone ) => {
@@ -112,6 +113,7 @@ const formatEventDateTime = ( dateTimeStart, dateTimeEnd, timezone ) => {
  *
  * @param {string} timezone Timezone string (IANA or manual offset).
  * @param {string} datetime Datetime to anchor IANA abbreviation against.
+ *
  * @return {string} Timezone abbreviation suitable for the display string.
  */
 const formatTimezoneAbbr = ( timezone, datetime ) => {
@@ -130,6 +132,7 @@ const formatTimezoneAbbr = ( timezone, datetime ) => {
  * setting is enabled.
  *
  * @param {Function} BlockEdit - The original BlockEdit component.
+ *
  * @return {Function} Enhanced BlockEdit component.
  */
 const withEventPostDateOverride = createHigherOrderComponent(

--- a/src/supports/post-id-override.js
+++ b/src/supports/post-id-override.js
@@ -20,6 +20,7 @@ import { addFilter } from '@wordpress/hooks';
  * their `supports` configuration.
  *
  * @param {Object} settings Original block settings.
+ *
  * @return {Object} Updated block settings with `postId` attribute if `postIdOverride` is supported.
  */
 function addPostIdOverrideSupport( settings ) {
@@ -56,6 +57,7 @@ addFilter(
  * that support `postIdOverride`, enabling users to specify a custom post ID.
  *
  * @param {Function} BlockEdit - The original BlockEdit component.
+ *
  * @return {Function} Enhanced BlockEdit component with postId override functionality.
  *
  * @example

--- a/src/variations/core/query/components.js
+++ b/src/variations/core/query/components.js
@@ -30,6 +30,7 @@ import { getPostTypeLabel, isInFSETemplate, usePostTypeLabel } from '../../../he
  * @param {Object}   props
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Function to update block attributes.
+ *
  * @return {Element}                     RangeControl for event "per page" count.
  */
 export const EventCountControls = ( { attributes, setAttributes } ) => {
@@ -79,6 +80,7 @@ export const EventCountControls = ( { attributes, setAttributes } ) => {
  * @param {Object}   props
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Function to update block attributes.
+ *
  * @return {Element}                        ToggleControl to exclude current event.
  */
 export const EventExcludeControls = ( { attributes, setAttributes } ) => {
@@ -131,6 +133,7 @@ export const EventExcludeControls = ( { attributes, setAttributes } ) => {
  * @param {Object}   props
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Function to update block attributes.
+ *
  * @return {Element}                        ToggleControl for unfinished events.
  */
 export const EventIncludeUnfinishedControls = ( {
@@ -211,6 +214,7 @@ export const EventIncludeUnfinishedControls = ( {
  * @param {Object}   props
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Function to update block attributes.
+ *
  * @return {Element}                     ToggleGroupControl for event list type.
  */
 export const EventListTypeControls = ( { attributes, setAttributes } ) => {
@@ -285,6 +289,7 @@ export const EventListTypeControls = ( { attributes, setAttributes } ) => {
  * @param {Object}   props.attributes        Block attributes.
  * @param {Function} props.setAttributes     Function to update block attributes.
  * @param {boolean}  props.inTemplateContext Whether the host editor is a template or template part.
+ *
  * @return {Element}                          ToggleControl for venue filtering.
  */
 export const VenueFilterControls = ( {
@@ -345,6 +350,7 @@ export const VenueFilterControls = ( {
  * @param {Object}   props
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Function to update block attributes.
+ *
  * @return {Element}                        RangeControl for event query offset.
  */
 export const EventOffsetControls = ( { attributes, setAttributes } ) => {
@@ -391,6 +397,7 @@ export const EventOffsetControls = ( { attributes, setAttributes } ) => {
  * @param {Object}   props
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Function to update block attributes.
+ *
  * @return {Element}                        Controls for event sorting and order.
  */
 export const EventOrderControls = ( { attributes, setAttributes } ) => {

--- a/src/variations/core/query/controls.js
+++ b/src/variations/core/query/controls.js
@@ -27,6 +27,7 @@ import { usePostTypeLabel } from '../../../helpers/editor';
  *
  * @param {Object} props            - Props passed to the block's edit component.
  * @param {Object} props.attributes - Block attributes.
+ *
  * @return {boolean} True if the block's namespace matches 'gatherpress-event-query', otherwise false.
  */
 const isEventQueryLoop = ( props ) => {
@@ -47,6 +48,7 @@ const isEventQueryLoop = ( props ) => {
  * @param {Object}   props
  * @param {Object}   props.attributes    - Block attributes.
  * @param {Function} props.setAttributes - Function to update block attributes.
+ *
  * @return {void}
  */
 const QueryPosttypeObserver = ( { attributes, setAttributes } ) => {
@@ -91,6 +93,7 @@ const QueryPosttypeObserver = ( { attributes, setAttributes } ) => {
  * instead of leaving stale event-only controls visible.
  *
  * @param {Object} props - Block props passed through from the HOC.
+ *
  * @return {Element|null} The InspectorControls panel, or null when not applicable.
  */
 export const EventQueryControlsPanel = ( props ) => {
@@ -185,6 +188,7 @@ export const EventQueryControlsPanel = ( props ) => {
  * - For GatherPress event queries, provides the relevant controls in a PanelBody within InspectorControls.
  *
  * @param {Function} BlockEdit - The Query block's BlockEdit component.
+ *
  * @return {Function} Enhanced BlockEdit component.
  */
 const withEventQueryControls = ( BlockEdit ) => ( props ) => {

--- a/src/variations/core/query/patterns/index.js
+++ b/src/variations/core/query/patterns/index.js
@@ -42,6 +42,7 @@ const QUERY_ATTRIBUTES = {
  * of `wp.blocks` block instances ready for `serialize()`.
  *
  * @param {Array} template Array of `[ block_name, attributes, inner_blocks ]` tuples.
+ *
  * @return {Array} Created block instances.
  */
 function templateToBlocks( template ) {
@@ -66,6 +67,7 @@ function templateToBlocks( template ) {
  * @param {string} props.title       Human-readable title shown in the modal.
  * @param {string} props.description Sentence summary shown alongside the preview.
  * @param {Array}  props.template    Inner template tuples (post-template + pagination + no-results).
+ *
  * @return {Object} Pattern descriptor in the shape `__experimentalBlockPatterns` accepts.
  */
 function buildPattern( { name, title, description, template } ) {

--- a/src/variations/core/query/start-blank.js
+++ b/src/variations/core/query/start-blank.js
@@ -21,6 +21,7 @@ const NAMESPACE = 'gatherpress-event-query';
  * its media-text wrapper).
  *
  * @param {Array} innerBlocks Inner blocks of a `core/query` block.
+ *
  * @return {boolean} True when the inner-block tree looks like a WP scoped-variation scaffold.
  */
 function isWpStartBlankShape( innerBlocks ) {
@@ -43,6 +44,7 @@ function isWpStartBlankShape( innerBlocks ) {
  *
  * @param {Array}  blocks    Block tree to search.
  * @param {string} blockName Name to look for, e.g. `gatherpress/event-date`.
+ *
  * @return {boolean} True if any node in the tree matches.
  */
 function treeContainsBlock( blocks, blockName ) {
@@ -71,6 +73,7 @@ function treeContainsBlock( blocks, blockName ) {
  * "Image, Date & Title" all swap out their `post-date` for an event date.
  *
  * @param {Array} blocks Inner blocks to rebuild.
+ *
  * @return {Array} Created block instances ready for `replaceInnerBlocks()`.
  */
 function rebuildWithEventDate( blocks ) {

--- a/test/e2e/helpers/create-event-via-admin.js
+++ b/test/e2e/helpers/create-event-via-admin.js
@@ -6,6 +6,7 @@
  * have permalink/cache issues).
  *
  * @param {import('@playwright/test').Page} page - Playwright page object.
+ *
  * @return {Promise<string>} The event URL.
  */
 async function createEventWithRSVP( page ) {

--- a/test/e2e/helpers/create-event-via-api.js
+++ b/test/e2e/helpers/create-event-via-api.js
@@ -6,6 +6,7 @@
  *
  * @param {import('@playwright/test').APIRequestContext} request - Playwright request context.
  * @param {string}                                       baseURL - WordPress base URL.
+ *
  * @return {Promise<string>} The event URL.
  */
 async function createEventWithRSVP( request, baseURL = 'http://localhost:8889' ) {

--- a/test/unit/js/src/helpers/editor.test.js
+++ b/test/unit/js/src/helpers/editor.test.js
@@ -557,6 +557,7 @@ describe( 'Editor helper functions', () => {
 	 * Helper to create a mock getPostType function that returns labels.
 	 *
 	 * @param {string} slug The post type slug.
+	 *
 	 * @return {Object|null} The post type object with labels.
 	 */
 	function mockGetPostTypeWithLabels( slug ) {

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -48,6 +48,7 @@ import { dateTimeDatabaseFormat } from '@src/helpers/datetime';
  * Returns supports.event_date: true for gatherpress_event, false for others.
  *
  * @param {string} slug The post type slug.
+ *
  * @return {Object|null} The post type object with supports.
  */
 function mockGetPostType( slug ) {
@@ -346,6 +347,7 @@ describe( 'isRsvpPostType', () => {
 	 * only, alongside the standard event/post mocks.
 	 *
 	 * @param {string} slug The post type slug.
+	 *
 	 * @return {Object|null} The post type object with supports.
 	 */
 	function mockGetPostTypeWithProduction( slug ) {

--- a/test/unit/js/src/helpers/settings-show-if.test.js
+++ b/test/unit/js/src/helpers/settings-show-if.test.js
@@ -27,6 +27,7 @@ const HIDDEN_CLASS = 'gatherpress--is-hidden';
  * @param {string}  options.controllingValue  The controlling input's initial value (or 'true'/'false' for checkbox).
  * @param {Object}  options.conditions        The show_if condition map.
  * @param {boolean} [options.initiallyHidden] Whether the dependent row starts with the hidden class.
+ *
  * @return {Object} Refs to the inserted DOM nodes for assertions.
  */
 function buildFixture( {
@@ -81,6 +82,7 @@ function buildFixture( {
  *
  * @param {string} type  'select', 'text', or 'checkbox'.
  * @param {string} value The initial value (or 'true'/'false' for checkbox).
+ *
  * @return {string} The HTML string for the controlling input.
  */
 function renderControllingInput( type, value ) {

--- a/test/unit/js/src/supports/block-guard.test.js
+++ b/test/unit/js/src/supports/block-guard.test.js
@@ -118,6 +118,7 @@ const setupMockDOM = () => {
  * @param {string}  clientId  - The block's client ID.
  * @param {string}  blockType - The block type name.
  * @param {boolean} queryLoop - Whether this block is in a query loop.
+ *
  * @return {Object} Mock block element.
  */
 const createMockBlockElement = ( clientId, blockType, queryLoop = false ) => {

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -29,6 +29,7 @@ class Test_Calendar extends Base {
 	 * a structured address attached.
 	 *
 	 * @param bool $with_venue When true, also create and attach a venue with an address.
+	 *
 	 * @return int The event post ID.
 	 */
 	private function make_event( bool $with_venue = false ): int {

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-endpoint.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-endpoint.php
@@ -680,6 +680,7 @@ class Test_Endpoint extends Base {
 	 *
 	 * @param Endpoint $instance The endpoint to inspect.
 	 * @param string   $message  Assertion failure message.
+	 *
 	 * @return void
 	 */
 	private function assertEndpointDidNotRegister( Endpoint $instance, string $message ): void {

--- a/test/unit/php/includes/tests/core/classes/class-test-coexistence-guard.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-coexistence-guard.php
@@ -45,6 +45,7 @@ class Test_Coexistence_Guard extends Base {
 	 * touching the real plugins directory.
 	 *
 	 * @param array<string, array<string, mixed>> $plugins Mapping of plugin basename to header data.
+	 *
 	 * @return void
 	 */
 	private function seed_plugins_cache( array $plugins ): void {

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -67,6 +67,7 @@ class Test_Geocoding extends Base {
 	 * Helper that fires a Photon JSON response for the next outbound HTTP call.
 	 *
 	 * @param array $features `features` payload (use empty array to simulate "no match").
+	 *
 	 * @return void
 	 */
 	private function mock_photon_response( array $features ): void {
@@ -84,6 +85,7 @@ class Test_Geocoding extends Base {
 	 * `country`, `countrycode`) at sensible default values for a US address.
 	 *
 	 * @param array $overrides Property overrides to merge over the defaults.
+	 *
 	 * @return array
 	 */
 	private function build_photon_feature( array $overrides = array() ): array {
@@ -115,6 +117,7 @@ class Test_Geocoding extends Base {
 	 * @param Geocoding $instance Instance.
 	 * @param string    $method   Method name.
 	 * @param array     $args     Arguments.
+	 *
 	 * @return mixed
 	 */
 	private function invoke_geocoding_private( Geocoding $instance, string $method, array $args = array() ) {
@@ -755,6 +758,7 @@ class Test_Geocoding extends Base {
 	 * Returns the transient key used for a given geocode lookup.
 	 *
 	 * @param string $address Address value.
+	 *
 	 * @return string Transient key.
 	 */
 	private function geocode_cache_key( string $address ): string {
@@ -943,6 +947,7 @@ class Test_Geocoding extends Base {
 	 * Returns the transient key used for a given search query.
 	 *
 	 * @param string $query Search query (already trimmed as it would arrive at the cache check).
+	 *
 	 * @return string Transient key.
 	 */
 	private function search_cache_key( string $query ): string {

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -549,6 +549,7 @@ class Test_Settings extends Base {
 	 *
 	 * @param string $input   The JSON string input to sanitize.
 	 * @param string $expects The expected sanitized output.
+	 *
 	 * @return void
 	 */
 	public function test_sanitize_autocomplete( $input, $expects ): void {

--- a/test/unit/php/includes/tests/core/classes/class-test-topic.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-topic.php
@@ -115,6 +115,7 @@ class Test_Topic extends Base {
 		 * @param string $translation Translated text.
 		 * @param string $text        Text to translate.
 		 * @param string $context     Context information for the translators.
+		 *
 		 * @return string Translated text.
 		 */
 		add_filter( 'gettext_with_context_gatherpress', $filter, 10, 3 );

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -742,6 +742,7 @@ class Test_Utility extends Base {
 	 *
 	 * @param float  $offset   Decimal hour offset from UTC.
 	 * @param string $expected Expected DateTimeZone-compatible string.
+	 *
 	 * @return void
 	 */
 	public function test_offset_to_timezone_string( float $offset, string $expected ): void {
@@ -782,6 +783,7 @@ class Test_Utility extends Base {
 	 *
 	 * @param string $input    Input timezone string.
 	 * @param string $expected Expected normalized output.
+	 *
 	 * @return void
 	 */
 	public function test_normalize_timezone_string( string $input, string $expected ): void {

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -434,6 +434,7 @@ class Test_Setup extends Base {
 		 * @param string $translation Translated text.
 		 * @param string $text        Text to translate.
 		 * @param string $context     Context information for the translators.
+		 *
 		 * @return string Translated text.
 		 */
 		add_filter( 'gettext_with_context_gatherpress', $filter, 10, 3 );

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
@@ -308,6 +308,7 @@ class Test_Manager extends Base {
 	 * Base with just enough plumbing to be registerable.
 	 *
 	 * @param string $slug Slug to advertise.
+	 *
 	 * @return Map_Provider
 	 */
 	private function make_stub_provider( string $slug ): Map_Provider {
@@ -355,6 +356,7 @@ class Test_Manager extends Base {
 			 * @param int   $width     Unused.
 			 * @param int   $height    Unused.
 			 * @param int   $density   Unused.
+			 *
 			 * @return null
 			 */
 			public function render(

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
@@ -82,6 +82,7 @@ class Test_Map extends Base {
 	 * @param mixed  $preempt Default false.
 	 * @param array  $args    HTTP args (unused).
 	 * @param string $url     Request URL (unused).
+	 *
 	 * @return array Mocked WP HTTP response.
 	 */
 	public function short_circuit_tile_requests( $preempt, $args, $url ): array {
@@ -105,6 +106,7 @@ class Test_Map extends Base {
 	 * used to live on the class, scoped down to what tests need.
 	 *
 	 * @param string $url Stored descriptor URL.
+	 *
 	 * @return string Absolute filesystem path.
 	 */
 	protected function path_for_url( string $url ): string {
@@ -3001,6 +3003,7 @@ class Test_Map extends Base {
 	 * each can swap in a deterministic non-OSM active provider.
 	 *
 	 * @param string $slug Slug to advertise via `get_slug()`.
+	 *
 	 * @return \GatherPress\Core\Venue\Map\Provider\Base
 	 */
 	private function make_null_provider( string $slug ): \GatherPress\Core\Venue\Map\Provider\Base {
@@ -3048,6 +3051,7 @@ class Test_Map extends Base {
 			 * @param int   $width     Unused.
 			 * @param int   $height    Unused.
 			 * @param int   $density   Unused.
+			 *
 			 * @return null
 			 */
 			public function render(
@@ -3068,6 +3072,7 @@ class Test_Map extends Base {
 	 * test that mutates Manager state leave it in a clean baseline.
 	 *
 	 * @param Manager $manager Manager instance.
+	 *
 	 * @return void
 	 */
 	private function reset_manager_to_core_providers( Manager $manager ): void {

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-base.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-base.php
@@ -107,6 +107,7 @@ class Test_Base extends GatherPress_Test_Base {
 			 * @param int   $width     Unused.
 			 * @param int   $height    Unused.
 			 * @param int   $density   Unused.
+			 *
 			 * @return null
 			 */
 			public function render(
@@ -169,6 +170,7 @@ class Test_Base extends GatherPress_Test_Base {
 			 * @param int   $width     Unused.
 			 * @param int   $height    Unused.
 			 * @param int   $density   Unused.
+			 *
 			 * @return null
 			 */
 			public function render(

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -68,6 +68,7 @@ class Test_OSM extends Base {
 	 * @param mixed  $preempt Default false.
 	 * @param array  $args    HTTP args (unused).
 	 * @param string $url     Request URL (unused).
+	 *
 	 * @return array
 	 */
 	public function short_circuit_tile_requests( $preempt, $args, $url ): array {


### PR DESCRIPTION
## Summary

Two related cleanups in one PR — both fall under the docblock/version-accuracy umbrella that #1678 + #1679 set up.

### 1. Docblock format normalization

Inserts the blank `*` separators AGENTS.md prescribes (under "Docblock conventions") between:
- description → `@since`
- `@since` → `@param` group
- `@param` group → `@return`

Touches **446 docblocks across 123 PHP files** under `includes/`, `src/`, and `test/`. Pure additive change — every diff line is a new blank `*` line; no removals, no semantic content modified.

**Intentionally NOT touched:** other tag transitions like `@coversDefaultClass` → `@group` (test docblocks), `@since` → `@var` (property docblocks), `@throws`, `@see`, `@deprecated` — AGENTS.md's rules only enumerate four specific separators, and existing convention keeps these adjacent. Normalizing them would create noise without authority.

### 2. `_doing_it_wrong` version arg fix in `venue/map/class-manager.php`

Both `_doing_it_wrong()` calls in `class-manager.php` (lines 117 and 204) carried the placeholder `'1.0.0'` version arg. Same semantics as `@since`: the arg should reflect the version the misuse-detection shipped in. Git history shows both calls were added 2026-04-26 in the current 0.34.0 development cycle (neither commit is contained by any released tag) — mapped both to `'0.34.0'`.

These two were the only production-code `'1.0.0'` literals; remaining matches across the codebase are test fixtures (`wp_register_script` version args, JSON test data) that legitimately want a literal version string and are left as-is.

## Pairs with

- [#1678](https://github.com/GatherPress/gatherpress/pull/1678) — `@since` version backfill
- [#1679](https://github.com/GatherPress/gatherpress/pull/1679) — AGENTS.md docblock conventions documentation

The four together: #1679 documents the rules, #1678 makes `@since` versions accurate, this PR normalizes the surrounding format and fixes the only stragglers in `_doing_it_wrong()` version args.

## Test plan

- [ ] PHP lint passes on touched files (sanity-checked locally with `php -l` on a sample).
- [ ] Existing PHPUnit suite still passes (no semantic changes; this is purely docblock-format whitespace + two version-string updates).
- [ ] Reviewer eyeballs a sample of docblock diffs to confirm every change is a single inserted blank `*` line at one of the three documented separator points.
- [ ] `grep -rn "'1\.0\.0'" includes/ src/ --include="*.php"` returns only legitimate test fixture matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
