### PR TITLE
Handle apiFetch failures in RsvpManager (#1770)

### DIFF
--- a/.github/changelog/1782-from-description
+++ b/.github/changelog/1782-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The RSVP manager in the editor now shows an error notice instead of silently clearing the attendee list when an RSVP request fails.

--- a/src/blocks/rsvp-response/rsvp-manager.js
+++ b/src/blocks/rsvp-response/rsvp-manager.js
@@ -5,7 +5,7 @@ import { useState, useEffect } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { FormTokenField, SelectControl } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -34,6 +34,7 @@ const RsvpManager = ( { defaultStatus, setDefaultStatus } ) => {
 		[],
 	);
 	const [ rsvpResponse, setRsvpResponse ] = useState( null );
+	const { createErrorNotice } = useDispatch( 'core/notices' );
 
 	/**
 	 * Fetches user records from the core store via getEntityRecords.
@@ -55,13 +56,26 @@ const RsvpManager = ( { defaultStatus, setDefaultStatus } ) => {
 		if ( postId ) {
 			apiFetch( {
 				path: `${ EVENT_REST_API }/rsvp-responses?post_id=${ postId }`,
-			} ).then( ( res ) => {
-				if ( res?.success && res?.data ) {
-					setRsvpResponse( res.data );
-				}
-			} );
+			} )
+				.then( ( res ) => {
+					if ( res?.success && res?.data ) {
+						setRsvpResponse( res.data );
+					}
+				} )
+				.catch( ( error ) => {
+					// Leave any existing responses on screen and surface the
+					// failure rather than silently rendering nothing.
+					createErrorNotice?.(
+						error?.message ||
+							__(
+								'Could not load RSVP responses. Please try again.',
+								'gatherpress',
+							),
+						{ type: 'snackbar' },
+					);
+				} );
 		}
-	}, [ postId ] );
+	}, [ postId, createErrorNotice ] );
 
 	if ( ! rsvpResponse ) {
 		return null;
@@ -97,9 +111,25 @@ const RsvpManager = ( { defaultStatus, setDefaultStatus } ) => {
 				status,
 				user_id: userId,
 			},
-		} ).then( ( res ) => {
-			setRsvpResponse( res.responses );
-		} );
+		} )
+			.then( ( res ) => {
+				// Only replace the list when the response actually carries
+				// one. An error-shaped response has no `responses` key, and
+				// blindly assigning it would wipe the displayed attendees.
+				if ( res?.responses ) {
+					setRsvpResponse( res.responses );
+				}
+			} )
+			.catch( ( error ) => {
+				createErrorNotice?.(
+					error?.message ||
+						__(
+							'Could not update the RSVP. Please try again.',
+							'gatherpress',
+						),
+					{ type: 'snackbar' },
+				);
+			} );
 	};
 
 	/**

--- a/test/unit/js/src/blocks/rsvp-response/rsvp-manager.test.js
+++ b/test/unit/js/src/blocks/rsvp-response/rsvp-manager.test.js
@@ -1,0 +1,249 @@
+/**
+ * External dependencies
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+} from '@jest/globals';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * Mocks — declared before the component import so jest hoists them.
+ */
+const mockApiFetch = jest.fn();
+const mockCreateErrorNotice = jest.fn();
+
+let mockPostId;
+let mockUserList;
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( args ) => mockApiFetch( args ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: ( store ) => {
+		if ( 'core/notices' === store ) {
+			return { createErrorNotice: mockCreateErrorNotice };
+		}
+		return {};
+	},
+	// The component calls useSelect twice: first for the post ID, then for
+	// the user list. Hand each call the value it expects by inspecting what
+	// the callback reads.
+	useSelect: ( callback ) => {
+		const result = callback( () => ( {
+			getCurrentPostId: () => mockPostId,
+			getEntityRecords: () => mockUserList,
+		} ) );
+		return result?.userList !== undefined ? result : mockPostId;
+	},
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+// Lightweight stand-ins so we don't pull in the full @wordpress/components
+// runtime. FormTokenField exposes buttons that drive its onChange the way a
+// user adding/removing a token would.
+jest.mock( '@wordpress/components', () => ( {
+	SelectControl: () => <div data-testid="select-control" />,
+	FormTokenField: ( { value, onChange } ) => (
+		<div data-testid="token-field">
+			<span data-testid="token-count">{ value?.length ?? 0 }</span>
+			<button
+				type="button"
+				data-testid="add-token"
+				onClick={ () => onChange( [ 'alice' ] ) }
+			>
+				add
+			</button>
+			<button
+				type="button"
+				data-testid="remove-token"
+				onClick={ () => onChange( [] ) }
+			>
+				remove
+			</button>
+		</div>
+	),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import RsvpManager from '@src/blocks/rsvp-response/rsvp-manager';
+
+/**
+ * Builds a populated responses payload with one attending member.
+ *
+ * @param {Object[]} attending Records for the attending bucket.
+ * @return {Object} A responses object shaped like the REST payload.
+ */
+function responsesWith( attending = [] ) {
+	return {
+		attending: { records: attending },
+		waiting_list: { records: [] },
+		not_attending: { records: [] },
+	};
+}
+
+const ATTENDEE = { userId: 5, name: 'Alice' };
+
+describe( 'RsvpManager', () => {
+	const defaultProps = {
+		defaultStatus: 'attending',
+		setDefaultStatus: jest.fn(),
+	};
+
+	beforeEach( () => {
+		mockApiFetch.mockReset();
+		mockCreateErrorNotice.mockReset();
+		mockPostId = 123;
+		mockUserList = [ { id: 5, username: 'alice' } ];
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'surfaces an error notice when the responses fetch rejects', async () => {
+		mockApiFetch.mockRejectedValueOnce( new Error( 'network down' ) );
+
+		render( <RsvpManager { ...defaultProps } /> );
+
+		await waitFor( () =>
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				'network down',
+				{ type: 'snackbar' },
+			),
+		);
+	} );
+
+	it( 'falls back to a default message when the responses rejection has no message', async () => {
+		mockApiFetch.mockRejectedValueOnce( {} );
+
+		render( <RsvpManager { ...defaultProps } /> );
+
+		await waitFor( () =>
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				'Could not load RSVP responses. Please try again.',
+				{ type: 'snackbar' },
+			),
+		);
+	} );
+
+	it( 'surfaces an error notice when updating an RSVP rejects', async () => {
+		// First call resolves the responses; the /rsvp update rejects.
+		mockApiFetch.mockImplementation( ( { path } ) => {
+			if ( path.includes( 'rsvp-responses' ) ) {
+				return Promise.resolve( {
+					success: true,
+					data: responsesWith( [] ),
+				} );
+			}
+			return Promise.reject( new Error( 'save failed' ) );
+		} );
+
+		render( <RsvpManager { ...defaultProps } /> );
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'token-field' ) ).toBeInTheDocument(),
+		);
+
+		fireEvent.click( screen.getByTestId( 'add-token' ) );
+
+		await waitFor( () =>
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith( 'save failed', {
+				type: 'snackbar',
+			} ),
+		);
+	} );
+
+	it( 'falls back to a default message when the update rejection has no message', async () => {
+		mockApiFetch.mockImplementation( ( { path } ) => {
+			if ( path.includes( 'rsvp-responses' ) ) {
+				return Promise.resolve( {
+					success: true,
+					data: responsesWith( [] ),
+				} );
+			}
+			return Promise.reject( {} );
+		} );
+
+		render( <RsvpManager { ...defaultProps } /> );
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'token-field' ) ).toBeInTheDocument(),
+		);
+
+		fireEvent.click( screen.getByTestId( 'add-token' ) );
+
+		await waitFor( () =>
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				'Could not update the RSVP. Please try again.',
+				{ type: 'snackbar' },
+			),
+		);
+	} );
+
+	it( 'does not wipe the attendee list when the update response has no responses key', async () => {
+		mockApiFetch.mockImplementation( ( { path } ) => {
+			if ( path.includes( 'rsvp-responses' ) ) {
+				return Promise.resolve( {
+					success: true,
+					data: responsesWith( [ ATTENDEE ] ),
+				} );
+			}
+			// Error-shaped response: success false, no `responses` key.
+			return Promise.resolve( { success: false, message: 'nope' } );
+		} );
+
+		render( <RsvpManager { ...defaultProps } /> );
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'token-count' ) ).toHaveTextContent( '1' ),
+		);
+
+		// Trigger a removal, which posts to /rsvp and gets the error shape back.
+		fireEvent.click( screen.getByTestId( 'remove-token' ) );
+
+		// The manager must stay rendered with its attendee, not collapse to null.
+		await waitFor( () =>
+			expect( screen.getByTestId( 'token-field' ) ).toBeInTheDocument(),
+		);
+		expect( screen.getByTestId( 'token-count' ) ).toHaveTextContent( '1' );
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'updates the attendee list when the update response carries responses', async () => {
+		mockApiFetch.mockImplementation( ( { path } ) => {
+			if ( path.includes( 'rsvp-responses' ) ) {
+				return Promise.resolve( {
+					success: true,
+					data: responsesWith( [] ),
+				} );
+			}
+			return Promise.resolve( { responses: responsesWith( [ ATTENDEE ] ) } );
+		} );
+
+		render( <RsvpManager { ...defaultProps } /> );
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'token-count' ) ).toHaveTextContent( '0' ),
+		);
+
+		fireEvent.click( screen.getByTestId( 'add-token' ) );
+
+		await waitFor( () =>
+			expect( screen.getByTestId( 'token-count' ) ).toHaveTextContent( '1' ),
+		);
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Fixes #1770

## Problem

The two \`apiFetch\` calls in \`src/blocks/rsvp-response/rsvp-manager.js\` had no error handling:

- The \`rsvp-responses\` load (\`useEffect\`) had no \`.catch()\`.
- \`updateRsvpStatus\` ran \`setRsvpResponse( res.responses )\` with no guard at all:

\`\`\`javascript
} ).then( ( res ) => {
	setRsvpResponse( res.responses );
} );
\`\`\`

On an error-shaped response (network error, 500, permission error), \`res.responses\` is \`undefined\`. Setting state to \`undefined\` trips the \`if ( ! rsvpResponse ) return null\` guard, so the **entire manager collapses to null** — the displayed attendees vanish — with no feedback to the user.

## Fix

- Add \`.catch()\` to both calls. They surface a snackbar error notice via \`core/notices\` and leave existing state intact, so a failed load/update no longer blanks the UI silently.
- Guard the update success path on \`res?.responses\` so an error response never overwrites the list with \`undefined\`.

Follows the \`createErrorNotice\` pattern already established in \`src/blocks/venue-map/helpers.js\` (optional-call \`createErrorNotice?.()\`, \`{ type: 'snackbar' }\`).

## Testing

This file had no prior test coverage. Adds a suite covering:

- responses-load rejection → error notice (and the default-message fallback when the error has no \`message\`)
- update rejection → error notice (and its default-message fallback)
- update returns an error shape (no \`responses\`) → attendee list is **not** wiped, manager stays rendered
- update returns \`responses\` → list updates (happy path)

All six pass; the changed lines (both catches + the guard) are fully covered. \`npm run build\` and ESLint clean.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch

#### Type
-   [x] Fixed

#### Message
The RSVP manager in the editor now shows an error notice instead of silently clearing the attendee list when an RSVP request fails.

</details>