### PR TITLE
Resolve event-date context inside a venue/source block, not the host event (#1794)

### DIFF
--- a/.github/changelog/1797-from-description
+++ b/.github/changelog/1797-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The event-date block inside a venue block with a source post type (e.g. productions/seasons) now shows the related source post's date instead of the host event's date in the editor.

--- a/src/blocks/event-date/helpers.js
+++ b/src/blocks/event-date/helpers.js
@@ -40,11 +40,23 @@ export function resolveEventDateData( select, contextPostType, contextQueryId, p
 	}
 
 	// When editing an event directly (not inside a query loop), use the
-	// datetime store for live updates. Skip this path when contextQueryId is
-	// a number — core/query sets it on every block in the loop template,
-	// meaning each instance represents a different queried post and must fetch
-	// its own dates via the entity record below.
-	if ( isDirectEditingEvent && undefined === contextQueryId ) {
+	// datetime store for live updates. Three conditions must hold:
+	// - isDirectEditingEvent: the editor document is itself an event.
+	// - undefined === contextQueryId: core/query sets queryId on every block in
+	//   the loop template, so a defined value means this instance represents a
+	//   different queried post and must fetch its own dates via the entity
+	//   record below.
+	// - postId === current post id: a gatherpress/venue block overrides the
+	//   postId/postType context for its inner blocks (e.g. sourcePostType
+	//   "gatherpress_production"), so an event-date block nested there points at
+	//   a different post than the one being edited. The live store only holds
+	//   the edited event's dates, so it is only correct when the resolved postId
+	//   is that edited post (#1794).
+	if (
+		isDirectEditingEvent &&
+		undefined === contextQueryId &&
+		postId === select( 'core/editor' )?.getCurrentPostId()
+	) {
 		const datetimeStore = select( 'gatherpress/datetime' );
 		return {
 			dateTimeStart: datetimeStore.getDateTimeStart(),

--- a/test/unit/js/src/blocks/event-date/helpers.test.js
+++ b/test/unit/js/src/blocks/event-date/helpers.test.js
@@ -59,7 +59,10 @@ describe( 'resolveEventDateData', () => {
 				return mockCoreStore;
 			}
 			if ( 'core/editor' === store ) {
-				return { getCurrentPostType: () => 'gatherpress_event' };
+				return {
+					getCurrentPostType: () => 'gatherpress_event',
+					getCurrentPostId: () => 42,
+				};
 			}
 			return {};
 		} );
@@ -144,6 +147,48 @@ describe( 'resolveEventDateData', () => {
 			);
 
 			expect( result.isValidEvent ).toBe( false );
+		} );
+	} );
+
+	describe( 'inside a venue/source-context block (#1794)', () => {
+		it( 'fetches the source post entity record, not the edited event datetime store, when the venue context overrides postId/postType', () => {
+			// A gatherpress/venue block with sourcePostType "gatherpress_production"
+			// wraps its inner blocks in a context override: postId = production id,
+			// postType = gatherpress_production. While editing an event, the nested
+			// event-date block must show the production's date, not the host event's.
+			const result = resolveEventDateData(
+				mockSelect,
+				'gatherpress_production',
+				undefined,
+				777,
+				false
+			);
+
+			expect( mockDatetimeStore.getDateTimeStart ).not.toHaveBeenCalled();
+			expect( mockCoreStore.getEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'gatherpress_production',
+				777
+			);
+			expect( result.dateTimeStart ).toBe( '2025-06-10 14:00:00' );
+			expect( result.timezone ).toBe( 'America/Chicago' );
+			expect( result.isValidEvent ).toBe( true );
+		} );
+
+		it( 'still uses the live datetime store for the host event-date block when its postId is the edited post', () => {
+			// The event's own event-date block (postId === edited post id) keeps
+			// live-updating from the datetime store, even though a sibling venue
+			// block exists elsewhere in the content.
+			const result = resolveEventDateData(
+				mockSelect,
+				'gatherpress_event',
+				undefined,
+				42,
+				false
+			);
+
+			expect( mockDatetimeStore.getDateTimeStart ).toHaveBeenCalled();
+			expect( result.dateTimeStart ).toBe( '2025-01-15 09:00:00' );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #1794

## Problem

When editing an event, a `gatherpress/event-date` block placed inside a `gatherpress/venue` block (with a `gatherpress-event-date`-supporting `sourcePostType` such as a production or season) shows the **host event's** date instead of the related source post's date. Editor-only — the frontend renders correctly.

## Root cause

The venue block wraps its inner blocks in a context override ([`src/blocks/venue/edit.js`](src/blocks/venue/edit.js)):

```js
<BlockContextProvider value={ { postId: venuePostId, postType: venuePostType } }>
```

So a nested `event-date` receives `context.postId = <production id>`, `context.postType = gatherpress_production`, and `context.queryId = undefined` (it is not in a query loop).

In `resolveEventDateData` the #1733 guard was:

```js
if ( isDirectEditingEvent && undefined === contextQueryId ) { /* live datetime store */ }
```

While editing an event, `isDirectEditingEvent` is `true` and `contextQueryId` is `undefined`, so it returned the live `gatherpress/datetime` store — i.e. the host event's date — ignoring the production's postId/postType from the venue context.

## Fix

The live store only holds the **edited event's** dates, so it is only correct when the block's resolved `postId` is the post being edited. Add that guard:

```js
if (
  isDirectEditingEvent &&
  undefined === contextQueryId &&
  postId === select( 'core/editor' )?.getCurrentPostId()
) { /* live store */ }
```

Inside a venue/source block `postId` is the source post (≠ the edited event), so resolution falls through to the entity-record fetch for `[ sourcePostType, sourceId ]` and shows the source post's date. Direct event editing still matches (`context.postId === currentPostId`) and keeps live-updating; the query-loop guard from #1733 is untouched.

This is the same family as #1733 (fixed by #1750).

## Testing

```bash
npm run build && npm run test:unit:js -- --testPathPattern 'blocks/event-date/helpers'
```

- Added two regression tests under `inside a venue/source-context block (#1794)`: nested event-date fetches the source post's entity record (not the datetime store); the host event-date still uses the live store when its postId is the edited post.
- `helpers.js` at 100% statement/branch/function/line coverage; full suite 15/15 green.

Verified live: with a production (Hamlet, 25 Dec 2027) related to an event (Spring Gala, 23 Jun 2026), the event-date inside the Production block now renders **25 Dec 2027** instead of the host event's date.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed

#### Message

The event-date block inside a venue block with a source post type (e.g. productions/seasons) now shows the related source post's date instead of the host event's date in the editor.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)