### PR TITLE
Fix playground preview comment formatting & add docs

### DIFF
--- a/.github/changelog/1791-fix-playground-preview-comment-formatting
+++ b/.github/changelog/1791-fix-playground-preview-comment-formatting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+New documentation about customizable Playground previews per pull-request

--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -278,7 +278,6 @@ function createPlaygroundLinks( blueprint, prText) {
 	const playgrounds = [
 		{ name: '**Normal** WordPress Playground ', url: 'https://playground.wordpress.net/#' },
 		{ name: '**Seamless** WordPress Playground ', url: 'https://playground.wordpress.net/?mode=seamless#' },
-		// { name: 'WordPress Playground **Builder** ', url: 'https://playground.wordpress.net/builder/builder.html#' },
 	];
 
 	return playgrounds.map(playground => ({

--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -374,6 +374,8 @@ Example:
 }
 \`\`\`
 </details>
+
+Go to [Playground PR preview customization](https://github.com/GatherPress/gatherpress/blob/develop/docs/contributor/playground-pr-preview/README.md) for more details.
 `;
 
 	// The title of the comment and its content, including preview links for all PHP versions.

--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -325,16 +325,14 @@ async function createPreviewLinksComment(github, context, prNumberOverride, file
 
 	const overrideNote = override
 		? `
-ℹ️ This preview includes a custom blueprint override from <code>${overridePath}</code>.
+ℹ️ This preview includes a custom blueprint override from <code>.github/playground/PR-${prNumber}-blueprint-override.json</code>.
 `
 		: `
 <details><summary>Customize PR Playground</summary>
 
 To customize the Playground preview for this specific PR, create a file at:
 
-<code>
-.github/playground/PR-${prNumber}-blueprint-override.json
-</code>
+<code>.github/playground/PR-${prNumber}-blueprint-override.json</code>
 
 The override is merged into the generated blueprint and can be used to:
 
@@ -345,7 +343,7 @@ The override is merged into the generated blueprint and can be used to:
 
 Example:
 
-<pre>
+\`\`\`json
 {
 	"$schema": "https://gatherpress.org/playground-preview/pr-override-schema.json",
 	"landingPage": "/wp-admin/edit.php?post_type=gatherpress_venue",
@@ -374,7 +372,7 @@ Example:
 		}
 	]
 }
-</pre>
+\`\`\`
 </details>
 `;
 

--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -278,7 +278,7 @@ function createPlaygroundLinks( blueprint, prText) {
 	const playgrounds = [
 		{ name: '**Normal** WordPress Playground ', url: 'https://playground.wordpress.net/#' },
 		{ name: '**Seamless** WordPress Playground ', url: 'https://playground.wordpress.net/?mode=seamless#' },
-		{ name: 'WordPress Playground **Builder** ', url: 'https://playground.wordpress.net/builder/builder.html#' },
+		// { name: 'WordPress Playground **Builder** ', url: 'https://playground.wordpress.net/builder/builder.html#' },
 	];
 
 	return playgrounds.map(playground => ({
@@ -325,7 +325,7 @@ async function createPreviewLinksComment(github, context, prNumberOverride, file
 
 	const overrideNote = override
 		? `
-> ℹ️ This preview includes a custom blueprint override from <code>${overridePath}</code>.
+ℹ️ This preview includes a custom blueprint override from <code>${overridePath}</code>.
 `
 		: `
 <details><summary>Customize PR Playground</summary>

--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -338,7 +338,7 @@ The override is merged into the generated blueprint and can be used to:
 - Enable Playground features
 - Install additional plugins
 - Change site options
-- Run setup steps before or after the default blueprint
+- Run steps before or after the GatherPress' default steps
 
 Example:
 
@@ -374,7 +374,7 @@ Example:
 \`\`\`
 </details>
 
-Go to [Playground PR preview customization](https://github.com/GatherPress/gatherpress/blob/develop/docs/contributor/playground-pr-preview/README.md) for more details.
+Go to [Playground PR preview customization](https://github.com/GatherPress/gatherpress/blob/develop/docs/contributor/playground-pr-preview/README.md#customize-your-pr-playground) for more details.
 `;
 
 	// The title of the comment and its content, including preview links for all PHP versions.

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -23,6 +23,10 @@ on:
     - 'includes/**'
     - 'src/**'
     - '*.php'
+	# Do start the workflow, even when just a PR preview blueprint was added or changed.
+	# That allows doing compatibility tests with 3rd-party plugins or
+	# just to get some reproducible debugging environment with "Query Monitor".
+    - '.github/playground/**'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -23,9 +23,9 @@ on:
     - 'includes/**'
     - 'src/**'
     - '*.php'
-	# Do start the workflow, even when just a PR preview blueprint was added or changed.
-	# That allows doing compatibility tests with 3rd-party plugins or
-	# just to get some reproducible debugging environment with "Query Monitor".
+    # Do start the workflow, even when just a PR preview blueprint was added or changed.
+    # That allows doing compatibility tests with 3rd-party plugins or
+    # just to get some reproducible debugging environment with "Query Monitor".
     - '.github/playground/**'
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/docs/contributor/playground-pr-preview/README.md
+++ b/docs/contributor/playground-pr-preview/README.md
@@ -19,6 +19,21 @@ your-gatherpress-branch
          └── PR-{NUMBER_OF_THE_PR}-blueprint-override.json
 ```
 
+The content of that new file looks very much like a regular *Playground blueprint*.
+
+The main difference is that you are not allowed to use any regular `steps`, but have to use `prependSteps` and `appendSteps`. This will make sure, your *steps* get loaded in the correct order, and before or after GatherPress core runs its own steps. `prependSteps` and `appendSteps` take all the same, you would put in `steps` in a regular blueprint.
+
+```json
+{
+	"$schema": "https://gatherpress.org/playground-override-schema.json",
+	"landingPage": " ... ",
+	"siteOptions": { ... },
+	"features": { ... },
+	"prependSteps": [ ... ],
+	"appendSteps": [ ... ]
+}
+```
+
 The override is merged into the generated default blueprint and as such still contains the different php version, GatherPress plugin and demo-data, but also allows to
 
 - Change the landing page
@@ -35,6 +50,7 @@ The override is merged into the generated default blueprint and as such still co
 
 	```json
 	{
+		"$schema": "https://gatherpress.org/playground-preview/pr-override-schema.json",
 		"prependSteps": [
 		{
 			"step": "installPlugin",
@@ -52,6 +68,7 @@ The override is merged into the generated default blueprint and as such still co
 
 	```json
 	{
+		"$schema": "https://gatherpress.org/playground-preview/pr-override-schema.json",
 		"landingPage": "/wp-admin/admin.php?page=monkeyman-rewrite-analyzer",
 		"prependSteps": [
 		{

--- a/docs/contributor/playground-pr-preview/README.md
+++ b/docs/contributor/playground-pr-preview/README.md
@@ -22,3 +22,89 @@ The override is merged into the generated default blueprint and as such still co
 - Run steps before GatherPress' default steps
 - Run steps after GatherPress' default steps
 
+###
+
+
+1.
+	<details><summary>Debug with *Query Monitor*</summary>
+
+	```json
+	{
+		"prependSteps": [
+		{
+			"step": "installPlugin",
+			"pluginData": { "resource": "wordpress.org/plugins", "slug": "query-monitor" },
+			"options": { "activate": true }
+		}
+		]
+	}
+	```
+
+	</details>
+
+2.
+	<details><summary>Test endpoints with *Monkeyman Rewrite Analyzer*</summary>
+
+	```json
+	{
+		"landingPage": "/wp-admin/admin.php?page=monkeyman-rewrite-analyzer",
+		"prependSteps": [
+		{
+			"step": "installPlugin",
+			"pluginData": { "resource": "wordpress.org/plugins", "slug": "monkeyman-rewrite-analyzer" },
+			"options": { "activate": true }
+		}
+		]
+	}
+	```
+
+	</details>
+
+3.
+	<details><summary>Full example</summary>
+
+	```json
+	{
+		"$schema": "https://gatherpress.org/playground-preview/pr-override-schema.json",
+		"landingPage": "/wp-admin/edit.php?post_type=gatherpress_event",
+		"siteOptions": {
+			"show_on_front": "page"
+		},
+		"features": {
+			"networking": true
+		},
+		"prependSteps": [
+			{
+			"step": "installPlugin",
+			"pluginData": { "resource": "wordpress.org/plugins", "slug": "gutenberg" },
+			"options": { "activate": true }
+			}
+		],
+		"appendSteps": [
+			{
+			"step": "runPHP",
+			"code": "<?php require '/wordpress/wp-load.php'; update_option('gatherpress_some_setting', 'value'); ?>"
+			}
+		]
+	}
+	```
+
+	</details>
+
+
+
+### Validation Schema
+
+Protected fields cannot be overridden, `preferredVersions` (the PHP version matrix), `phpExtensionBundles`, and raw `step`s are rejected. PR authors must use `prependSteps` and `appendSteps`.
+
+To help with the override style, GatherPress published its own Playground Override Scheme under https://gatherpress.org/playground-preview/pr-override-schema.json.
+
+This should be referenced in a `PR-*-blueprint-override.json` like so:
+
+```json
+{
+  "$schema": "https://gatherpress.org/playground-preview/pr-override-schema.json",
+  [...]
+}
+```
+Editors like *VS Code* will provide autocompletion for all standard and our custom Playground properties with full step-type validation.

--- a/docs/contributor/playground-pr-preview/README.md
+++ b/docs/contributor/playground-pr-preview/README.md
@@ -30,7 +30,7 @@ The override is merged into the generated default blueprint and as such still co
 ### Examples
 
 
-1.
+1.	<!-- markdownlint-disable-next-line MD033 -->
 	<details><summary><strong>Debug with <em>Query Monitor</em></strong></summary>
 
 	```json
@@ -47,7 +47,7 @@ The override is merged into the generated default blueprint and as such still co
 
 	</details>
 
-2.
+2.	<!-- markdownlint-disable-next-line MD033 -->
 	<details><summary><strong>Test <code>/ical</code>endpoints with <em>Monkeyman Rewrite Analyzer</em></strong></summary>
 
 	```json
@@ -65,7 +65,7 @@ The override is merged into the generated default blueprint and as such still co
 
 	</details>
 
-3.
+3.	<!-- markdownlint-disable-next-line MD033 -->
 	<details><summary><strong>Full example</strong></summary>
 
 	```json
@@ -102,7 +102,7 @@ The override is merged into the generated default blueprint and as such still co
 
 Protected fields cannot be overridden, `preferredVersions` (the PHP version matrix), `phpExtensionBundles`, and raw `step`s are rejected. PR authors must use `prependSteps` and `appendSteps`.
 
-To help with the override style, GatherPress published its own Playground Override Scheme under https://gatherpress.org/playground-preview/pr-override-schema.json.
+To help with the override style, GatherPress published its own Playground Override Scheme under [`gatherpress.org/playground-preview/pr-override-schema.json`](https://gatherpress.org/playground-preview/pr-override-schema.json).
 
 This should be referenced in a `PR-*-blueprint-override.json` like so:
 
@@ -112,4 +112,5 @@ This should be referenced in a `PR-*-blueprint-override.json` like so:
   [...]
 }
 ```
+
 Editors like *VS Code* will provide autocompletion for all standard and our custom Playground properties with full step-type validation.

--- a/docs/contributor/playground-pr-preview/README.md
+++ b/docs/contributor/playground-pr-preview/README.md
@@ -4,11 +4,11 @@ GatherPress PRs have Playground powered previews available in 3 PHP version, and
 
 A PR preview Playground contains the latest changes from this PR, built, installed and activated. The setup gets seeded with the regular gatherpress-demo-data.
 
-## Customize PR Playground
+## Customize your PR Playground
 
-GatherPress allows to customise the generated Playground for your PR.
+GatherPress allows to customize the generated Playground for your PR.
 
-You can change the landing page, set options, do stuff before GatherPress is loaded, do stuff afterwards. Everything you can with a regular Playground blueprint. GatherPress loads its important blueprint steps together with yours, resulting in a nicely, reproducable and highly customisable setup.
+You can change the landing page, set options, do stuff before GatherPress is loaded, do stuff afterwards. Everything you can with a regular Playground blueprint. GatherPress loads its important blueprint steps together with yours, resulting in a nicely, reproducible and highly customizable setup.
 
 To customize the Playground preview for a specific PR, create a file at:
 

--- a/docs/contributor/playground-pr-preview/README.md
+++ b/docs/contributor/playground-pr-preview/README.md
@@ -1,8 +1,8 @@
 # Playground PR previews
 
-GatherPress PRs have Playground powered previews available in 3 PHP version, and prepared as normal, seamless and builder-enabled Playgrounds. The prepared instances are provided as a comment on each PR, that gets updated automatically.
+GatherPress PRs have Playground powered previews available in 3 PHP version, and prepared as normal and seamless Playgrounds. The prepared instances are provided as a comment on each PR, that gets updated automatically.
 
-A PR preview Playground contains the latest changes from this PR, built, installed and activated. The setup gets seeded with the regular gatherpress-demo-data.
+A PR preview Playground contains the latest changes from this PR, built, installed and activated. The setup gets seeded with the regular [gatherpress-demo-data](https://github.com/GatherPress/gatherpress-demo-data).
 
 ## Customize your PR Playground
 

--- a/docs/contributor/playground-pr-preview/README.md
+++ b/docs/contributor/playground-pr-preview/README.md
@@ -8,7 +8,7 @@ A PR preview Playground contains the latest changes from this PR, built, install
 
 GatherPress allows to customize the generated Playground for your PR.
 
-You can change the landing page, set options, do stuff before GatherPress is loaded, do stuff afterwards. Everything you can with a regular Playground blueprint. GatherPress loads its important blueprint steps together with yours, resulting in a nicely, reproducible and highly customizable setup.
+You can change the landing page, set options, do stuff before GatherPress is loaded, do stuff afterwards. Everything you can with a regular Playground blueprint. GatherPress loads its important blueprint steps together with yours, resulting in a nicely reproducible and highly customizable setup.
 
 To customize the Playground preview for a specific PR, create a file at:
 
@@ -27,7 +27,7 @@ The override is merged into the generated default blueprint and as such still co
 - Run steps before GatherPress' default steps
 - Run steps after GatherPress' default steps
 
-###
+### Examples
 
 
 1.

--- a/docs/contributor/playground-pr-preview/README.md
+++ b/docs/contributor/playground-pr-preview/README.md
@@ -26,7 +26,7 @@ The override is merged into the generated default blueprint and as such still co
 
 
 1.
-	<details><summary>Debug with *Query Monitor*</summary>
+	<details><summary><strong>Debug with <em>Query Monitor</em></strong></summary>
 
 	```json
 	{
@@ -43,7 +43,7 @@ The override is merged into the generated default blueprint and as such still co
 	</details>
 
 2.
-	<details><summary>Test endpoints with *Monkeyman Rewrite Analyzer*</summary>
+	<details><summary><strong>Test <code>/ical</code>endpoints with <em>Monkeyman Rewrite Analyzer</em></strong></summary>
 
 	```json
 	{
@@ -61,7 +61,7 @@ The override is merged into the generated default blueprint and as such still co
 	</details>
 
 3.
-	<details><summary>Full example</summary>
+	<details><summary><strong>Full example</strong></summary>
 
 	```json
 	{

--- a/docs/contributor/playground-pr-preview/README.md
+++ b/docs/contributor/playground-pr-preview/README.md
@@ -12,7 +12,12 @@ You can change the landing page, set options, do stuff before GatherPress is loa
 
 To customize the Playground preview for a specific PR, create a file at:
 
-<code>.github/playground/PR-{NUMBER_OF_THE_PR}-blueprint-override.json</code>
+```sh
+your-gatherpress-branch
+ └── .github
+     └──playground
+         └── PR-{NUMBER_OF_THE_PR}-blueprint-override.json
+```
 
 The override is merged into the generated default blueprint and as such still contains the different php version, GatherPress plugin and demo-data, but also allows to
 

--- a/docs/contributor/playground-pr-preview/README.md
+++ b/docs/contributor/playground-pr-preview/README.md
@@ -1,0 +1,24 @@
+# Playground PR previews
+
+GatherPress PRs have Playground powered previews available in 3 PHP version, and prepared as normal, seamless and builder-enabled Playgrounds. The prepared instances are provided as a comment on each PR, that gets updated automatically.
+
+A PR preview Playground contains the latest changes from this PR, built, installed and activated. The setup gets seeded with the regular gatherpress-demo-data.
+
+## Customize PR Playground
+
+GatherPress allows to customise the generated Playground for your PR.
+
+You can change the landing page, set options, do stuff before GatherPress is loaded, do stuff afterwards. Everything you can with a regular Playground blueprint. GatherPress loads its important blueprint steps together with yours, resulting in a nicely, reproducable and highly customisable setup.
+
+To customize the Playground preview for a specific PR, create a file at:
+
+<code>.github/playground/PR-{NUMBER_OF_THE_PR}-blueprint-override.json</code>
+
+The override is merged into the generated default blueprint and as such still contains the different php version, GatherPress plugin and demo-data, but also allows to
+
+- Change the landing page
+- Enable Playground features
+- Change site options
+- Run steps before GatherPress' default steps
+- Run steps after GatherPress' default steps
+

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -9,7 +9,8 @@ The GatherPress Playground is a live, interactive demo environment powered by [W
 ## 🧪 What You Can Do
 
 - Explore the current plugin version with preloaded demo data
-- Preview plugin updates via pull request-linked blueprints
+- Preview plugin updates via [pull request-linked blueprints](docs/contributor/playground-pr-preview/README.md)
+- Test compatibility with your and third-party plugins using [customizable Playground PR previews](docs/contributor/playground-pr-preview/README.md#customize-your-pr-playground)
 - Automatically generate multilingual screenshots
 - Run end-to-end tests (in progress)
 - Curate and reuse custom demo data for consistency


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Finally finishes #1775 with formatting fixes and a new contributor/doc. The changes are based on the findings from #1778, which could be seen as the issue for this PR.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
### Changes to the `playground-preview` workflow

* Start the `playground-preview` workflow, even with no changes at all to the core plugin, but by adding a `blueprint-override.json`. That allows doing compatibility tests with 3rd-party plugins or just to get some reproducible debugging environment with "Query Monitor".

###  Changes to the `playground-preview-comment` workflow

* Fix some formatting issue of the _Playground preview comment_, found in #1778
* Also adds a link to the new docs directly into the comment, so documentation is available to every PR author

### Changes to the `/docs`

* Adds a new `/docs/contributor/playground-pr-preview/README.md` explain the inner workings and usage of the Playground PR preview links generated by GatherPress.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? _**No**_

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a PR with any change
* _(wait for the comment to appear)_
* Confirm the _Playground preview comment_ contains a "Customize PR Playground" section, wrapped in a collapsed `details` tag
* Confirm it is
  *  well formatted
  * does not contain any typos
  * and contains a link to the new docs
* update your PR with a `.github/playground/PR-{NUMBER_OF_THE_PR}-blueprint-override.json` with some steps from https://github.com/carstingaxion/gatherpress/blob/fix/playground-preview-comment-formatting/docs/contributor/playground-pr-preview/README.md
* Confirm the _Playground preview comment_ contains a "ℹ️ This preview includes a custom blueprint override from ..." section
* Confirm the generated Playground links start an instance incl. your changes

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs created from a fork under GitHub organizations. -->
<!-- In this case, you can create the entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
