### PR TITLE
Make pre-release tags produce a real changelog body

### DIFF
--- a/.github/changelog/prerelease-changelog-body
+++ b/.github/changelog/prerelease-changelog-body
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Pre-release tags (alpha / beta / rc) now produce a release body containing the rolled-up changelog of every queued entry, computed in an ephemeral checkout so the entry files stay in place for the eventual stable release. Previously the body only showed CHANGELOG.md's `[Unreleased]` section, which is empty until the stable rollup happens, so testers downloading pre-release zips never saw what they were testing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,10 @@ name: Release
 #
 # Pushing a tag like `0.34.0-alpha.1`, `-beta.1`, or `-rc.1` cuts a pre-release:
 # distro zip is attached to a GitHub Pre-Release (marked NOT-latest), the
-# release body is a snapshot of CHANGELOG.md's `[Unreleased]` section so
-# people testing alphas can see what's queued, and the .github/changelog/*
-# entries are LEFT IN PLACE so the eventual stable release still has them.
+# release body is the SAME rolled-up section that would ship at stable (so
+# testers see what they're testing), but the rollup is computed in an
+# ephemeral checkout — no commit, no PR, no entry files deleted. Pre-releases
+# never deploy to wp.org.
 #
 # Release-manager docs: docs/developer/release-process.md.
 
@@ -25,8 +26,7 @@ permissions:
   contents: read
 
 jobs:
-  # Classify the tag and extract the matching changelog body so downstream
-  # jobs don't have to redo it.
+  # Classify the tag so downstream jobs know which path to take.
   prepare:
     name: Prepare release context
     runs-on: ubuntu-latest
@@ -35,13 +35,7 @@ jobs:
     outputs:
       version: ${{ steps.context.outputs.version }}
       is_prerelease: ${{ steps.context.outputs.is_prerelease }}
-      release_body: ${{ steps.body.outputs.release_body }}
     steps:
-      - name: Checkout the tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
       - name: Classify tag
         id: context
         run: |
@@ -57,55 +51,14 @@ jobs:
             echo "Tag ${version} is a stable release."
           fi
 
-      - name: Extract changelog body
-        id: body
-        env:
-          IS_PRERELEASE: ${{ steps.context.outputs.is_prerelease }}
-          VERSION: ${{ steps.context.outputs.version }}
-        run: |
-          # Pre-release: snapshot the [Unreleased] section as-is. Stable: the
-          # release body is written later by the rollup job (this output is
-          # only used by pre-releases). For stable, we still emit something
-          # here so the output isn't empty — the rollup job overrides it.
-          if [[ "${IS_PRERELEASE}" == "true" ]]; then
-            # Single-pass capture between the [Unreleased] header and the next
-            # version header. Suppresses leading blanks until the first non-blank
-            # line, and buffers trailing blanks so they never get flushed.
-            section="$(awk '
-              /^## \[Unreleased\]/ { capture = 1; next }
-              /^## \[/ && capture { exit }
-              capture {
-                if ($0 ~ /[^[:space:]]/) {
-                  seen = 1
-                  if (buffered) { printf "%s", buffered; buffered = "" }
-                  print
-                } else if (seen) {
-                  buffered = buffered $0 ORS
-                }
-              }
-            ' CHANGELOG.md)"
-
-            if [[ -z "$section" ]]; then
-              section="_No changelog entries queued yet for this pre-release._"
-            fi
-          else
-            section="_Will be populated by the rollup job._"
-          fi
-
-          # Multi-line output via the GH Actions heredoc protocol.
-          {
-            echo "release_body<<EOF_BODY"
-            echo "$section"
-            echo "EOF_BODY"
-          } >> "$GITHUB_OUTPUT"
-
-  # Roll up .github/changelog/* into CHANGELOG.md under a new [X.Y.Z] header,
-  # push to a release/X.Y.Z branch, and open a PR back to develop for human
-  # review. Stable releases only — pre-releases preserve the entries.
-  rollup-changelog:
-    name: Roll up CHANGELOG.md
+  # Always runs: aggregate `.github/changelog/*` into a new [X.Y.Z] section
+  # and capture the section text as the release body. For stable tags we
+  # additionally commit the rollup back via an auto-PR; for pre-releases the
+  # working-dir changes evaporate when the job ends, so the entry files stay
+  # intact for the eventual stable release.
+  rollup:
+    name: Roll up changelog
     needs: prepare
-    if: needs.prepare.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -140,6 +93,10 @@ jobs:
           # --release-date defaults to today, --add-pr-num appends [#NNNN] from
           # merge commit subjects, and --deduplicate=-1 disables looking back
           # at prior versions (we trust each entry file to be unique-by-author).
+          #
+          # On pre-releases this modifies the ephemeral working dir; the
+          # changes never get pushed because the commit step below is gated
+          # on the stable path.
           vendor/bin/changelogger write \
             --use-version="${VERSION}" \
             --release-date="$(date +%Y-%m-%d)" \
@@ -151,6 +108,7 @@ jobs:
         id: extract
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
         run: |
           # Capture lines between the new [X.Y.Z] header and the next ## header.
           # Single-pass: suppress leading blanks until first non-blank, buffer
@@ -170,8 +128,12 @@ jobs:
           ' CHANGELOG.md)"
 
           if [[ -z "$section" ]]; then
-            echo "::error::Rolled-up CHANGELOG.md does not contain a [${VERSION}] section. Did the changelogger write command succeed?"
-            exit 1
+            if [[ "${IS_PRERELEASE}" == "true" ]]; then
+              section="_No changelog entries queued yet for this pre-release._"
+            else
+              echo "::error::Rolled-up CHANGELOG.md does not contain a [${VERSION}] section. Did the changelogger write command succeed? .github/changelog/ may have been empty at tag time."
+              exit 1
+            fi
           fi
 
           {
@@ -180,7 +142,8 @@ jobs:
             echo "EOF_BODY"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Open PR with rolled-up changelog
+      - name: Open PR with rolled-up changelog (stable only)
+        if: needs.prepare.outputs.is_prerelease == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.prepare.outputs.version }}
@@ -249,19 +212,10 @@ jobs:
           retention-days: 7
 
   # Create the GitHub Release (or Pre-Release) with the zip attached and the
-  # appropriate changelog body. The body source differs by path:
-  #   - Pre-release: [Unreleased] snapshot from prepare.outputs.release_body
-  #   - Stable: rolled-up [X.Y.Z] section from rollup-changelog.outputs.release_body
+  # rolled-up changelog section as the body.
   release:
     name: Create GitHub release
-    needs: [prepare, build, rollup-changelog]
-    # rollup-changelog is skipped on pre-releases; without `always()` this job
-    # would skip too. Re-gate so we only run when build succeeded AND either
-    # rollup succeeded (stable) or was skipped (pre-release).
-    if: |
-      always()
-      && needs.build.result == 'success'
-      && (needs.rollup-changelog.result == 'success' || needs.rollup-changelog.result == 'skipped')
+    needs: [prepare, build, rollup]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -276,8 +230,7 @@ jobs:
         with:
           tag_name: ${{ needs.prepare.outputs.version }}
           name: ${{ needs.prepare.outputs.version }}
-          body: |
-            ${{ needs.rollup-changelog.outputs.release_body || needs.prepare.outputs.release_body }}
+          body: ${{ needs.rollup.outputs.release_body }}
           files: gatherpress.${{ needs.prepare.outputs.version }}.zip
           prerelease: ${{ needs.prepare.outputs.is_prerelease == 'true' }}
           make_latest: ${{ needs.prepare.outputs.is_prerelease == 'false' && 'true' || 'false' }}

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -13,9 +13,9 @@ Pushing a tag of the form `X.Y.Z` (stable) or `X.Y.Z-alpha.N` / `-beta.N` /
 
 | Tag pattern             | Distro zip                  | GitHub Release entry | Changelog body source                       | wp.org deploy |
 | ----------------------- | --------------------------- | -------------------- | ------------------------------------------- | ------------- |
-| `0.34.0`                | `gatherpress.0.34.0.zip`    | Release (latest)     | Rolled-up `[0.34.0]` section in CHANGELOG.md | Yes           |
-| `0.34.0-alpha.1`        | `gatherpress.0.34.0-alpha.1.zip` | Pre-Release    | Snapshot of `[Unreleased]` section          | No            |
-| `0.34.0-beta.1` / `-rc.1` | Same as alpha             | Pre-Release          | Snapshot of `[Unreleased]` section          | No            |
+| `0.34.0`                | `gatherpress.0.34.0.zip`    | Release (latest)     | Rolled-up `[0.34.0]` section, committed back to `CHANGELOG.md` via auto-PR | Yes |
+| `0.34.0-alpha.1`        | `gatherpress.0.34.0-alpha.1.zip` | Pre-Release    | Rolled-up `[0.34.0-alpha.1]` section computed in an ephemeral checkout (no commit) | No |
+| `0.34.0-beta.1` / `-rc.1` | Same shape as alpha       | Pre-Release          | Same shape as alpha                         | No            |
 
 The distro zip's outer filename carries the version; the inner layout is
 always `gatherpress/...` so it installs cleanly under the right slug.
@@ -38,10 +38,12 @@ git push origin 0.34.0-alpha.1
 
 1. Detects the tag is a pre-release (the `-alpha.` / `-beta.` / `-rc.` suffix).
 2. Builds `gatherpress.0.34.0-alpha.1.zip` via `npm run plugin-zip`.
-3. Extracts the current `[Unreleased]` section from `CHANGELOG.md` as the release body. If the section is empty (no changelog entries queued yet), the body falls back to a generic placeholder.
-4. Creates a GitHub **Pre-Release** with the zip attached and the snapshot as the body. The Pre-Release is **not** marked as the latest release.
-5. **`.github/changelog/*` entries are left in place** so the eventual stable release still has them.
+3. Runs `composer changelog:write --use-version=0.34.0-alpha.1 ...` in an ephemeral working copy and extracts the resulting `[0.34.0-alpha.1]` section as the release body. The changes never get committed anywhere — they evaporate when the job ends.
+4. Creates a GitHub **Pre-Release** with the zip attached and the rolled-up body. The Pre-Release is **not** marked as the latest release.
+5. **`.github/changelog/*` entries are left in place** in the repository so the eventual stable release still has them.
 6. Skips the wp.org deploy entirely.
+
+Testers downloading the pre-release zip see the same changelog body they'd see at stable release time — minus any further entries that land between now and then.
 
 **Verify after the workflow lands:**
 


### PR DESCRIPTION
### Description of the Change

Follow-up to #1692. After cutting a throwaway `0.34.0-alpha.3` Pre-Release to smoke-test the new release workflow, surfaced that the Pre-Release body said `_No changelog entries queued yet for this pre-release._` even though `.github/changelog/` had three queued entries (from #1690, #1689, #1692). Root cause: the workflow read `CHANGELOG.md`'s `[Unreleased]` section as the body for pre-releases, but that section stays empty until the next stable release rolls things up. Meanwhile actual entries accumulate in `.github/changelog/`, invisible to the Pre-Release body.

**The fix.** Collapse the workflow's two body-extraction paths into one: the rollup job now ALWAYS runs `composer changelog:write` (producing the rolled-up section as a job output), and the commit-back / auto-PR step gates on `is_prerelease == 'false'`. Pre-releases get the same rolled-up body that stable releases would produce, computed in an ephemeral working copy — no commits pushed anywhere, entry files preserved for the eventual stable release.

**Side benefits:**
- Job graph drops from 5 jobs to 5 jobs but eliminates the awkward `if: always() && ...` gating on the release job.
- The `prepare` job no longer needs to extract `[Unreleased]`; just classifies the tag.
- The release-process docs simplify — pre-release and stable behavior is now "same body, different commit / deploy semantics" instead of "different body sources."

Closes follow-up to #1691.

### How to test the Change

1. **Local smoke test.** From develop with the fix applied:
   ```bash
   composer install
   cp CHANGELOG.md /tmp/changelog-before
   vendor/bin/changelogger write \
     --use-version=0.34.0-alpha.4 \
     --release-date="$(date +%Y-%m-%d)" \
     --add-pr-num \
     --deduplicate=-1 \
     --yes
   git diff CHANGELOG.md  # should show the new [0.34.0-alpha.4] section with current queued entries
   mv /tmp/changelog-before CHANGELOG.md
   git checkout .github/changelog/  # restore consumed entries
   ```
2. **End-to-end** after merge, re-cut a `0.34.0-alpha.4` tag and confirm:
   - Pre-Release body shows the queued entries (#1690 / #1689 / #1692 / this PR), grouped by type.
   - `.github/changelog/` files still exist on develop after the workflow runs.
   - No auto-PR opened (commit-back step skipped for pre-releases).
   - wp.org listing unchanged.

### Changelog Entry

Ships its own entry under `.github/changelog/prerelease-changelog-body`:

> Significance: patch
> Type: fixed
>
> Pre-release tags (alpha / beta / rc) now produce a release body containing the rolled-up changelog of every queued entry, computed in an ephemeral checkout so the entry files stay in place for the eventual stable release.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's **Code of Conduct**.
- [x] I have updated the documentation accordingly (`docs/developer/release-process.md`).
- [x] Changelog entry included.
- [x] N/A for unit tests — this is a workflow, not application code.