### PR TITLE
Stop the Event Query spinner inside block templates (#1753)

### DIFF
--- a/.github/changelog/1792-from-description
+++ b/.github/changelog/1792-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Event Query blocks placed inside a block template no longer leave the editor preview spinning indefinitely.

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -422,9 +422,20 @@ class Event_Query {
 			'enum'        => array( 0, 1 ),
 		);
 
+		// exclude_current and gatherpress_shadow_source_post_id are post IDs,
+		// but inside a block template the editor preview sends the template
+		// identifier (e.g. "twentytwentyfive//single-gatherpress_event")
+		// because there is no concrete post providing numeric context. A bare
+		// `type => integer` rejects that with a 400, which leaves the Query
+		// Loop spinning forever in the template editor (#1753). Accept any
+		// value and coerce it to a non-negative int instead: a non-numeric
+		// template id collapses to 0, which downstream treats as "no context"
+		// and renders the query unfiltered rather than erroring.
 		$query_params['exclude_current'] = array(
-			'description' => __( 'Post ID to exclude from results', 'gatherpress' ),
-			'type'        => 'integer',
+			'description'       => __( 'Post ID to exclude from results', 'gatherpress' ),
+			'type'              => 'integer',
+			'validate_callback' => '__return_true',
+			'sanitize_callback' => 'absint',
 		);
 
 		$query_params['shadow_filter'] = array(
@@ -434,11 +445,13 @@ class Event_Query {
 		);
 
 		$query_params['gatherpress_shadow_source_post_id'] = array(
-			'description' => __(
+			'description'       => __(
 				'Editor-side post ID used to scope the venue contextual filter in the REST preview.',
 				'gatherpress'
 			),
-			'type'        => 'integer',
+			'type'              => 'integer',
+			'validate_callback' => '__return_true',
+			'sanitize_callback' => 'absint',
 		);
 
 		$query_params['gatherpress_shadow_source_post_type'] = array(

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -291,6 +291,29 @@ class Test_Event_Query extends Base {
 		$this->assertContains( 'title', $result['orderby']['enum'] );
 		$this->assertContains( 'rand', $result['orderby']['enum'] );
 		$this->assertContains( 'datetime', $result['orderby']['enum'] );
+
+		// Regression for #1753: the post-ID params must coerce a non-numeric
+		// value to 0 rather than rejecting it. Inside a block template the
+		// editor preview sends the template identifier (e.g.
+		// "twentytwentyfive//single-gatherpress_event") for these, and a strict
+		// integer rejection 400s the request and leaves the Query Loop spinning.
+		$template_id = 'twentytwentyfive//single-gatherpress_event';
+		foreach ( array( 'exclude_current', 'gatherpress_shadow_source_post_id' ) as $param ) {
+			$this->assertSame(
+				'absint',
+				$result[ $param ]['sanitize_callback'],
+				sprintf( '%s should sanitize to a non-negative int.', $param )
+			);
+			$this->assertTrue(
+				call_user_func( $result[ $param ]['validate_callback'], $template_id ),
+				sprintf( '%s should accept a non-numeric template identifier (no 400).', $param )
+			);
+			$this->assertSame(
+				0,
+				call_user_func( $result[ $param ]['sanitize_callback'], $template_id ),
+				sprintf( '%s should coerce a non-numeric template identifier to 0 (no context).', $param )
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Partially addresses #1753 — the editor-not-hanging half.

## Problem

Place an Event Query block (or a `gatherpress/venue` block with a `sourcePostType` containing one) inside a **block template** (e.g. a Single Event template), and the Query Loop preview **spins forever** in the editor.

## Root cause

In a template there is no concrete post, so `getCurrentPostId()` returns the **template identifier** — a string like `twentytwentyfive//single-gatherpress_event` — and that gets baked into the block's `exclude_current` / `gatherpress_shadow_source_post_id` query attributes. Those are registered as REST collection params with `type: integer`, so the editor preview request fails validation:

```
GET /wp/v2/gatherpress_events?gatherpress_shadow_source_post_id=twentytwentyfive//single-gatherpress_event
  -> HTTP 400 rest_invalid_param
```

A 400 leaves the Query Loop spinning (same failure shape as #1756). A numeric id (post content) returns `200`.

## Fix

Accept any value for those two ID params and coerce it to a non-negative int (`validate_callback => __return_true`, `sanitize_callback => absint`). A non-numeric template identifier collapses to `0`, which the downstream resolution already treats as "no context" — so the preview returns **200 and renders the query unfiltered** instead of erroring and hanging. A real numeric post id is unaffected and still filters correctly.

## Verification (live, with Carsten's companion plugins)

Set up a Single Event template + `gatherpress-productions` / `gatherpress-seasons`, with a season-scoped Event Query:

| | Before | After |
|---|---|---|
| Template editor | Query Loop spins forever | Renders the event list (unfiltered) |
| REST preview (template id) | `400 rest_invalid_param` | `200` (9 results, unfiltered) |
| REST preview (numeric id) | `200` (3 filtered) | `200` (3 filtered) — unchanged |

Adds a regression test asserting both params coerce a non-numeric template identifier to `0` (fails on the old code, where there is no `sanitize_callback`). Full `Test_Event_Query` suite (32 tests) green; PHPCS clean.

## Scope

This is the **editor-not-hanging** half. The remaining, larger piece — resolving the shadow source from the *event being viewed* so a Single Event template filters by that event's season/venue rather than rendering unfiltered — is a separate change and intentionally out of scope here.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance
-   [x] Patch

#### Type
-   [x] Fixed

#### Message
Event Query blocks placed inside a block template no longer leave the editor preview spinning indefinitely.

</details>