### PR TITLE
Guard responses shape in sendRsvpApiRequest against partial payloads (#1769)

### DIFF
--- a/.github/changelog/1798-from-description
+++ b/.github/changelog/1798-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RSVP requests no longer throw and leave the UI inconsistent when the server returns a success response with a missing or partial responses object.

--- a/src/helpers/interactivity.js
+++ b/src/helpers/interactivity.js
@@ -253,9 +253,9 @@ export async function sendRsvpApiRequest(
 				state.posts[ postId ] = {
 					...state.posts[ postId ],
 					eventResponses: {
-						attending: res.responses.attending.count,
-						waitingList: res.responses.waiting_list.count,
-						notAttending: res.responses.not_attending.count,
+						attending: res.responses?.attending?.count ?? 0,
+						waitingList: res.responses?.waiting_list?.count ?? 0,
+						notAttending: res.responses?.not_attending?.count ?? 0,
 					},
 					currentUser: {
 						status: res.status,

--- a/test/unit/js/src/helpers/interactivity.test.js
+++ b/test/unit/js/src/helpers/interactivity.test.js
@@ -1,0 +1,145 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+
+/**
+ * Mock the Interactivity API store so the module can read
+ * `gatherPressState.eventApiUrl` at import time without a real store.
+ */
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: jest.fn( () => ( {
+			state: {
+				eventApiUrl: 'https://example.test/wp-json/gatherpress/v1',
+			},
+		} ) ),
+	} ),
+	{ virtual: true }
+);
+
+/**
+ * Internal dependencies
+ */
+import { sendRsvpApiRequest, getNonce } from '@src/helpers/interactivity';
+
+/**
+ * Regression coverage for #1769 — sendRsvpApiRequest must not throw when a
+ * success-shaped response is missing some or all of `res.responses`. A partial
+ * payload (server error, proxy/WAF rewrite) used to read `.count` off undefined
+ * and leave the interactivity state inconsistent.
+ */
+describe( 'sendRsvpApiRequest', () => {
+	let state;
+	let rsvpPayload;
+
+	beforeEach( () => {
+		// Reset the module-level nonce cache so each test fetches fresh.
+		getNonce.clearCache();
+
+		state = { posts: { 123: {} } };
+
+		// alert() is not implemented in jsdom; stub it so the failure path
+		// (if reached) doesn't throw a "not implemented" error.
+		window.alert = jest.fn();
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+		global.fetch = jest.fn( ( url ) => {
+			if ( url.endsWith( '/nonce' ) ) {
+				return Promise.resolve( {
+					json: () => Promise.resolve( { nonce: 'test-nonce' } ),
+				} );
+			}
+
+			// POST /rsvp.
+			return Promise.resolve( {
+				status: 200,
+				json: () => Promise.resolve( rsvpPayload ),
+			} );
+		} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+		delete global.fetch;
+	} );
+
+	it( 'reads counts from a well-formed responses object', async () => {
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 2,
+			anonymous: false,
+			online_link: '',
+			responses: {
+				attending: { count: 7 },
+				waiting_list: { count: 3 },
+				not_attending: { count: 1 },
+			},
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 2, anonymous: false },
+			state
+		);
+
+		expect( state.posts[ 123 ].eventResponses ).toEqual( {
+			attending: 7,
+			waitingList: 3,
+			notAttending: 1,
+		} );
+		expect( window.alert ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls back to 0 for every count when responses is missing entirely', async () => {
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 0,
+			anonymous: false,
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 0, anonymous: false },
+			state
+		);
+
+		// The key assertion: no throw, and the state is still updated with
+		// safe zeroed counts rather than left half-written.
+		expect( state.posts[ 123 ].eventResponses ).toEqual( {
+			attending: 0,
+			waitingList: 0,
+			notAttending: 0,
+		} );
+		expect( state.posts[ 123 ].currentUser.status ).toBe( 'attending' );
+		expect( window.alert ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls back to 0 only for the missing sub-keys of a partial responses object', async () => {
+		rsvpPayload = {
+			success: true,
+			status: 'not_attending',
+			guests: 0,
+			anonymous: false,
+			responses: {
+				// attending present, the other two missing.
+				attending: { count: 4 },
+			},
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'not_attending', guests: 0, anonymous: false },
+			state
+		);
+
+		expect( state.posts[ 123 ].eventResponses ).toEqual( {
+			attending: 4,
+			waitingList: 0,
+			notAttending: 0,
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes #1769

## Problem

In `sendRsvpApiRequest` ([`src/helpers/interactivity.js`](src/helpers/interactivity.js)), a `success`-shaped response had its `responses` counts read directly:

```js
eventResponses: {
  attending: res.responses.attending.count,
  waitingList: res.responses.waiting_list.count,
  notAttending: res.responses.not_attending.count,
},
```

If `res.responses` (or any sub-key) is missing — a server error, or a proxy/WAF returning a partial/error-shaped body that still reads as `success` — this throws mid-update and leaves the Interactivity API state half-written.

## Fix

Guard each access with optional chaining and a `?? 0` fallback:

```js
eventResponses: {
  attending: res.responses?.attending?.count ?? 0,
  waitingList: res.responses?.waiting_list?.count ?? 0,
  notAttending: res.responses?.not_attending?.count ?? 0,
},
```

A malformed payload now yields safe zeroed counts instead of an exception. This mirrors the `res?.responses` guard added to `rsvp-manager.js` for the sibling #1770 (#1782).

The change is purely syntactic (optional chaining, no new imports), so it stays compatible with the Interactivity API script-module graph — verified with `npm run build` (`--experimental-modules`); the guarded access is present in the built `rsvp` / `rsvp-form` view modules.

## Tests

Adds the first unit tests for `sendRsvpApiRequest` (new `test/unit/js/src/helpers/interactivity.test.js`), covering:

- a well-formed `responses` object → real counts;
- a fully-missing `responses` object → all counts fall back to `0`, state still updated (no throw);
- a partial `responses` object → only the missing sub-keys fall back to `0`.

```bash
npm run build && npm run test:unit:js -- --testPathPattern 'helpers/interactivity'
```

The changed lines are fully covered.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed

#### Message

RSVP requests no longer throw and leave the UI inconsistent when the server returns a success response with a missing or partial responses object.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)