### PR TITLE
Degrade gracefully when interactive map tiles fail to load

### DIFF
--- a/.github/changelog/map-tile-graceful-degradation
+++ b/.github/changelog/map-tile-graceful-degradation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show a clear "Map could not be loaded" state instead of a blank gray box when the interactive map's tile provider fails to serve tiles (e.g. CartoDB returning 502s for uncached high-zoom tiles). A failed tile fetch no longer leaves the map silently empty.

--- a/src/components/OpenStreetMap.js
+++ b/src/components/OpenStreetMap.js
@@ -269,7 +269,9 @@ const OpenStreetMap = ( props ) => {
 						position: 'absolute',
 						inset: 0,
 						display: 'flex',
-						alignItems: 'center',
+						// Pin the message to the top so it clears the centered
+						// map marker, which Leaflet paints above the overlay.
+						alignItems: 'flex-start',
 						justifyContent: 'center',
 						padding: '1rem',
 						textAlign: 'center',

--- a/src/components/OpenStreetMap.js
+++ b/src/components/OpenStreetMap.js
@@ -42,6 +42,7 @@ const OpenStreetMap = ( props ) => {
 		pluginUrl,
 	} = props;
 	const [ Leaflet, setLeaflet ] = useState( null );
+	const [ tilesFailed, setTilesFailed ] = useState( false );
 	const mapId = `map-${ uuidv4() }`;
 	const mapRef = useRef( null );
 	const mapInstanceRef = useRef( null );
@@ -141,9 +142,26 @@ const OpenStreetMap = ( props ) => {
 				'<a href="https://carto.com/attributions">CARTO</a>'
 			);
 
-		Leaflet.tileLayer( tileUrl, {
+		// Surface a clear "unavailable" state instead of a blank gray map when
+		// the tile provider fails (e.g. CartoDB returning 502s for uncached
+		// high-zoom tiles). Only flag failure when no tile has loaded — a few
+		// stray edge-tile errors on an otherwise-working basemap shouldn't
+		// trip the message (#1731).
+		setTilesFailed( false );
+		let tilesLoaded = 0;
+		const tileLayer = Leaflet.tileLayer( tileUrl, {
 			attribution: tileAttribution,
-		} ).addTo( map );
+		} );
+		tileLayer.on( 'tileload', () => {
+			tilesLoaded += 1;
+			setTilesFailed( false );
+		} );
+		tileLayer.on( 'tileerror', () => {
+			if ( 0 === tilesLoaded ) {
+				setTilesFailed( true );
+			}
+		} );
+		tileLayer.addTo( map );
 
 		// Center the marker icon on the coord (both axes) so the pin's
 		// visual center matches the map center — mirrors the static map's
@@ -221,16 +239,53 @@ const OpenStreetMap = ( props ) => {
 		return null;
 	}
 
-	// Add inert attribute in editor to prevent all interactions and focus.
-	const mapProps = {
+	// Wrap the Leaflet container so the tile-failure overlay can sit on top of
+	// it. Add inert in the editor to prevent all interactions and focus.
+	const wrapperProps = {
 		className,
-		id: mapId,
-		ref: mapRef,
-		style,
+		// Carry the block's border-radius down so the Leaflet container (and the
+		// failure overlay) stay clipped to the same rounded corners — the inner
+		// elements inherit from this wrapper.
+		style: {
+			...style,
+			position: 'relative',
+			borderRadius: 'inherit',
+			overflow: 'hidden',
+		},
 		...( isPostEditor && { inert: '' } ),
 	};
 
-	return <div { ...mapProps }></div>;
+	return (
+		<div { ...wrapperProps }>
+			<div
+				id={ mapId }
+				ref={ mapRef }
+				style={ { width: '100%', height: '100%', borderRadius: 'inherit' } }
+			></div>
+			{ tilesFailed && (
+				<output
+					className="gatherpress-venue-map__tile-error"
+					style={ {
+						position: 'absolute',
+						inset: 0,
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						padding: '1rem',
+						textAlign: 'center',
+						backgroundColor: '#e0e0e0',
+						color: '#757575',
+						borderRadius: 'inherit',
+					} }
+				>
+					{ __(
+						'Map could not be loaded. Please try again later.',
+						'gatherpress'
+					) }
+				</output>
+			) }
+		</div>
+	);
 };
 
 export default OpenStreetMap;


### PR DESCRIPTION
Closes #1731.

## Problem
The interactive (Leaflet) OSM map created its tile layer with no error handling:
```js
Leaflet.tileLayer( tileUrl, { attribution } ).addTo( map );
```
So when the tile provider failed — e.g. CartoDB returning **502** for uncached high-zoom tiles in less-trafficked areas (the root cause diagnosed in #1731) — the map rendered as a silent **blank gray box** with no indication anything was wrong. Google Maps was unaffected since it uses its own tiles.

## Fix
Track Leaflet's `tileload` / `tileerror` events and, when **no tile loads at all**, overlay a clear unavailable state instead of leaving the container empty:

> Map could not be loaded. Please try again later.

- The threshold is "zero tiles loaded" — a few stray edge-tile errors on an otherwise-working basemap won't trip the message. The moment any tile loads, the message clears.
- The message is an `<output>` element (implicit `role="status"`) so assistive tech announces it.
- The Leaflet container is now wrapped so the overlay can sit on top; `border-radius` is carried down through the wrapper so block-level rounded corners are preserved.

This satisfies the issue's acceptance criterion: a failed tile fetch no longer results in a fully blank interactive map — the user sees tiles, or a clear "unavailable" state.

## Notes / scope
- Deliberately did **not** add `maxNativeZoom` — as discussed in #1731 the failures were non-monotonic, so capping native zoom is a blunt instrument that softens detail everywhere. The graceful-state approach handles any tile failure, not just the high-zoom case.
- Auto-retry/backoff and a static-map fallback are possible future enhancements but kept out of scope here.

## Testing
- `npm run lint:js` clean; `npm run build` (incl. `--experimental-modules`) compiles.
- `src/components/**` is in `sonar.coverage.exclusions` (these map components are exercised via e2e, not unit), so no unit-coverage gate applies.
- **Runtime check still recommended before merge:** force a failure by pointing the tile URL at a bad host via the `gatherpress_interactive_map_tile_url` filter and confirm the overlay appears (the CartoDB 502s have since recovered, so they can't be reproduced naturally right now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)