### PR TITLE
Regenerate README.md + readme.txt with External Services preserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,11 @@ GatherPress is built by and for the community -- contributions are always welcom
 
 [Contributor Guide](https://github.com/GatherPress/gatherpress/blob/main/docs/contributing.md)
 
-## Third-Party Libraries & Services
-
-### Libraries
+## Third-Party Libraries
 
 - [Leaflet](https://leafletjs.com/) -- interactive maps for venues
 
-### External services
+## External Services
 
 GatherPress calls the following services when editing venues or displaying maps. Each can be overridden or swapped out via a filter; see links for filter names.
 
@@ -83,4 +81,3 @@ GatherPress calls the following services when editing venues or displaying maps.
 ---
 
 *GatherPress is still in active development. Thank you for helping us build a better way to gather.*
-

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === GatherPress ===
-Contributors: mauteri, patricia70, hrmervin, jmarx75, stephenerdelyi, carstenbach, jordanpak, mahimadave, tusharaddweb, pkbhatt, dd32, kofimokome, richsalvucci
+Contributors: mauteri, patricia70, hrmervin, jmarx75, stephenerdelyi, carstenbach, jordanpak, mahimadave, tusharaddweb, pkbhatt
 Tags: events, event, meetup, community
 Tested up to: 7.0
 Stable tag: 0.34.0-alpha.2


### PR DESCRIPTION
### Description of the Change

Output of `wp gatherpress develop generate_version --version=0.34.0-alpha.2` after the companion fixes landed on gatherpress-develop ([GatherPress/gatherpress-develop#1](https://github.com/GatherPress/gatherpress-develop/pull/1)).

**Why this PR exists.** Running the script on the gatherpress repo would have silently stripped two things from `README.md` and `readme.txt`:

1. The **External Services** section (Photon, CARTO Basemaps, Google Maps disclosures) — wp.org requires this for plugins that contact external services, so losing it is a real compliance risk.
2. Random contributors from the wp.org `Contributors:` line — historically the script dumped every contributor in `data/credits.php` into the plugin header, which over-credits one-off PR landings as if they were sustained maintainers.

The companion gatherpress-develop PR fixes both upstream. This PR just lands the regenerated output.

### Diffs in this PR

**README.md:**
- `## Third-Party Libraries & Services` (h2) with `### Libraries` + `### External services` (h3 subsections) → flattened into two h2 siblings: `## Third-Party Libraries` + `## External Services`. Matches the structure of the readme.txt and reads cleaner in the GitHub render.

**readme.txt:**
- `Contributors:` line drops the `contributors` group — only leads + team listed.
- Trailing whitespace cleanup.

The External Services content itself is unchanged (now sourced from `parts/github/external-services.md` and `parts/wporg/external-services.md` on gatherpress-develop).

### Merge order

Wait for [GatherPress/gatherpress-develop#1](https://github.com/GatherPress/gatherpress-develop/pull/1) to merge first. Otherwise the next `generate_version` run on a fresh checkout would strip External Services again.

### Skip Changelog

Carries the `Skip Changelog` label since this PR is purely the mechanical regeneration; the substantive changes are documented in the gatherpress-develop PR.

### Credits

Props @mauteri

### Checklist

- [x] I agree to follow this project's Code of Conduct.
- [x] N/A for unit tests — content regeneration only.
- [x] `Skip Changelog` label applied (regeneration, no user-facing behavior change beyond what the previous version of these files already documented).