### PR TITLE
Fix/1733 event date query loop context

### DIFF
--- a/.github/changelog/fix-1733-event-date-query-loop-context
+++ b/.github/changelog/fix-1733-event-date-query-loop-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the event-date block incorrectly showing the edited event's dates for all events inside a query loop on an event post.

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -39,6 +39,7 @@ import {
 import DateTimeRange from '../../components/DateTimeRange';
 import { getFromSettings } from '../../helpers/editor-settings';
 import {
+	isEventPostType,
 	DISABLED_FIELD_OPACITY,
 } from '../../helpers/event';
 import { isInFSETemplate } from '../../helpers/editor';
@@ -208,9 +209,12 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const postId = attributes?.postId ?? context?.postId ?? null;
 	const hasExplicitOverride = !! attributes?.postId;
 
+	const contextPostType = context?.postType;
+	const contextQueryId = context?.queryId;
+
 	const { dateTimeStart, dateTimeEnd, timezone, isLoading, isValidEvent } = useSelect(
-		( select ) => resolveEventDateData( select, context, postId, hasExplicitOverride ),
-		[ postId, context?.postType, context?.queryId, hasExplicitOverride ]
+		( select ) => resolveEventDateData( select, contextPostType, contextQueryId, postId, hasExplicitOverride ),
+		[ postId, contextPostType, contextQueryId, hasExplicitOverride ]
 	);
 
 	const blockProps = useBlockProps( {

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -39,11 +39,10 @@ import {
 import DateTimeRange from '../../components/DateTimeRange';
 import { getFromSettings } from '../../helpers/editor-settings';
 import {
-	isEventPostType,
-	findEventPostById,
 	DISABLED_FIELD_OPACITY,
 } from '../../helpers/event';
 import { isInFSETemplate } from '../../helpers/editor';
+import { resolveEventDateData } from './helpers';
 
 /**
  * Similar to get_display_datetime method in class-event.php.
@@ -210,87 +209,8 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const hasExplicitOverride = !! attributes?.postId;
 
 	const { dateTimeStart, dateTimeEnd, timezone, isLoading, isValidEvent } = useSelect(
-		( select ) => {
-			// Resolve the post type from context or fall back to the editor's current post type.
-			// This ensures custom post types with gatherpress-event-date support work correctly
-			// in Query Loop blocks and postId override scenarios.
-			const postType =
-				context?.postType ||
-				select( 'core/editor' )?.getCurrentPostType();
-
-			// Reactive supports check — `getPostType` is read inside useSelect so the
-			// component re-renders once the post-type definition (and its supports) load.
-			const supportsEventDate = !! select( 'core' )
-				.getPostType( postType )?.supports?.[ 'gatherpress-event-date' ];
-
-			if ( ! postId ) {
-				return { isValidEvent: false };
-			}
-
-			// When editing an event directly, use the datetime store for live updates.
-			if ( isEventPostType() ) {
-				const datetimeStore = select( 'gatherpress/datetime' );
-				return {
-					dateTimeStart: datetimeStore.getDateTimeStart(),
-					dateTimeEnd: datetimeStore.getDateTimeEnd(),
-					timezone: datetimeStore.getTimezone(),
-					isValidEvent: supportsEventDate,
-				};
-			}
-
-			// Postid override on a host that itself doesn't support event-date
-			// (e.g. a regular page or template part). Resolve the override target
-			// across event-supporting post types so the block can light up.
-			if ( hasExplicitOverride && ! supportsEventDate ) {
-				const overridePost = findEventPostById( select, postId );
-				if ( ! overridePost ) {
-					return { isValidEvent: false };
-				}
-				const overrideMeta = overridePost?.meta;
-				return {
-					dateTimeStart: overrideMeta?.gatherpress_datetime_start,
-					dateTimeEnd: overrideMeta?.gatherpress_datetime_end,
-					timezone: overrideMeta?.gatherpress_timezone,
-					isValidEvent: true,
-				};
-			}
-
-			// Short-circuit before checking resolution: if the context post type doesn't
-			// support event-date we never call `getEntityRecord`, so its resolver never
-			// fires and `hasFinishedResolution` would stay false forever — blocking the
-			// component on a spinner that never resolves.
-			if ( ! supportsEventDate ) {
-				return { isValidEvent: false };
-			}
-
-			// For Query Loop and override contexts, fetch from entity record.
-			const hasResolved = select( 'core' ).hasFinishedResolution(
-				'getEntityRecord',
-				[ 'postType', postType, postId ]
-			);
-
-			if ( ! hasResolved ) {
-				return { isLoading: true, isValidEvent: false };
-			}
-
-			const post = select( 'core' ).getEntityRecord(
-				'postType',
-				postType,
-				postId
-			);
-			const meta = post?.meta;
-
-			// Match the original `hasValidEventId` semantics: only treat the block as
-			// "connected" when the referenced post is published. Drafts/scheduled posts
-			// referenced via Query Loop or postId override stay dim by design.
-			return {
-				dateTimeStart: meta?.gatherpress_datetime_start,
-				dateTimeEnd: meta?.gatherpress_datetime_end,
-				timezone: meta?.gatherpress_timezone,
-				isValidEvent: !! post && 'publish' === post?.status,
-			};
-		},
-		[ postId, context?.postType, hasExplicitOverride ]
+		( select ) => resolveEventDateData( select, context, postId, hasExplicitOverride ),
+		[ postId, context?.postType, context?.queryId, hasExplicitOverride ]
 	);
 
 	const blockProps = useBlockProps( {

--- a/src/blocks/event-date/helpers.js
+++ b/src/blocks/event-date/helpers.js
@@ -1,0 +1,89 @@
+/**
+ * Internal dependencies
+ */
+import { isEventPostType, findEventPostById } from '../../helpers/event';
+
+/**
+ * Resolves the event datetime data for the event-date block editor.
+ *
+ * Extracted from the useSelect callback in edit.js so the routing logic can be
+ * unit-tested independently of React rendering. Called once per render inside
+ * the component's useSelect with the reactive `select` function.
+ *
+ * @since 0.34.0
+ *
+ * @param {Function} select              WordPress data select function.
+ * @param {Object}   context             Block context (postId, postType, queryId).
+ * @param {number}   postId              Resolved post ID (attribute override or context).
+ * @param {boolean}  hasExplicitOverride Whether postId comes from block attributes.
+ *
+ * @return {Object} Datetime data: dateTimeStart, dateTimeEnd, timezone, isValidEvent, isLoading.
+ */
+export function resolveEventDateData( select, context, postId, hasExplicitOverride ) {
+	const postType =
+		context?.postType ||
+		select( 'core/editor' )?.getCurrentPostType();
+
+	const supportsEventDate = !! select( 'core' )
+		.getPostType( postType )?.supports?.[ 'gatherpress-event-date' ];
+
+	if ( ! postId ) {
+		return { isValidEvent: false };
+	}
+
+	// When editing an event directly (not inside a query loop), use the
+	// datetime store for live updates.
+	if ( isEventPostType() ) {
+		const datetimeStore = select( 'gatherpress/datetime' );
+		return {
+			dateTimeStart: datetimeStore.getDateTimeStart(),
+			dateTimeEnd: datetimeStore.getDateTimeEnd(),
+			timezone: datetimeStore.getTimezone(),
+			isValidEvent: supportsEventDate,
+		};
+	}
+
+	// postId override on a host that itself doesn't support event-date
+	// (e.g. a regular page or template part). Resolve the override target
+	// across event-supporting post types so the block can light up.
+	if ( hasExplicitOverride && ! supportsEventDate ) {
+		const overridePost = findEventPostById( select, postId );
+		if ( ! overridePost ) {
+			return { isValidEvent: false };
+		}
+		const overrideMeta = overridePost?.meta;
+		return {
+			dateTimeStart: overrideMeta?.gatherpress_datetime_start,
+			dateTimeEnd: overrideMeta?.gatherpress_datetime_end,
+			timezone: overrideMeta?.gatherpress_timezone,
+			isValidEvent: true,
+		};
+	}
+
+	// Short-circuit before checking resolution: if the context post type
+	// doesn't support event-date we never call getEntityRecord, so its
+	// resolver never fires and hasFinishedResolution would stay false forever.
+	if ( ! supportsEventDate ) {
+		return { isValidEvent: false };
+	}
+
+	// For Query Loop and override contexts, fetch from entity record.
+	const hasResolved = select( 'core' ).hasFinishedResolution(
+		'getEntityRecord',
+		[ 'postType', postType, postId ]
+	);
+
+	if ( ! hasResolved ) {
+		return { isLoading: true, isValidEvent: false };
+	}
+
+	const post = select( 'core' ).getEntityRecord( 'postType', postType, postId );
+	const meta = post?.meta;
+
+	return {
+		dateTimeStart: meta?.gatherpress_datetime_start,
+		dateTimeEnd: meta?.gatherpress_datetime_end,
+		timezone: meta?.gatherpress_timezone,
+		isValidEvent: !! post && 'publish' === post?.status,
+	};
+}

--- a/src/blocks/event-date/helpers.js
+++ b/src/blocks/event-date/helpers.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isEventPostType, findEventPostById } from '../../helpers/event';
+import { findEventPostById } from '../../helpers/event';
 
 /**
  * Resolves the event datetime data for the event-date block editor.
@@ -12,34 +12,46 @@ import { isEventPostType, findEventPostById } from '../../helpers/event';
  *
  * @since 0.34.0
  *
- * @param {Function} select              WordPress data select function.
- * @param {Object}   context             Block context (postId, postType, queryId).
- * @param {number}   postId              Resolved post ID (attribute override or context).
- * @param {boolean}  hasExplicitOverride Whether postId comes from block attributes.
+ * @param {Function}         select              WordPress data select function.
+ * @param {string|null}      contextPostType     Block context postType value.
+ * @param {number|undefined} contextQueryId      Block context queryId value (set by core/query).
+ * @param {number}           postId              Resolved post ID (attribute override or context).
+ * @param {boolean}          hasExplicitOverride Whether postId comes from block attributes.
  *
  * @return {Object} Datetime data: dateTimeStart, dateTimeEnd, timezone, isValidEvent, isLoading.
  */
-export function resolveEventDateData( select, context, postId, hasExplicitOverride ) {
+export function resolveEventDateData( select, contextPostType, contextQueryId, postId, hasExplicitOverride ) {
 	const postType =
-		context?.postType ||
+		contextPostType ??
 		select( 'core/editor' )?.getCurrentPostType();
 
 	const supportsEventDate = !! select( 'core' )
 		.getPostType( postType )?.supports?.[ 'gatherpress-event-date' ];
 
+	// Check the editor document type reactively, distinct from the block
+	// context post type. In the site editor the document type is wp_template,
+	// so this guard is false even when contextPostType is gatherpress_event.
+	const editorPostType = select( 'core/editor' )?.getCurrentPostType();
+	const isDirectEditingEvent = !! select( 'core' )
+		.getPostType( editorPostType )?.supports?.[ 'gatherpress-event-date' ];
+
 	if ( ! postId ) {
-		return { isValidEvent: false };
+		return { dateTimeStart: undefined, dateTimeEnd: undefined, timezone: undefined, isLoading: false, isValidEvent: false };
 	}
 
 	// When editing an event directly (not inside a query loop), use the
-	// datetime store for live updates.
-	if ( isEventPostType() ) {
+	// datetime store for live updates. Skip this path when contextQueryId is
+	// a number — core/query sets it on every block in the loop template,
+	// meaning each instance represents a different queried post and must fetch
+	// its own dates via the entity record below.
+	if ( isDirectEditingEvent && undefined === contextQueryId ) {
 		const datetimeStore = select( 'gatherpress/datetime' );
 		return {
 			dateTimeStart: datetimeStore.getDateTimeStart(),
 			dateTimeEnd: datetimeStore.getDateTimeEnd(),
 			timezone: datetimeStore.getTimezone(),
-			isValidEvent: supportsEventDate,
+			isLoading: false,
+			isValidEvent: true,
 		};
 	}
 
@@ -49,13 +61,14 @@ export function resolveEventDateData( select, context, postId, hasExplicitOverri
 	if ( hasExplicitOverride && ! supportsEventDate ) {
 		const overridePost = findEventPostById( select, postId );
 		if ( ! overridePost ) {
-			return { isValidEvent: false };
+			return { dateTimeStart: undefined, dateTimeEnd: undefined, timezone: undefined, isLoading: false, isValidEvent: false };
 		}
-		const overrideMeta = overridePost?.meta;
+		const overrideMeta = overridePost.meta;
 		return {
 			dateTimeStart: overrideMeta?.gatherpress_datetime_start,
 			dateTimeEnd: overrideMeta?.gatherpress_datetime_end,
 			timezone: overrideMeta?.gatherpress_timezone,
+			isLoading: false,
 			isValidEvent: true,
 		};
 	}
@@ -64,7 +77,7 @@ export function resolveEventDateData( select, context, postId, hasExplicitOverri
 	// doesn't support event-date we never call getEntityRecord, so its
 	// resolver never fires and hasFinishedResolution would stay false forever.
 	if ( ! supportsEventDate ) {
-		return { isValidEvent: false };
+		return { dateTimeStart: undefined, dateTimeEnd: undefined, timezone: undefined, isLoading: false, isValidEvent: false };
 	}
 
 	// For Query Loop and override contexts, fetch from entity record.
@@ -74,7 +87,7 @@ export function resolveEventDateData( select, context, postId, hasExplicitOverri
 	);
 
 	if ( ! hasResolved ) {
-		return { isLoading: true, isValidEvent: false };
+		return { dateTimeStart: undefined, dateTimeEnd: undefined, timezone: undefined, isLoading: true, isValidEvent: false };
 	}
 
 	const post = select( 'core' ).getEntityRecord( 'postType', postType, postId );
@@ -84,6 +97,7 @@ export function resolveEventDateData( select, context, postId, hasExplicitOverri
 		dateTimeStart: meta?.gatherpress_datetime_start,
 		dateTimeEnd: meta?.gatherpress_datetime_end,
 		timezone: meta?.gatherpress_timezone,
+		isLoading: false,
 		isValidEvent: !! post && 'publish' === post?.status,
 	};
 }

--- a/test/unit/js/src/blocks/event-date/helpers.test.js
+++ b/test/unit/js/src/blocks/event-date/helpers.test.js
@@ -4,14 +4,13 @@
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 
 jest.mock( '@src/helpers/event', () => ( {
-	isEventPostType: jest.fn(),
 	findEventPostById: jest.fn(),
 } ) );
 
 /**
  * Internal dependencies
  */
-import { isEventPostType, findEventPostById } from '@src/helpers/event';
+import { findEventPostById } from '@src/helpers/event';
 import { resolveEventDateData } from '@src/blocks/event-date/helpers';
 
 /**
@@ -29,7 +28,6 @@ describe( 'resolveEventDateData', () => {
 	let mockSelect;
 
 	beforeEach( () => {
-		isEventPostType.mockReset();
 		findEventPostById.mockReset();
 
 		mockDatetimeStore = {
@@ -69,11 +67,10 @@ describe( 'resolveEventDateData', () => {
 
 	describe( 'direct event editing (no query loop)', () => {
 		it( 'reads from gatherpress/datetime store when editing a standalone event block', () => {
-			isEventPostType.mockReturnValue( true );
-
 			const result = resolveEventDateData(
 				mockSelect,
-				{ postType: 'gatherpress_event' },
+				'gatherpress_event',
+				undefined,
 				42,
 				false
 			);
@@ -82,14 +79,15 @@ describe( 'resolveEventDateData', () => {
 			expect( result.dateTimeStart ).toBe( '2025-01-15 09:00:00' );
 			expect( result.dateTimeEnd ).toBe( '2025-01-15 11:00:00' );
 			expect( result.timezone ).toBe( 'America/New_York' );
+			expect( result.isValidEvent ).toBe( true );
+			expect( result.isLoading ).toBe( false );
 		} );
 
-		it( 'reads from gatherpress/datetime store when context.queryId is undefined', () => {
-			isEventPostType.mockReturnValue( true );
-
+		it( 'reads from gatherpress/datetime store when contextQueryId is undefined', () => {
 			const result = resolveEventDateData(
 				mockSelect,
-				{ postType: 'gatherpress_event', queryId: undefined },
+				'gatherpress_event',
+				undefined,
 				42,
 				false
 			);
@@ -99,29 +97,26 @@ describe( 'resolveEventDateData', () => {
 		} );
 	} );
 
-	describe( 'inside a query loop (context.queryId is a number)', () => {
+	describe( 'inside a query loop (contextQueryId is a number)', () => {
 		it( 'fetches from entity record instead of datetime store when queryId is 0', () => {
-			isEventPostType.mockReturnValue( true );
-
 			const result = resolveEventDateData(
 				mockSelect,
-				{ postType: 'gatherpress_event', queryId: 0 },
+				'gatherpress_event',
+				0,
 				42,
 				false
 			);
 
-			// Bug: the datetime store IS called before the fix — test will fail here.
 			expect( mockDatetimeStore.getDateTimeStart ).not.toHaveBeenCalled();
 			expect( result.dateTimeStart ).toBe( '2025-06-10 14:00:00' );
 			expect( result.timezone ).toBe( 'America/Chicago' );
 		} );
 
 		it( 'fetches from entity record instead of datetime store when queryId is a positive integer', () => {
-			isEventPostType.mockReturnValue( true );
-
 			const result = resolveEventDateData(
 				mockSelect,
-				{ postType: 'gatherpress_event', queryId: 1 },
+				'gatherpress_event',
+				1,
 				42,
 				false
 			);
@@ -131,7 +126,6 @@ describe( 'resolveEventDateData', () => {
 		} );
 
 		it( 'returns isValidEvent false for an unpublished queried post', () => {
-			isEventPostType.mockReturnValue( true );
 			mockCoreStore.getEntityRecord.mockReturnValue( {
 				status: 'draft',
 				meta: {
@@ -143,7 +137,8 @@ describe( 'resolveEventDateData', () => {
 
 			const result = resolveEventDateData(
 				mockSelect,
-				{ postType: 'gatherpress_event', queryId: 0 },
+				'gatherpress_event',
+				0,
 				42,
 				false
 			);
@@ -154,51 +149,75 @@ describe( 'resolveEventDateData', () => {
 
 	describe( 'edge cases', () => {
 		it( 'returns isValidEvent false when postId is null', () => {
-			isEventPostType.mockReturnValue( true );
-
 			const result = resolveEventDateData(
 				mockSelect,
-				{ postType: 'gatherpress_event' },
+				'gatherpress_event',
+				undefined,
 				null,
 				false
 			);
 
-			expect( result ).toEqual( { isValidEvent: false } );
+			expect( result.isValidEvent ).toBe( false );
+			expect( result.isLoading ).toBe( false );
 			expect( mockDatetimeStore.getDateTimeStart ).not.toHaveBeenCalled();
 		} );
 
 		it( 'returns isValidEvent false when post type does not support event-date', () => {
-			isEventPostType.mockReturnValue( false );
 			mockCoreStore.getPostType.mockReturnValue( {
 				supports: {},
 			} );
 
 			const result = resolveEventDateData(
 				mockSelect,
-				{ postType: 'post', queryId: 0 },
+				'post',
+				0,
 				42,
 				false
 			);
 
-			expect( result ).toEqual( { isValidEvent: false } );
+			expect( result.isValidEvent ).toBe( false );
+			expect( result.isLoading ).toBe( false );
+		} );
+
+		it( 'returns isValidEvent false and empty dates when entity record is null', () => {
+			mockCoreStore.getEntityRecord.mockReturnValue( null );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				'gatherpress_event',
+				1,
+				42,
+				false
+			);
+
+			expect( result.isValidEvent ).toBe( false );
+			expect( result.dateTimeStart ).toBeUndefined();
+			expect( result.dateTimeEnd ).toBeUndefined();
+			expect( result.timezone ).toBeUndefined();
+			expect( result.isLoading ).toBe( false );
 		} );
 
 		it( 'returns isLoading true while entity record resolution is pending', () => {
-			isEventPostType.mockReturnValue( false );
 			mockCoreStore.hasFinishedResolution.mockReturnValue( false );
 
 			const result = resolveEventDateData(
 				mockSelect,
-				{ postType: 'gatherpress_event', queryId: 1 },
+				'gatherpress_event',
+				1,
 				42,
 				false
 			);
 
-			expect( result ).toEqual( { isLoading: true, isValidEvent: false } );
+			expect( result ).toEqual( {
+				dateTimeStart: undefined,
+				dateTimeEnd: undefined,
+				timezone: undefined,
+				isLoading: true,
+				isValidEvent: false,
+			} );
 		} );
 
 		it( 'resolves postId override target from non-event host when outside a query loop', () => {
-			isEventPostType.mockReturnValue( false );
 			mockCoreStore.getPostType.mockReturnValue( { supports: {} } );
 			findEventPostById.mockReturnValue( {
 				meta: {
@@ -210,7 +229,8 @@ describe( 'resolveEventDateData', () => {
 
 			const result = resolveEventDateData(
 				mockSelect,
-				{ postType: 'page' },
+				'page',
+				undefined,
 				99,
 				true
 			);
@@ -218,6 +238,59 @@ describe( 'resolveEventDateData', () => {
 			expect( findEventPostById ).toHaveBeenCalledWith( mockSelect, 99 );
 			expect( result.dateTimeStart ).toBe( '2025-08-01 10:00:00' );
 			expect( result.isValidEvent ).toBe( true );
+			expect( result.isLoading ).toBe( false );
+		} );
+
+		it( 'falls back to editor post type when contextPostType is null', () => {
+			const result = resolveEventDateData(
+				mockSelect,
+				null,
+				undefined,
+				42,
+				false
+			);
+
+			// Editor post type 'gatherpress_event' supports event-date, so
+			// live-store path fires.
+			expect( mockDatetimeStore.getDateTimeStart ).toHaveBeenCalled();
+			expect( result.isValidEvent ).toBe( true );
+		} );
+
+		it( 'does not use datetime store in site editor even when contextPostType is an event type', () => {
+			// In the site editor the editor document type is wp_template, not an
+			// event. isDirectEditingEvent must check the editor type, not the
+			// context type, so the live-store path is skipped correctly.
+			mockSelect = jest.fn( ( store ) => {
+				if ( 'gatherpress/datetime' === store ) {
+					return mockDatetimeStore;
+				}
+				if ( 'core' === store ) {
+					return {
+						...mockCoreStore,
+						getPostType: jest.fn( ( type ) => {
+							if ( 'wp_template' === type ) {
+								return { supports: {} };
+							}
+							return { supports: { 'gatherpress-event-date': true } };
+						} ),
+					};
+				}
+				if ( 'core/editor' === store ) {
+					return { getCurrentPostType: () => 'wp_template' };
+				}
+				return {};
+			} );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				'gatherpress_event',
+				undefined,
+				42,
+				false
+			);
+
+			expect( mockDatetimeStore.getDateTimeStart ).not.toHaveBeenCalled();
+			expect( result.dateTimeStart ).toBe( '2025-06-10 14:00:00' );
 		} );
 	} );
 } );

--- a/test/unit/js/src/blocks/event-date/helpers.test.js
+++ b/test/unit/js/src/blocks/event-date/helpers.test.js
@@ -217,6 +217,28 @@ describe( 'resolveEventDateData', () => {
 			} );
 		} );
 
+		it( 'returns isValidEvent false when postId override target is not found', () => {
+			mockCoreStore.getPostType.mockReturnValue( { supports: {} } );
+			findEventPostById.mockReturnValue( null );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				'page',
+				undefined,
+				99,
+				true
+			);
+
+			expect( findEventPostById ).toHaveBeenCalledWith( mockSelect, 99 );
+			expect( result ).toEqual( {
+				dateTimeStart: undefined,
+				dateTimeEnd: undefined,
+				timezone: undefined,
+				isLoading: false,
+				isValidEvent: false,
+			} );
+		} );
+
 		it( 'resolves postId override target from non-event host when outside a query loop', () => {
 			mockCoreStore.getPostType.mockReturnValue( { supports: {} } );
 			findEventPostById.mockReturnValue( {

--- a/test/unit/js/src/blocks/event-date/helpers.test.js
+++ b/test/unit/js/src/blocks/event-date/helpers.test.js
@@ -1,0 +1,223 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+
+jest.mock( '@src/helpers/event', () => ( {
+	isEventPostType: jest.fn(),
+	findEventPostById: jest.fn(),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import { isEventPostType, findEventPostById } from '@src/helpers/event';
+import { resolveEventDateData } from '@src/blocks/event-date/helpers';
+
+/**
+ * Regression coverage for #1733 — event-date block uses the live datetime
+ * store for all blocks in an editor session, including query-loop instances
+ * that should show their own contextual post's dates.
+ *
+ * resolveEventDateData is the selector body extracted from the edit.js
+ * useSelect call so the routing logic can be tested without rendering the
+ * full block component.
+ */
+describe( 'resolveEventDateData', () => {
+	let mockDatetimeStore;
+	let mockCoreStore;
+	let mockSelect;
+
+	beforeEach( () => {
+		isEventPostType.mockReset();
+		findEventPostById.mockReset();
+
+		mockDatetimeStore = {
+			getDateTimeStart: jest.fn( () => '2025-01-15 09:00:00' ),
+			getDateTimeEnd: jest.fn( () => '2025-01-15 11:00:00' ),
+			getTimezone: jest.fn( () => 'America/New_York' ),
+		};
+
+		mockCoreStore = {
+			getPostType: jest.fn( () => ( {
+				supports: { 'gatherpress-event-date': true },
+			} ) ),
+			hasFinishedResolution: jest.fn( () => true ),
+			getEntityRecord: jest.fn( () => ( {
+				status: 'publish',
+				meta: {
+					gatherpress_datetime_start: '2025-06-10 14:00:00',
+					gatherpress_datetime_end: '2025-06-10 16:00:00',
+					gatherpress_timezone: 'America/Chicago',
+				},
+			} ) ),
+		};
+
+		mockSelect = jest.fn( ( store ) => {
+			if ( 'gatherpress/datetime' === store ) {
+				return mockDatetimeStore;
+			}
+			if ( 'core' === store ) {
+				return mockCoreStore;
+			}
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: () => 'gatherpress_event' };
+			}
+			return {};
+		} );
+	} );
+
+	describe( 'direct event editing (no query loop)', () => {
+		it( 'reads from gatherpress/datetime store when editing a standalone event block', () => {
+			isEventPostType.mockReturnValue( true );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				{ postType: 'gatherpress_event' },
+				42,
+				false
+			);
+
+			expect( mockDatetimeStore.getDateTimeStart ).toHaveBeenCalled();
+			expect( result.dateTimeStart ).toBe( '2025-01-15 09:00:00' );
+			expect( result.dateTimeEnd ).toBe( '2025-01-15 11:00:00' );
+			expect( result.timezone ).toBe( 'America/New_York' );
+		} );
+
+		it( 'reads from gatherpress/datetime store when context.queryId is undefined', () => {
+			isEventPostType.mockReturnValue( true );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				{ postType: 'gatherpress_event', queryId: undefined },
+				42,
+				false
+			);
+
+			expect( mockDatetimeStore.getDateTimeStart ).toHaveBeenCalled();
+			expect( result.dateTimeStart ).toBe( '2025-01-15 09:00:00' );
+		} );
+	} );
+
+	describe( 'inside a query loop (context.queryId is a number)', () => {
+		it( 'fetches from entity record instead of datetime store when queryId is 0', () => {
+			isEventPostType.mockReturnValue( true );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				{ postType: 'gatherpress_event', queryId: 0 },
+				42,
+				false
+			);
+
+			// Bug: the datetime store IS called before the fix — test will fail here.
+			expect( mockDatetimeStore.getDateTimeStart ).not.toHaveBeenCalled();
+			expect( result.dateTimeStart ).toBe( '2025-06-10 14:00:00' );
+			expect( result.timezone ).toBe( 'America/Chicago' );
+		} );
+
+		it( 'fetches from entity record instead of datetime store when queryId is a positive integer', () => {
+			isEventPostType.mockReturnValue( true );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				{ postType: 'gatherpress_event', queryId: 1 },
+				42,
+				false
+			);
+
+			expect( mockDatetimeStore.getDateTimeStart ).not.toHaveBeenCalled();
+			expect( result.dateTimeStart ).toBe( '2025-06-10 14:00:00' );
+		} );
+
+		it( 'returns isValidEvent false for an unpublished queried post', () => {
+			isEventPostType.mockReturnValue( true );
+			mockCoreStore.getEntityRecord.mockReturnValue( {
+				status: 'draft',
+				meta: {
+					gatherpress_datetime_start: '2025-06-10 14:00:00',
+					gatherpress_datetime_end: '2025-06-10 16:00:00',
+					gatherpress_timezone: 'UTC',
+				},
+			} );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				{ postType: 'gatherpress_event', queryId: 0 },
+				42,
+				false
+			);
+
+			expect( result.isValidEvent ).toBe( false );
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'returns isValidEvent false when postId is null', () => {
+			isEventPostType.mockReturnValue( true );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				{ postType: 'gatherpress_event' },
+				null,
+				false
+			);
+
+			expect( result ).toEqual( { isValidEvent: false } );
+			expect( mockDatetimeStore.getDateTimeStart ).not.toHaveBeenCalled();
+		} );
+
+		it( 'returns isValidEvent false when post type does not support event-date', () => {
+			isEventPostType.mockReturnValue( false );
+			mockCoreStore.getPostType.mockReturnValue( {
+				supports: {},
+			} );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				{ postType: 'post', queryId: 0 },
+				42,
+				false
+			);
+
+			expect( result ).toEqual( { isValidEvent: false } );
+		} );
+
+		it( 'returns isLoading true while entity record resolution is pending', () => {
+			isEventPostType.mockReturnValue( false );
+			mockCoreStore.hasFinishedResolution.mockReturnValue( false );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				{ postType: 'gatherpress_event', queryId: 1 },
+				42,
+				false
+			);
+
+			expect( result ).toEqual( { isLoading: true, isValidEvent: false } );
+		} );
+
+		it( 'resolves postId override target from non-event host when outside a query loop', () => {
+			isEventPostType.mockReturnValue( false );
+			mockCoreStore.getPostType.mockReturnValue( { supports: {} } );
+			findEventPostById.mockReturnValue( {
+				meta: {
+					gatherpress_datetime_start: '2025-08-01 10:00:00',
+					gatherpress_datetime_end: '2025-08-01 12:00:00',
+					gatherpress_timezone: 'Europe/London',
+				},
+			} );
+
+			const result = resolveEventDateData(
+				mockSelect,
+				{ postType: 'page' },
+				99,
+				true
+			);
+
+			expect( findEventPostById ).toHaveBeenCalledWith( mockSelect, 99 );
+			expect( result.dateTimeStart ).toBe( '2025-08-01 10:00:00' );
+			expect( result.isValidEvent ).toBe( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes #1733

## Problem

When editing an event post that contains a `core/query` block, every `gatherpress/event-date` block inside the query loop displays the dates of the event being edited rather than each queried event's own dates. The bug only appears in the block editor; the published frontend renders correctly.

The root cause was in the `useSelect` callback in `edit.js`. When the editor document is an event post, `isEventPostType()` returns `true` for the entire session. This caused the callback to branch into the live `gatherpress/datetime` store path for every `event-date` block on the canvas — including blocks inside a query loop that should be fetching each queried event's dates from the entity record via `context.postId`.

## Fix

The `useSelect` body was extracted into an exported `resolveEventDateData` helper in a new `src/blocks/event-date/helpers.js` file. This separates the routing logic from the React component and makes it directly unit-testable.

The fix adds two guards to the live-store path:

1. **`undefined === contextQueryId`** — `core/query` sets `context.queryId` to a number on every block in its template. When this value is defined, the block represents a queried post and must fetch from the entity record rather than the live editor store.

2. **`isDirectEditingEvent`** — computed from the reactive `select` parameter using the editor's current document type (not the block context type). This ensures the live-store path is correctly skipped in the site editor, where `context.postType` can be `gatherpress_event` (from the template context) but the editor document type is `wp_template`.

The block's `block.json` already declared `"queryId"` in `usesContext`; it simply was never checked.

## Testing instructions

```bash
npm run build && npm run test:unit:js -- --testPathPattern 'blocks/event-date/helpers'
```

Manual testing steps:

1. Open any published event post in the block editor.
2. Add a Query Loop block to the event's content. Configure it to query `gatherpress_event` post type.
3. Add a `gatherpress/event-date` block to the query template.
4. Verify each queried event shows its own date, not the outer event's date.
5. Confirm the outer event's `event-date` block (placed directly in the content, outside the query) still shows live-updating dates when the date is changed in the sidebar.
6. Open the same query loop on a plain page — confirm dates still render correctly there.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Notes

- The `resolveEventDateData` extraction also normalizes all return paths to the same five-key shape (`dateTimeStart`, `dateTimeEnd`, `timezone`, `isLoading`, `isValidEvent`), resolving a pre-existing SonarCloud S3801 finding in the original `useSelect` callback.
- The site editor edge case (template context providing `gatherpress_event` post type without a query ID) is covered by a dedicated test and confirmed to skip the live-store path correctly.
