### PR TITLE
Promote Open RSVP attendees off the waiting list (#1771)

### DIFF
--- a/.github/changelog/1777-from-description
+++ b/.github/changelog/1777-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Open RSVP attendees are now correctly promoted from the waiting list when a spot opens up.

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Settings;
 use GatherPress\Core\Settings\Roles;
+use WP_Comment;
 use WP_Post;
 
 /**
@@ -519,9 +520,20 @@ class Rsvp {
 
 				$response = $waiting_list[ $i ];
 
-				// @todo need to look into this since Open RSVP will not have a userId,
-				// but email or commentId if we can use that.
-				$this->save( $response['userId'], 'attending', $response['anonymous'] );
+				// Resolve the identifier save() expects. Logged-in attendees
+				// carry a userId; Open RSVP attendees have userId 0 and are
+				// keyed by the email on their RSVP comment instead. Without
+				// this, save( 0, ... ) hits the empty-identifier guard and the
+				// promotion is silently dropped (#1771).
+				$comment         = empty( $response['userId'] ) ? get_comment( (int) $response['commentId'] ) : null;
+				$user_identifier = ! empty( $response['userId'] )
+					? $response['userId']
+					: ( $comment instanceof WP_Comment ? $comment->comment_author_email : '' );
+
+				if ( ! empty( $user_identifier ) ) {
+					$this->save( $user_identifier, 'attending', $response['anonymous'] );
+				}
+
 				++$i;
 			}
 		}

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
@@ -296,6 +296,53 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
+	 * Test that an Open RSVP (email-keyed, userId 0) attendee is promoted off the waiting list.
+	 *
+	 * Regression for #1771: the promotion loop previously passed the record's
+	 * userId straight to save(), which is 0 for non-logged-in Open RSVP
+	 * attendees, so save() hit its empty-identifier guard and the promotion
+	 * was silently dropped.
+	 *
+	 * @since  0.34.0
+	 * @covers ::check_waiting_list
+	 *
+	 * @return void
+	 */
+	public function test_check_waiting_list_promotes_open_rsvp_attendee(): void {
+		$event_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+		$rsvp     = new Rsvp( $event_id );
+		$email    = 'open-rsvp-attendee@example.com';
+
+		Utility::set_and_get_hidden_property( $rsvp, 'max_attendance_limit', 1 );
+
+		// Fill the single spot with a logged-in user, then add an email-keyed
+		// Open RSVP attendee who lands on the waiting list.
+		$rsvp->save( $this->factory->user->create(), 'attending' );
+		$rsvp->save( $email, 'attending' );
+
+		$this->assertSame(
+			'waiting_list',
+			$rsvp->get( $email )['status'],
+			'Open RSVP attendee should start on the waiting list'
+		);
+
+		// Open the event up and run the promotion sweep.
+		Utility::set_and_get_hidden_property( $rsvp, 'max_attendance_limit', 0 );
+
+		$this->assertSame(
+			1,
+			$rsvp->check_waiting_list(),
+			'Should promote the email-keyed Open RSVP attendee'
+		);
+
+		$this->assertSame(
+			'attending',
+			$rsvp->get( $email )['status'],
+			'Open RSVP attendee should be moved to attending'
+		);
+	}
+
+	/**
 	 * Coverage for attending_limit_reached method.
 	 *
 	 * @covers ::attending_limit_reached


### PR DESCRIPTION
Fixes #1771

## Problem

\`Rsvp::check_waiting_list()\` passed each waiting-list record's \`userId\` straight to \`save()\`:

\`\`\`php
$this->save( $response['userId'], 'attending', $response['anonymous'] );
\`\`\`

For non-logged-in **Open RSVP** attendees \`userId\` is \`0\`, so \`save( 0, ... )\` hit its \`empty( $user_id ) && empty( $email )\` guard and returned a no-status result. When a spot opened up, a logged-out attendee on the waiting list was never moved to attending. Logged-in attendees promoted fine. The spot was flagged with a \`@todo\` in source.

## Fix

Resolve the identifier \`save()\` actually expects:

- Logged-in attendee → keep the \`userId\`.
- Open RSVP attendee (\`userId\` 0) → look up the email on their RSVP comment via \`commentId\`. \`save()\` already accepts an email and matches the existing comment by \`author_email\`, so no change to \`save()\` is needed.
- Records that resolve to neither are skipped rather than passed as \`0\`.

The record carries \`commentId\` but not the email directly (\`responses()\` strips it for privacy), so the email is read from the comment.

## Testing

Adds \`test_check_waiting_list_promotes_open_rsvp_attendee\`, which fills the single spot with a logged-in user, puts an email-keyed Open RSVP attendee on the waiting list, lifts the limit, and asserts the sweep promotes them. Verified it **fails on the old code** (attendee stuck on \`waiting_list\`) and passes with the fix. Full \`Test_Rsvp\` suite (200 tests) green.

### Scope note

A logged-in-but-anonymous attendee promoted during an *anonymous-triggered* sweep still won't resolve (their \`userId\` is masked to 0 by \`responses()\` and their comment has no email). That was already broken before this change and is a separate, narrower issue — this PR is scoped to the Open RSVP case in #1771.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch

#### Type
-   [x] Fixed

#### Message
Open RSVP attendees are now correctly promoted from the waiting list when a spot opens up.

</details>