### PR TITLE
Fix initial context for event date supporting types inside venue block

### DIFF
--- a/.github/changelog/1754-fix-initial-context-for-event-date-supporting-types-inside-venue-block
+++ b/.github/changelog/1754-fix-initial-context-for-event-date-supporting-types-inside-venue-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix initial context for event date supporting types inside venue block

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -246,7 +246,7 @@ class Event_Query {
 			? $block_query['postType']
 			: get_post_types_by_support( 'gatherpress-event-date' );
 
-		// Type of event list: 'upcoming' or 'past',
+		// Type of event list: 'upcoming', 'past', or 'all',
 		// @see wp-content/plugins/gatherpress/includes/core/classes/class-event-query.php.
 		$query_args['gatherpress_event_query'] = $block_query['gatherpress_event_query'];
 
@@ -330,7 +330,7 @@ class Event_Query {
 		// Generate a new custom query will all potential query vars.
 		$custom_args = array();
 
-		// Type of event list: 'upcoming' or 'past',
+		// Type of event list: 'upcoming', 'past', or 'all',
 		// @see wp-content/plugins/gatherpress/includes/core/classes/class-event-query.php .
 		$custom_args['gatherpress_event_query'] = $request->get_param( 'gatherpress_event_query' );
 
@@ -410,7 +410,7 @@ class Event_Query {
 
 		// Add custom GatherPress query parameters.
 		$query_params['gatherpress_event_query'] = array(
-			'description' => __( 'Type of events to query: upcoming or past', 'gatherpress' ),
+			'description' => __( 'Type of events to query: upcoming, past, or all', 'gatherpress' ),
 			'type'        => 'string',
 			'enum'        => array( 'upcoming', 'past', 'all' ),
 			'default'     => 'upcoming',

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -412,7 +412,7 @@ class Event_Query {
 		$query_params['gatherpress_event_query'] = array(
 			'description' => __( 'Type of events to query: upcoming or past', 'gatherpress' ),
 			'type'        => 'string',
-			'enum'        => array( 'upcoming', 'past' ),
+			'enum'        => array( 'upcoming', 'past', 'all' ),
 			'default'     => 'upcoming',
 		);
 

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -105,9 +105,14 @@ export function useVenuePostFromTermId( termId, venuePostType = DEFAULT_VENUE_PO
 			// In case the Venue post (source post type) does also support gatherpress-event-date,
 			// we need to ensure that all posts of that type are queried,
 			// not only upcoming ones, which would be the default.
-			const isEventDateSupported = wpSelect( 'core' ).getPostType( venuePostType )
-				?.supports?.[ 'gatherpress-event-date' ] ? 'all' : null;
-			// Query for one venue post with the matching slug.
+			const supportsEventDate = !! wpSelect( 'core' )
+				.getPostType( venuePostType )?.supports?.[
+					'gatherpress-event-date'
+				];
+			// Query for one venue post with the matching slug. The param is
+			// spread conditionally rather than passed as null: buildQueryString
+			// serializes null as an empty string, which fails the REST enum
+			// validation on event-date post types before getPostType resolves.
 			return {
 				venuePost: wpSelect( 'core' ).getEntityRecords(
 					'postType',
@@ -115,7 +120,9 @@ export function useVenuePostFromTermId( termId, venuePostType = DEFAULT_VENUE_PO
 					{
 						per_page: 1,
 						slug: venueSlug,
-						gatherpress_event_query: isEventDateSupported,
+						...( supportsEventDate && {
+							gatherpress_event_query: 'all',
+						} ),
 					}
 				),
 			};

--- a/src/helpers/venue.js
+++ b/src/helpers/venue.js
@@ -102,6 +102,11 @@ export function useVenuePostFromTermId( termId, venuePostType = DEFAULT_VENUE_PO
 			);
 			// If term object exists, strip any leading underscore from its slug.
 			const venueSlug = venueTerm?.slug?.replace( /^_/, '' );
+			// In case the Venue post (source post type) does also support gatherpress-event-date,
+			// we need to ensure that all posts of that type are queried,
+			// not only upcoming ones, which would be the default.
+			const isEventDateSupported = wpSelect( 'core' ).getPostType( venuePostType )
+				?.supports?.[ 'gatherpress-event-date' ] ? 'all' : null;
 			// Query for one venue post with the matching slug.
 			return {
 				venuePost: wpSelect( 'core' ).getEntityRecords(
@@ -110,6 +115,7 @@ export function useVenuePostFromTermId( termId, venuePostType = DEFAULT_VENUE_PO
 					{
 						per_page: 1,
 						slug: venueSlug,
+						gatherpress_event_query: isEventDateSupported,
 					}
 				),
 			};

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -268,6 +268,9 @@ describe( 'useVenuePostFromTermId', () => {
 					capturedSlug = query.slug;
 					return [];
 				} ),
+				getPostType: jest.fn( () => ( {
+					supports: {},
+				} ) ),
 			} ) );
 			return callback( wpSelect );
 		} );
@@ -290,6 +293,9 @@ describe( 'useVenuePostFromTermId', () => {
 					capturedSlug = query.slug;
 					return [];
 				} ),
+				getPostType: jest.fn( () => ( {
+					supports: {},
+				} ) ),
 			} ) );
 			return callback( wpSelect );
 		} );
@@ -308,6 +314,9 @@ describe( 'useVenuePostFromTermId', () => {
 			const wpSelect = jest.fn( () => ( {
 				getEntityRecord: jest.fn( () => mockVenueTerm ),
 				getEntityRecords: jest.fn( () => mockVenuePost ),
+				getPostType: jest.fn( () => ( {
+					supports: {},
+				} ) ),
 			} ) );
 			return callback( wpSelect );
 		} );
@@ -327,6 +336,9 @@ describe( 'useVenuePostFromTermId', () => {
 					capturedSlug = query.slug;
 					return [];
 				} ),
+				getPostType: jest.fn( () => ( {
+					supports: {},
+				} ) ),
 			} ) );
 			return callback( wpSelect );
 		} );
@@ -346,6 +358,9 @@ describe( 'useVenuePostFromTermId', () => {
 					capturedSlug = query.slug;
 					return [];
 				} ),
+				getPostType: jest.fn( () => ( {
+					supports: {},
+				} ) ),
 			} ) );
 			return callback( wpSelect );
 		} );
@@ -525,6 +540,9 @@ describe( 'GetVenuePostFromEventId', () => {
 			const wpSelect = jest.fn( () => ( {
 				getEntityRecord: jest.fn( () => mockVenueTerm ),
 				getEntityRecords: jest.fn( () => mockVenuePost ),
+				getPostType: jest.fn( () => ( {
+					supports: {},
+				} ) ),
 			} ) );
 			return callback( wpSelect );
 		} );
@@ -561,6 +579,9 @@ describe( 'GetVenuePostFromEventId', () => {
 			const wpSelect = jest.fn( () => ( {
 				getEntityRecord: jest.fn( () => mockVenueTerm ),
 				getEntityRecords: jest.fn( () => mockVenuePost ),
+				getPostType: jest.fn( () => ( {
+					supports: {},
+				} ) ),
 			} ) );
 			return callback( wpSelect );
 		} );
@@ -598,6 +619,9 @@ describe( 'GetVenuePostFromEventId', () => {
 			const wpSelect = jest.fn( () => ( {
 				getEntityRecord: jest.fn( () => venueTerm ),
 				getEntityRecords: jest.fn( () => mockVenuePost ),
+				getPostType: jest.fn( () => ( {
+					supports: {},
+				} ) ),
 			} ) );
 			return callback( wpSelect );
 		} );

--- a/test/unit/js/src/helpers/venue.test.js
+++ b/test/unit/js/src/helpers/venue.test.js
@@ -368,6 +368,81 @@ describe( 'useVenuePostFromTermId', () => {
 		renderHook( () => useVenuePostFromTermId( 1 ) );
 		expect( capturedSlug ).toBe( 'venue-no-underscore' );
 	} );
+
+	it( 'queries all posts when the post type supports gatherpress-event-date', () => {
+		// An event-date-supporting source post type defaults to upcoming-only
+		// filtering on its REST collection, which hides past posts from the
+		// slug lookup — the hook must opt out by querying 'all'.
+		const mockVenueTerm = { id: 1, slug: '_my-production' };
+		let capturedQuery = null;
+
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( () => ( {
+				getEntityRecord: jest.fn( () => mockVenueTerm ),
+				getEntityRecords: jest.fn( ( type, postType, query ) => {
+					capturedQuery = query;
+					return [];
+				} ),
+				getPostType: jest.fn( () => ( {
+					supports: { 'gatherpress-event-date': true },
+				} ) ),
+			} ) );
+			return callback( wpSelect );
+		} );
+
+		renderHook( () => useVenuePostFromTermId( 1, 'production' ) );
+		expect( capturedQuery.gatherpress_event_query ).toBe( 'all' );
+	} );
+
+	it( 'omits the event query param when the post type lacks event-date support', () => {
+		// The param must be absent, not null: null serializes to an empty
+		// string in the request URL instead of being dropped.
+		const mockVenueTerm = { id: 1, slug: '_my-venue' };
+		let capturedQuery = null;
+
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( () => ( {
+				getEntityRecord: jest.fn( () => mockVenueTerm ),
+				getEntityRecords: jest.fn( ( type, postType, query ) => {
+					capturedQuery = query;
+					return [];
+				} ),
+				getPostType: jest.fn( () => ( {
+					supports: {},
+				} ) ),
+			} ) );
+			return callback( wpSelect );
+		} );
+
+		renderHook( () => useVenuePostFromTermId( 1 ) );
+		expect( capturedQuery ).not.toHaveProperty(
+			'gatherpress_event_query'
+		);
+	} );
+
+	it( 'omits the event query param while the post type is still resolving', () => {
+		// Before getPostType resolves, supports are unknown — the hook must
+		// not send a placeholder value that would fail REST enum validation.
+		const mockVenueTerm = { id: 1, slug: '_my-production' };
+		let capturedQuery = null;
+
+		useSelect.mockImplementation( ( callback ) => {
+			const wpSelect = jest.fn( () => ( {
+				getEntityRecord: jest.fn( () => mockVenueTerm ),
+				getEntityRecords: jest.fn( ( type, postType, query ) => {
+					capturedQuery = query;
+					return [];
+				} ),
+				getPostType: jest.fn( () => undefined ),
+			} ) );
+			return callback( wpSelect );
+		} );
+
+		renderHook( () => useVenuePostFromTermId( 1, 'production' ) );
+		expect( capturedQuery ).not.toHaveProperty(
+			'gatherpress_event_query'
+		);
+	} );
 } );
 
 /**

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -280,7 +280,7 @@ class Test_Event_Query extends Base {
 		// Verify gatherpress_event_query parameter is registered.
 		$this->assertArrayHasKey( 'gatherpress_event_query', $result );
 		$this->assertSame( 'string', $result['gatherpress_event_query']['type'] );
-		$this->assertSame( array( 'upcoming', 'past' ), $result['gatherpress_event_query']['enum'] );
+		$this->assertSame( array( 'upcoming', 'past', 'all' ), $result['gatherpress_event_query']['enum'] );
 
 		// Verify exclude_current parameter is registered.
 		$this->assertArrayHasKey( 'exclude_current', $result );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

>The REST requests that sets up the `gatherpress/venue` block with initial context fails, when: 
>
>- the set `sourcePostType` does also support `gatherpress-event-date`
>- the requested source post has a event-date in the past

Fixes #1754

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make the `gatherpress/venue` block aware, if the currently requested post type supports `gatherpress-event-date`
* Set the query variable `gatherpress_event_query` to either `'all'` or `null`, for all requests made by the block to find its context post
* Allow the a value of `'all'` for the `gatherpress_event_query` query variable during a REST request

### Other information:

This use case will not apply to a default GatherPress setup. But using the multiple options, GatherPress provides with `post_type_supports`, one can reach such a use case or situation relatively fast. 

>This has happened with _Productions_ and _Seasons_ as well, because they both use `gatherpress-event-date` AND `gatherpress-shadow-source` supports.

A combination that likely does not take place in core GatherPress, but makes a lot of sense as extension point.

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Install the Productions companion plugins, create a two entries: one with a past, one with an upcoming event-date (named _Premiere_ here).
   - https://github.com/carstingaxion/gatherpress-productions
2. Edit an **Event**, relate it to one of the productions
3. Add a _**Production Details**_ block, which is a `gatherpress/venue` block with `sourcePostType` set.
4. Inside the editor: Confirm that the context for the production is loaded properly, if you relate the upcoming production to that event
5. Inside the editor: Confirm that the context for the production is also loaded properly, if you relate the past production to that event
6. On the frontend: Confirm that context resolution works, no matter of upcoming or past Production

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs created from a fork under GitHub organizations. -->
<!-- In this case, you can create the entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
