### PR TITLE
Harden RSVP front-end against failures and malformed blocks

### DIFF
--- a/.github/changelog/rsvp-button-disappears-guard
+++ b/.github/changelog/rsvp-button-disappears-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop the front-end RSVP button from vanishing when a request fails or the block markup is incomplete. The status switcher now falls back to the no_status state when no inner block matches, the request handler guards against missing/non-JSON responses and surfaces an error instead of failing silently, and the post-RSVP modal logic no longer throws on malformed markup.

--- a/src/blocks/rsvp/view.js
+++ b/src/blocks/rsvp/view.js
@@ -109,11 +109,19 @@ const { state, actions } = store( 'gatherpress', {
 				() => {
 					const parentWithRsvpStatus =
 						element.ref.closest( '[data-rsvp-status]' );
-					const rsvpStatus =
-						parentWithRsvpStatus.dataset.rsvpStatus;
-					const rsvpContainer = parentWithRsvpStatus.closest(
+					const rsvpContainer = parentWithRsvpStatus?.closest(
 						'.wp-block-gatherpress-rsvp',
 					);
+
+					// Bail if the expected wrappers aren't in the DOM
+					// (malformed/partial block markup) so we don't throw on a
+					// null reference and abort the post-RSVP UI update (#1719).
+					if ( ! parentWithRsvpStatus || ! rsvpContainer ) {
+						return;
+					}
+
+					const rsvpStatus =
+						parentWithRsvpStatus.dataset.rsvpStatus;
 
 					if ( [ 'not_attending', 'no_status' ].includes( rsvpStatus ) ) {
 						const attendingStatusButton =
@@ -189,20 +197,39 @@ const { state, actions } = store( 'gatherpress', {
 
 			const innerBlocks =
 				element.ref.querySelectorAll( '[data-rsvp-status]' );
+			const currentStatus = state.posts[ postId ].currentUser.status;
+
+			let matched = false;
 
 			innerBlocks.forEach( ( innerBlock ) => {
 				const parent = innerBlock.parentNode;
-				if (
-					innerBlock.dataset.rsvpStatus ===
-					state.posts[ postId ].currentUser.status
-				) {
+				if ( innerBlock.dataset.rsvpStatus === currentStatus ) {
 					innerBlock.classList.remove( 'gatherpress--is-hidden' );
 					// Move the visible block to the start of its parent.
 					parent.insertBefore( innerBlock, parent.firstChild );
+					matched = true;
 				} else {
 					innerBlock.classList.add( 'gatherpress--is-hidden' );
 				}
 			} );
+
+			// Fallback: if the saved block is missing the inner block for the
+			// current status (malformed or partial markup), the loop above
+			// hides every state and leaves nothing on screen. Re-show the
+			// no_status block so the RSVP button never fully disappears (#1719).
+			if ( ! matched ) {
+				const fallback = element.ref.querySelector(
+					'[data-rsvp-status="no_status"]',
+				);
+
+				if ( fallback ) {
+					fallback.classList.remove( 'gatherpress--is-hidden' );
+					fallback.parentNode.insertBefore(
+						fallback,
+						fallback.parentNode.firstChild,
+					);
+				}
+			}
 		},
 		updateGuestCountDisplay() {
 			const context = getContext();

--- a/src/helpers/interactivity.js
+++ b/src/helpers/interactivity.js
@@ -2,8 +2,34 @@
  * WordPress dependencies
  */
 import { store } from '@wordpress/interactivity';
+import { __ } from '@wordpress/i18n';
 
 const { state: gatherPressState } = store( 'gatherpress' );
+
+/**
+ * Surface an RSVP request failure to the user.
+ *
+ * Logs the underlying error for debugging and shows a brief alert so a failed
+ * request doesn't leave the UI in a silent half-updated state. Mirrors the
+ * server-error handling in the rsvp-form block (#1719).
+ *
+ * @since 0.34.0
+ *
+ * @param {*} [error=null] Optional error to log for debugging.
+ *
+ * @return {void}
+ */
+function notifyRsvpFailure( error = null ) {
+	// eslint-disable-next-line no-console
+	console.warn( 'RSVP API request failed:', error );
+	// eslint-disable-next-line no-alert
+	alert(
+		__(
+			'Sorry, there was an issue processing your RSVP. Please try again.',
+			'gatherpress'
+		)
+	);
+}
 
 /**
  * Initializes the post context within the application state.
@@ -216,16 +242,13 @@ export async function sendRsvpApiRequest(
 	try {
 		const res = await makeRequest();
 
-		if ( res.success ) {
+		// `makeRequest` resolves to undefined when the nonce can't be fetched,
+		// and to a `{ success: false }` / error payload when the server (or a
+		// proxy/WAF returning non-JSON) rejects the request. Guard against both
+		// so a failed request surfaces an error instead of throwing on
+		// `res.success` and leaving the button hidden (#1719).
+		if ( res?.success ) {
 			if ( state ) {
-				// eslint-disable-next-line no-console
-				console.log( '[RSVP API] Response received:', {
-					postId,
-					status: res.status,
-					onlineLink: res.online_link,
-					fullResponse: res,
-				} );
-
 				state.posts[ postId ] = {
 					...state.posts[ postId ],
 					eventResponses: {
@@ -240,19 +263,16 @@ export async function sendRsvpApiRequest(
 					},
 					onlineEventLink: res.online_link || '',
 				};
-
-				// eslint-disable-next-line no-console
-				console.log( '[RSVP API] State updated:', state.posts[ postId ] );
 			}
 
 			if ( 'function' === typeof onSuccess ) {
 				onSuccess( res );
 			}
+		} else {
+			notifyRsvpFailure();
 		}
 	} catch ( error ) {
-		// Handle error silently - log for debugging but don't interrupt user.
-		// eslint-disable-next-line no-console
-		console.warn( 'RSVP API request failed:', error );
+		notifyRsvpFailure( error );
 	} finally {
 		// Always remove loading class when request completes.
 		if ( loadingElement ) {

--- a/src/helpers/interactivity.js
+++ b/src/helpers/interactivity.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { store } from '@wordpress/interactivity';
-import { __ } from '@wordpress/i18n';
 
 const { state: gatherPressState } = store( 'gatherpress' );
 
@@ -12,6 +11,11 @@ const { state: gatherPressState } = store( 'gatherpress' );
  * Logs the underlying error for debugging and shows a brief alert so a failed
  * request doesn't leave the UI in a silent half-updated state. Mirrors the
  * server-error handling in the rsvp-form block (#1719).
+ *
+ * The message is a plain string, not wrapped in `__()`: this helper runs in the
+ * Interactivity API script-module graph (`wp-scripts build --experimental-modules`),
+ * which does not support `@wordpress/i18n` as a module dependency yet — the same
+ * reason the rsvp-form block hardcodes its alert copy.
  *
  * @since 0.34.0
  *
@@ -24,10 +28,7 @@ function notifyRsvpFailure( error = null ) {
 	console.warn( 'RSVP API request failed:', error );
 	// eslint-disable-next-line no-alert
 	alert(
-		__(
-			'Sorry, there was an issue processing your RSVP. Please try again.',
-			'gatherpress'
-		)
+		'Sorry, there was an issue processing your RSVP. Please try again.'
 	);
 }
 


### PR DESCRIPTION
Addresses GatherPress/gatherpress#1719 ("RSVP button disappears after rsvp" / "RSVP API request failed"), reported on a WP 7.0 / PHP 8.3 staging site behind a proxy, running core `0.34.0-beta.1` alongside GatherPress Alpha `0.34.0-alpha.2`.

The root cause looks environment-specific (malformed/partial block markup and/or a proxy intercepting `/wp-json/` so the response isn't JSON — see the issue thread). These are **defensive fixes** that make the front end degrade gracefully and stop the symptom regardless of the underlying trigger. They are not a substitute for the reporter's raw blocks / Network response, but the first fix alone would have prevented the button from vanishing.

## Why the button disappeared
`renderRsvpBlock` in [view.js](src/blocks/rsvp/view.js) shows the inner block whose `data-rsvp-status` matches `currentUser.status` and hides all others — **with no fallback**. If the saved block is missing the inner block for the status the user transitions to, every state (including the `no_status` button) gets hidden and nothing replaces it.

## Changes
1. **Fallback in `renderRsvpBlock`** — when no inner block matches the current status, re-show the `no_status` block so the RSVP button never fully disappears.
2. **Guard `sendRsvpApiRequest`** ([interactivity.js](src/helpers/interactivity.js)) — `makeRequest` resolves to `undefined` when the nonce can't be fetched and to a non-success/error payload when a proxy/WAF returns non-JSON. Switched the success check to `res?.success` (no more throw on `res.success`) and surface a brief `alert()` on failure, matching the existing rsvp-form error handling, instead of a silent `console.warn`.
3. **Removed two shipped debug `console.log`s** (`[RSVP API] Response received` / `State updated`).
4. **Null-guard the `updateRsvp` success callback** — bail when the `[data-rsvp-status]` wrapper or `.wp-block-gatherpress-rsvp` container isn't in the DOM, so a `null` `closest()` doesn't throw and abort the post-RSVP UI update.

## Testing
- `npm run lint:js` clean on both files.
- Existing `src/blocks/rsvp` unit suites pass (42 tests).
- Both files are in `sonar.coverage.exclusions` (interactivity/view files are exercised via the Playwright `rsvp-flows` e2e, not unit tests), so no unit coverage gate applies. Behavior is best verified against the reporter's raw blocks once provided.

## Follow-ups (not in this PR)
- Get the reporter's raw blocks + the `/rsvp` Network response (status + body) to pin the real trigger.
- The core `0.34.0-beta.1` + Alpha `0.34.0-alpha.2` version mismatch is a strong suspect for the malformed markup — worth asking them to match versions / deactivate Alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)