### PR TITLE
Resolve template-baked block context from the viewed event on the frontend (#1753)

### DIFF
--- a/.github/changelog/1793-from-description
+++ b/.github/changelog/1793-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Event Query blocks placed in a Single Event block template now filter by the viewed event's season/venue and can exclude the current event on the frontend, instead of rendering every event unfiltered.

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -211,7 +211,20 @@ class Event_Query {
 
 		// Exclude Current Post.
 		if ( isset( $attributes['exclude_current'] ) && boolval( $attributes['exclude_current'] ) ) {
-			array_push( $exclude_ids, $attributes['exclude_current'] );
+			$exclude_id = (int) $attributes['exclude_current'];
+
+			// Inside a block template `exclude_current` holds the template
+			// identifier (e.g. "twentytwentyfive//single-gatherpress_event"),
+			// not a post id, so it casts to 0. On a singular page the "current"
+			// post is the queried object, so resolve to it at render time. This
+			// makes "exclude current event" work inside a template too (#1753).
+			if ( $exclude_id <= 0 && is_singular() ) {
+				$exclude_id = get_queried_object_id();
+			}
+
+			if ( $exclude_id > 0 ) {
+				array_push( $exclude_ids, $exclude_id );
+			}
 		}
 
 		return $exclude_ids;

--- a/includes/core/classes/class-shadow-source.php
+++ b/includes/core/classes/class-shadow-source.php
@@ -510,9 +510,16 @@ class Shadow_Source {
 	/**
 	 * Resolve the shadow-source post for the current query context.
 	 *
-	 * Two resolution paths:
-	 * 1. Frontend — `is_singular()` is true and the queried object is a shadow-source post.
-	 * 2. REST editor preview — the consumer (typically the `gatherpress/event-query` block)
+	 * Three resolution paths, tried in order:
+	 * 1. Frontend, queried object is itself a shadow source — `is_singular()` is true and the
+	 *    queried object (e.g. a single venue or season) declares `gatherpress-shadow-source`.
+	 * 2. Frontend, queried object is an event — `is_singular()` is true and the queried object is
+	 *    an event (or other consumer post type). The block's baked context id points at the
+	 *    template, not a post, so the source post of the requested type is resolved from the
+	 *    event's own relationship via its shadow taxonomy. This is what makes a contextual Event
+	 *    Query inside a Single Event template filter by the season/venue of the event being viewed
+	 *    (#1753).
+	 * 3. REST editor preview — the consumer (typically the `gatherpress/event-query` block)
 	 *    writes the editor's current post id + post type into the `gatherpress_shadow_source_post_id`
 	 *    and `gatherpress_shadow_source_post_type` query vars when the contextual toggle is on. We
 	 *    use those as the source when `is_singular()` is false.
@@ -524,18 +531,35 @@ class Shadow_Source {
 	 * @return WP_Post|null The source post if one can be resolved, otherwise null.
 	 */
 	public function resolve_post_from_query_context( WP_Query $query ): ?WP_Post {
+		$context_post_type = (string) $query->get( 'gatherpress_shadow_source_post_type' );
+		$resolved          = null;
+
 		if ( is_singular() ) {
 			$queried = get_queried_object();
-			if (
-				$queried instanceof WP_Post
-				&& post_type_supports( $queried->post_type, 'gatherpress-shadow-source' )
-			) {
-				return $queried;
+
+			if ( $queried instanceof WP_Post ) {
+				if ( post_type_supports( $queried->post_type, 'gatherpress-shadow-source' ) ) {
+					// The page itself is a shadow source (e.g. a single venue or
+					// season): scope the query to it directly.
+					$resolved = $queried;
+				} elseif (
+					'' !== $context_post_type
+					&& post_type_supports( $context_post_type, 'gatherpress-shadow-source' )
+				) {
+					// The page is an event (Single Event template). Resolve the
+					// source post of the requested type from the event's own
+					// relationship so "filter by season/venue" means "the same
+					// season/venue as the event being viewed" (#1753).
+					$resolved = $this->get_source_post_from_event_post_id( $queried->ID, $context_post_type );
+				}
 			}
 		}
 
-		$context_post_id   = (int) $query->get( 'gatherpress_shadow_source_post_id' );
-		$context_post_type = (string) $query->get( 'gatherpress_shadow_source_post_type' );
+		if ( $resolved instanceof WP_Post ) {
+			return $resolved;
+		}
+
+		$context_post_id = (int) $query->get( 'gatherpress_shadow_source_post_id' );
 
 		if (
 			$context_post_id <= 0

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -609,6 +609,84 @@ class Test_Event_Query extends Base {
 	}
 
 	/**
+	 * Inside a block template `exclude_current` holds the template identifier
+	 * (non-numeric), which casts to 0. On a singular event the "current" post
+	 * is the queried object, so it must be excluded by the queried event id
+	 * rather than the unusable template slug (#1753).
+	 *
+	 * @since 0.34.0
+	 * @covers ::query_loop_block_query_vars
+	 * @covers ::get_exclude_ids
+	 *
+	 * @return void
+	 */
+	public function test_get_exclude_ids_resolves_current_event_in_template_context(): void {
+		$instance = Event_Query::get_instance();
+
+		$event_id = $this->factory->post->create(
+			array( 'post_type' => Event::POST_TYPE )
+		);
+		$this->go_to( get_permalink( $event_id ) );
+
+		$block          = $this->createMock( \WP_Block::class );
+		$block->context = array(
+			'query' => array(
+				'gatherpress_event_query' => 'upcoming',
+				'exclude_current'         => 'twentytwentyfive//single-gatherpress_event',
+			),
+		);
+
+		$result = $instance->query_loop_block_query_vars( array(), $block );
+
+		$this->assertContains(
+			$event_id,
+			$result['post__not_in'],
+			'A non-numeric template identifier should resolve to the queried event id on a singular page.'
+		);
+		$this->assertNotContains(
+			'twentytwentyfive//single-gatherpress_event',
+			$result['post__not_in'],
+			'The raw template identifier must not be pushed into post__not_in.'
+		);
+
+		wp_delete_post( $event_id, true );
+	}
+
+	/**
+	 * A baked template identifier in `exclude_current` is dropped (not
+	 * excluded) when there is no singular post to resolve it against — e.g. an
+	 * archive or the REST editor preview. This keeps the editor best-effort
+	 * unfiltered rather than excluding a bogus id (#1753).
+	 *
+	 * @since 0.34.0
+	 * @covers ::query_loop_block_query_vars
+	 * @covers ::get_exclude_ids
+	 *
+	 * @return void
+	 */
+	public function test_get_exclude_ids_drops_template_identifier_without_singular(): void {
+		$instance = Event_Query::get_instance();
+
+		$this->go_to( '/' );
+
+		$block          = $this->createMock( \WP_Block::class );
+		$block->context = array(
+			'query' => array(
+				'gatherpress_event_query' => 'upcoming',
+				'exclude_current'         => 'twentytwentyfive//single-gatherpress_event',
+			),
+		);
+
+		$result = $instance->query_loop_block_query_vars( array(), $block );
+
+		$this->assertArrayNotHasKey(
+			'post__not_in',
+			$result,
+			'A non-numeric template identifier with no singular context should not produce an exclusion.'
+		);
+	}
+
+	/**
 	 * Test rest_query with exclude_current parameter.
 	 *
 	 * @since 0.33.0

--- a/test/unit/php/includes/tests/core/classes/class-test-shadow-source.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-shadow-source.php
@@ -981,6 +981,104 @@ class Test_Shadow_Source extends Base {
 	}
 
 	/**
+	 * Resolves the related source post from a singular event when the block
+	 * supplies a source post type but the context id is the baked template
+	 * identifier. This is the #1753 frontend template-context path: a
+	 * contextual Event Query in a Single Event template must filter by the
+	 * season/venue of the event being viewed.
+	 *
+	 * @covers ::resolve_post_from_query_context
+	 *
+	 * @return void
+	 */
+	public function test_resolve_post_from_query_context_resolves_source_from_singular_event(): void {
+		$instance = Shadow_Source::get_instance();
+
+		$venue = $this->mock->post(
+			array(
+				'post_type' => Venue::POST_TYPE,
+				'post_name' => 'template-context-venue',
+			)
+		)->get();
+		$event = $this->mock->post(
+			array( 'post_type' => 'gatherpress_event' )
+		)->get();
+
+		wp_set_post_terms( $event->ID, '_template-context-venue', Venue::TAXONOMY );
+
+		// Navigate to the single event so is_singular() is true and the queried
+		// object is the event (not a shadow source).
+		$this->go_to( get_permalink( $event->ID ) );
+
+		$query = $this->getMockBuilder( 'WP_Query' )
+			->setMethods( array( 'get' ) )
+			->getMock();
+
+		// The block bakes the template identifier into the context id, so only
+		// the source post type is usable; resolution must come from the event.
+		$query->expects( $this->any() )
+			->method( 'get' )
+			->willReturnCallback(
+				static function ( $key ) {
+					if ( 'gatherpress_shadow_source_post_type' === $key ) {
+						return Venue::POST_TYPE;
+					}
+					if ( 'gatherpress_shadow_source_post_id' === $key ) {
+						return 'twentytwentyfive//single-gatherpress_event';
+					}
+					return null;
+				}
+			);
+
+		$resolved = $instance->resolve_post_from_query_context( $query );
+
+		$this->assertInstanceOf( WP_Post::class, $resolved, 'Singular event should resolve to a related source post.' );
+		$this->assertSame( $venue->ID, $resolved->ID, 'Resolved post should be the venue linked to the event.' );
+	}
+
+	/**
+	 * Returns null on a singular event that has no relationship to the
+	 * requested source type — the event-relationship branch finds no term and
+	 * the unusable baked context id cannot rescue it.
+	 *
+	 * @covers ::resolve_post_from_query_context
+	 *
+	 * @return void
+	 */
+	public function test_resolve_post_from_query_context_singular_event_without_relationship(): void {
+		$instance = Shadow_Source::get_instance();
+
+		$event = $this->mock->post(
+			array( 'post_type' => 'gatherpress_event' )
+		)->get();
+
+		$this->go_to( get_permalink( $event->ID ) );
+
+		$query = $this->getMockBuilder( 'WP_Query' )
+			->setMethods( array( 'get' ) )
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'get' )
+			->willReturnCallback(
+				static function ( $key ) {
+					if ( 'gatherpress_shadow_source_post_type' === $key ) {
+						return Venue::POST_TYPE;
+					}
+					if ( 'gatherpress_shadow_source_post_id' === $key ) {
+						return 'twentytwentyfive//single-gatherpress_event';
+					}
+					return null;
+				}
+			);
+
+		$this->assertNull(
+			$instance->resolve_post_from_query_context( $query ),
+			'A singular event with no related source post should resolve to null.'
+		);
+	}
+
+	/**
 	 * Builds the correct tax_query clause shape from a venue post.
 	 *
 	 * @covers ::build_tax_query_clause


### PR DESCRIPTION
## What

Makes a contextual Event Query placed inside a **Single Event block template** filter correctly on the frontend. This is the frontend half of #1753; the editor-spinner half is #1792.

## Why

In the template editor, `getCurrentPostId()` returns the template slug (e.g. `twentytwentyfive//single-gatherpress_event`), not a post id. That slug gets baked into the query block's `gatherpress_shadow_source_post_id` and `exclude_current` attributes. On the frontend those values are unusable (they cast to `0`), so:

- **"Filter by `<sourcePostType>`"** (season/venue/production) was silently dropped → the list rendered **every** event instead of just the current event's season/venue.
- **"Exclude current event"** was silently dropped → the event being viewed appeared in its own "other events" list.

## How

Resolve both from the runtime queried object on singular pages instead of trusting the baked template value:

- **`Shadow_Source::resolve_post_from_query_context()`** gains a third resolution path: when the singular queried object is an event (not itself a shadow source), resolve the source post of the requested type from the event's own shadow-taxonomy relationship via the existing `get_source_post_from_event_post_id()` helper. "Filter by season" now means "the same season as the event being viewed." (The helper's first-term-wins rule defines behavior when an event belongs to more than one season/venue.)
- **`Event_Query::get_exclude_ids()`** falls back to `get_queried_object_id()` when `exclude_current` is non-numeric on a singular page.

The in-template **editor preview** still renders unfiltered, which is expected: a template has no concrete event to bind to. The preview no longer hangs (that spinner was fixed in #1792).

## Verified

Live repro on a Single Event template with a season-scoped Event Query:

- **Before:** the "Other events in this Season" list on a Spring 2026 event rendered all 9 site events (unrelated workshops, demo-data events, etc.).
- **After:** it renders only the other Spring 2026 events, and the current event excludes itself.

## Tests

- `Test_Shadow_Source`: resolves the related source post from a singular event; returns null when the event has no relationship to the requested type.
- `Test_Event_Query`: `exclude_current` resolves to the queried event id in template context; a non-numeric identifier is dropped (not excluded) when there's no singular context.
- Full `Test_Shadow_Source` + `Test_Event_Query` suites green (65 tests).

## Closes

Together with #1792 (editor spinner), this closes #1753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed

#### Message

Event Query blocks placed in a Single Event block template now filter by the viewed event's season/venue and can exclude the current event on the frontend, instead of rendering every event unfiltered.

</details>
