### PR TITLE
Guard "Venue Settings" against venue post type being selected

### DIFF
--- a/.github/changelog/1734-guard-venue-settings-on-venue-information-supporting-types
+++ b/.github/changelog/1734-guard-venue-settings-on-venue-information-supporting-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only show "Venue Settings" panel for post types supporting `gatherpress-venue-information`

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -411,7 +411,7 @@ const Edit = ( props ) => {
 					) ) }
 			</BlockContextProvider>
 			<InspectorControls>
-				{ ! isDescendentOfQueryLoop && ! isInFSETemplate() && isEventContext && (
+				{ 'gatherpress_venue' === sourcePostType && ! isDescendentOfQueryLoop && ! isInFSETemplate() && isEventContext && (
 					<PanelBody
 						title={ __( 'Venue settings', 'gatherpress' ) }
 						initialOpen={ true }

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -151,6 +151,8 @@ const Edit = ( props ) => {
 	// any shadow-source-supporting CPT without renaming.
 	const sourcePostType =
 		attributes?.sourcePostType || getVenuePostType( effectivePostType );
+	// Only a venue-information source has anything to configure in this panel.
+	const isVenueSource = usePostTypeSupports( 'gatherpress-venue-information', sourcePostType );
 	const venuePostType =
 		'venue' === overrideResolution?.kind
 			? overrideResolution.postType
@@ -411,7 +413,7 @@ const Edit = ( props ) => {
 					) ) }
 			</BlockContextProvider>
 			<InspectorControls>
-				{ 'gatherpress_venue' === sourcePostType && ! isDescendentOfQueryLoop && ! isInFSETemplate() && isEventContext && (
+				{ isVenueSource && ! isDescendentOfQueryLoop && ! isInFSETemplate() && isEventContext && (
 					<PanelBody
 						title={ __( 'Venue settings', 'gatherpress' ) }
 						initialOpen={ true }


### PR DESCRIPTION
Fixes #1724

## Proposed changes:

The `gatherpress/venue` block can be used through custom block variations that re-point it at a different shadow-source CPT via the `sourcePostType` attribute (for example the "Productions Details" block in [gatherpress-productions](https://github.com/carstingaxion/gatherpress-productions), which sets `sourcePostType: "gatherpress_play"`). When such a variation is selected in the editor, the sidebar still exposed the **Venue settings** panel (the `VenueNavigator` term picker), even though that control is meaningless for a non-venue source.

This PR guards the `InspectorControls` panel in [`src/blocks/venue/edit.js`](src/blocks/venue/edit.js) so it only renders when the block's resolved `sourcePostType` is an actual venue source, in addition to the existing `! isDescendentOfQueryLoop && ! isInFSETemplate() && isEventContext` conditions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Open the [Playground demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/carstingaxion/gatherpress-productions/main/.wordpress-org/blueprints/blueprint.json) for gatherpress-productions (or run the PR build with the gatherpress-productions plugin active).
2. Create a Production.
3. Create an Event and relate it to the Production.
4. Add the **Productions Details** block (a variation of `gatherpress/venue` with `sourcePostType` set to `gatherpress_play`) to the event.
5. Select the block and open the sidebar.

**Expected:** the **Venue settings** panel is NOT shown for the Productions Details block.

**Regression checks (should be unchanged):**
- A normal `gatherpress/venue` block on an event still shows **Venue settings**.
- Editing a venue post directly still behaves as before (panel hidden there because it is not an event context).

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Guard "Venue Settings" against venue post type being selected

</details>
