### PR TITLE
Ship SECURITY.md in the distributed plugin zip

### DIFF
--- a/.github/changelog/ship-security-md-in-plugin-zip
+++ b/.github/changelog/ship-security-md-in-plugin-zip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Include `SECURITY.md` in the distributed plugin zip. `wp-scripts plugin-zip` ignores `.distignore` and builds from a fixed allowlist, so a `package.json` `files` list now pins the shipped fileset and adds the security policy.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,13 @@
 		"url": "https://github.com/GatherPress/gatherpress/issues"
 	},
 	"main": "index.js",
+	"files": [
+		"build",
+		"includes",
+		"gatherpress.php",
+		"CHANGELOG.md",
+		"SECURITY.md"
+	],
 	"devDependencies": {
 		"@anthropic-ai/claude-code": "^2.1.84",
 		"@jest/globals": "^30.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 	"bugs": {
 		"url": "https://github.com/GatherPress/gatherpress/issues"
 	},
-	"main": "index.js",
 	"files": [
 		"build",
 		"includes",
@@ -24,6 +23,7 @@
 		"CHANGELOG.md",
 		"SECURITY.md"
 	],
+	"main": "index.js",
 	"devDependencies": {
 		"@anthropic-ai/claude-code": "^2.1.84",
 		"@jest/globals": "^30.2.0",


### PR DESCRIPTION
Resolves part of GatherPress/gatherpress#1718 (core half; the gatherpress-alpha half is GatherPress/gatherpress-alpha#44).

## Problem
The issue assumed `npm run plugin-zip` honors `.distignore`. It does not — `wp-scripts plugin-zip` (v31.7.0 here) has **no reference to `.distignore`** anywhere. With no `files` field in `package.json` it builds the archive from a fixed Plugin Handbook allowlist:

```
admin/** build/** includes/** languages/** public/**
<name>.php uninstall.php block.json changelog.* license.* readme.*
```

`SECURITY.md` matches none of those, so it was **silently excluded** from the GitHub release zip. (Verified locally: ran `plugin-zip` and inspected the source.)

## Fix
Add a `package.json` `files` list. This switches plugin-zip to `npm-packlist`, which pins the shipped fileset and includes `SECURITY.md`.

The list mirrors what the old allowlist actually produced, so the release zip is unchanged **except** it now contains `SECURITY.md` (and `package.json`, which npm-packlist always bundles):

| Entry | Before | After |
|---|---|---|
| `build/`, `includes/`, `gatherpress.php` | ✅ | ✅ |
| `CHANGELOG.md`, `readme.txt`, `README.md`, `license.txt` | ✅ | ✅ (must-haves) |
| `SECURITY.md` | ❌ | ✅ |
| `package.json` | ❌ | ✅ (npm-packlist always) |

`build/` is gitignored but is **force-included** by the `files` list — verified with `npm-packlist` against the real tree (196 build files survive).

## wordpress.org deploy
No change needed. `deploy-wporg` uses `10up/action-wordpress-plugin-deploy`, which honors `.distignore`; `SECURITY.md` is not excluded there, so it already ships to SVN trunk.

## Acceptance criteria
- [x] `SECURITY.md` present in `npm run plugin-zip` artifact
- [x] `SECURITY.md` present in the wordpress.org deployment (already shipped; confirmed mechanism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)