### PR TITLE
Gate Default Map Type setting behind the Google platform (#1760)

### DIFF
--- a/.github/changelog/1787-from-description
+++ b/.github/changelog/1787-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+The Default Map Type venue setting now only appears when the Google Maps platform is selected.

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -142,6 +142,33 @@ class Venues extends Base {
 							'map_platform' => 'google',
 						),
 					),
+					'venue_map_default_type'         => array(
+						'labels'      => array(
+							'name' => __( 'Default Map Type', 'gatherpress' ),
+						),
+						'description' => __(
+							'Default map type for new venue map blocks.',
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Map type for new blocks:', 'gatherpress' ),
+							'type'    => 'select',
+							'options' => array(
+								'default' => Map::DEFAULT_MAP_TYPE,
+								'items'   => array(
+									'roadmap'   => __( 'Roadmap', 'gatherpress' ),
+									'satellite' => __( 'Satellite', 'gatherpress' ),
+									'hybrid'    => __( 'Hybrid', 'gatherpress' ),
+									'terrain'   => __( 'Terrain', 'gatherpress' ),
+								),
+							),
+						),
+						// Map type only affects Google Maps rendering, so only
+						// surface this field when the Google platform is selected.
+						'show_if'     => array(
+							'map_platform' => 'google',
+						),
+					),
 					'venue_map_default_render_mode'  => array(
 						'labels'      => array(
 							'name' => __( 'Default Render Mode', 'gatherpress' ),
@@ -263,29 +290,6 @@ class Venues extends Base {
 									'cover'   => __( 'Cover', 'gatherpress' ),
 									'contain' => __( 'Contain', 'gatherpress' ),
 									'fill'    => __( 'Fill', 'gatherpress' ),
-								),
-							),
-						),
-					),
-					'venue_map_default_type'         => array(
-						'labels'      => array(
-							'name' => __( 'Default Map Type', 'gatherpress' ),
-						),
-						'description' => __(
-							// phpcs:ignore Generic.Files.LineLength.TooLong -- Single translator-facing sentence; keep on one line for .pot extractor.
-							'Default map type for new venue map blocks. Only rendered by Google Maps; OpenStreetMap and static images ignore this value.',
-							'gatherpress'
-						),
-						'field'       => array(
-							'label'   => __( 'Map type for new blocks:', 'gatherpress' ),
-							'type'    => 'select',
-							'options' => array(
-								'default' => Map::DEFAULT_MAP_TYPE,
-								'items'   => array(
-									'roadmap'   => __( 'Roadmap', 'gatherpress' ),
-									'satellite' => __( 'Satellite', 'gatherpress' ),
-									'hybrid'    => __( 'Hybrid', 'gatherpress' ),
-									'terrain'   => __( 'Terrain', 'gatherpress' ),
 								),
 							),
 						),

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -163,8 +163,6 @@ class Venues extends Base {
 								),
 							),
 						),
-						// Map type only affects Google Maps rendering, so only
-						// surface this field when the Google platform is selected.
 						'show_if'     => array(
 							'map_platform' => 'google',
 						),

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
@@ -118,5 +118,13 @@ class Test_Venues extends Base {
 				sprintf( 'Failed to assert default value for %s.', $key )
 			);
 		}
+
+		// Default Map Type only affects Google Maps rendering, so it is gated
+		// behind the Google platform via show_if (#1760).
+		$this->assertSame(
+			array( 'map_platform' => 'google' ),
+			$section['maps']['options']['venue_map_default_type']['show_if'],
+			'Failed to assert Default Map Type is gated to the Google platform.'
+		);
 	}
 }


### PR DESCRIPTION
Fixes #1760

The **Default Map Type** setting only affects Google Maps rendering — OpenStreetMap and static images ignore it. This adds a `show_if` so the field only appears when the Google mapping platform is selected, mirroring the existing `google_maps_api_key` gate.

## Changes

- **`show_if` gate**: `venue_map_default_type` now declares `show_if => array( map_platform => 'google' )`, so it is hidden unless Google Maps is the selected platform.
- **Simpler description**: since the field is only visible for Google now, dropped the redundant *"Only rendered by Google Maps; OpenStreetMap and static images ignore this value."* caveat — it just reads *"Default map type for new venue map blocks."*
- **Reordered**: moved the field up next to **Google Maps API Key** so the two Google-only fields sit together directly under the platform toggle, instead of being buried below the generic block-default fields.

## Verification

Confirmed live on the Venues → Maps settings page:
- **OpenStreetMap selected** → Default Map Type (and Google Maps API Key) are hidden.
- **Google Maps selected** → both appear together right under the Mapping Platform selector.

Added a unit test asserting the `show_if` condition; full `Test_Venues` suite green; PHPCS clean.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch

#### Type
-   [x] Changed

#### Message
The Default Map Type venue setting now only appears when the Google Maps platform is selected.

</details>