### PR TITLE
Fix venue map breaking out of body on mobile (#1703)

### DIFF
--- a/.github/changelog/fix-venue-map-mobile-overflow
+++ b/.github/changelog/fix-venue-map-mobile-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop the venue map from breaking out of the body on narrow viewports. With an auto width, the inline `height` + `aspect-ratio` pair resolved to a fixed pixel width (300px tall at 2/1 → 600px wide) that overflowed mobile screens; the wrapper is now capped to its container width. [#1703]

--- a/src/blocks/venue-map/style.scss
+++ b/src/blocks/venue-map/style.scss
@@ -20,6 +20,15 @@
 	position: relative;
 	overflow: hidden;
 
+	// Never exceed the container. With an auto width the inline
+	// `height` + `aspect-ratio` pair resolves to a fixed pixel width
+	// (e.g. 300px tall at 2/1 → 600px wide), which overflows narrow
+	// viewports — the map "breaks out" of the body on mobile (#1703).
+	// Capping the width lets the box shrink to its container; `box-sizing`
+	// keeps the block-supports border inside that cap.
+	max-width: 100%;
+	box-sizing: border-box;
+
 	// Inherit the wrapper's border-radius (the `border` block support
 	// stamps radius onto the block wrapper) so inner elements — static
 	// <img>, Leaflet container, placeholder — get clipped to the same


### PR DESCRIPTION
## Summary

Fixes #1703 — the venue map is wider than the body and breaks out of it on mobile.

### Root cause

The venue-map wrapper is sized by inline styles from `render.php`. With the default attributes (`width: 0`/auto, `height: 300`, `aspectRatio: 2/1`) it stamps **both** `height:300px` and `aspect-ratio:2/1`. CSS then derives the width from `height × aspect-ratio = 600px` — a fixed-width box with nothing capping it to the container, so on a ~375px phone viewport the map overflows the body. The reporter saw the same thing with the interactive iframe, which lives inside the same wrapper.

### Fix

Cap the wrapper with `max-width: 100%` (and `box-sizing: border-box` so the block-supports border stays within the cap). The box now shrinks to its container on narrow screens, while desktop layouts — where the container is wider than the 600px computed width — are unchanged. This covers both the static `<img>` baseline and the interactive (Leaflet/Google) iframe.

This is the clean version of the reporter's suggested workaround: rather than forcing width to `auto` (which discards the sizing logic), we just keep the existing inline sizing from overflowing its container.

## Testing

- `npm run build` compiles; output contains `.gatherpress-venue-map{box-sizing:border-box;max-width:100%;...}`.
- `lint:css` clean.
- Pure CSS change; no unit-testable logic. Verified the overflow math against the `Map::DEFAULT_HEIGHT` (300) / `DEFAULT_ASPECT_RATIO` (2/1) constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)