### PR TITLE
Fix 5 SonarCloud S1848 bugs by splitting Calendar\Endpoint construction from registration

### DIFF
--- a/.github/changelog/endpoint-construct-vs-init-split
+++ b/.github/changelog/endpoint-construct-vs-init-split
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Calendar endpoint registration is now an explicit `(new Foo(...))->init()` chain instead of a side effect of `new Foo(...)`. The `Calendar\\Endpoint` constructor only stores validated args; `init()` performs rewrite-rule registration and hook wiring, and returns `$this` for chaining. Fixes five SonarCloud `php:S1848` bugs flagged on `Calendar\\Setup` and makes the registration side effect surface at the call site.

--- a/includes/core/classes/calendar/class-endpoint.php
+++ b/includes/core/classes/calendar/class-endpoint.php
@@ -132,15 +132,18 @@ class Endpoint {
 		string $reg_ex,
 		string $object_type = 'post_type'
 	) {
-		// ...
+		// Construction stores the validated args; the actual registration
+		// (rewrite rules + filter / action hooks) happens in init(), which
+		// callers invoke explicitly via the `(new Endpoint(...))->init()`
+		// chain. Separating construction from registration keeps callers
+		// honest about side effects (SonarCloud php:S1848 flags the older
+		// "instantiate for side effects" pattern).
 		if ( $this->is_valid_registration( $type_name, $types, $object_type ) ) {
 			$this->query_var           = $query_var;
 			$this->validation_callback = $validation_callback;
 			$this->types               = $types;
 			$this->reg_ex              = $reg_ex;
 			$this->object_type         = $object_type;
-
-			$this->init();
 		}
 	}
 
@@ -155,9 +158,9 @@ class Endpoint {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return void
+	 * @return self
 	 */
-	public function init(): void {
+	public function init(): self {
 		// Build the regular expression pattern for matching the custom endpoint URL structure.
 		$reg_ex_pattern = $this->get_regex_pattern();
 
@@ -176,6 +179,8 @@ class Endpoint {
 
 		// Handle whether to include a template or redirect the request.
 		add_action( 'template_redirect', array( $this, 'template_redirect' ) );
+
+		return $this;
 	}
 
 	/**

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -132,14 +132,14 @@ class Setup {
 
 		// Important: register the feed endpoint before the single endpoint,
 		// to make sure rewrite rules get saved in the correct order.
-		new Post_Type_Feed(
+		( new Post_Type_Feed(
 			array(
 				new Template( self::ICAL_SLUG, array( $this, 'get_ical_feed_template' ) ),
 			),
 			self::QUERY_VAR,
 			$post_type
-		);
-		new Post_Type_Single(
+		) )->init();
+		( new Post_Type_Single(
 			array(
 				new Template( self::ICAL_SLUG, array( $this, 'get_ical_file_template' ) ),
 				new Template( 'outlook', array( $this, 'get_ical_file_template' ) ),
@@ -148,7 +148,7 @@ class Setup {
 			),
 			self::QUERY_VAR,
 			$post_type
-		);
+		) )->init();
 	}
 
 	/**
@@ -165,13 +165,13 @@ class Setup {
 			return;
 		}
 
-		new Post_Type_Single_Feed(
+		( new Post_Type_Single_Feed(
 			array(
 				new Template( self::ICAL_SLUG, array( $this, 'get_ical_feed_template' ) ),
 			),
 			self::QUERY_VAR,
 			$post_type
-		);
+		) )->init();
 	}
 
 	/**
@@ -194,13 +194,13 @@ class Setup {
 			return;
 		}
 
-		new Taxonomy_Feed(
+		( new Taxonomy_Feed(
 			array(
 				new Template( self::ICAL_SLUG, array( $this, 'get_ical_feed_template' ) ),
 			),
 			self::QUERY_VAR,
 			$taxonomy
-		);
+		) )->init();
 	}
 
 	/**
@@ -215,12 +215,12 @@ class Setup {
 	 * @return void
 	 */
 	public function init_sitewide(): void {
-		new Sitewide_Feed(
+		( new Sitewide_Feed(
 			array(
 				new Template( self::ICAL_SLUG, array( $this, 'get_ical_feed_template' ) ),
 			),
 			self::QUERY_VAR
-		);
+		) )->init();
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-endpoint.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-endpoint.php
@@ -174,6 +174,10 @@ class Test_Endpoint extends Base {
 			$types,
 			$reg_ex,
 		);
+		// Registration is no longer a constructor side effect — call init()
+		// explicitly so add_rewrite_rule() runs and the rule is present in
+		// the rebuilt rule set after flush_rewrite_rules() below.
+		$instance->init();
 
 		// Build the regular expression pattern and target URL for this endpoint.
 		$reg_ex_pattern = Utility::invoke_hidden_method( $instance, 'get_regex_pattern' );
@@ -460,8 +464,12 @@ class Test_Endpoint extends Base {
 			$types,
 			$reg_ex,
 		);
+		// Construction stores the validated args; init() does the actual
+		// hook + rewrite-rule registration. Caller-explicit so SonarCloud
+		// (php:S1848) doesn't flag "instantiate for side effects".
+		$instance->init();
 
-		// init() is called from __construct; verify the rule registered globally.
+		// Verify the rule, query_vars filter, and template_redirect action all registered globally.
 		global $wp_rewrite;
 		$pattern = Utility::invoke_hidden_method( $instance, 'get_regex_pattern' );
 		$this->assertArrayHasKey(


### PR DESCRIPTION
### Description of the Change

Fixes the 5 open BUGs flagged on `develop` by SonarCloud's `php:S1848` rule ("Either remove this useless object instantiation or use it"), all sitting in `Calendar\Setup`. Sites are #135, #142, #168, #197, #218 — every place `Calendar\Setup` constructs an endpoint feed handler purely for the constructor's side effect:

```php
new Post_Type_Feed( $types, $query_var, $post_type );  // discards return, runs side effects
```

**Root cause.** `Calendar\Endpoint::__construct()` was calling `$this->init()` at the bottom, registering rewrite rules + `query_vars` filter + `template_redirect` action as part of construction. Callers then instantiated the object and immediately discarded the reference because the work was already done. SonarCloud rightly flags this — "instantiate for side effects" hides the side effect and is brittle (easy to accidentally drop the `new` without realizing you've removed a registration).

**The fix.** Separate construction from registration.

- `Endpoint::__construct()` now only stores validated args (`query_var`, `validation_callback`, `types`, `reg_ex`, `object_type`) when `is_valid_registration()` passes. No more side effects.
- `Endpoint::init()` is the explicit registration step. Same body as before (add_rewrite_rule, query_vars filter, template_redirect action, maybe_flush_rewrite_rules). Now returns `self` for chaining.
- The 5 call sites in `Calendar\Setup` change shape:

  ```php
  ( new Post_Type_Feed( $types, $query_var, $post_type ) )->init();
  ```

  The instance is used (`->init()`), the side effect surfaces at the call site, and SonarCloud's S1848 is satisfied.

**Test coverage.** Two tests in `class-test-endpoint.php` relied on the construct-side-effect behavior:
- `test_init_registers_rule_and_hooks` (line 446) — directly asserts hooks are registered after `new Endpoint(...)`. Now calls `$instance->init()` explicitly before the assertions.
- `test_maybe_flush_rewrite_rules` (line 158) — depends on the rewrite rule being added so it shows up after `flush_rewrite_rules()`. Now calls `$instance->init()` explicitly before the flush.

The other calendar tests (`Test_Post_Type_Feed`, `Test_Post_Type_Single`, `Test_Post_Type_Single_Feed`, `Test_Sitewide_Feed`, `Test_Taxonomy_Feed`) only check property assignment and helper methods, so they're unaffected.

### How to test the Change

1. **Run the full PHPUnit suite locally:**
   ```bash
   npm run test:unit:php
   ```
   1487 tests, 6462 assertions. Verified locally (was 1487 before, still 1487 — no test count regression).

2. **Spot-check the 5 patched call sites** in `includes/core/classes/calendar/class-setup.php`:
   - `init_events()` lines 135 + 142 — `Post_Type_Feed` + `Post_Type_Single`
   - `init_venues()` line 168 — `Post_Type_Single_Feed`
   - `init_taxonomies()` line 197 — `Taxonomy_Feed`
   - `init_sitewide()` line 218 — `Sitewide_Feed`

3. **End-to-end** the calendar feeds still work on a real install — pretty-permalink site with an event, hit `/event/<slug>/ical/` and `/feed/ical/` and confirm `.ics` downloads.

4. **SonarCloud should clear the 5 BUGs** after analysis runs against this branch. URL: <https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&branch=develop&types=BUG&id=GatherPress_gatherpress>

### Why this refactor over a SonarCloud suppression

The constructor-side-effect pattern is a real architectural smell (S1848 isn't wrong to flag it), and the refactor cost is small:

- 1 file behavior change (`class-endpoint.php`)
- 5 call sites updated (`class-setup.php`)
- 2 test assertions adjusted (`class-test-endpoint.php`)

Marking 5 issues won't-fix in SonarCloud would have been faster but leaves the smell in place. The explicit `(new X(...))->init()` chain is the WordPress-idiomatic way to express "construct and register" and reads cleanly.

### Changelog Entry

Ships under `.github/changelog/endpoint-construct-vs-init-split`:

> Significance: patch
> Type: changed
>
> Calendar endpoint registration is now an explicit `(new Foo(...))->init()` chain instead of a side effect of `new Foo(...)`. The `Calendar\Endpoint` constructor only stores validated args; `init()` performs rewrite-rule registration and hook wiring, and returns `$this` for chaining.

### Credits

Props @mauteri

### Checklist

- [x] I agree to follow this project's Code of Conduct.
- [x] N/A for documentation updates (the change is internal API).
- [x] Changelog entry included.
- [x] Existing tests updated; full suite passes (1487 tests).