### PR TITLE
Fix misleading single-event iCal URL in render_alternate_links test fixture

### DIFF
--- a/.github/changelog/fix-ical-download-url-test-fixture
+++ b/.github/changelog/fix-ical-download-url-test-fixture
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Correct the misleading `/event/sample/feed/ical/` test-fixture URL in `test_render_alternate_links_prints_link_tags` to the real single-event iCal download shape (`/event/sample/ical/`). [#1730]

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -116,6 +116,29 @@ class Test_Calendar extends Base {
 	}
 
 	/**
+	 * Regression for #1730 — single-event iCal download URL must use the
+	 * `ical` slug directly, never `feed/ical`.
+	 *
+	 * @covers ::get_ical_url
+	 * @covers ::get_endpoint_url
+	 *
+	 * @return void
+	 */
+	public function test_get_ical_url_does_not_use_feed_slug(): void {
+		$instance = new Calendar( $this->make_event() );
+
+		$url = $instance->get_ical_url();
+
+		$this->assertIsString( $url );
+		$this->assertStringNotContainsString(
+			'feed',
+			$url,
+			'Single-event iCal download URL must not contain "feed" — ' .
+			'download uses /ical/ directly; /feed/ical/ is for feed endpoints only.'
+		);
+	}
+
+	/**
 	 * Coverage for get_outlook_url — uses the `outlook` sibling slug pointing
 	 * at the same iCal template.
 	 *

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -1290,7 +1290,7 @@ class Test_Setup extends Base {
 				'attr' => 'Example iCal Feed',
 			),
 			array(
-				'url'  => 'https://example.org/event/sample/feed/ical/',
+				'url'  => 'https://example.org/event/sample/ical/',
 				'attr' => 'Example iCal Download',
 			),
 		);


### PR DESCRIPTION
Fixes #1730

## Summary

The `test_render_alternate_links_prints_link_tags()` fixture used `/event/sample/feed/ical/` (the feed URL shape) for an entry labelled `"iCal Download"`. Those are two distinct URL contracts in GatherPress:

- **Single-event download** → `…/event/<slug>/ical/` (no `/feed/` segment)
- **Feed** → `…/event/<slug>/feed/ical/`

No production code was broken — `Calendar::get_ical_url()` already emits the correct shape — but the misleading fixture implied the wrong URL contract to anyone reading the test.

**Changes:**
- Corrects the fixture URL from `…/feed/ical/` → `…/ical/`
- Adds `test_get_ical_url_does_not_use_feed_slug()` as a regression lock: asserts the download URL never contains `"feed"`, so a future refactor that accidentally swaps the slugs will produce a named, descriptive failure
- Adds a `patch`-level changelog entry

## Testing steps

1. `npm run build && npm run test:unit:php -- --filter="test_render_alternate_links|test_get_ical_url"`
2. Confirm **3 tests, 8 assertions, OK**
3. Optionally mutate `get_ical_url()` to return `'feed/' . Setup::ICAL_SLUG` and confirm both new assertions fail with clear messages, then revert