### PR TITLE
Fix Event Query block stalling on non-event post types (#1756)

### DIFF
--- a/.github/changelog/1783-from-description
+++ b/.github/changelog/1783-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the Event Query block hanging on an endless spinner when its post type is switched to one that does not support event dates.

--- a/src/variations/core/query/controls.js
+++ b/src/variations/core/query/controls.js
@@ -146,6 +146,52 @@ export const EventQueryControlsPanel = ( props ) => {
 		updateBlockAttributes,
 	] );
 
+	// Strip the event-only query vars when the selected post type doesn't
+	// support event dates. `orderBy: 'datetime'` (and 'rand') are added to the
+	// REST orderby enum only for event-date post types, so leaving them on a
+	// plain post/page/venue query makes the core endpoint reject the request
+	// (rest_invalid_param) and the Query Loop spins forever (#1756). The
+	// gatherpress_event_query / include_unfinished vars are harmless on those
+	// endpoints but meaningless there, so drop them too. Guarded on the vars
+	// still being present so this doesn't re-fire in a loop.
+	useEffect( () => {
+		if ( queryPostTypeSupportsEvents ) {
+			return;
+		}
+
+		const { query } = props.attributes;
+		const hasEventOnlyOrderBy =
+			'datetime' === query.orderBy || 'rand' === query.orderBy;
+		const hasEventOnlyVars =
+			undefined !== query.gatherpress_event_query ||
+			undefined !== query.include_unfinished ||
+			hasEventOnlyOrderBy;
+
+		if ( ! hasEventOnlyVars ) {
+			return;
+		}
+
+		const {
+			gatherpress_event_query: removedEventQuery,
+			include_unfinished: removedIncludeUnfinished,
+			...remainingQuery
+		} = query;
+
+		// Reset the GatherPress-only ordering to the core default the
+		// posts/pages endpoint accepts; leave any other orderBy intact.
+		if ( hasEventOnlyOrderBy ) {
+			remainingQuery.orderBy = 'date';
+			remainingQuery.order = 'desc';
+		}
+
+		updateBlockAttributes( clientId, { query: remainingQuery } );
+	}, [
+		queryPostTypeSupportsEvents,
+		props.attributes,
+		clientId,
+		updateBlockAttributes,
+	] );
+
 	// Read the singular label so the label reflects what the currently
 	// selected post type is actually called — a custom event-supporting post type with
 	// `singular_name => 'Production'` shows "Production Query Settings".

--- a/test/unit/js/src/variations/core/query/controls.test.js
+++ b/test/unit/js/src/variations/core/query/controls.test.js
@@ -71,9 +71,10 @@ jest.mock( '@src/helpers/editor', () => ( {
 	usePostTypeLabel: jest.fn( ( key, postType, fallback ) => fallback ),
 } ) );
 
+const mockUpdateBlockAttributes = jest.fn();
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: jest.fn( () => ( {
-		updateBlockAttributes: jest.fn(),
+		updateBlockAttributes: mockUpdateBlockAttributes,
 	} ) ),
 } ) );
 
@@ -180,6 +181,103 @@ describe( 'EventQueryControlsPanel', () => {
 			'gatherpress-event-date',
 			undefined
 		);
+	} );
+} );
+
+describe( 'EventQueryControlsPanel query cleanup (#1756)', () => {
+	// Pull just the `query` payload from the most recent updateBlockAttributes
+	// call that targeted the query (the metadata-name effect also fires).
+	const lastQueryUpdate = () => {
+		const call = mockUpdateBlockAttributes.mock.calls
+			.filter( ( [ , attrs ] ) => attrs?.query )
+			.at( -1 );
+		return call ? call[ 1 ].query : undefined;
+	};
+
+	beforeEach( () => {
+		usePostTypeSupports.mockReset();
+		mockUpdateBlockAttributes.mockClear();
+	} );
+
+	it( 'strips event-only vars and resets orderBy=datetime when switching to a non-event post type', () => {
+		usePostTypeSupports.mockReturnValue( false );
+
+		render(
+			<EventQueryControlsPanel
+				clientId="abc"
+				attributes={ {
+					query: {
+						postType: 'post',
+						perPage: 5,
+						gatherpress_event_query: 'upcoming',
+						include_unfinished: 1,
+						orderBy: 'datetime',
+						order: 'asc',
+					},
+				} }
+			/>
+		);
+
+		expect( lastQueryUpdate() ).toEqual( {
+			postType: 'post',
+			perPage: 5,
+			orderBy: 'date',
+			order: 'desc',
+		} );
+	} );
+
+	it( 'resets orderBy=rand as well, since rand is GatherPress-only on the REST enum', () => {
+		usePostTypeSupports.mockReturnValue( false );
+
+		render(
+			<EventQueryControlsPanel
+				clientId="abc"
+				attributes={ {
+					query: { postType: 'page', orderBy: 'rand' },
+				} }
+			/>
+		);
+
+		expect( lastQueryUpdate() ).toEqual( {
+			postType: 'page',
+			orderBy: 'date',
+			order: 'desc',
+		} );
+	} );
+
+	it( 'does not touch the query when no event-only vars are present', () => {
+		usePostTypeSupports.mockReturnValue( false );
+
+		render(
+			<EventQueryControlsPanel
+				clientId="abc"
+				attributes={ {
+					query: { postType: 'post', orderBy: 'title' },
+				} }
+			/>
+		);
+
+		expect( lastQueryUpdate() ).toBeUndefined();
+	} );
+
+	it( 'does not clean up while the post type still supports event dates', () => {
+		usePostTypeSupports.mockReturnValue( true );
+
+		render(
+			<EventQueryControlsPanel
+				clientId="abc"
+				attributes={ {
+					query: {
+						postType: 'gatherpress_event',
+						orderBy: 'datetime',
+						gatherpress_event_query: 'upcoming',
+						inherit: false,
+					},
+				} }
+			/>
+		);
+
+		expect( lastQueryUpdate() ).toBeUndefined();
 	} );
 } );
 


### PR DESCRIPTION
Fixes #1756

## Problem

Switching an Event Query block to a post type that does not support `gatherpress-event-date` (Post, Page, Venue, …) left the Query Loop spinning forever.

## Root cause

The variation injects `orderBy: 'datetime'` when a block becomes an Event Query (and the user can pick "Random" → `'rand'`). Both values are added to the REST `orderby` enum **only for event-date post types**, via `rest_collection_params` (registered through `rest_<post_type>_collection_params`). On a plain `post`/`page`/`venue` query those values aren't in the core `orderby` enum, so the editor's REST request fails with `rest_invalid_param` and the Query Loop never resolves.

**This corrects the issue's hypothesis.** The report suggested unsetting `gatherpress_event_query` and `include_unfinished`, but those aren't the problem — WordPress ignores unregistered params. Verified against the running site's posts endpoint:

| param | result |
|---|---|
| `gatherpress_event_query=upcoming` | HTTP 200 |
| `include_unfinished=1` | HTTP 200 |
| `orderby=datetime` | **HTTP 400** `rest_invalid_param` |
| `orderby=rand` | **HTTP 400** `rest_invalid_param` |

## Fix

In `EventQueryControlsPanel`, when the selected post type stops supporting event dates, strip the event-only query vars and reset the GatherPress-only ordering (`datetime`/`rand`) back to the core default `date`/`desc` that the posts/pages endpoint accepts. The gatherpress params are dropped too (harmless but meaningless on those endpoints). Guarded on the vars still being present so the effect doesn't re-fire in a loop.

## Testing

Adds tests covering:
- `orderBy: 'datetime'` + gatherpress vars on a non-event type → stripped, ordering reset to `date`/`desc`, other query keys preserved
- `orderBy: 'rand'` → reset the same way
- a clean non-event query (e.g. `orderBy: 'title'`) → left untouched (no update loop)
- an event-supporting type → no cleanup

`controls.js` changed lines fully covered; full variations suite (18 tests) green; ESLint and `npm run build` clean.

> Visual editor confirmation pending — the logic and REST root cause are verified, but I have not yet driven the actual block in the editor.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch

#### Type
-   [x] Fixed

#### Message
Fixed the Event Query block hanging on an endless spinner when its post type is switched to one that does not support event dates.

</details>