### PR TITLE
Fix/1735 useselect stable refs

### DIFF
--- a/.github/changelog/fix-1735-useselect-stable-refs
+++ b/.github/changelog/fix-1735-useselect-stable-refs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The venue-map block returned new empty-object references from its useSelect selector on every render, triggering Gutenberg's "Non-equal value keys" warning and causing unnecessary re-renders when no venue address was set.

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -94,6 +94,7 @@ const LINK_DESTINATION_CUSTOM = 'custom';
 // the underlying data is absent.
 const EMPTY_META = Object.freeze( {} );
 const EMPTY_STATIC_MAP_DESCRIPTORS = Object.freeze( {} );
+const EMPTY_POST = Object.freeze( {} );
 
 /**
  * Build the canonical external-map URL for a preset destination.
@@ -192,7 +193,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 				const meta =
 					select( 'core/editor' )?.getEditedPostAttribute( 'meta' ) || EMPTY_META;
 				const savedPost =
-					select( 'core/editor' )?.getCurrentPost() || {};
+					select( 'core/editor' )?.getCurrentPost() || EMPTY_POST;
 				// Prefer the `core` entity cache for the descriptors map —
 				// `regenerate` patches that cache directly via
 				// receiveEntityRecords, but `core/editor`'s in-memory copy of

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -87,6 +87,14 @@ const LINK_DESTINATION_OPENSTREETMAP = 'openstreetmap';
 const LINK_DESTINATION_GOOGLE = 'google';
 const LINK_DESTINATION_CUSTOM = 'custom';
 
+// Stable empty-object sentinels used as fallbacks in the useSelect selector.
+// Returning inline `{}` literals on every call creates new references each
+// render, triggering Gutenberg's "Non-equal value keys" warning and causing
+// unnecessary re-renders. Frozen constants ensure referential stability when
+// the underlying data is absent.
+const EMPTY_META = Object.freeze( {} );
+const EMPTY_STATIC_MAP_DESCRIPTORS = Object.freeze( {} );
+
 /**
  * Build the canonical external-map URL for a preset destination.
  *
@@ -169,9 +177,9 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 			if ( ! effectiveVenuePostId ) {
 				return {
 					isEditingThisVenue: false,
-					venueMeta: {},
-					savedVenueMeta: {},
-					staticMapDescriptors: {},
+					venueMeta: EMPTY_META,
+					savedVenueMeta: EMPTY_META,
+					staticMapDescriptors: EMPTY_STATIC_MAP_DESCRIPTORS,
 					venuePostId: 0,
 					venuePostType: '',
 				};
@@ -182,7 +190,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 
 			if ( isEditing ) {
 				const meta =
-					select( 'core/editor' )?.getEditedPostAttribute( 'meta' ) || {};
+					select( 'core/editor' )?.getEditedPostAttribute( 'meta' ) || EMPTY_META;
 				const savedPost =
 					select( 'core/editor' )?.getCurrentPost() || {};
 				// Prefer the `core` entity cache for the descriptors map —
@@ -198,11 +206,11 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 				return {
 					isEditingThisVenue: true,
 					venueMeta: meta,
-					savedVenueMeta: savedPost?.meta || {},
+					savedVenueMeta: savedPost?.meta || EMPTY_META,
 					staticMapDescriptors:
 						editedVenuePost?.meta?.gatherpress_static_map ||
 						meta?.gatherpress_static_map ||
-						{},
+						EMPTY_STATIC_MAP_DESCRIPTORS,
 					venuePostId: effectiveVenuePostId,
 					venuePostType: resolvedVenuePostType,
 				};
@@ -215,14 +223,14 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 				effectiveVenuePostId
 			);
 
-			const meta = venuePost?.meta || {};
+			const meta = venuePost?.meta || EMPTY_META;
 
 			return {
 				isEditingThisVenue: false,
 				venueMeta: meta,
 				savedVenueMeta: meta,
 				staticMapDescriptors:
-					meta?.gatherpress_static_map || {},
+					meta?.gatherpress_static_map || EMPTY_STATIC_MAP_DESCRIPTORS,
 				venuePostId: effectiveVenuePostId,
 				venuePostType: context?.postType || '',
 			};

--- a/test/unit/js/src/blocks/venue-map/edit.test.js
+++ b/test/unit/js/src/blocks/venue-map/edit.test.js
@@ -1,0 +1,318 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { render } from '@testing-library/react';
+
+/**
+ * Mocks — declared before the component import so jest hoists them.
+ *
+ * The goal of this test file is to verify that the useSelect selector in the
+ * venue-map Edit block returns stable object references for venueMeta,
+ * savedVenueMeta, and staticMapDescriptors across multiple calls with the same
+ * underlying state. Unstable references trigger Gutenberg's "Non-equal value
+ * keys" warning and unnecessary re-renders (issue #1735).
+ */
+
+// Capture the venue-state selector from the Edit block's first useSelect call
+// so we can invoke it directly in tests.
+let capturedVenueStateSelector = null;
+
+// A minimal select mock that puts the block into the early-bail path:
+// effectiveVenuePostId === 0 because both context.postId and
+// core/editor.getCurrentPostId() return falsy values.
+const noVenueMockSelect = ( storeName ) => {
+	switch ( storeName ) {
+		case 'core/editor':
+			return {
+				getCurrentPostId: () => 0,
+				getCurrentPostType: () => '',
+				getEditedPostAttribute: () => null,
+				getCurrentPost: () => null,
+			};
+		case 'core':
+			return { getEditedEntityRecord: () => null };
+		case 'core/block-editor':
+			return { getBlockParentsByBlockName: () => [] };
+		case 'gatherpress/venue':
+			return {
+				getVenueLatitude: () => null,
+				getVenueLongitude: () => null,
+			};
+		default:
+			return {};
+	}
+};
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn( ( selector ) => {
+		const result = selector( noVenueMockSelect );
+		// Identify the venue-state selector by its return shape.
+		if (
+			null !== result &&
+			'object' === typeof result &&
+			'venueMeta' in result
+		) {
+			capturedVenueStateSelector = selector;
+		}
+		return result;
+	} ),
+	useDispatch: jest.fn( () => ( {} ) ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+} ) );
+
+jest.mock( '@wordpress/element', () => ( {
+	useEffect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	BlockControls: ( { children } ) => <div>{ children }</div>,
+	InspectorControls: ( { children } ) => <div>{ children }</div>,
+	useBlockProps: jest.fn( () => ( {} ) ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Dropdown: ( { renderToggle, renderContent } ) => (
+		<div>
+			{ renderToggle( { isOpen: false, onToggle: () => {} } ) }
+			{ renderContent() }
+		</div>
+	),
+	Flex: ( { children } ) => <div>{ children }</div>,
+	FlexItem: ( { children } ) => <div>{ children }</div>,
+	PanelBody: ( { children } ) => <div>{ children }</div>,
+	RangeControl: () => null,
+	ResizableBox: ( { children } ) => <div>{ children }</div>,
+	SelectControl: () => null,
+	TextControl: () => null,
+	ToggleControl: () => null,
+	ToolbarButton: () => null,
+	ToolbarGroup: ( { children } ) => <div>{ children }</div>,
+	Icon: () => null,
+	__experimentalToolsPanel: ( { children } ) => <div>{ children }</div>,
+	__experimentalToolsPanelItem: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	Icon: () => null,
+	link: null,
+	mapMarker: null,
+} ) );
+
+jest.mock( '@src/helpers/venue', () => ( {
+	isVenuePostType: jest.fn( () => false ),
+} ) );
+
+jest.mock( '@src/helpers/editor', () => ( {
+	isInFSETemplate: jest.fn( () => false ),
+} ) );
+
+jest.mock( '@src/helpers/editor-settings', () => ( {
+	getFromSettings: jest.fn( () => null ),
+} ) );
+
+jest.mock( '@src/components/MapEmbed', () => () => null );
+
+jest.mock( '@src/components/GoogleMap', () => ( {
+	GOOGLE_IFRAME_UNSUPPORTED_MAP_TYPE_SLUGS: [],
+	GOOGLE_MAP_TYPE_DEFINITIONS: [],
+	toMapsEmbedApiMapType: jest.fn( ( type ) => type ),
+} ) );
+
+jest.mock( '@src/supports/block-guard', () => ( {
+	useSharedBlockGuardState: jest.fn( () => [ false ] ),
+	generateBlockGuardStateKey: jest.fn(
+		( type, id ) => `${ type }:${ id }`
+	),
+} ) );
+
+jest.mock( '@src/blocks/venue-map/helpers', () => ( {
+	RegenerateMapButton: () => null,
+	parseAspectRatio: jest.fn( () => false ),
+	pickDescriptorForCombo: jest.fn( () => undefined ),
+	resolveDimensions: jest.fn( () => ( { width: 800, height: 400 } ) ),
+	usePlaceholderPolling: jest.fn(),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import Edit from '@src/blocks/venue-map/edit';
+
+const DEFAULT_ATTRIBUTES = {
+	zoom: 18,
+	type: 'roadmap',
+	width: 0,
+	height: 300,
+	aspectRatio: '2/1',
+	scale: 'cover',
+	renderMode: 'static',
+	align: '',
+	href: '',
+	linkDestination: 'none',
+	linkTarget: '',
+	rel: '',
+};
+
+describe( 'venue-map Edit useSelect selector stability', () => {
+	beforeEach( () => {
+		capturedVenueStateSelector = null;
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns the same venueMeta reference on repeated calls when there is no venue post', () => {
+		render(
+			<Edit
+				attributes={ DEFAULT_ATTRIBUTES }
+				setAttributes={ jest.fn() }
+				context={ {} }
+				clientId=""
+			/>
+		);
+
+		expect( capturedVenueStateSelector ).not.toBeNull();
+
+		const result1 = capturedVenueStateSelector( noVenueMockSelect );
+		const result2 = capturedVenueStateSelector( noVenueMockSelect );
+
+		expect( result1.venueMeta ).toBe( result2.venueMeta );
+	} );
+
+	it( 'returns the same savedVenueMeta reference on repeated calls when there is no venue post', () => {
+		render(
+			<Edit
+				attributes={ DEFAULT_ATTRIBUTES }
+				setAttributes={ jest.fn() }
+				context={ {} }
+				clientId=""
+			/>
+		);
+
+		expect( capturedVenueStateSelector ).not.toBeNull();
+
+		const result1 = capturedVenueStateSelector( noVenueMockSelect );
+		const result2 = capturedVenueStateSelector( noVenueMockSelect );
+
+		expect( result1.savedVenueMeta ).toBe( result2.savedVenueMeta );
+	} );
+
+	it( 'returns the same staticMapDescriptors reference on repeated calls when there is no venue post', () => {
+		render(
+			<Edit
+				attributes={ DEFAULT_ATTRIBUTES }
+				setAttributes={ jest.fn() }
+				context={ {} }
+				clientId=""
+			/>
+		);
+
+		expect( capturedVenueStateSelector ).not.toBeNull();
+
+		const result1 = capturedVenueStateSelector( noVenueMockSelect );
+		const result2 = capturedVenueStateSelector( noVenueMockSelect );
+
+		expect( result1.staticMapDescriptors ).toBe(
+			result2.staticMapDescriptors
+		);
+	} );
+
+	it( 'returns the same venueMeta reference when the venue post has null meta', () => {
+		const nullMetaSelect = ( storeName ) => {
+			switch ( storeName ) {
+				case 'core/editor':
+					return {
+						getCurrentPostId: () => 0,
+						getCurrentPostType: () => '',
+						getEditedPostAttribute: () => null,
+						getCurrentPost: () => null,
+					};
+				case 'core':
+					return {
+						// Venue post exists but has no meta.
+						getEditedEntityRecord: () => ( {
+							id: 99,
+							meta: null,
+						} ),
+					};
+				case 'core/block-editor':
+					return { getBlockParentsByBlockName: () => [] };
+				case 'gatherpress/venue':
+					return {
+						getVenueLatitude: () => null,
+						getVenueLongitude: () => null,
+					};
+				default:
+					return {};
+			}
+		};
+
+		// Render with a context.postId to bypass the early bail.
+		render(
+			<Edit
+				attributes={ DEFAULT_ATTRIBUTES }
+				setAttributes={ jest.fn() }
+				context={ { postId: 99, postType: 'gatherpress_venue' } }
+				clientId=""
+			/>
+		);
+
+		expect( capturedVenueStateSelector ).not.toBeNull();
+
+		const result1 = capturedVenueStateSelector( nullMetaSelect );
+		const result2 = capturedVenueStateSelector( nullMetaSelect );
+
+		expect( result1.venueMeta ).toBe( result2.venueMeta );
+	} );
+
+	it( 'returns the same staticMapDescriptors reference when the venue post has no static map meta', () => {
+		const noMapSelect = ( storeName ) => {
+			switch ( storeName ) {
+				case 'core/editor':
+					return {
+						getCurrentPostId: () => 0,
+						getCurrentPostType: () => '',
+						getEditedPostAttribute: () => null,
+						getCurrentPost: () => null,
+					};
+				case 'core':
+					return {
+						// Venue post with meta but no gatherpress_static_map key.
+						getEditedEntityRecord: () => ( {
+							id: 99,
+							meta: { gatherpress_address: '123 Main St' },
+						} ),
+					};
+				case 'core/block-editor':
+					return { getBlockParentsByBlockName: () => [] };
+				case 'gatherpress/venue':
+					return {
+						getVenueLatitude: () => null,
+						getVenueLongitude: () => null,
+					};
+				default:
+					return {};
+			}
+		};
+
+		render(
+			<Edit
+				attributes={ DEFAULT_ATTRIBUTES }
+				setAttributes={ jest.fn() }
+				context={ { postId: 99, postType: 'gatherpress_venue' } }
+				clientId=""
+			/>
+		);
+
+		expect( capturedVenueStateSelector ).not.toBeNull();
+
+		const result1 = capturedVenueStateSelector( noMapSelect );
+		const result2 = capturedVenueStateSelector( noMapSelect );
+
+		expect( result1.staticMapDescriptors ).toBe(
+			result2.staticMapDescriptors
+		);
+	} );
+} );

--- a/test/unit/js/src/blocks/venue-map/edit.test.js
+++ b/test/unit/js/src/blocks/venue-map/edit.test.js
@@ -5,14 +5,13 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { render } from '@testing-library/react';
 
 /**
- * Mocks — declared before the component import so jest hoists them.
- *
- * The goal of this test file is to verify that the useSelect selector in the
- * venue-map Edit block returns stable object references for venueMeta,
- * savedVenueMeta, and staticMapDescriptors across multiple calls with the same
- * underlying state. Unstable references trigger Gutenberg's "Non-equal value
- * keys" warning and unnecessary re-renders (issue #1735).
+ * Mocks
  */
+
+// Verify that the useSelect selector returns stable object references for
+// venueMeta, savedVenueMeta, and staticMapDescriptors across repeated calls
+// with the same state. Unstable references trigger Gutenberg's "Non-equal
+// value keys" warning and cause unnecessary re-renders (issue #1735).
 
 // Capture the venue-state selector from the Edit block's first useSelect call
 // so we can invoke it directly in tests.
@@ -141,6 +140,7 @@ jest.mock( '@src/blocks/venue-map/helpers', () => ( {
  * Internal dependencies
  */
 import Edit from '@src/blocks/venue-map/edit';
+import { isVenuePostType } from '@src/helpers/venue';
 
 const DEFAULT_ATTRIBUTES = {
 	zoom: 18,
@@ -161,6 +161,9 @@ describe( 'venue-map Edit useSelect selector stability', () => {
 	beforeEach( () => {
 		capturedVenueStateSelector = null;
 		jest.clearAllMocks();
+		// clearAllMocks does not reset mockReturnValue; restore the default
+		// so each test starts with isVenuePostType returning false.
+		isVenuePostType.mockReturnValue( false );
 	} );
 
 	it( 'returns the same venueMeta reference on repeated calls when there is no venue post', () => {
@@ -311,6 +314,56 @@ describe( 'venue-map Edit useSelect selector stability', () => {
 		const result1 = capturedVenueStateSelector( noMapSelect );
 		const result2 = capturedVenueStateSelector( noMapSelect );
 
+		expect( result1.staticMapDescriptors ).toBe(
+			result2.staticMapDescriptors
+		);
+	} );
+
+	it( 'returns stable savedVenueMeta and staticMapDescriptors references in the isEditing branch', () => {
+		// Trigger the isEditing path: getCurrentPostId() matches context.postId
+		// and isVenuePostType() returns true.
+		isVenuePostType.mockReturnValue( true );
+
+		const editingSelect = ( storeName ) => {
+			switch ( storeName ) {
+				case 'core/editor':
+					return {
+						getCurrentPostId: () => 42,
+						getCurrentPostType: () => 'gatherpress_venue',
+						// Null meta and null post ensure the || EMPTY_META and
+						// || EMPTY_STATIC_MAP_DESCRIPTORS fallbacks are exercised.
+						getEditedPostAttribute: () => null,
+						getCurrentPost: () => null,
+					};
+				case 'core':
+					return { getEditedEntityRecord: () => null };
+				case 'core/block-editor':
+					return { getBlockParentsByBlockName: () => [] };
+				case 'gatherpress/venue':
+					return {
+						getVenueLatitude: () => null,
+						getVenueLongitude: () => null,
+					};
+				default:
+					return {};
+			}
+		};
+
+		render(
+			<Edit
+				attributes={ DEFAULT_ATTRIBUTES }
+				setAttributes={ jest.fn() }
+				context={ { postId: 42, postType: 'gatherpress_venue' } }
+				clientId=""
+			/>
+		);
+
+		expect( capturedVenueStateSelector ).not.toBeNull();
+
+		const result1 = capturedVenueStateSelector( editingSelect );
+		const result2 = capturedVenueStateSelector( editingSelect );
+
+		expect( result1.savedVenueMeta ).toBe( result2.savedVenueMeta );
 		expect( result1.staticMapDescriptors ).toBe(
 			result2.staticMapDescriptors
 		);


### PR DESCRIPTION
Fixes #1735

## Problem

The `useSelect` selector in `src/blocks/venue-map/edit.js` constructed new `{}` object literals inline as fallback values for `venueMeta`, `savedVenueMeta`, and `staticMapDescriptors` on every render. Because React uses referential equality to detect selector output changes, each render produced three brand-new empty objects — guaranteeing that Gutenberg's internal equality check always failed. This triggered the "Non-equal value keys: venueMeta, savedVenueMeta, staticMapDescriptors" console warning in development and caused the block to re-render continuously whenever it was open on an event with a static map image.

## Fix

Three `Object.freeze({})` sentinels are added at module scope:

```js
const EMPTY_META = Object.freeze({});
const EMPTY_STATIC_MAP_DESCRIPTORS = Object.freeze({});
const EMPTY_POST = Object.freeze({});
```

Every `|| {}` fallback and inline `{}` literal returned from the `useSelect` selector is replaced with the appropriate constant across all three return paths (early bail, editing, and non-editing). `EMPTY_META` covers absent or null meta objects, `EMPTY_POST` covers an absent `getCurrentPost()` return, and `EMPTY_STATIC_MAP_DESCRIPTORS` covers absent static map descriptor maps. `Object.freeze` guards against accidental mutation of the shared references.

## Testing instructions

```bash
npm run test:unit:js -- --testPathPattern 'venue-map/edit'
```

The six new tests in `test/unit/js/src/blocks/venue-map/edit.test.js` capture the `useSelect` selector directly and assert referential equality (`toBe`) across repeated calls for each affected return path: the early-bail path (no venue post), the non-editing path with `null` meta, the non-editing path with meta that has no `gatherpress_static_map` key, and the `isEditing` branch (same post ID, `isVenuePostType` true) asserting stability of `savedVenueMeta` and `staticMapDescriptors`.

Manual verification: open an event in the block editor, add the Venue Map block, and confirm the "Non-equal value keys" warning no longer appears in the browser console.

### Other information:

- [x] Have you written new tests for your changes, if applicable?