### PR TITLE
#1730 - Fix misleading single-event iCal URL in calendar tests

### DIFF
--- a/.github/changelog/fix-ical-download-url-test
+++ b/.github/changelog/fix-ical-download-url-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix misleading single-event iCal URL in calendar test fixtures. [#1730]

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -151,7 +151,6 @@ class Test_Calendar extends Base {
 			'gatherpress_calendar=' . Setup::ICAL_SLUG,
 			$plain_url
 		);
-
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -133,26 +133,25 @@ class Test_Calendar extends Base {
 		$path_filter = static function () {
 			return home_url( '/event/sample-event/' );
 		};
-		add_filter( 'post_link', $path_filter, 10, 1 );
-		add_filter( 'post_type_link', $path_filter, 10, 1 );
+		add_filter( 'post_link', $path_filter );
+		add_filter( 'post_type_link', $path_filter );
 
 		$pretty_url = ( new Calendar( $event_id ) )->get_ical_url();
 
-		remove_filter( 'post_link', $path_filter, 10 );
-		remove_filter( 'post_type_link', $path_filter, 10 );
+		remove_filter( 'post_link', $path_filter );
+		remove_filter( 'post_type_link', $path_filter );
 
 		$plain_url = ( new Calendar( $event_id ) )->get_ical_url();
 
 		$this->assertIsString( $pretty_url );
 		$this->assertStringContainsString( 'sample-event/ical', $pretty_url );
-		$this->assertStringNotContainsString( 'feed/ical', $pretty_url );
 
 		$this->assertIsString( $plain_url );
 		$this->assertStringContainsString(
 			'gatherpress_calendar=' . Setup::ICAL_SLUG,
 			$plain_url
 		);
-		$this->assertStringNotContainsString( 'feed/ical', $plain_url );
+
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -116,6 +116,46 @@ class Test_Calendar extends Base {
 	}
 
 	/**
+	 * Single-event iCal downloads must not use the feed/ical URL shape.
+	 *
+	 * With pretty permalinks, the download is …/event/<slug>/ical/. With plain
+	 * permalinks, WordPress uses the gatherpress_calendar query arg instead —
+	 * never get_post_comments_feed_link() (…/feed/ical/), which is for feeds only.
+	 *
+	 * @covers ::get_ical_url
+	 * @covers ::get_endpoint_url
+	 *
+	 * @return void
+	 */
+	public function test_get_ical_url_uses_permalink_download_path(): void {
+		$event_id = $this->make_event();
+
+		$path_filter = static function () {
+			return home_url( '/event/sample-event/' );
+		};
+		add_filter( 'post_link', $path_filter, 10, 1 );
+		add_filter( 'post_type_link', $path_filter, 10, 1 );
+
+		$pretty_url = ( new Calendar( $event_id ) )->get_ical_url();
+
+		remove_filter( 'post_link', $path_filter, 10 );
+		remove_filter( 'post_type_link', $path_filter, 10 );
+
+		$plain_url = ( new Calendar( $event_id ) )->get_ical_url();
+
+		$this->assertIsString( $pretty_url );
+		$this->assertStringContainsString( 'sample-event/ical', $pretty_url );
+		$this->assertStringNotContainsString( 'feed/ical', $pretty_url );
+
+		$this->assertIsString( $plain_url );
+		$this->assertStringContainsString(
+			'gatherpress_calendar=' . Setup::ICAL_SLUG,
+			$plain_url
+		);
+		$this->assertStringNotContainsString( 'feed/ical', $plain_url );
+	}
+
+	/**
 	 * Coverage for get_outlook_url — uses the `outlook` sibling slug pointing
 	 * at the same iCal template.
 	 *

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -1290,7 +1290,7 @@ class Test_Setup extends Base {
 				'attr' => 'Example iCal Feed',
 			),
 			array(
-				'url'  => 'https://example.org/event/sample/feed/ical/',
+				'url'  => 'https://example.org/event/sample/ical/',
 				'attr' => 'Example iCal Download',
 			),
 		);


### PR DESCRIPTION
Fixes #1730

## Proposed changes:
- Fix `render_alternate_links` test fixture: single-event download uses `…/event/sample/ical/` (not `…/feed/ical/`).
- Add regression test for `get_ical_url()`.

Test-only. Follow-up to #1673 review.

### Other information:

- [x] Have you written new tests for your changes, if applicable?



WordPress.org username: vineettalwar

## Testing instructions:

```bash
npm run test:unit:php -- --filter 'test_render_alternate_links_prints_link_tags|test_get_ical_url_uses_permalink_download_path'



