### PR TITLE
fix(ci): drop COMPOSER_AUTH from dist-archive-command install (unblocks Playground Preview + wp.org Guidelines)

### DIFF
--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -50,8 +50,6 @@ jobs:
           tools: wp-cli
 
       - name: Install dist-archive-command
-        env:
-          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
         run: wp package install wp-cli/dist-archive-command:^2
 
       - name: Setup Node

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -32,8 +32,6 @@ jobs:
           tools: wp-cli
 
       - name: Install dist-archive-command
-        env:
-          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
         run: wp package install wp-cli/dist-archive-command:^2
 
       - name: Setup Node


### PR DESCRIPTION
## Problem
Both `playground-preview.yml` and `wordpress-org-plugin-guidelines.yml` fail on:
```
Error: Failed to get composer instance: Your github oauth token for github.com contains invalid characters: "***"
```
The `COMPOSER_AUTH: GITHUB_TOKEN` (added in #1670 to avoid API rate limits) trips Composer's github-oauth token validation, so `wp package install wp-cli/dist-archive-command` aborts.

## Fix
`dist-archive-command` is a public package and needs no auth — remove the `COMPOSER_AUTH` env from the install step in both workflows. This restores the pre-#1670 working install.

If anonymous API rate limits become a real issue again, the right re-fix is git-credential auth (`git config url.insteadOf` with the token), which doesn't go through Composer's oauth validation.