### PR TITLE
Fix modal flicker when changing RSVP guest count, fixes #1741

### DIFF
--- a/.github/changelog/fix-1741-rsvp-guest-modal-flicker
+++ b/.github/changelog/fix-1741-rsvp-guest-modal-flicker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stopped the RSVP attendance modal from flickering when the Number of Guests field was changed.

--- a/src/blocks/rsvp/view.js
+++ b/src/blocks/rsvp/view.js
@@ -197,8 +197,13 @@ const { state, actions } = store( 'gatherpress', {
 					state.posts[ postId ].currentUser.status
 				) {
 					innerBlock.classList.remove( 'gatherpress--is-hidden' );
-					// Move the visible block to the start of its parent.
-					parent.insertBefore( innerBlock, parent.firstChild );
+					// Guard against a spurious DOM remove+reinsert: when the block
+					// is already firstChild, insertBefore(node, node) per the DOM
+					// spec becomes insertBefore(node, node.nextSibling), which is
+					// still a real mutation and restarts CSS animations on descendants.
+					if ( parent.firstChild !== innerBlock ) {
+						parent.insertBefore( innerBlock, parent.firstChild );
+					}
 				} else {
 					innerBlock.classList.add( 'gatherpress--is-hidden' );
 				}


### PR DESCRIPTION
Fixes #1741

## Problem

When a logged-in user opens the RSVP attendance modal and clicks the up or down arrow on the "Number of Guests" field, the modal disappears and reappears. Even a single click causes this.

The cause is a chain of three steps. The `change` event on the number input fires `actions.updateGuestCount`, which immediately calls `sendRsvpApiRequest`. When the API response arrives, `sendRsvpApiRequest` replaces the entire `state.posts[postId]` object. That triggers the `data-wp-watch` callback `callbacks.renderRsvpBlock` to re-run.

`renderRsvpBlock` always called `parent.insertBefore(innerBlock, parent.firstChild)` on the active status block. After the initial page render the attending block is already `parent.firstChild`. Per the WHATWG DOM pre-insert algorithm (step 3), calling `insertBefore(node, node)` transforms the call to `parent.insertBefore(node, node.nextSibling)` — a real remove-then-reinsert mutation even though the visual order does not change. That mutation causes the CSS `gatherpress-modal-content-appear` animation on the modal content to restart from `opacity: 0`, making the popup appear to disappear and reappear.

## Fix

Guard the `insertBefore` call in `renderRsvpBlock` so it only runs when the active block is not already in the first-child position:

```js
if ( parent.firstChild !== innerBlock ) {
    parent.insertBefore( innerBlock, parent.firstChild );
}
```

The RSVP status-switching path (attending → not_attending → attending) is unaffected: when the status changes, the target block is not yet `firstChild`, so the move still happens.

## Testing instructions

Manual steps:

1. Open any published event page where RSVP is enabled.
2. Log in as a user who is already attending.
3. Click **Edit RSVP** to open the attendance modal.
4. Click the up or down arrow on the **Number of Guests** field.
5. Confirm the modal stays open and stable — the content does not disappear and reappear.
6. Repeat several times rapidly to confirm no flicker on any click.
7. Click **Not Attending**, confirm the modal switches states correctly.
8. Click the RSVP button again and click **Attending** — confirm the modal appears with the entrance animation exactly once, then stays stable while editing guest count.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?