### PR TITLE
Fix RSVP from event archive pages not persisting (#1752)

### DIFF
--- a/.github/changelog/1784-from-description
+++ b/.github/changelog/1784-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RSVP status changes now save correctly from event archive and Query Loop pages, not only from individual event pages.

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -153,21 +153,24 @@ class Assets {
 	/**
 	 * Set initial interactivity state for frontend blocks.
 	 *
-	 * Provides the REST API URL to the gatherpress interactivity store
-	 * so that frontend view scripts can make API requests without
-	 * relying on window globals.
+	 * Provides the REST API URL to the gatherpress interactivity store so
+	 * frontend view scripts (RSVP nonce/status requests) can build API URLs
+	 * without relying on window globals.
+	 *
+	 * The state is set on every front-end view rather than only on singular
+	 * event pages: RSVP and other interactive blocks also render in event
+	 * archives and Query Loops, where the previous `is_singular()` gate left
+	 * `eventApiUrl` undefined — the view scripts then requested
+	 * `/event/undefined/nonce` (404) and every RSVP from an archive failed
+	 * (#1752). The value is a static site URL, so emitting it broadly is
+	 * cheap; the interactivity runtime only serializes it when a gatherpress
+	 * interactive block is actually present on the page.
 	 *
 	 * @since 0.34.0
 	 *
 	 * @return void
 	 */
 	public function add_interactivity_state(): void {
-		$event_post_types = get_post_types_by_support( 'gatherpress-event-date' );
-
-		if ( ! is_singular( $event_post_types ) ) {
-			return;
-		}
-
 		$event_rest_api_slug = sprintf( '%s/event', GATHERPRESS_REST_NAMESPACE );
 
 		wp_interactivity_state(

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -164,6 +164,13 @@ class Test_Assets extends Base {
 	/**
 	 * Coverage for add_interactivity_state method.
 	 *
+	 * Regression for #1752: the eventApiUrl must be available on event
+	 * archives (and Query Loops), not only singular event pages — RSVP and
+	 * other interactive blocks render there too. The previous `is_singular()`
+	 * gate left `eventApiUrl` undefined on the archive, so the RSVP view
+	 * scripts requested `/event/undefined/nonce` (404) and every RSVP from an
+	 * archive failed.
+	 *
 	 * @covers ::add_interactivity_state
 	 *
 	 * @return void
@@ -171,22 +178,9 @@ class Test_Assets extends Base {
 	public function test_add_interactivity_state(): void {
 		$instance = Assets::get_instance();
 
-		// Should not set state on a non-event singular page.
-		$post = $this->mock->post( array( 'post_type' => 'post' ) )->get();
-		$this->go_to( get_permalink( $post->ID ) );
-
-		$instance->add_interactivity_state();
-		$state = wp_interactivity_state( 'gatherpress' );
-
-		$this->assertArrayNotHasKey(
-			'eventApiUrl',
-			$state,
-			'Failed to assert interactivity state is not set for non-event post types.'
-		);
-
-		// Should set state on an event singular page.
-		$event = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
-		$this->go_to( get_permalink( $event->ID ) );
+		// Visit the event archive — the context that previously bailed.
+		$this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+		$this->go_to( get_post_type_archive_link( Event::POST_TYPE ) );
 
 		$instance->add_interactivity_state();
 		$state = wp_interactivity_state( 'gatherpress' );
@@ -194,7 +188,7 @@ class Test_Assets extends Base {
 		$this->assertArrayHasKey(
 			'eventApiUrl',
 			$state,
-			'Failed to assert eventApiUrl is set in interactivity state.'
+			'Failed to assert eventApiUrl is set in interactivity state on the event archive.'
 		);
 		$this->assertStringContainsString(
 			'wp-json/gatherpress/v1/event',


### PR DESCRIPTION
Fixes #1752

## Problem

Changing RSVP status from the **Events archive** (or any Query Loop of events) silently failed — the modal opened and let you pick a status, but it never saved. The same RSVP worked fine on an individual event page.

## Root cause

`Assets::add_interactivity_state()` set the `eventApiUrl` value in the gatherpress interactivity store **only on singular event pages**:

```php
if ( ! is_singular( $event_post_types ) ) {
    return;
}
```

But RSVP (and other interactive) blocks also render in event archives and Query Loops. There `eventApiUrl` was never set, so the front-end view scripts built their request URLs from `undefined`:

```
GET  /event/undefined/nonce        → 404
POST /event/undefined/rsvp-status-html → 404
```

`getNonce()` then failed, the RSVP request never went through, and (since #1719 added failure feedback) the user now sees *“Sorry, there was an issue processing your RSVP.”* On a singular event page `is_singular()` is true, the URL is set, and it works — exactly the reported asymmetry.

## Fix

Drop the `is_singular()` gate and always provide the state on the front end. `eventApiUrl` is a static site URL, so emitting it broadly is cheap, and the interactivity runtime only serializes it when a gatherpress interactive block is actually present on the page.

## Verification

Confirmed live on an event archive (via the page’s interactivity state):

| | Before | After |
|---|---|---|
| `eventApiUrl` | `undefined` | `https://…/wp-json/gatherpress/v1/event` |
| nonce URL | `/event/undefined/nonce` → **404** | `…/gatherpress/v1/event/nonce` → **200, nonce returned** |

Updated the unit test to assert the state is set on the **event archive** (the context that previously bailed) rather than asserting it is absent on non-singular pages. Full `Test_Assets` suite (36 tests) green.

> Note: while tracing this I also found that `Blocks\Setup::get_post_id()` ignores the Query Loop `context.postId` (it only reads the `postId` attribute, then falls back to `get_the_ID()`). It happens not to bite here because the archive’s main loop sets up `get_the_ID()` correctly, but it’s a latent issue for blocks rendered without global post setup. Happy to file/handle that separately to keep this PR focused.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch

#### Type
-   [x] Fixed

#### Message
RSVP status changes now save correctly from event archive and Query Loop pages, not only from individual event pages.

</details>