### PR TITLE
Sync SECURITY.md + regenerated files for 0.34.0-beta.1

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -75,42 +75,21 @@ jobs:
             ./node_modules
           key: ${{ steps.node_modules-cache.outputs.cache-primary-key }}
 
-      # Resolve the exact Playwright version from the installed package so the
-      # browser cache key tracks it. node_modules is restored/installed above,
-      # so @playwright/test is available here.
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
-
-      # Cache the downloaded browser binaries so a healthy run skips the CDN
-      # download entirely. Keyed on the Playwright version: a version bump
-      # invalidates the cache and triggers a fresh download.
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
-
-      # System libraries (apt) are part of the runner, not the cache, so install
-      # them every run. Split out from the browser download so an apt lock/stall
-      # surfaces fast against its own short timeout. Only chromium is needed —
-      # playwright.config.js defines a single chromium project.
-      - name: Install Playwright system dependencies
-        timeout-minutes: 5
-        run: npx playwright install-deps chromium
-
-      # Download only the chromium binary (was --with-deps, which also pulled
-      # firefox + webkit). Wrapped in retry with a tight per-attempt timeout so
-      # a stalled CDN download is killed and retried in minutes instead of
-      # hanging for hours (observed 1-2h+ hangs on 2026-05-30).
-      - name: Install Playwright browser (chromium)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 8
-          max_attempts: 3
-          command: npx playwright install chromium
+      # Do NOT run `npx playwright install chromium` here. On 2026-05-30 that
+      # download hung after the chromium binary reached 100% — Playwright's
+      # post-download/extract phase stalled until killed, every attempt. Instead
+      # run the suite against the Google Chrome that GitHub's ubuntu runners ship
+      # preinstalled: playwright.config.js sets `channel: 'chrome'` when CI is
+      # set, so no browser download is needed. This step just asserts Chrome is
+      # present so a runner-image change that drops it fails fast and obvious.
+      - name: Verify preinstalled Google Chrome
+        run: |
+          BIN="$(command -v google-chrome || command -v google-chrome-stable)"
+          if [ -z "$BIN" ]; then
+            echo "::error::Google Chrome is not preinstalled on this runner; E2E uses channel: 'chrome'."
+            exit 1
+          fi
+          "$BIN" --version
 
       - name: Build plugin assets
         run: npm run build

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,6 +15,13 @@ on:
     - '*.php'
     - '*.js'
 
+# Cancel an in-progress run when a newer commit is pushed to the same ref so
+# stacked PR runs do not pile up (three were running simultaneously on
+# 2026-05-30).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -22,6 +29,10 @@ jobs:
   playwright:
     name: Playwright Tests
     runs-on: ubuntu-latest
+    # A healthy run finishes well under 30 minutes; without this a hung step
+    # (e.g. the Playwright browser download stalling) inherits GitHub's 6-hour
+    # default before it is killed.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,8 +75,42 @@ jobs:
             ./node_modules
           key: ${{ steps.node_modules-cache.outputs.cache-primary-key }}
 
-      - name: Playwright install
-        run: npx playwright install --with-deps
+      # Resolve the exact Playwright version from the installed package so the
+      # browser cache key tracks it. node_modules is restored/installed above,
+      # so @playwright/test is available here.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      # Cache the downloaded browser binaries so a healthy run skips the CDN
+      # download entirely. Keyed on the Playwright version: a version bump
+      # invalidates the cache and triggers a fresh download.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      # System libraries (apt) are part of the runner, not the cache, so install
+      # them every run. Split out from the browser download so an apt lock/stall
+      # surfaces fast against its own short timeout. Only chromium is needed —
+      # playwright.config.js defines a single chromium project.
+      - name: Install Playwright system dependencies
+        timeout-minutes: 5
+        run: npx playwright install-deps chromium
+
+      # Download only the chromium binary (was --with-deps, which also pulled
+      # firefox + webkit). Wrapped in retry with a tight per-attempt timeout so
+      # a stalled CDN download is killed and retried in minutes instead of
+      # hanging for hours (observed 1-2h+ hangs on 2026-05-30).
+      - name: Install Playwright browser (chromium)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 8
+          max_attempts: 3
+          command: npx playwright install chromium
 
       - name: Build plugin assets
         run: npm run build

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -12,6 +12,11 @@ on:
     - 'phpunit.xml.dist'
     - 'composer.*'
 
+# Cancel superseded runs on the same ref so stacked PR pushes do not pile up.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -50,7 +50,14 @@ jobs:
           tools: wp-cli
 
       - name: Install dist-archive-command
-        run: wp package install wp-cli/dist-archive-command:^2
+        run: |
+          # shivammathur/setup-php stores a GitHub OAuth token in Composer's
+          # global auth config; wp-cli's bundled Composer rejects its format
+          # ("invalid characters"), breaking this install. dist-archive-command
+          # is public, so drop the token and install unauthenticated.
+          composer config --global --unset github-oauth.github.com 2>/dev/null || true
+          rm -f "$HOME/.config/composer/auth.json" "$HOME/.composer/auth.json" "$HOME/.wp-cli/packages/auth.json" 2>/dev/null || true
+          wp package install wp-cli/dist-archive-command:^2
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -50,8 +50,6 @@ jobs:
           tools: wp-cli
 
       - name: Install dist-archive-command
-        env:
-          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
         run: wp package install wp-cli/dist-archive-command:^2
 
       - name: Setup Node

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,6 +5,12 @@ on:
       - develop
       - main
 
+# Cancel superseded runs on the same ref so rapid pushes to develop/main do
+# not stack full SonarCloud analyses.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -32,7 +32,14 @@ jobs:
           tools: wp-cli
 
       - name: Install dist-archive-command
-        run: wp package install wp-cli/dist-archive-command:^2
+        run: |
+          # shivammathur/setup-php stores a GitHub OAuth token in Composer's
+          # global auth config; wp-cli's bundled Composer rejects its format
+          # ("invalid characters"), breaking this install. dist-archive-command
+          # is public, so drop the token and install unauthenticated.
+          composer config --global --unset github-oauth.github.com 2>/dev/null || true
+          rm -f "$HOME/.config/composer/auth.json" "$HOME/.composer/auth.json" "$HOME/.wp-cli/packages/auth.json" 2>/dev/null || true
+          wp package install wp-cli/dist-archive-command:^2
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -106,7 +106,15 @@ jobs:
           # Same config the official action emits.
           echo "{ \"core\": null, \"port\": 8880, \"testsPort\": 8881, \"plugins\": [ \"https://downloads.wordpress.org/plugin/plugin-check.zip\" ], \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
 
-          npm -g --no-fund i @wordpress/env
+          # Pin @wordpress/env to 11.2.0. Installing unpinned (`@wordpress/env`)
+          # pulls whatever is tagged `latest`, which since 11.3.0 changed
+          # `wp-env start` so it exits 0 right after "Reading configuration"
+          # without ever bringing the containers up — the next step then fails
+          # with "Environment not initialized." 11.2.0 is the version this
+          # workflow's docker-config.js sed patch targets and the version the
+          # repo already validates via patches/@wordpress+env+11.2.0.patch.
+          # Bump this in lockstep with that patch once upstream is sorted.
+          npm -g --no-fund i @wordpress/env@11.2.0
 
           # Bypass Composer's new audit block on PHPUnit security advisories.
           WP_ENV_DOCKER_CONFIG="$(npm root -g)/@wordpress/env/lib/runtime/docker/docker-config.js"

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -81,19 +81,19 @@ jobs:
           mkdir tmp-build
           unzip gatherpress.zip -d tmp-build
 
-      # The wordpress/plugin-check-action composite action installs
-      # @wordpress/env globally and runs it, but the wp-env Dockerfile
-      # currently fails because Composer's audit blocks every PHPUnit
-      # version covered by the new PKSA-5jz8-6tcw-pbk4 / PKSA-z3gr-8qht-p93v
-      # advisories. Inline the action's steps here so we can patch the
-      # generated Dockerfile to skip the audit before `wp-env start` runs.
-      # Revert to `uses: wordpress/plugin-check-action@…` once upstream ships
-      # a fix.
-      - name: Set up Node for plugin-check
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
+      # Run Plugin Check against a wp-env environment. We deliberately do NOT
+      # use `uses: wordpress/plugin-check-action@…` or a fresh global
+      # `npm i -g @wordpress/env`: the wp-env Docker image build runs
+      # `composer global require phpunit/phpunit`, which Composer's audit blocks
+      # on the PKSA-5jz8-6tcw-pbk4 / PKSA-z3gr-8qht-p93v advisories. The repo
+      # already solves this for its other wp-env CI (e2e, phpunit) by patching
+      # the generated Dockerfile via patches/@wordpress+env+11.2.0.patch, which
+      # `npm ci` applies above (patch-package fails loudly if it ever stops
+      # matching). So we use that local, validated wp-env (`npm run wp-env`)
+      # instead of an unpinned global install + a silent best-effort `sed`,
+      # which broke when `latest` drifted and the WordPress image stopped
+      # building (only the db containers came up → "Environment not
+      # initialized"). Revert to the upstream action once it ships a fix.
       - name: Export plugin paths
         run: |
           PLUGIN_DIR=$(realpath "./tmp-build/gatherpress")
@@ -101,50 +101,32 @@ jobs:
           echo "PLUGIN_SLUG=$(basename $PLUGIN_DIR)" >> "$GITHUB_ENV"
         shell: bash
 
-      - name: Install and patch wp-env
+      - name: Configure wp-env
         run: |
-          # Same config the official action emits.
-          echo "{ \"core\": null, \"port\": 8880, \"testsPort\": 8881, \"plugins\": [ \"https://downloads.wordpress.org/plugin/plugin-check.zip\" ], \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
-
-          # Pin @wordpress/env to 11.2.0 for deterministic CI: it's the version
-          # the repo validates locally (package.json + the
-          # patches/@wordpress+env+11.2.0.patch postinstall) and the one the
-          # docker-config.js sed patch below targets. Unpinned drifts to
-          # whatever is tagged `latest`. Bump in lockstep with that patch.
-          npm -g --no-fund i @wordpress/env@11.2.0
-
-          # Bypass Composer's new audit block on PHPUnit security advisories.
-          WP_ENV_DOCKER_CONFIG="$(npm root -g)/@wordpress/env/lib/runtime/docker/docker-config.js"
-          if grep -q 'composer global require --dev phpunit/phpunit' "$WP_ENV_DOCKER_CONFIG" \
-             && ! grep -q 'audit.block-insecure' "$WP_ENV_DOCKER_CONFIG"; then
-            sed -i \
-              's|RUN composer global require --dev phpunit/phpunit:|RUN composer global config --no-plugins audit.abandoned ignore\nRUN composer global config --no-plugins audit.block-insecure false\nRUN composer global require --dev phpunit/phpunit:|' \
-              "$WP_ENV_DOCKER_CONFIG"
-          fi
+          # Dev-only environment (no tests env needed for Plugin Check) with the
+          # plugin-check plugin installed and the built plugin mapped in.
+          echo "{ \"core\": null, \"port\": 8880, \"testsEnvironment\": false, \"plugins\": [ \"https://downloads.wordpress.org/plugin/plugin-check.zip\" ], \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
         shell: bash
 
-      # Run `wp-env start` directly rather than via nick-fields/retry: under the
-      # retry wrapper the command returned exit 0 immediately after "Reading
-      # configuration" without ever bringing the containers up, so the next step
-      # failed with "Environment not initialized." A direct step runs in the
-      # workspace cwd (same as Run Plugin Check), streams full `--debug` output,
-      # and we assert the container is actually reachable before moving on so a
-      # silent no-op start fails loudly here instead of downstream.
       - name: Start wp-env
         run: |
           echo "cwd: $(pwd)"
-          wp-env start --update --debug
+          # Local, patch-package-patched wp-env from node_modules (audit bypass
+          # already baked in) — the same binary e2e/phpunit CI boot successfully.
+          npm run wp-env -- start
           echo "::group::docker ps"
           docker ps -a
           echo "::endgroup::"
-          # Fail here (with context) if the env didn't actually come up.
-          wp-env run cli wp core version
+          # Block until WordPress actually answers, and fail loudly here (rather
+          # than downstream with "Environment not initialized") if it never does.
+          npx wait-on http://localhost:8880/wp-admin/install.php -t 120000
+          npm run wp-env -- run cli wp core version
         shell: bash
 
       - name: Run Plugin Check
         run: |
-          wp-env run cli wp plugin activate "$PLUGIN_SLUG"
-          wp-env run cli wp plugin check "$PLUGIN_SLUG" \
+          npm run wp-env -- run cli wp plugin activate "$PLUGIN_SLUG"
+          npm run wp-env -- run cli wp plugin check "$PLUGIN_SLUG" \
             --format=json \
             --exclude-files=.wp-env.json \
             --require=./wp-content/plugins/plugin-check/cli.php

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -32,8 +32,6 @@ jobs:
           tools: wp-cli
 
       - name: Install dist-archive-command
-        env:
-          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
         run: wp package install wp-cli/dist-archive-command:^2
 
       - name: Setup Node

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -103,12 +103,12 @@ jobs:
 
       - name: Configure wp-env
         run: |
-          # Faithful mirror of the repo's proven .wp-env.test.json (the exact
-          # config the e2e job boots successfully): testsEnvironment + a theme +
-          # WP_DEBUG. Only additions are the plugin-check plugin and mapping the
-          # built plugin in. Earlier dev-environment configs left wp-env
-          # provisioning only the database here.
-          echo "{ \"\$schema\": \"https://schemas.wp.org/trunk/wp-env.json\", \"testsEnvironment\": true, \"themes\": [ \"WordPress/twentytwentyfive\" ], \"config\": { \"WP_DEBUG\": true }, \"plugins\": [ \"https://downloads.wordpress.org/plugin/plugin-check.zip\" ], \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
+          # Mirror the repo's proven local-only .wp-env.json (what e2e/phpunit
+          # boot). Crucially NO remote plugin URL in `plugins`: having wp-env
+          # fetch plugin-check from downloads.wordpress.org during `wp-env start`
+          # is what left the env provisioning only the database. Map the built
+          # plugin in here; plugin-check is installed at runtime once WP is live.
+          echo "{ \"\$schema\": \"https://schemas.wp.org/trunk/wp-env.json\", \"testsEnvironment\": false, \"themes\": [ \"WordPress/twentytwentyfive\" ], \"config\": { \"WP_DEBUG\": true }, \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
           cat .wp-env.json
         shell: bash
 
@@ -116,15 +116,18 @@ jobs:
         run: |
           # Strip only docker layer-progress lines (hex-id prefixed) so wp-env's
           # own provisioning output stays visible; docker ps + wait-on are the
-          # real gates. e2e waits on the tests environment at port 8889.
+          # real gates. Dev environment serves on port 8888.
           npm run wp-env -- start --debug 2>&1 | grep -vE '^ [0-9a-f]{8,} ' || true
           echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
-          npx wait-on http://localhost:8889/wp-admin -t 180000
+          npx wait-on http://localhost:8888/wp-admin -t 180000
           npm run wp-env -- run cli wp core version
         shell: bash
 
       - name: Run Plugin Check
         run: |
+          # Install Plugin Check inside the running env (a runtime fetch, after
+          # WordPress is up, rather than during wp-env start).
+          npm run wp-env -- run cli wp plugin install plugin-check --activate
           npm run wp-env -- run cli wp plugin activate "$PLUGIN_SLUG"
           npm run wp-env -- run cli wp plugin check "$PLUGIN_SLUG" \
             --format=json \

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -103,41 +103,27 @@ jobs:
 
       - name: Configure wp-env
         run: |
-          # Dev-only environment (no tests env needed for Plugin Check) with the
-          # plugin-check plugin installed and the built plugin mapped in.
-          echo "{ \"core\": null, \"port\": 8880, \"testsEnvironment\": false, \"plugins\": [ \"https://downloads.wordpress.org/plugin/plugin-check.zip\" ], \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
+          # Modeled on the repo's proven .wp-env.test.json (the config e2e boots
+          # successfully). The upstream action's minimal `"core": null` config
+          # left wp-env provisioning ONLY the database here — no WordPress image
+          # build, no wordpress container — so Plugin Check had nothing to run
+          # against. Omitting `core` (defaults to the latest WP), specifying a
+          # theme, and enabling WP_DEBUG matches the shape that actually starts.
+          echo "{ \"\$schema\": \"https://schemas.wp.org/trunk/wp-env.json\", \"plugins\": [ \"https://downloads.wordpress.org/plugin/plugin-check.zip\" ], \"themes\": [ \"WordPress/twentytwentyfive\" ], \"config\": { \"WP_DEBUG\": true }, \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
+          cat .wp-env.json
         shell: bash
 
       - name: Start wp-env
         run: |
-          echo "::group::env"
-          echo "node: $(node -v)  npm: $(npm -v)"
-          echo "patched docker-config.js? (expect 1):"
-          grep -c 'audit.block-insecure' node_modules/@wordpress/env/lib/runtime/docker/docker-config.js || echo "PATCH MISSING"
-          echo "::endgroup::"
-
-          echo "::group::wp-env start --debug"
-          npm run wp-env -- start --debug > /tmp/wpenv.log 2>&1 && echo "start exit 0" || echo "start exit $?"
-          grep -viE 'Downloading|Extracting|Pull complete|Download complete|Pulling fs|Already exists|[0-9.]+ ?[kKMG]?B/' /tmp/wpenv.log | tail -160
-          echo "::endgroup::"
-
-          echo "::group::docker images"; docker images; echo "::endgroup::"
+          # --debug output (minus image-pull noise) and docker ps are kept so a
+          # non-booting env stays diagnosable without a separate run; wait-on is
+          # the real gate that fails loudly if WordPress never answers.
+          npm run wp-env -- start --debug 2>&1 \
+            | grep -viE 'Downloading|Extracting|Pull complete|Download complete|Pulling fs|Already exists|[0-9.]+ ?[kKMG]?B/' || true
           echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
-
-          echo "::group::generated docker-compose.yml"
-          find ~/.wp-env -name 'docker-compose.yml' -exec cat {} \; 2>/dev/null | head -160
-          echo "::endgroup::"
-
-          echo "::group::generated Dockerfile(s)"
-          find ~/.wp-env -iname '*ockerfile*' -exec echo '---- {} ----' \; -exec cat {} \; 2>/dev/null | head -160
-          echo "::endgroup::"
-
-          echo "::group::wordpress container logs (if any)"
-          docker ps -a --format '{{.Names}}' | grep -i wordpress | head -1 | xargs -r -I{} docker logs {} 2>&1 | tail -60 || true
-          echo "::endgroup::"
-
-          # Diagnostic run: stop here with everything captured.
-          exit 1
+          # Default development environment serves on port 8888.
+          npx wait-on http://localhost:8888/wp-admin -t 180000
+          npm run wp-env -- run cli wp core version
         shell: bash
 
       - name: Run Plugin Check

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -114,13 +114,10 @@ jobs:
 
       - name: Start wp-env
         run: |
-          # Strip only docker layer-progress lines (hex-id prefixed) so wp-env's
-          # own provisioning output stays visible; docker ps + wait-on are the
-          # real gates. Dev environment serves on port 8888.
-          npm run wp-env -- start --debug 2>&1 | grep -vE '^ [0-9a-f]{8,} ' || true
-          echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
+          npm run wp-env -- start
+          # Block until the dev site (port 8888) actually answers, so a
+          # non-booting env fails here rather than at the Plugin Check step.
           npx wait-on http://localhost:8888/wp-admin -t 180000
-          npm run wp-env -- run cli wp core version
         shell: bash
 
       - name: Run Plugin Check

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -103,26 +103,23 @@ jobs:
 
       - name: Configure wp-env
         run: |
-          # Modeled on the repo's proven .wp-env.test.json (the config e2e boots
-          # successfully). The upstream action's minimal `"core": null` config
-          # left wp-env provisioning ONLY the database here — no WordPress image
-          # build, no wordpress container — so Plugin Check had nothing to run
-          # against. Omitting `core` (defaults to the latest WP), specifying a
-          # theme, and enabling WP_DEBUG matches the shape that actually starts.
-          echo "{ \"\$schema\": \"https://schemas.wp.org/trunk/wp-env.json\", \"plugins\": [ \"https://downloads.wordpress.org/plugin/plugin-check.zip\" ], \"themes\": [ \"WordPress/twentytwentyfive\" ], \"config\": { \"WP_DEBUG\": true }, \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
+          # Faithful mirror of the repo's proven .wp-env.test.json (the exact
+          # config the e2e job boots successfully): testsEnvironment + a theme +
+          # WP_DEBUG. Only additions are the plugin-check plugin and mapping the
+          # built plugin in. Earlier dev-environment configs left wp-env
+          # provisioning only the database here.
+          echo "{ \"\$schema\": \"https://schemas.wp.org/trunk/wp-env.json\", \"testsEnvironment\": true, \"themes\": [ \"WordPress/twentytwentyfive\" ], \"config\": { \"WP_DEBUG\": true }, \"plugins\": [ \"https://downloads.wordpress.org/plugin/plugin-check.zip\" ], \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
           cat .wp-env.json
         shell: bash
 
       - name: Start wp-env
         run: |
-          # --debug output (minus image-pull noise) and docker ps are kept so a
-          # non-booting env stays diagnosable without a separate run; wait-on is
-          # the real gate that fails loudly if WordPress never answers.
-          npm run wp-env -- start --debug 2>&1 \
-            | grep -viE 'Downloading|Extracting|Pull complete|Download complete|Pulling fs|Already exists|[0-9.]+ ?[kKMG]?B/' || true
+          # Strip only docker layer-progress lines (hex-id prefixed) so wp-env's
+          # own provisioning output stays visible; docker ps + wait-on are the
+          # real gates. e2e waits on the tests environment at port 8889.
+          npm run wp-env -- start --debug 2>&1 | grep -vE '^ [0-9a-f]{8,} ' || true
           echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
-          # Default development environment serves on port 8888.
-          npx wait-on http://localhost:8888/wp-admin -t 180000
+          npx wait-on http://localhost:8889/wp-admin -t 180000
           npm run wp-env -- run cli wp core version
         shell: bash
 

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -13,6 +13,11 @@ on: # rebuild any PRs and main branch changes
     branches:
     - main
 
+# Cancel superseded runs on the same ref so stacked PR pushes do not pile up.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -110,17 +110,34 @@ jobs:
 
       - name: Start wp-env
         run: |
-          echo "cwd: $(pwd)"
-          # Local, patch-package-patched wp-env from node_modules (audit bypass
-          # already baked in) — the same binary e2e/phpunit CI boot successfully.
-          npm run wp-env -- start
-          echo "::group::docker ps"
-          docker ps -a
+          echo "::group::env"
+          echo "node: $(node -v)  npm: $(npm -v)"
+          echo "patched docker-config.js? (expect 1):"
+          grep -c 'audit.block-insecure' node_modules/@wordpress/env/lib/runtime/docker/docker-config.js || echo "PATCH MISSING"
           echo "::endgroup::"
-          # Block until WordPress actually answers, and fail loudly here (rather
-          # than downstream with "Environment not initialized") if it never does.
-          npx wait-on http://localhost:8880/wp-admin/install.php -t 120000
-          npm run wp-env -- run cli wp core version
+
+          echo "::group::wp-env start --debug"
+          npm run wp-env -- start --debug > /tmp/wpenv.log 2>&1 && echo "start exit 0" || echo "start exit $?"
+          grep -viE 'Downloading|Extracting|Pull complete|Download complete|Pulling fs|Already exists|[0-9.]+ ?[kKMG]?B/' /tmp/wpenv.log | tail -160
+          echo "::endgroup::"
+
+          echo "::group::docker images"; docker images; echo "::endgroup::"
+          echo "::group::docker ps -a"; docker ps -a; echo "::endgroup::"
+
+          echo "::group::generated docker-compose.yml"
+          find ~/.wp-env -name 'docker-compose.yml' -exec cat {} \; 2>/dev/null | head -160
+          echo "::endgroup::"
+
+          echo "::group::generated Dockerfile(s)"
+          find ~/.wp-env -iname '*ockerfile*' -exec echo '---- {} ----' \; -exec cat {} \; 2>/dev/null | head -160
+          echo "::endgroup::"
+
+          echo "::group::wordpress container logs (if any)"
+          docker ps -a --format '{{.Names}}' | grep -i wordpress | head -1 | xargs -r -I{} docker logs {} 2>&1 | tail -60 || true
+          echo "::endgroup::"
+
+          # Diagnostic run: stop here with everything captured.
+          exit 1
         shell: bash
 
       - name: Run Plugin Check

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -106,14 +106,11 @@ jobs:
           # Same config the official action emits.
           echo "{ \"core\": null, \"port\": 8880, \"testsPort\": 8881, \"plugins\": [ \"https://downloads.wordpress.org/plugin/plugin-check.zip\" ], \"mappings\": { \"wp-content/plugins/$PLUGIN_SLUG\": \"$PLUGIN_DIR\" } }" > .wp-env.json
 
-          # Pin @wordpress/env to 11.2.0. Installing unpinned (`@wordpress/env`)
-          # pulls whatever is tagged `latest`, which since 11.3.0 changed
-          # `wp-env start` so it exits 0 right after "Reading configuration"
-          # without ever bringing the containers up — the next step then fails
-          # with "Environment not initialized." 11.2.0 is the version this
-          # workflow's docker-config.js sed patch targets and the version the
-          # repo already validates via patches/@wordpress+env+11.2.0.patch.
-          # Bump this in lockstep with that patch once upstream is sorted.
+          # Pin @wordpress/env to 11.2.0 for deterministic CI: it's the version
+          # the repo validates locally (package.json + the
+          # patches/@wordpress+env+11.2.0.patch postinstall) and the one the
+          # docker-config.js sed patch below targets. Unpinned drifts to
+          # whatever is tagged `latest`. Bump in lockstep with that patch.
           npm -g --no-fund i @wordpress/env@11.2.0
 
           # Bypass Composer's new audit block on PHPUnit security advisories.
@@ -126,13 +123,23 @@ jobs:
           fi
         shell: bash
 
+      # Run `wp-env start` directly rather than via nick-fields/retry: under the
+      # retry wrapper the command returned exit 0 immediately after "Reading
+      # configuration" without ever bringing the containers up, so the next step
+      # failed with "Environment not initialized." A direct step runs in the
+      # workspace cwd (same as Run Plugin Check), streams full `--debug` output,
+      # and we assert the container is actually reachable before moving on so a
+      # silent no-op start fails loudly here instead of downstream.
       - name: Start wp-env
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          shell: bash
-          command: wp-env start --update
+        run: |
+          echo "cwd: $(pwd)"
+          wp-env start --update --debug
+          echo "::group::docker ps"
+          docker ps -a
+          echo "::endgroup::"
+          # Fail here (with context) if the env didn't actually come up.
+          wp-env run cli wp core version
+        shell: bash
 
       - name: Run Plugin Check
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We release patches for security vulnerabilities only for the current version:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.33.x  | :white_check_mark: |
-| < 0.33  | :x:                |
+| 0.34.x  | :white_check_mark: |
+| < 0.34  | :x:                |
 
 **We strongly recommend always using the latest stable version of GatherPress.** Security updates are only provided for the current release.
 

--- a/includes/data/credits.php
+++ b/includes/data/credits.php
@@ -140,6 +140,19 @@ return array (
         96 => '//www.gravatar.com/avatar/8c23225a67ae866951341a9d5844af55?s=96&#038;r=g&#038;d=mm',
       ),
     ),
+    8 => 
+    array (
+      'id' => 1321993,
+      'name' => 'Velda',
+      'link' => 'https://profiles.wordpress.org/supernovia/',
+      'slug' => 'supernovia',
+      'avatar_urls' => 
+      array (
+        24 => '//www.gravatar.com/avatar/b56caeb30157e1e1dd6c7d0a7ad00d78?s=24&#038;r=g&#038;d=mm',
+        48 => '//www.gravatar.com/avatar/b56caeb30157e1e1dd6c7d0a7ad00d78?s=48&#038;r=g&#038;d=mm',
+        96 => '//www.gravatar.com/avatar/b56caeb30157e1e1dd6c7d0a7ad00d78?s=96&#038;r=g&#038;d=mm',
+      ),
+    ),
   ),
   'contributors' => 
   array (

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -32,6 +32,13 @@ module.exports = defineConfig( {
 			name: 'chromium',
 			use: {
 				...devices[ 'Desktop Chrome' ],
+				// In CI, run against the Google Chrome preinstalled on the
+				// GitHub runner instead of Playwright's downloaded Chromium —
+				// the `playwright install chromium` download hangs after
+				// completing on the runners (observed 2026-05-30). Local runs
+				// keep using the downloaded Chromium so no system Chrome is
+				// required for development.
+				...( process.env.CI ? { channel: 'chrome' } : {} ),
 				storageState: './test/e2e/storageState.json',
 			},
 		},

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === GatherPress ===
-Contributors: mauteri, patricia70, hrmervin, jmarx75, stephenerdelyi, carstenbach, jordanpak, mahimadave, tusharaddweb, pkbhatt
+Contributors: mauteri, patricia70, hrmervin, jmarx75, stephenerdelyi, carstenbach, jordanpak, mahimadave, tusharaddweb, pkbhatt, supernovia
 Tags: events, event, meetup, community
 Tested up to: 7.0
 Stable tag: 0.34.0-beta.1


### PR DESCRIPTION
Setup for the next prerelease (no changelog). Generated via the `gatherpress-develop` tooling:
- `SECURITY.md` supported-versions table → `0.34.x` / `< 0.34`
- `includes/data/credits.php` regenerated (adds `supernovia`)
- `readme.txt` regenerated

Based on `develop`.