### PR TITLE
Fix Playground proxy zip download returning text/html

### DIFF
--- a/.gatherpress-org/playground-preview/.htaccess
+++ b/.gatherpress-org/playground-preview/.htaccess
@@ -9,11 +9,14 @@
 
 
 <IfModule mod_headers.c>
-    # THIS IS IMPORTANT
-    # The missing piece I was hunting for 2 days.
+    # plugin-proxy.php now sets Content-Type and Content-Disposition itself,
+    # before it flushes the output buffer, so the download works even without
+    # this rule. These `Header set` lines are kept as a server-level fallback;
+    # `set` replaces with an identical value, so there is no duplicate header.
     #
-    # TODO # WEIRD
-    # Having this here DOES WORK,
-    # the exact same line DOES NOT WORK when placed in plugin-proxy.php.
+    # (The earlier "only works from .htaccess, not from PHP" note was a symptom
+    # of the proxy flushing PHP's default text/html header too early; that is
+    # fixed in plugin-proxy.php.)
+    Header set Content-Type "application/zip"
     Header set Content-Disposition "attachment; filename=\"gatherpress-pr.zip\""
 </IfModule>

--- a/.gatherpress-org/playground-preview/plugin-proxy.php
+++ b/.gatherpress-org/playground-preview/plugin-proxy.php
@@ -75,7 +75,7 @@ class PluginDownloader {
 
 			$allowed_headers = array(
 				// 'accept-ranges',
-				'content-disposition',
+				// 'content-disposition', // Set explicitly below so the filename is ours, not the upstream artifact's.
 				'content-length',
 				// 'content-type',
 				'x-frame-options',
@@ -87,6 +87,21 @@ class PluginDownloader {
 				'cache-Control',
 			);
 			$artifact_res    = $this->gitHubRequest( $zip_download_api_endpoint, false, false );
+
+			// Emit the download headers *before* flushing the output buffer.
+			//
+			// PHP commits the response headers the moment the buffer is flushed.
+			// If we wait until streamHttpResponse() to set the Content-Type, PHP
+			// has already sent its default `text/html`, every later header() call
+			// becomes a silent no-op, and the browser renders the zip bytes as
+			// gibberish (made worse by `X-Content-Type-Options: nosniff`).
+			//
+			// Setting them here makes the download work without depending on a
+			// server-level .htaccess `Header set Content-Disposition` rule.
+			if ( ! headers_sent() ) {
+				header( 'Content-Type: application/zip' );
+				header( 'Content-Disposition: attachment; filename="gatherpress-pr.zip"' );
+			}
 
 			// die(var_export($artifact_res['headers'],true));
 			ob_end_flush();
@@ -104,11 +119,10 @@ class PluginDownloader {
 						null,
 						$allowed_headers,
 						[
+							// Content-Type and Content-Disposition are already set
+							// (and committed) above, before the output buffer was
+							// flushed. They are intentionally not repeated here.
 							'Content-Type: application/zip',
-							// TODO // WEIRD
-							// Having this here DOES NOT WORK,
-							// the exact same line needs to be placed in .htaccess.
-							// 'Content-Disposition: attachment; filename="gatherpress-pr.zip"',
 						]
 					);
 					die();


### PR DESCRIPTION
## Summary

The **Download `.zip` with build changes** link in the Playground Preview PR comment ([example](https://github.com/GatherPress/gatherpress/pull/1714#issuecomment-4585385904)) pointed at `plugin-proxy.php`, which streamed a valid zip but served it as `Content-Type: text/html` with `X-Content-Type-Options: nosniff` and **no** `Content-Disposition`. Browsers were told "this is HTML, don't sniff it" and rendered the raw zip bytes as gibberish instead of downloading.

## Root cause

The GitHub-PR-artifact path called `ob_end_flush(); flush();` **before** `streamHttpResponse()` set `Content-Type: application/zip`. On hosts with `output_buffering` on (gatherpress.org behind Apache + Cloudflare), the flush commits PHP's default `text/html` header, after which every `header()` call is a silent no-op. The `.htaccess` `Header set Content-Disposition` workaround was not taking effect on the live host either, so the response had no `Content-Disposition` at all.

This explains why the same vendored proxy works on playground.wordpress.net (likely `output_buffering` off there) but not on gatherpress.org.

## Fix

- Set `Content-Type: application/zip` and `Content-Disposition: attachment; filename="gatherpress-pr.zip"` **before** the flush, guarded by `headers_sent()`. This works regardless of `output_buffering` and no longer depends on the `.htaccess` rule.
- Stop passing the upstream `content-disposition` through, so the download filename stays ours.
- Keep the `.htaccess` lines as a harmless server-level fallback (`Header set` replaces with an identical value) and correct the stale "only works from .htaccess, not from PHP" comments.

## Verification

Patched and verified live on gatherpress.org. The proxy response changed from:

```
content-type: text/html; charset=UTF-8
```

to:

```
content-type: application/zip
content-disposition: attachment; filename="gatherpress-pr.zip"
```

The header-ordering behavior was also reproduced locally under `output_buffering=on`: the old ordering yields `text/html`, the new ordering yields `application/zip` + the attachment disposition.

## Notes

- This file is a GatherPress-customized copy of WordPress Playground's `plugin-proxy.php` (note the `gatherpress-pr.zip` filename and the GatherPress-only allowlist), so no upstream PR is needed.
- The Playground previews themselves were unaffected (they fetch the zip programmatically, ignoring `Content-Disposition`); this only fixes the human-facing download link.
- `Skip Changelog`: deploy-asset/tooling change, not user-facing plugin behavior.