### PR TITLE
ci: stabilize E2E workflow and add concurrency cancellation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,6 +15,13 @@ on:
     - '*.php'
     - '*.js'
 
+# Cancel an in-progress run when a newer commit is pushed to the same ref so
+# stacked PR runs do not pile up (three were running simultaneously on
+# 2026-05-30).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -22,6 +29,10 @@ jobs:
   playwright:
     name: Playwright Tests
     runs-on: ubuntu-latest
+    # A healthy run finishes well under 30 minutes; without this a hung step
+    # (e.g. the Playwright browser download stalling) inherits GitHub's 6-hour
+    # default before it is killed.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,8 +75,42 @@ jobs:
             ./node_modules
           key: ${{ steps.node_modules-cache.outputs.cache-primary-key }}
 
-      - name: Playwright install
-        run: npx playwright install --with-deps
+      # Resolve the exact Playwright version from the installed package so the
+      # browser cache key tracks it. node_modules is restored/installed above,
+      # so @playwright/test is available here.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      # Cache the downloaded browser binaries so a healthy run skips the CDN
+      # download entirely. Keyed on the Playwright version: a version bump
+      # invalidates the cache and triggers a fresh download.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      # System libraries (apt) are part of the runner, not the cache, so install
+      # them every run. Split out from the browser download so an apt lock/stall
+      # surfaces fast against its own short timeout. Only chromium is needed —
+      # playwright.config.js defines a single chromium project.
+      - name: Install Playwright system dependencies
+        timeout-minutes: 5
+        run: npx playwright install-deps chromium
+
+      # Download only the chromium binary (was --with-deps, which also pulled
+      # firefox + webkit). Wrapped in retry with a tight per-attempt timeout so
+      # a stalled CDN download is killed and retried in minutes instead of
+      # hanging for hours (observed 1-2h+ hangs on 2026-05-30).
+      - name: Install Playwright browser (chromium)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 8
+          max_attempts: 3
+          command: npx playwright install chromium
 
       - name: Build plugin assets
         run: npm run build

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -12,6 +12,11 @@ on:
     - 'phpunit.xml.dist'
     - 'composer.*'
 
+# Cancel superseded runs on the same ref so stacked PR pushes do not pile up.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,6 +5,12 @@ on:
       - develop
       - main
 
+# Cancel superseded runs on the same ref so rapid pushes to develop/main do
+# not stack full SonarCloud analyses.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -13,6 +13,11 @@ on: # rebuild any PRs and main branch changes
     branches:
     - main
 
+# Cancel superseded runs on the same ref so stacked PR pushes do not pile up.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Why

Three reliability problems were observed on the **Playwright Tests** job (`e2e-tests.yml`) on 2026-05-30:

1. **Runs hung 1-2h+ on `npx playwright install --with-deps`.** Normal time is 1-3 min. `--with-deps` runs `apt-get` for system libraries and downloads browser binaries from Playwright's CDN; with no timeout, a stalled download or apt lock just hangs.
2. **No `timeout-minutes` on the job,** so a hung run inherited GitHub's 6-hour default cap before being killed.
3. **No `concurrency:` block,** so every push to a PR started a fresh full run. Three runs were stacked at once for the same PR.

## What changed

### `e2e-tests.yml`
- **Concurrency** — top-level group keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, so a newer push cancels the superseded run.
- **Job timeout** — `timeout-minutes: 30` on the Playwright Tests job (healthy runs finish well under that).
- **Playwright install hang** — replaced the single `npx playwright install --with-deps` step with:
  - **Cache** `~/.cache/ms-playwright` keyed on the resolved Playwright version, so a healthy run skips the CDN download entirely.
  - **Chromium only** — `playwright.config.js` defines a single `chromium` project, but `--with-deps` also downloaded firefox + webkit. Narrowing to chromium cuts the download surface ~2/3.
  - **Split system-deps from browser download** — `playwright install-deps chromium` (apt, runs every run, 5-min timeout) is separate from the binary download, so an apt lock/stall surfaces fast against its own short timeout.
  - **Retry + per-attempt timeout** on the browser download via `nick-fields/retry@v3` (8-min per attempt, 3 attempts) — already a dependency used in `wordpress-org-plugin-guidelines.yml`. A stalled CDN download is now killed and retried in minutes instead of hanging for hours.

### Concurrency applied consistently to other workflows
Added the same `${{ github.workflow }}-${{ github.ref }}` / `cancel-in-progress: true` group to:
- `phpunit-tests.yml`
- `sonarcloud.yml`
- `wordpress-org-plugin-guidelines.yml`

`pr-coverage.yml` already had an equivalent block (keyed on `github.event.pull_request.number`) and is left unchanged.

## On the egress question
`runs-on: ubuntu-latest` means GitHub-hosted runners, which have unrestricted egress to Playwright's CDN by default — a hard egress block is unlikely. The 1-2h hang is far more consistent with a stalled CDN download or apt lock with no timeout to kill it. The combination of cache + chromium-only + per-step timeout + retry resolves the symptom regardless of root cause, and the split makes the actual failure point visible in future runs.

## Testing
- All four edited workflow files pass `yaml.safe_load` parsing.
- Concurrency cancellation can be verified on this PR by pushing twice in quick succession to this branch and observing the first E2E run get cancelled (the workflow file with the concurrency block is on the branch, so it's active for these PR runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)