### PR TITLE
Always return an array for events_list current_user (#1766)

### DIFF
--- a/.github/changelog/1781-from-description
+++ b/.github/changelog/1781-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The events list REST endpoint now always returns an array for the current_user field instead of an empty string when no RSVP exists.

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -730,7 +730,11 @@ class Rest_Api {
 				$event             = new Event( $post_id );
 				$venue_information = $event->get_venue_information();
 				$user_identifier   = Setup::get_instance()->get_user_identifier();
-				$current_user_rsvp = ( $event->rsvp ) ? $event->rsvp->get( $user_identifier ) : '';
+				// Rsvp::get() is typed `: array` — an empty array when there's
+				// no RSVP, a populated record otherwise. Mirror that with an
+				// empty-array fallback so `current_user` is always an array
+				// rather than flipping between '' and an object (#1766).
+				$current_user_rsvp = ( $event->rsvp ) ? $event->rsvp->get( $user_identifier ) : array();
 				$posts[]           = array(
 					'ID'                       => $post_id,
 					'datetime_start'           => $event->get_datetime_start( $datetime_format ),
@@ -748,7 +752,7 @@ class Rest_Api {
 						true
 					),
 					'responses'                => ( $event->rsvp ) ? $event->rsvp->responses() : array(),
-					'current_user'             => ( $current_user_rsvp ) ? $current_user_rsvp : '',
+					'current_user'             => $current_user_rsvp,
 					'venue'                    => ( $venue_information['name'] )
 						? $event->get_venue_information()
 						: null,

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -584,6 +584,73 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
+	 * Coverage for the current_user field type stability in events_list.
+	 *
+	 * Regression for #1766: current_user previously returned '' when there was
+	 * no RSVP and an array when one existed. It should always be an array so JS
+	 * consumers can safely read current_user.status.
+	 *
+	 * @covers ::events_list
+	 *
+	 * @return void
+	 */
+	public function test_events_list_current_user_is_always_array(): void {
+		$instance = Rest_Api::get_instance();
+		$event_id = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+		$event    = new Event( $event_id );
+
+		$event->save_datetimes(
+			array(
+				'datetime_start' => gmdate( Event::DATETIME_FORMAT, strtotime( '+1 day' ) ),
+				'datetime_end'   => gmdate( Event::DATETIME_FORMAT, strtotime( '+2 day' ) ),
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_query_params( array( 'event_list_type' => 'upcoming' ) );
+
+		// Logged-out, no RSVP: current_user should be an empty array, not ''.
+		wp_set_current_user( 0 );
+		$response = $instance->events_list( $request );
+		$current  = $this->find_event_in_list( $response->data, $event_id )['current_user'];
+
+		$this->assertIsArray( $current, 'current_user should be an array with no RSVP.' );
+		$this->assertSame( array(), $current, 'current_user should be empty with no RSVP.' );
+
+		// Logged-in with an RSVP: current_user should still be an array, now populated.
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+		$event->rsvp->save( $user_id, 'attending' );
+
+		$response = $instance->events_list( $request );
+		$current  = $this->find_event_in_list( $response->data, $event_id )['current_user'];
+
+		$this->assertIsArray( $current, 'current_user should be an array with an RSVP.' );
+		$this->assertSame( 'attending', $current['status'], 'current_user should carry the RSVP status.' );
+	}
+
+	/**
+	 * Helper to find a single event entry in an events_list response.
+	 *
+	 * @param array $events   Response data from events_list.
+	 * @param int   $event_id The event ID to locate.
+	 *
+	 * @return array The matching event entry, or an empty array if not found.
+	 */
+	private function find_event_in_list( array $events, int $event_id ): array {
+		foreach ( $events as $event ) {
+			if ( isset( $event['ID'] ) && $event_id === $event['ID'] ) {
+				return $event;
+			}
+		}
+
+		return array();
+	}
+
+	/**
 	 * Helper to get members IDs for test.
 	 *
 	 * @param array $events Response from events_list.


### PR DESCRIPTION
Fixes #1766

## Problem

The \`current_user\` field in the \`events_list\` response was type-unstable — \`\ \`(empty string) when there was no RSVP, an array when one existed:

\`\`\`php
$current_user_rsvp = ( $event->rsvp ) ? $event->rsvp->get( $user_identifier ) : '';
...
'current_user' => ( $current_user_rsvp ) ? $current_user_rsvp : '',
\`\`\`

\`Rsvp::get()\` returns an array (empty for logged-out / no RSVP, populated otherwise), but the empty array is falsy in PHP so the \`''\` fallback kicked in. JS consumers reading \`current_user.status\` get a field that's an object sometimes and a string other times.

## Fix

\`Rsvp::get()\` is already declared \`: array\`, so mirror that contract: fall back to \`array()\` when the event has no \`rsvp\` object, and drop the \`''\` fallback on the field. \`current_user\` is now always an array — empty when there's no RSVP, populated (\`status\`, \`guests\`, …) when one exists.

No internal consumer depends on the old shape — the \`events-list\` endpoint isn't referenced anywhere in \`src/\`. (Note: the original report's claim that the frontend receives \`current_user: []\` because "an empty array is truthy in PHP" is incorrect — an empty array is falsy, so the old code did emit \`''\`. The type-instability is the real issue.)

## Testing

Adds \`test_events_list_current_user_is_always_array\`: asserts \`current_user\` is an empty array for a logged-out viewer with no RSVP, and a populated array carrying \`status\` once a user RSVPs. Verified it **fails on the old code** (\`Failed asserting that '' is of type "array"\`) and passes with the fix. Full \`Test_Rest_Api\` suite (64 tests) green.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch

#### Type
-   [x] Fixed

#### Message
The events list REST endpoint now always returns an array for the current_user field instead of an empty string when no RSVP exists.

</details>