### PR TITLE
Fix: correct aira-disabled typo to aria-disabled in dropdown and rsvp-response views

### DIFF
--- a/src/blocks/dropdown/view.js
+++ b/src/blocks/dropdown/view.js
@@ -58,7 +58,7 @@ const { actions } = store( 'gatherpress', {
 			if ( clickedAnchor ) {
 				clickedAnchor.classList.add( 'gatherpress--is-disabled' );
 				clickedAnchor.setAttribute( 'tabindex', '-1' );
-				clickedAnchor.setAttribute( 'aira-disabled', 'true' );
+				clickedAnchor.setAttribute( 'aria-disabled', 'true' );
 			}
 
 			// Enable sibling items.

--- a/src/blocks/rsvp-response/view.js
+++ b/src/blocks/rsvp-response/view.js
@@ -177,7 +177,7 @@ const { state, actions } = store( 'gatherpress', {
 
 				element.ref.classList.add( 'gatherpress--is-disabled' );
 				element.ref.setAttribute( 'tabindex', '-1' );
-				element.ref.setAttribute( 'aira-disabled', 'true' );
+				element.ref.setAttribute( 'aria-disabled', 'true' );
 
 				triggerElement.textContent = activeText;
 			}


### PR DESCRIPTION
Fixes #1764

## Proposed changes:

Corrects the invalid attribute name `aira-disabled` to the valid ARIA
attribute `aria-disabled` in two files:
- `src/blocks/dropdown/view.js`
- `src/blocks/rsvp-response/view.js`

`aira-disabled` is not a real attribute, so the intended disabled state was
never exposed to assistive technologies. Using `aria-disabled` ensures screen
readers correctly announce the control as disabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

N/A — single attribute-name typo fix, no logic change, so no new tests needed.

## Testing instructions:

1. Use a page with the dropdown / RSVP blocks.
2. Trigger the control's disabled state.
3. In DevTools, confirm the element now has `aria-disabled="true"` (was `aira-disabled="true"`).

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch
- [ ] Minor
- [ ] Major

#### Type
- [ ] Added
- [ ] Changed
- [ ] Deprecated
- [ ] Removed
- [x] Fixed
- [ ] Security

#### Message
Fixed an invalid `aira-disabled` attribute (now `aria-disabled`) so disabled dropdown and RSVP controls are correctly announced to assistive technologies.

</details>