### PR TITLE
Guard prepare_event_data against a missing response id (#1765)

### DIFF
--- a/.github/changelog/1779-from-description
+++ b/.github/changelog/1779-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent a fatal error when the event REST response is prepared without an id field (e.g. a _fields= request that excludes it).

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -1088,7 +1088,17 @@ class Rest_Api {
 	 * @return WP_REST_Response The response object with enhanced event data.
 	 */
 	public function prepare_event_data( WP_REST_Response $response ): WP_REST_Response {
-		$event = new Event( $response->data['id'] );
+		// The response data shape depends on what the controller included: a
+		// `_fields=` request that drops `id`, or another plugin filtering the
+		// response, can leave it absent. Bail rather than emit an undefined-key
+		// notice and construct Event( 0 ), which would silently do nothing.
+		$post_id = $response->data['id'] ?? 0;
+
+		if ( ! $post_id ) {
+			return $response;
+		}
+
+		$event = new Event( $post_id );
 
 		// Retrieve the online event link only if:
 		// - The user is attending the event.

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -1159,6 +1159,38 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
+	 * Coverage for prepare_event_data when the response has no id.
+	 *
+	 * Regression for #1765: a `_fields=` request (or another plugin filtering
+	 * the response) can produce data without an `id` key. The method should
+	 * bail instead of emitting an undefined-key notice and constructing
+	 * Event( 0 ).
+	 *
+	 * @covers ::prepare_event_data
+	 *
+	 * @return void
+	 */
+	public function test_prepare_event_data_without_id_returns_response_unchanged(): void {
+		$instance = Rest_Api::get_instance();
+
+		// Mimic a `_fields=title` response: no `id`, no `meta`.
+		$response = new WP_REST_Response( array( 'title' => 'Filtered Event' ) );
+
+		$result = $instance->prepare_event_data( $response );
+
+		$this->assertSame(
+			array( 'title' => 'Filtered Event' ),
+			$result->data,
+			'Response data should be returned untouched when id is absent.'
+		);
+		$this->assertArrayNotHasKey(
+			'meta',
+			$result->data,
+			'No meta should be injected when id is absent.'
+		);
+	}
+
+	/**
 	 * Coverage for events_list with topics filter.
 	 *
 	 * @covers ::events_list


### PR DESCRIPTION
Fixes #1765

## Problem

\`prepare_event_data()\` runs on the \`rest_prepare_gatherpress_event\` filter and assumed \`$response->data['id']\` is always present:

\`\`\`php
$event = new Event( $response->data['id'] );
\`\`\`

The response shape depends on what the controller included — a \`_fields=\` request that excludes \`id\`, or another plugin filtering the response, produces data without that key.

## Impact

The original report assumed an undefined-key notice plus a silent \`Event( 0 )\`. It's actually worse: \`Event::__construct\` is typed \`int\`, so the missing key (\`null\`) throws a **TypeError** — a fatal 500 on the REST request, not a notice.

\`\`\`
TypeError: Event::__construct(): Argument #1 ($post_id) must be of type int, null given
\`\`\`

## Fix

Bail early when \`id\` is absent, returning the response untouched:

\`\`\`php
$post_id = $response->data['id'] ?? 0;

if ( ! $post_id ) {
	return $response;
}
\`\`\`

The report's secondary note about \`meta\` injection under \`_fields\` filtering is a non-issue: WordPress applies \`_fields\` filtering on \`rest_post_dispatch\`, *after* \`rest_prepare_*\` runs, so any injected \`meta.online_event_link\` is stripped afterward if the client didn't request it.

## Testing

Adds \`test_prepare_event_data_without_id_returns_response_unchanged\`, mimicking a \`_fields=title\` response (no \`id\`, no \`meta\`). It throws a TypeError on the old code and passes with the fix, asserting the response data is returned untouched and no \`meta\` is injected. Existing \`test_prepare_event_data\` still green.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch

#### Type
-   [x] Fixed

#### Message
Prevent a fatal error when the event REST response is prepared without an id field (e.g. a _fields= request that excludes it).

</details>