### PR TITLE
Make Online Event Link a URL field and space it from the toggle

### DIFF
--- a/.github/changelog/1745-from-description
+++ b/.github/changelog/1745-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make the Online Event Link field a URL input and add spacing between the toggle and the field

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -7,7 +7,13 @@ import {
 	InspectorControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import {
+	PanelBody,
+	TextControl,
+	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -216,22 +222,31 @@ const Edit = ( { attributes, context } ) => {
 						title={ __( 'Online Event Settings', 'gatherpress' ) }
 						initialOpen={ true }
 					>
-						<ToggleControl
-							label={ __( 'This is an online event', 'gatherpress' ) }
-							checked={ isOnlineEvent }
-							onChange={ toggleOnlineEvent }
-						/>
-						{ isOnlineEvent && (
-							<TextControl
-								label={ __( 'Online event link', 'gatherpress' ) }
-								value={ onlineEventLink }
-								placeholder={ __(
-									'Add link to online event',
+						<VStack spacing={ 3 }>
+							<ToggleControl
+								label={ __(
+									'This is an online event',
 									'gatherpress'
 								) }
-								onChange={ updateOnlineEventLink }
+								checked={ isOnlineEvent }
+								onChange={ toggleOnlineEvent }
 							/>
-						) }
+							{ isOnlineEvent && (
+								<TextControl
+									type="url"
+									label={ __(
+										'Online event link',
+										'gatherpress'
+									) }
+									value={ onlineEventLink }
+									placeholder={ __(
+										'Add link to online event',
+										'gatherpress'
+									) }
+									onChange={ updateOnlineEventLink }
+								/>
+							) }
+						</VStack>
 					</PanelBody>
 				</InspectorControls>
 			) }

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -222,7 +222,7 @@ const Edit = ( { attributes, context } ) => {
 						title={ __( 'Online Event Settings', 'gatherpress' ) }
 						initialOpen={ true }
 					>
-						<VStack spacing={ 3 }>
+						<VStack spacing={ 2 }>
 							<ToggleControl
 								label={ __(
 									'This is an online event',

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -222,7 +222,7 @@ const Edit = ( { attributes, context } ) => {
 						title={ __( 'Online Event Settings', 'gatherpress' ) }
 						initialOpen={ true }
 					>
-						<VStack spacing={ 2 }>
+						<VStack spacing={ 3 }>
 							<ToggleControl
 								label={ __(
 									'This is an online event',

--- a/src/components/OnlineEvent.js
+++ b/src/components/OnlineEvent.js
@@ -139,7 +139,7 @@ const OnlineEvent = () => {
 	};
 
 	return (
-		<VStack spacing={ 2 }>
+		<VStack spacing={ 3 }>
 			<ToggleControl
 				label={ __( 'This is an online event', 'gatherpress' ) }
 				checked={ isOnlineEvent }

--- a/src/components/OnlineEvent.js
+++ b/src/components/OnlineEvent.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import { TextControl, ToggleControl } from '@wordpress/components';
+import {
+	TextControl,
+	ToggleControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 
@@ -134,7 +139,7 @@ const OnlineEvent = () => {
 	};
 
 	return (
-		<>
+		<VStack spacing={ 3 }>
 			<ToggleControl
 				label={ __( 'This is an online event', 'gatherpress' ) }
 				checked={ isOnlineEvent }
@@ -142,6 +147,7 @@ const OnlineEvent = () => {
 			/>
 			{ isOnlineEvent && (
 				<TextControl
+					type="url"
 					label={ __( 'Online event link', 'gatherpress' ) }
 					value={ onlineEventLink }
 					placeholder={ __( 'Add link to online event', 'gatherpress' ) }
@@ -150,7 +156,7 @@ const OnlineEvent = () => {
 					} }
 				/>
 			) }
-		</>
+		</VStack>
 	);
 };
 

--- a/src/components/OnlineEvent.js
+++ b/src/components/OnlineEvent.js
@@ -139,7 +139,7 @@ const OnlineEvent = () => {
 	};
 
 	return (
-		<VStack spacing={ 3 }>
+		<VStack spacing={ 2 }>
 			<ToggleControl
 				label={ __( 'This is an online event', 'gatherpress' ) }
 				checked={ isOnlineEvent }


### PR DESCRIPTION
Fixes #1742

## Proposed changes:

The Online Event Link field used the default text input type, so non-URL values (physical addresses, plain text like `Dubai Mall station, Dubai, 00000`) were accepted, saved, and rendered on the frontend as if they were links.

- Set the link field to `type="url"` so the input is a URL field. This applies in both places that render the toggle + link pair:
  - the Online Event block inspector — `src/blocks/online-event/edit.js`
  - the venue-settings sidebar panel — `src/components/OnlineEvent.js`
- Wrap the "This is an online event" toggle and the link field in a `VStack` so there is visible spacing between the toggle and the "Online event link" label, matching the spacing idiom already used by the sibling settings panels.

> [!NOTE]
> The two surfaces share this toggle + field markup (and most of the meta/term logic). This PR keeps the fix minimal and applies it in both places; extracting a shared presentational component is a reasonable follow-up if we want to stop the two from drifting.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Create or edit an Event.
2. Add the Online Event block and enable "This is an online event".
3. Observe there is now spacing between the toggle and the "Online event link" field.
4. The link field is now a URL input. Browsers surface URL affordances/validation, and the intent is clearly a URL rather than free text.
5. Repeat via the venue-settings sidebar panel surface to confirm both render the same way.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Make the Online Event Link field a URL input and add spacing between the toggle and the field

</details>
