### PR TITLE
Backfill 0.34.0 changelog entries (~75 PRs from pre-changelogger work)

### DIFF
--- a/.github/changelog/admin-list-extends-to-event-cpts
+++ b/.github/changelog/admin-list-extends-to-event-cpts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Extend the admin list-table columns, sorting, and views to every event-supporting post type — not just the built-in `gatherpress_event`. [#1467] [#1619]

--- a/.github/changelog/admin-list-native-venue-taxonomy-column
+++ b/.github/changelog/admin-list-native-venue-taxonomy-column
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the WordPress-native taxonomy column for venues in the events admin list, replacing the custom column. [#1544]

--- a/.github/changelog/autoloader-deep-namespaces
+++ b/.github/changelog/autoloader-deep-namespaces
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Support arbitrarily deep namespaces in the GatherPress class autoloader. [#1526]

--- a/.github/changelog/block-transform-core-post-date
+++ b/.github/changelog/block-transform-core-post-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a block transform from `core/post-date` to `gatherpress/event-date`, re-implemented via the WordPress Block Transforms API. [#1565] [#1664]

--- a/.github/changelog/blocks-stop-dimming-in-query-loops
+++ b/.github/changelog/blocks-stop-dimming-in-query-loops
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stop dimming GatherPress blocks inside Query Loop contexts when valid event context is present. [#1549]

--- a/.github/changelog/calendar-ics-route-rewrite
+++ b/.github/changelog/calendar-ics-route-rewrite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Re-implement the calendar .ics download endpoint with proper rewrites and feed handling, replacing the legacy Event ICS code. [#1669]

--- a/.github/changelog/comment-privacy-on-rsvp
+++ b/.github/changelog/comment-privacy-on-rsvp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Honor the WordPress comment privacy filters when inserting RSVP comments. [#1470]

--- a/.github/changelog/editor-stop-forcing-upcoming-filter
+++ b/.github/changelog/editor-stop-forcing-upcoming-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Editor no longer forces the events admin list back to the Upcoming filter when the user explicitly selects All — the previously-saved filter sticks. [#1515]

--- a/.github/changelog/event-archive-setting
+++ b/.github/changelog/event-archive-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Event Archive setting so site organizers can choose whether the post-type archive defaults to upcoming, past, or is disabled. [#1587]

--- a/.github/changelog/event-meta-venue-meta-extracted
+++ b/.github/changelog/event-meta-venue-meta-extracted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Extract `Event\Meta` and `Venue\Meta` from their respective `Setup` classes so meta registration lives in a dedicated, testable component. [#1542]

--- a/.github/changelog/event-query-block-aql
+++ b/.github/changelog/event-query-block-aql
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Integrate with the Advanced Query Loop plugin, including a Venue facet in the taxonomy filter. [#1411]

--- a/.github/changelog/event-query-default-template
+++ b/.github/changelog/event-query-default-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a default template for the Event Query Loop block so it has a sensible starting point on themes that don't ship one. [#1399]

--- a/.github/changelog/fix-anonymous-rsvp-magic-link
+++ b/.github/changelog/fix-anonymous-rsvp-magic-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix anonymous RSVP deletion breaking magic-link tokens. [#1424]

--- a/.github/changelog/fix-archive-temporal-handling-cpts
+++ b/.github/changelog/fix-archive-temporal-handling-cpts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the default archive temporal handling (upcoming / past / none) for event-supporting custom post types. The `gatherpress_event_archive_mode` filter receives the queried post type as its second argument. [#1624]

--- a/.github/changelog/fix-datetime-relative-year-down
+++ b/.github/changelog/fix-datetime-relative-year-down
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a datetime-picker stack overflow when pressing the down-arrow on the year field in relative mode. [#1621]

--- a/.github/changelog/fix-dropdown-richtext-deprecation
+++ b/.github/changelog/fix-dropdown-richtext-deprecation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove the dead `RichText` `onSplit` prop on the dropdown-item block, silencing a WordPress 6.4 deprecation warning. [#1663]

--- a/.github/changelog/fix-duplicate-folders-activation
+++ b/.github/changelog/fix-duplicate-folders-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Refuse activation when duplicate GatherPress folders are on disk to prevent silent class collisions. [#1560]

--- a/.github/changelog/fix-event-archive-404
+++ b/.github/changelog/fix-event-archive-404
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Return 404 for the event archive URL when no matching page exists, instead of rendering an empty archive. [#1381]

--- a/.github/changelog/fix-event-query-block-improvements
+++ b/.github/changelog/fix-event-query-block-improvements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Several improvements and bug fixes to the Event Query Loop block surface (template handling, attribute migration, pattern selection). [#1396] [#1398]

--- a/.github/changelog/fix-event-query-context-toggle
+++ b/.github/changelog/fix-event-query-context-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide the Filter by Current Venue toggle when the host post type doesn't support venues, and gate the Event Query Settings panel by context. [#1566]

--- a/.github/changelog/fix-event-query-settings-rest-params
+++ b/.github/changelog/fix-event-query-settings-rest-params
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Event Query Settings panel and REST collection params so they work for any event-supporting post type. [#1622]

--- a/.github/changelog/fix-fse-template-issues
+++ b/.github/changelog/fix-fse-template-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Multiple JS fixes for blocks inside FSE templates. [#1459] [#1461]

--- a/.github/changelog/fix-icon-block-http-self-request
+++ b/.github/changelog/fix-icon-block-http-self-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Read SVGs from the filesystem instead of issuing an HTTP self-request, fixing icon-block rendering on hosts behind authenticating reverse proxies. [#1455]

--- a/.github/changelog/fix-ics-export-lowercase-n
+++ b/.github/changelog/fix-ics-export-lowercase-n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix ICS export escaping of lowercase `n` characters in event titles and descriptions. [#1416]

--- a/.github/changelog/fix-orderby-past-filter
+++ b/.github/changelog/fix-orderby-past-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the orderby behavior of the default Past events filter. [#1442]

--- a/.github/changelog/fix-post-date-block-event-date
+++ b/.github/changelog/fix-post-date-block-event-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Post Date block to display the event date when the 'use event date for post date' setting is enabled. [#1430]

--- a/.github/changelog/fix-protected-meta-followup
+++ b/.github/changelog/fix-protected-meta-followup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Follow-up to the 0.33.3 protected-meta hardening. Additional GatherPress meta keys are now protected from the Custom Fields panel to prevent stale data overwrites on event save. [#1387]

--- a/.github/changelog/fix-rsvp-comment-query-exclusion-filter
+++ b/.github/changelog/fix-rsvp-comment-query-exclusion-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add the `gatherpress_exclude_rsvp_from_comment_query` filter so integrations (like comment moderation plugins) can opt back into seeing RSVP comments in the comment query. [#1640]

--- a/.github/changelog/fix-rsvp-token-cache-invalidation
+++ b/.github/changelog/fix-rsvp-token-cache-invalidation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Invalidate caches on RSVP token redemption and bypass page cache for magic-link URLs so the user sees the result of their RSVP immediately. [#1636]

--- a/.github/changelog/fix-rsvp-ui-scope
+++ b/.github/changelog/fix-rsvp-ui-scope
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Scope the RSVP UI to the `gatherpress-rsvp` support so non-RSVP event post types don't see RSVP fields. [#1594]

--- a/.github/changelog/fix-send-updates-gating
+++ b/.github/changelog/fix-send-updates-gating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Gate the 'Send Updates' email notice so it only appears on event-supporting post types, and surface post-type-aware label / pattern filters for related UI. [#1598]

--- a/.github/changelog/fix-sql-identifier-quoting-admin-sort
+++ b/.github/changelog/fix-sql-identifier-quoting-admin-sort
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Deduplicate admin column sorting in `Event_Setup` and fix SQL identifier quoting on the sort query. [#1449]

--- a/.github/changelog/fix-timezone-html-leakage
+++ b/.github/changelog/fix-timezone-html-leakage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix timezone parsing so option values can no longer leak HTML attributes into rendered markup. [#1558]

--- a/.github/changelog/fix-venue-sorting-admin
+++ b/.github/changelog/fix-venue-sorting-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix venue sorting in the admin venues list. [#1448]

--- a/.github/changelog/google-maps-api-key-setting
+++ b/.github/changelog/google-maps-api-key-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a setting for the Google Maps API key, so sites that prefer Google over OpenStreetMap can wire credentials in through the UI. [#1568]

--- a/.github/changelog/hook-naming-convention
+++ b/.github/changelog/hook-naming-convention
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Apply the GatherPress hook naming convention across the codebase. New `shadow_*` subsystem row added to the hooks-naming-convention doc. [#1550]

--- a/.github/changelog/isEditorPanelOpened-source
+++ b/.github/changelog/isEditorPanelOpened-source
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Read `isEditorPanelOpened` from `core/editor` instead of `core/edit-post`, silencing a WordPress 6.5 deprecation warning. [#1653]

--- a/.github/changelog/namespace-flatten-event
+++ b/.github/changelog/namespace-flatten-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Flatten `Event_*` classes into the `GatherPress\Core\Event` subnamespace. `Event_Admin_List` is extracted into its own class. [#1450] [#1508]

--- a/.github/changelog/namespace-flatten-rsvp
+++ b/.github/changelog/namespace-flatten-rsvp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Flatten `Rsvp_*` classes into the `GatherPress\Core\Rsvp` subnamespace. [#1524]

--- a/.github/changelog/namespace-flatten-venue
+++ b/.github/changelog/namespace-flatten-venue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Flatten `Venue_*` classes into the `GatherPress\Core\Venue` subnamespace. [#1522]

--- a/.github/changelog/network-wide-settings
+++ b/.github/changelog/network-wide-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add network-wide GatherPress settings with per-option inheritance so multisite installs can share or override individual settings at the site level. [#1500]

--- a/.github/changelog/online-event-rename
+++ b/.github/changelog/online-event-rename
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Rename `OnlineEventLink` to `OnlineEvent` and remove the legacy Listener / Broadcaster code that was no longer used. [#1420]

--- a/.github/changelog/osm-tile-referrer-policy
+++ b/.github/changelog/osm-tile-referrer-policy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set `referrerPolicy: 'no-referrer-when-downgrade'` on OpenStreetMap tile requests so tile providers that gate access on the `Referer` header (e.g. CARTO basemaps) receive the request correctly. [#1433]

--- a/.github/changelog/post-id-override-blocks
+++ b/.github/changelog/post-id-override-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make `postIdOverride` work for the event and venue blocks, with the dim-gate suppressed on non-event hosts when the override resolves. [#1552] [#1554]

--- a/.github/changelog/post-type-supports-event-date
+++ b/.github/changelog/post-type-supports-event-date
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the `gatherpress-event-date` post type support so any post type can opt into event datetime storage, the `gatherpress_events` DB table, date-based query ordering, and the Event Date / Add to Calendar blocks. [#1440]

--- a/.github/changelog/post-type-supports-rsvp
+++ b/.github/changelog/post-type-supports-rsvp
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the `gatherpress-rsvp` post type support so any post type can opt into the comment-based RSVP system, attendee management, waiting lists, and the RSVP block family. [#1444]

--- a/.github/changelog/post-type-supports-venue-online-event
+++ b/.github/changelog/post-type-supports-venue-online-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the `gatherpress-venue` and `gatherpress-online-event` post type supports so venue association and online-event link handling can be enabled on any custom event post type. [#1453]

--- a/.github/changelog/removed-window-gatherpress-global
+++ b/.github/changelog/removed-window-gatherpress-global
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove the `window.GatherPress` global in favor of editor settings, interactivity state, and per-block data stores. [#1465]

--- a/.github/changelog/rest-route-edit-capabilities
+++ b/.github/changelog/rest-route-edit-capabilities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enforce per-post edit capability on venue / event meta and post-specific REST routes. [#1520]

--- a/.github/changelog/rsvp-mode-and-open-rsvp
+++ b/.github/changelog/rsvp-mode-and-open-rsvp
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a configurable RSVP mode with a sitewide disable switch and per-event control, plus an Open RSVP setting that lets non-logged-in users RSVP via magic-link comments. [#1468] [#1469]

--- a/.github/changelog/rsvp-online-event-settings-reorg
+++ b/.github/changelog/rsvp-online-event-settings-reorg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move RSVP-related settings to a dedicated RSVP settings panel and relocate the online event link to Venue settings for better organization. [#1394]

--- a/.github/changelog/safehtml-rename
+++ b/.github/changelog/safehtml-rename
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Rename the `safeHTML` helper to `stripScriptsAndEventHandlers` and document its narrow scope (it strips `<script>` tags and `on*=` event handlers — it is not a full HTML sanitizer). [#1545]

--- a/.github/changelog/security-geocoding-rate-limit
+++ b/.github/changelog/security-geocoding-rate-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Rate-limit the geocoding REST endpoints to prevent abuse-by-loop. [#1546]

--- a/.github/changelog/security-github-token-permissions
+++ b/.github/changelog/security-github-token-permissions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Lock down `GITHUB_TOKEN` permissions across CI workflows to least-privilege scopes, reducing the blast radius of a compromised workflow. [#1650]

--- a/.github/changelog/security-pr-workflow-isolation
+++ b/.github/changelog/security-pr-workflow-isolation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Split privileged PR workflows to remove the untrusted-checkout / cache-poisoning exposure that pull-request-target workflows otherwise inherit. [#1652]

--- a/.github/changelog/security-rest-route-edit-capabilities
+++ b/.github/changelog/security-rest-route-edit-capabilities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Enforce per-post edit capability on venue / event meta and post-specific REST routes so unauthenticated or under-privileged callers cannot modify another user's events or venues. [#1520]

--- a/.github/changelog/security-transitive-deps
+++ b/.github/changelog/security-transitive-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Override vulnerable transitive npm dependencies (`qs`, `uuid`, `webpack-dev-server`) via npm overrides. [#1651]

--- a/.github/changelog/select-controls-wp-6.8-size
+++ b/.github/changelog/select-controls-wp-6.8-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Apply the WordPress 6.8 `__next40pxDefaultSize` opt-in to every `SelectControl` instance so admin form controls match the upcoming default sizing. [#1661]

--- a/.github/changelog/settings-api-restructure
+++ b/.github/changelog/settings-api-restructure
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Refactor the Settings API with flat storage, a config-driven architecture, import / export, and reorganized tabs. [#1434]

--- a/.github/changelog/settings-show-if
+++ b/.github/changelog/settings-show-if
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a `show_if` field key to the Settings API so settings fields can be conditionally hidden based on the value of other fields. [#1634]

--- a/.github/changelog/settings-tabs-restructure
+++ b/.github/changelog/settings-tabs-restructure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Restructure settings tabs — Date & Time moves under Events, Maps moves under a new Venues tab. `Venue` splits into an instance class plus a `Venue_Setup` singleton. [#1477]

--- a/.github/changelog/shadow-source-primitive
+++ b/.github/changelog/shadow-source-primitive
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Extract the `gatherpress-shadow-source` primitive. Hidden `_<post_type>` taxonomies with post-name-derived terms can now be enabled on any post type, providing the foundation for the venue ⇄ event tagging mechanism and letting companion plugins register their own source-style CPTs (productions, organizers, etc.). [#1569]

--- a/.github/changelog/site-health-pretty-permalink
+++ b/.github/changelog/site-health-pretty-permalink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a site health test that flags installs running on plain permalinks, since several GatherPress features (notably RSVP magic links and .ics downloads) require pretty permalinks. [#1660]

--- a/.github/changelog/split-readme-files
+++ b/.github/changelog/split-readme-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Separate `README.md` (GitHub-facing) and `readme.txt` (wp.org-facing) so each surface gets content tailored to its audience. [#1423]

--- a/.github/changelog/starter-pattern-pickers
+++ b/.github/changelog/starter-pattern-pickers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add starter pattern pickers to the Event, Venue, RSVP Form, RSVP Response, and RSVP blocks, plus an Event Query Loop starter pattern with a Start blank event scaffold. Patterns are hookable so themes can register their own. [#1571] [#1578] [#1579] [#1580] [#1581] [#1582] [#1584]

--- a/.github/changelog/tested-up-to-wp-7.0
+++ b/.github/changelog/tested-up-to-wp-7.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Bump 'Tested up to' to WordPress 7.0. [#1649]

--- a/.github/changelog/ui-strings-use-post-type-labels
+++ b/.github/changelog/ui-strings-use-post-type-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+GatherPress UI strings now pull from each post type's registered labels rather than hardcoding 'Event' / 'Venue'. Custom event-supporting post types see their own labels everywhere in the settings sub-menus, admin list, sidebar panels, and Query block UI. [#1627] [#1629] [#1631] [#1647] [#1659]

--- a/.github/changelog/unregister-blocks-cleanup
+++ b/.github/changelog/unregister-blocks-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Re-implement block-unregistration handling and clean up legacy unregister flow. [#1409]

--- a/.github/changelog/utility-style-block-assets
+++ b/.github/changelog/utility-style-block-assets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move the gatherpress-utility-style enqueue onto `enqueue_block_assets` so it reaches the editor iframe in FSE themes. [#1655]

--- a/.github/changelog/v2-blocks-replace-originals
+++ b/.github/changelog/v2-blocks-replace-originals
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Replace the original RSVP / RSVP Response / RSVP Template / Venue blocks with their V2 equivalents that shipped in 0.32.0. The V2 naming is dropped now that the new blocks are canonical. [#1407]

--- a/.github/changelog/venue-address-async-geocode-on-save
+++ b/.github/changelog/venue-address-async-geocode-on-save
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Persist structured venue address fields (house number, street, city, county, state, postcode, country, country code) via an async geocode-on-save cron handler. Exposed via individual meta keys for block bindings. [#1517] [#1530]

--- a/.github/changelog/venue-address-autocomplete-search
+++ b/.github/changelog/venue-address-autocomplete-search
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add venue address autocomplete search powered by the Photon geocoder, with a rate-limited REST endpoint and graceful fallback to manual entry. [#1451] [#1546]

--- a/.github/changelog/venue-block-interactive-clientnavigation
+++ b/.github/changelog/venue-block-interactive-clientnavigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Support the Interactivity API's `clientNavigation` flag for the venue block so navigation between venue pages stays SPA-style on themes that opt in. [#1464]

--- a/.github/changelog/venue-detail-block-refactor
+++ b/.github/changelog/venue-detail-block-refactor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Refactor the venue-detail block architecture and fix context handling so it composes cleanly inside Query Loops and FSE templates. [#1391] [#1405]

--- a/.github/changelog/venue-geodata-meta
+++ b/.github/changelog/venue-geodata-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Expose WordPress Geodata standard meta on venue post types so third-party themes and plugins that consume `geo_latitude` / `geo_longitude` / `geo_address` work out of the box. [#1471]

--- a/.github/changelog/venue-map-prewarm-filter
+++ b/.github/changelog/venue-map-prewarm-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Expose the `gatherpress_venue_map_prewarm_pre_enqueue_job` filter so extensions can short-circuit individual venue-map prewarm jobs (useful for sites with hundreds of venues where a `switch_theme` would otherwise flood WP-Cron with warm jobs). [#1504]

--- a/.github/changelog/venue-map-provider-strategy
+++ b/.github/changelog/venue-map-provider-strategy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Refactor the venue map block into a swappable provider strategy so Google Maps and OpenStreetMap (and future providers) share a common interface. [#1534]

--- a/.github/changelog/venue-map-static-server-rendered
+++ b/.github/changelog/venue-map-static-server-rendered
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add server-rendered static maps to the venue-map block, with a regenerate button, prewarming, retina (2×) srcset rendering, a scale attribute, and Inspector polish. Editor previews now poll for async-arriving map descriptors so the block reflects geocode-on-save state in real time. [#1480] [#1483] [#1485] [#1489] [#1491] [#1492] [#1497] [#1498]

--- a/.github/changelog/wp-conventions-and-settings-tweaks
+++ b/.github/changelog/wp-conventions-and-settings-tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WordPress conventions sweep across the codebase (blank line after class openings per WP core style, JS docblock dependency-header normalization, `str_contains` / `str_starts_with` migration from `strpos`), plus two small settings panel fixes. [#1589]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+Pending entries for the next release live as individual files under
+[`.github/changelog/`](.github/changelog/) and get rolled up into a new
+version section by `composer changelog:write` at release time.
 
 ## [0.33.3] - 2026-02-16
 
@@ -304,7 +306,6 @@ Initial public release. Represents 18+ months of pre-1.0 development and ships t
 - Initial unit test suite with code coverage via SonarCloud.
 - Multilingual screenshots and i18n scaffolding.
 
-[Unreleased]: https://github.com/GatherPress/gatherpress/compare/0.33.3...HEAD
 [0.33.3]: https://github.com/GatherPress/gatherpress/compare/0.33.2...0.33.3
 [0.33.2]: https://github.com/GatherPress/gatherpress/compare/0.33.1...0.33.2
 [0.33.1]: https://github.com/GatherPress/gatherpress/compare/0.33.0...0.33.1


### PR DESCRIPTION
### Description of the Change

Backfills 75 individual changelog entry files under `.github/changelog/` covering all user-visible work that landed in 0.34.0 between 0.33.3 (Feb 16) and #1690 (the changelogger workflow itself, May 24). Those PRs merged before the per-PR changelog gate existed, so they had no entries queued; without this backfill, the stable 0.34.0 release would ship with only the 4 entries that have files today.

**What's in the 75:**
- ~20 **Added** — post-type supports decoupling (event-date, RSVP, venue, online-event), shadow-source primitive, Settings API restructure, network-wide settings, Event Archive setting, Open RSVP + RSVP mode, server-rendered static venue maps with retina + prewarming + regenerate, async geocode-on-save, address autocomplete, pattern pickers across the block family, Event Query Loop AQL integration, block transforms, more
- ~25 **Changed** — namespace flattening (Event/Venue/Rsvp), `Event\Meta`/`Venue\Meta` extraction, ui-strings-use-post-type-labels, admin list extends to all event CPTs, venue map provider strategy, V2 blocks promoted to canonical, OnlineEventLink → OnlineEvent rename, safeHTML → stripScriptsAndEventHandlers, settings reorg, RSVP comment privacy, WP 6.5/6.8 deprecation fixes
- ~21 **Fixed** — datetime picker year-down stack overflow, ICS lowercase `n` escaping, anonymous RSVP magic-link tokens, archive temporal handling for CPTs, event query settings panel for CPTs, post date block, RSVP cache invalidation, FSE template issues, dropdown deprecation, icon block HTTP self-request
- 1 **Removed** — `window.GatherPress` global
- 5 **Security** — REST route edit caps, geocoding rate limit, GITHUB_TOKEN scopes, PR workflow isolation, transitive dep overrides

**One related fix in this PR.** PR #1690's backfill of `CHANGELOG.md` added a `## [Unreleased]` section that turns out to break `composer changelog:write` (jetpack-changelogger doesn't recognize the placeholder — activitypub's CHANGELOG.md doesn't have one either; "unreleased" is implicit in the `.github/changelog/` queue). Dropped the `[Unreleased]` heading + compare-link entry; replaced with a short paragraph pointing readers at `.github/changelog/` for the queued state. Without this fix the rollup-at-release-time would fail with `Failed to parse changelog: Invalid heading: ## [Unreleased]`.

**Sourcing.** Entries were synthesized from `gh pr list --base develop` between 0.33.3 and #1690, filtered against the 87 dependabot/hook-docs-bot/screenshot-bot/version-bump noise PRs, and grouped where related work spanned multiple PRs (e.g. all the venue-map-static work → one entry, all the namespace-flatten work → three entries). PR numbers are embedded in the entry text as \`[#NNNN]\` markdown refs (since \`--add-pr-num\` can't reach back into pre-backfill commits — every entry in this PR has the same commit-subject, so the rollup-time PR-number tagging won't help).

**Carries the \`Skip Changelog\` label** — the 75 entries ARE the changelog content for this PR's substance; adding a meta-entry would just be noise.

### How to test the Change

1. **Validate every entry parses:** \`composer install && vendor/bin/changelogger validate\` — should exit 0 (verified locally).

2. **Dry-run the rollup** to preview the resulting `[0.34.0]` section that'll ship at stable release time:
   \`\`\`bash
   cp CHANGELOG.md /tmp/changelog-backup
   vendor/bin/changelogger write --use-version=0.34.0-preview --release-date="\$(date +%Y-%m-%d)" --add-pr-num --deduplicate=-1 --yes
   awk '/^## \\[0\\.34\\.0-preview\\]/,/^## \\[/' CHANGELOG.md | head -90
   # Restore from this PR's branch:
   git checkout .github/changelog/ CHANGELOG.md
   \`\`\`
   Should produce a properly-categorized section (Security → Added → Changed → Removed → Fixed) with entries sorted within each category.

3. **Read the 75 entry files** — each is a 4-line file (Significance / Type / blank / body). Spot-check that the categorization matches the work; flag anything misclassified.

### Out of scope

- The 0.27.0 → 0.33.3 entries in \`CHANGELOG.md\` are the existing curated history from #1690 and stay as-is.
- The 87 noise PRs (dependabot, hook-docs auto-PR, screenshot bot, claude-code dep bumps, version-bump PRs, internal SonarCloud cleanup) are deliberately omitted. Anyone who needs the full firehose can read the GitHub Releases page once 0.34.0 ships (auto-generated from PR titles via \`.github/release.yml\`).
- Some grey-area PRs were judgment-called as internal-only (refactors with no user-visible effect, agents/docs conventions, AGENTS.md updates). Open to expanding if you spot something I dropped that should be in.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's **Code of Conduct**.
- [x] N/A for documentation updates (the entries themselves are the docs).
- [x] N/A — \`Skip Changelog\` label applied per above.
- [x] N/A for unit tests — content-only PR.