### PR TITLE
Use the post type's singular label in the "already passed" notice

### DIFF
--- a/.github/changelog/past-notice-post-type-label
+++ b/.github/changelog/past-notice-post-type-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+The editor's "already passed" notice now uses the post type's own singular label, so a custom event-supporting post type (e.g. a `production`) reads "Production has already passed." instead of the hardcoded "event".

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -7,12 +7,13 @@ import moment from 'moment';
  * WordPress dependencies
  */
 import { dispatch, select, useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { createMomentWithTimezone, getTimezone } from './datetime';
+import { getPostTypeLabel } from './editor';
 import { getVenueTaxonomy, getVenuePostType } from './venue';
 
 /**
@@ -384,9 +385,22 @@ export function hasEventPastNotice() {
 	notices.removeNotice( id );
 
 	if ( hasEventPast() ) {
+		// Reflect the post type's own label so a custom event-supporting post
+		// type with `singular_name => 'Production'` reads "Production has
+		// already passed." instead of the hardcoded "event" (#1722).
+		const singularLabel = getPostTypeLabel(
+			'singular_name',
+			null,
+			__( 'Event', 'gatherpress' )
+		);
+
 		notices.createNotice(
 			'warning',
-			__( 'This event has already passed.', 'gatherpress' ),
+			sprintf(
+				/* translators: %s: Singular post type label, e.g. "Event". */
+				__( '%s has already passed.', 'gatherpress' ),
+				singularLabel
+			),
 			{
 				id,
 				isDismissible: false,

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -1127,7 +1127,50 @@ describe( 'hasEventPastNotice', () => {
 
 		expect( dispatch( 'core/notices' ).createNotice ).toHaveBeenCalledWith(
 			'warning',
-			'This event has already passed.',
+			'Event has already passed.',
+			{
+				id: 'gatherpress_event_past',
+				isDismissible: false,
+			},
+		);
+	} );
+
+	it( 'notice uses the post type singular label', () => {
+		const pastEnd = moment()
+			.subtract( 1, 'days' )
+			.format( dateTimeDatabaseFormat );
+
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'gatherpress/datetime' === store ) {
+				return {
+					getDateTimeEnd: () => pastEnd,
+					getTimezone: () => 'America/New_York',
+				};
+			}
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'production' };
+			}
+			if ( 'core' === store ) {
+				return {
+					getPostType: ( slug ) => {
+						if ( 'production' === slug ) {
+							return {
+								supports: { 'gatherpress-event-date': true },
+								labels: { singular_name: 'Production' },
+							};
+						}
+						return mockGetPostType( slug );
+					},
+				};
+			}
+			return {};
+		} );
+
+		hasEventPastNotice();
+
+		expect( dispatch( 'core/notices' ).createNotice ).toHaveBeenCalledWith(
+			'warning',
+			'Production has already passed.',
 			{
 				id: 'gatherpress_event_past',
 				isDismissible: false,


### PR DESCRIPTION
Closes GatherPress/gatherpress#1722.

## Problem
When an event-supporting custom post type (e.g. a `production`) has passed, the editor notice still read **"This event has already passed."** — wrong noun for anything that isn't the default event post type.

## Fix
In `hasEventPastNotice()` (`src/helpers/event.js`), resolve the current post type's `singular_name` via the existing `getPostTypeLabel()` helper (the JS counterpart to `Utility::post_type_label()`, with caching), and render the notice as `"<Label> has already passed."`:

- `production` → **"Production has already passed."**
- default event post type → **"Event has already passed."** (label falls back to `__( 'Event' )` when unresolved)

Dropped the leading "This" per the issue discussion so the registered label carries the sentence and the casing reads naturally. The string is wrapped in `sprintf` with a translators comment.

## Notes
- `getPostTypeLabel` is imported from `./editor`, which already imports from `./event`; the references are runtime-only so the cycle is harmless, and the repo doesn't enable `import/no-cycle`.
- Added a unit test asserting the label-driven string for a `production` post type, alongside the existing default-event case. While here, hardened that test's `getPostType` mock to delegate to `mockGetPostType` for non-production slugs — the `getEventMeta` suite that follows was implicitly relying on the global `getPostType` mock left behind by the preceding test.
- `npm run lint:js` and the full `event.test.js` suite (90 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)