### PR TITLE
Add missed param to fn signature

### DIFF
--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -151,7 +151,7 @@ function createBlueprintUrl(context, number) {
  * @param {object|null} override - Optional override loaded from the PR branch.
  * @returns {string} - A JSON string representing the blueprint.
  */
-function createBlueprint(context, number, zipArtifactUrl, phpVersion) {
+function createBlueprint(context, number, zipArtifactUrl, phpVersion, override) {
 	const { repo, owner } = context;
 
 	// TODO


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
After some Playground PR preview logic was changed in #1775, this is the PR to fix things, revealed in https://github.com/GatherPress/gatherpress/actions/runs/27439740244/job/81110585926.

<img width="2398" height="706" alt="image" src="https://github.com/user-attachments/assets/9318e17e-fab6-4f83-ac7b-9d209a998ed8" />


Fixes #1775

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the missing `override` parameter to the function call.

---

> please add the "Skip Changelog" label