### PR TITLE
Update PR preview workflow with a mechanism to override parts of the default blueprint per PR.

### DIFF
--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -13,7 +13,6 @@ const path = require('path');
  * @returns {object|null} - Parsed override object, or null if not found / invalid.
  */
 function loadBlueprintOverride(filePath) {
-
 	try {
 		if (!fs.existsSync(filePath)) {
 			console.log(`No blueprint override found at ${filePath}`);
@@ -240,7 +239,7 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion) {
 				step: 'importWxr',
 				file: {
 					resource: 'url',
-					url: 'https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.33.0.xml',
+					url: 'https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.34.0.xml',
 				},
 			},
 			/**

--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -1,7 +1,127 @@
+const fs = require('fs');
+const path = require('path');
+
 /**
- * Based on:
- * https://github.com/Automattic/themes/blob/a0c9b91f827f46ed60c502d41ef881b2f0552f03/.github/scripts/create-preview-links.js
+ * Attempts to read and parse a per-PR blueprint override file.
+ *
+ * The file is looked up at `.github/playground/PR-123-blueprint-override.json`
+ * in the checked-out PR branch code. When called from `workflow_run`,
+ * this requires a separate checkout of the PR head ref (see workflow
+ * changes below).
+ *
+ * @param {string} [filePath] - Path to the override file.
+ * @returns {object|null} - Parsed override object, or null if not found / invalid.
  */
+function loadBlueprintOverride(filePath) {
+
+	try {
+		if (!fs.existsSync(filePath)) {
+			console.log(`No blueprint override found at ${filePath}`);
+			return null;
+		}
+
+		const raw = fs.readFileSync(filePath, 'utf8');
+		const override = JSON.parse(raw);
+
+		console.log(`Loaded blueprint override from ${filePath}`);
+		return override;
+	} catch (err) {
+		console.warn(`Warning: Failed to load blueprint override: ${err.message}`);
+		return null;
+	}
+}
+
+/**
+ * Validates that an override doesn't try to set protected fields.
+ *
+ * @param {object} override - The parsed override object.
+ * @returns {object} - The sanitized override with protected fields removed.
+ */
+function sanitizeOverride(override) {
+	const sanitized = { ...override };
+
+	// These fields are controlled by the generation script and must not
+	// be overridden, because they are either driven by the version matrix
+	// or contain PR-specific dynamic values.
+	const protectedFields = ['preferredVersions', 'phpExtensionBundles'];
+
+	for (const field of protectedFields) {
+		if (field in sanitized) {
+			console.warn(
+				`Warning: Override tried to set protected field "${field}" — ignoring.`
+			);
+			delete sanitized[field];
+		}
+	}
+
+	// Prevent overriding steps directly — use prependSteps / appendSteps instead.
+	if ('steps' in sanitized) {
+		console.warn(
+			'Warning: Override contains "steps" — use "prependSteps" or "appendSteps" instead. Ignoring "steps".'
+		);
+		delete sanitized.steps;
+	}
+
+	return sanitized;
+}
+
+/**
+ * Merges a sanitized override into the base blueprint template.
+ *
+ * Merge strategy:
+ * - `landingPage`: override replaces base.
+ * - `features`: shallow merge (override keys win).
+ * - `siteOptions`: merged into the setSiteOptions step.
+ * - `prependSteps`: inserted after login + setSiteOptions, before mkdir.
+ * - `appendSteps`: appended after all base steps.
+ *
+ * @param {object} template - The base blueprint object (mutated in place).
+ * @param {object} override - The sanitized override object.
+ * @returns {object} - The merged blueprint.
+ */
+function mergeOverride(template, override) {
+	// landingPage — simple replacement
+	if (override.landingPage) {
+		template.landingPage = override.landingPage;
+	}
+
+	// features — shallow merge
+	if (override.features) {
+		template.features = {
+			...template.features,
+			...override.features,
+		};
+	}
+
+	// siteOptions — merge into existing setSiteOptions step
+	if (override.siteOptions) {
+		const siteOptionsStep = template.steps.find(
+			(s) => s.step === 'setSiteOptions'
+		);
+		if (siteOptionsStep) {
+			siteOptionsStep.options = {
+				...siteOptionsStep.options,
+				...override.siteOptions,
+			};
+		}
+	}
+
+	// prependSteps — insert after setSiteOptions, before mkdir
+	if (override.prependSteps && Array.isArray(override.prependSteps)) {
+		const mkdirIndex = template.steps.findIndex(
+			(s) => s.step === 'mkdir'
+		);
+		const insertAt = mkdirIndex >= 0 ? mkdirIndex : 2; // fallback after login + setSiteOptions
+		template.steps.splice(insertAt, 0, ...override.prependSteps);
+	}
+
+	// appendSteps — add after all existing steps
+	if (override.appendSteps && Array.isArray(override.appendSteps)) {
+		template.steps.push(...override.appendSteps);
+	}
+
+	return template;
+}
 
 /**
  * This function creates the URL to download the built & zipped plugin artifact.
@@ -22,12 +142,14 @@ function createBlueprintUrl(context, number) {
 
 /**
  * Creates a WordPress Playground blueprint JSON string.
- * The blueprint specifies the PHP version to use, among other configuration details.
+ * The blueprint specifies the PHP version to use, among other configuration details
+ * optionally merging a per-PR override.
  *
  * @param {object} context - The context of the event that triggered the action.
  * @param {number} number - The PR number where the plugin changes are located.
  * @param {string} zipArtifactUrl - The URL where the built plugin artifact can be downloaded.
  * @param {string} phpVersion - The PHP version to use in the WordPress Playground.
+ * @param {object|null} override - Optional override loaded from the PR branch.
  * @returns {string} - A JSON string representing the blueprint.
  */
 function createBlueprint(context, number, zipArtifactUrl, phpVersion) {
@@ -41,13 +163,11 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion) {
 		landingPage: '/wp-admin/post-new.php?post_type=gatherpress_event',
 		preferredVersions: {
 			php: phpVersion,
-			wp: 'latest'
+			wp: 'latest',
 		},
-		phpExtensionBundles: [
-			'kitchen-sink'
-		],
+		phpExtensionBundles: ['kitchen-sink'],
 		features: {
-			networking: true
+			networking: true,
 		},
 		steps: [
 			{
@@ -60,7 +180,7 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion) {
 				options: {
 					blogname: `${owner}/${repo} PR #${number}`,
 					blogdescription: `Testing pull_request #${number} with playground`,
-				}
+				},
 			},
 			{
 				step: 'mkdir',
@@ -120,8 +240,8 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion) {
 				step: 'importWxr',
 				file: {
 					resource: 'url',
-					url: 'https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.33.0.xml'
-				}
+					url: 'https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.33.0.xml',
+				},
 			},
 			/**
 			 * Run 'enableMultisite' after the plugin activation!
@@ -138,6 +258,12 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion) {
 		],
 	};
 
+	// Apply override if provided
+	if (override) {
+		const sanitized = sanitizeOverride(override);
+		mergeOverride(template, sanitized);
+	}
+
 	return JSON.stringify(template);
 }
 
@@ -151,9 +277,9 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion) {
  */
 function createPlaygroundLinks( blueprint, prText) {
 	const playgrounds = [
-		{ name: '**Normal** WordPress playground ', url: 'https://playground.wordpress.net/#' },
-		{ name: '**Seamless** WordPress playground ', url: 'https://playground.wordpress.net/?mode=seamless#' },
-		{ name: 'WordPress playground **Builder** ', url: 'https://playground.wordpress.net/builder/builder.html#' }
+		{ name: '**Normal** WordPress Playground ', url: 'https://playground.wordpress.net/#' },
+		{ name: '**Seamless** WordPress Playground ', url: 'https://playground.wordpress.net/?mode=seamless#' },
+		{ name: 'WordPress Playground **Builder** ', url: 'https://playground.wordpress.net/builder/builder.html#' },
 	];
 
 	return playgrounds.map(playground => ({
@@ -170,31 +296,95 @@ function createPlaygroundLinks( blueprint, prText) {
  * @param {object} context - The context of the event.
  * @param {number} [prNumberOverride] - Explicit PR number; required when called from a workflow_run
  *   context where context.payload.pull_request is not present.
+ * @param {string} [filePath] - Path to the blueprint override file (for testing or
+ *   when the PR head is checked out to a non-default location).
  */
-async function createPreviewLinksComment(github, context, prNumberOverride) {
+async function createPreviewLinksComment(github, context, prNumberOverride, filePath) {
 	const prNumber       = prNumberOverride ?? context.payload.pull_request.number;
 	const zipArtifactUrl = createBlueprintUrl(context.repo, prNumber);  // URL to the built plugin artifact
 	const prText         = `for PR#${prNumber}`;  // Descriptive text for the PR
 
+	// Load per-PR override
+	const overridePath = filePath + 'PR-' + prNumber + '-blueprint-override.json';
+	const override = loadBlueprintOverride(overridePath);
+
 	// Retrieve PHP versions from environment variable (JSON string)
-	const phpVersionsEnv = process.env.PHP_VERSIONS || '["8.4","8.2","7.4"]';  // Default to common versions if not set
+	const phpVersionsEnv = process.env.PHP_VERSIONS || '["8.4","8.2","7.4"]';  // Default to common versions if not set.
 	const phpVersions    = JSON.parse( phpVersionsEnv );  // Parse the JSON string into an array
 
 	// Generate preview links for each PHP version
 	let previewLinks = '';
 	for (const phpVersion of phpVersions) {
-		const blueprint      = encodeURI(createBlueprint(context.repo, prNumber, zipArtifactUrl, phpVersion));  // Generate blueprint
+		const blueprint      = encodeURI(
+			createBlueprint(context.repo, prNumber, zipArtifactUrl, phpVersion, override)
+		);
 		const links          = createPlaygroundLinks( blueprint, prText );  // Create preview links
 		const versionHeading = `#### PHP Version ${phpVersion}\n`;
 		const versionLinks   = links.map(link => `- [${link.title}](${link.url})\n`).join('');
 		previewLinks        += `\n${versionHeading}\n${versionLinks}`;
 	}
 
-	// The title of the comment and its content, including preview links for all PHP versions
+	const overrideNote = override
+		? `
+> ℹ️ This preview includes a custom blueprint override from <code>${overridePath}</code>.
+`
+		: `
+<details><summary>Customize PR Playground</summary>
+
+To customize the Playground preview for this specific PR, create a file at:
+
+<code>
+.github/playground/PR-${prNumber}-blueprint-override.json
+</code>
+
+The override is merged into the generated blueprint and can be used to:
+
+- Enable Playground features
+- Install additional plugins
+- Change site options
+- Run setup steps before or after the default blueprint
+
+Example:
+
+<pre>
+{
+	"$schema": "https://gatherpress.org/playground-preview/pr-override-schema.json",
+	"landingPage": "/wp-admin/edit.php?post_type=gatherpress_venue",
+	"siteOptions": {
+		"show_on_front": "page"
+	},
+	"features": {
+		"networking": true
+	},
+	"prependSteps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "simple-location"
+			},
+			"options": {
+				"activate": true
+			}
+		}
+	],
+	"appendSteps": [
+		{
+			"step": "runPHP",
+			"code": ""
+		}
+	]
+}
+</pre>
+</details>
+`;
+
+	// The title of the comment and its content, including preview links for all PHP versions.
 	const title       = '### Preview changes with Playground';
 	const commentBody = `
-You can preview the recent changes ${prText} with the following PHP versions:
+${overrideNote}
 
+You can preview the recent changes ${prText} with the following PHP versions:
 ${previewLinks}
 
 [Download <code>.zip</code> with build changes](${zipArtifactUrl})

--- a/.github/workflows/playground-preview-comment.yml
+++ b/.github/workflows/playground-preview-comment.yml
@@ -46,6 +46,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
+          path: base
+
+      # PR head — ONLY to read the override file, never to execute code from it.
+      # Sparse checkout limits what we pull to just the override directory.
+      - name: Checkout PR head for blueprint override
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          path: pr-head
+          sparse-checkout: |
+            .github/playground
+          sparse-checkout-cone-mode: true
 
       - name: Add Preview Links comment
         uses: actions/github-script@v7
@@ -55,5 +67,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const createPreviewLinks = require('.github/scripts/playground-preview');
-            await createPreviewLinks(github, context, Number(process.env.PR_NUMBER));
+            const overrideFilePath = 'pr-head/.github/playground/';
+            const createPreviewLinks = require('./base/.github/scripts/playground-preview');
+            await createPreviewLinks(
+                github,
+                context,
+                Number(process.env.PR_NUMBER),
+                overrideFilePath
+            );


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

NEEDS #1774 FIRST!, Fixes #1736

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This change allows PR authors to customize the Playground preview for their specific case. A properly named `.github/playground/PR-${prNumber}-blueprint-override.json` can be used to override things like:

- landingPage
- Additional steps (appended or prepended to the default steps)
- siteOptions overrides
- features

The logic protects the dynamic and generated parts:

- preferredVersions.php (controlled by the version matrix)
- The plugin download/install steps (the core pipeline)
- blogname / blogdescription (which embeds the PR number)

### Example override blueprint

```json
{
  "$schema": "https://gatherpress.org/playground-override-schema.json",
  "landingPage": "/wp-admin/edit.php?post_type=gatherpress_event",
  "siteOptions": {
    "show_on_front": "page"
  },
  "features": {
    "networking": true
  },
  "prependSteps": [
    {
      "step": "installPlugin",
      "pluginData": { "resource": "wordpress.org/plugins", "slug": "gutenberg" },
      "options": { "activate": true }
    }
  ],
  "appendSteps": [
    {
      "step": "runPHP",
      "code": "<?php require '/wordpress/wp-load.php'; update_option('gatherpress_some_setting', 'value'); ?>"
    }
  ]
}
```
Hopefully the validation schema `https://gatherpress.org/playground-override-schema.json` introduced in #1774 does its work.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unfortunately, this is **_untestable before being merged_**, because the updated workflow will only be called first after merge.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs created from a fork under GitHub organizations. -->
<!-- In this case, you can create the entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
