### PR TITLE
Sync SECURITY.md + regenerated files for 0.34.0-beta.1

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We release patches for security vulnerabilities only for the current version:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.33.x  | :white_check_mark: |
-| < 0.33  | :x:                |
+| 0.34.x  | :white_check_mark: |
+| < 0.34  | :x:                |
 
 **We strongly recommend always using the latest stable version of GatherPress.** Security updates are only provided for the current release.
 

--- a/includes/data/credits.php
+++ b/includes/data/credits.php
@@ -140,6 +140,19 @@ return array (
         96 => '//www.gravatar.com/avatar/8c23225a67ae866951341a9d5844af55?s=96&#038;r=g&#038;d=mm',
       ),
     ),
+    8 => 
+    array (
+      'id' => 1321993,
+      'name' => 'Velda',
+      'link' => 'https://profiles.wordpress.org/supernovia/',
+      'slug' => 'supernovia',
+      'avatar_urls' => 
+      array (
+        24 => '//www.gravatar.com/avatar/b56caeb30157e1e1dd6c7d0a7ad00d78?s=24&#038;r=g&#038;d=mm',
+        48 => '//www.gravatar.com/avatar/b56caeb30157e1e1dd6c7d0a7ad00d78?s=48&#038;r=g&#038;d=mm',
+        96 => '//www.gravatar.com/avatar/b56caeb30157e1e1dd6c7d0a7ad00d78?s=96&#038;r=g&#038;d=mm',
+      ),
+    ),
   ),
   'contributors' => 
   array (

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === GatherPress ===
-Contributors: mauteri, patricia70, hrmervin, jmarx75, stephenerdelyi, carstenbach, jordanpak, mahimadave, tusharaddweb, pkbhatt
+Contributors: mauteri, patricia70, hrmervin, jmarx75, stephenerdelyi, carstenbach, jordanpak, mahimadave, tusharaddweb, pkbhatt, supernovia
 Tags: events, event, meetup, community
 Tested up to: 7.0
 Stable tag: 0.34.0-beta.1


### PR DESCRIPTION
Setup for the next prerelease (no changelog). Generated via the `gatherpress-develop` tooling:
- `SECURITY.md` supported-versions table → `0.34.x` / `< 0.34`
- `includes/data/credits.php` regenerated
- `readme.txt` regenerated

Based on `version-0.34.0-beta.1`.