### PR TITLE
Lower default Venue Map zoom from 18 to 16 (#1746)

### DIFF
--- a/.github/changelog/1799-from-description
+++ b/.github/changelog/1799-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Lowered the default Venue Map zoom level from 18 to 16 so new venue maps show more neighborhood context. Sites that already set a custom Default Zoom Level are unaffected.

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -74,7 +74,7 @@ class Map {
 	 * @since 0.34.0
 	 * @var int
 	 */
-	const DEFAULT_ZOOM = 18;
+	const DEFAULT_ZOOM = 16;
 
 	/**
 	 * Default height (in pixels). Used by the generator and the block.

--- a/src/blocks/venue-map/block.json
+++ b/src/blocks/venue-map/block.json
@@ -12,7 +12,7 @@
 	"attributes": {
 		"zoom": {
 			"type": "number",
-			"default": 18
+			"default": 16
 		},
 		"type": {
 			"type": "string",

--- a/test/unit/js/src/blocks/venue-map/edit.test.js
+++ b/test/unit/js/src/blocks/venue-map/edit.test.js
@@ -143,7 +143,7 @@ import Edit from '@src/blocks/venue-map/edit';
 import { isVenuePostType } from '@src/helpers/venue';
 
 const DEFAULT_ATTRIBUTES = {
-	zoom: 18,
+	zoom: 16,
 	type: 'roadmap',
 	width: 0,
 	height: 300,

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
@@ -102,7 +102,7 @@ class Test_Venues extends Base {
 		// via Venue\Map::apply_block_attribute_defaults().
 		foreach ( array(
 			'venue_map_default_render_mode' => 'interactive',
-			'venue_map_default_zoom'        => 18,
+			'venue_map_default_zoom'        => 16,
 			'venue_map_default_height'      => '',
 			'venue_map_default_scale'       => 'cover',
 			'venue_map_default_type'        => 'roadmap',


### PR DESCRIPTION
Fixes #1746

## What

Lowers the built-in default Venue Map zoom from **18** to **16** so a freshly geocoded venue shows useful neighborhood context (nearby streets, landmarks, transit) instead of a tight street-level view of one block.

**Why 16 and not 15:** the issue suggested ~15, and we tried it, but at 15 the map read a touch too zoomed out — street names and similar labels weren't reliably visible, which loses the "where exactly is this" readability. **16** is the balance: it pulls back from 18's street-level tightness to show surrounding context while keeping street names and nearby labels legible.

## How

`Venue\Map::DEFAULT_ZOOM` is the single source of truth — changing it `18 → 16` cascades to:

- the **"Default Zoom Level"** setting default (`Settings → Venues → Maps`, via `Map::DEFAULT_ZOOM`),
- the prewarm fallback (`class-prewarm.php`),
- the runtime block-attribute defaults (`apply_block_attribute_defaults()`).

The venue-map `block.json` static `zoom` default is updated to **16** to match.

**Existing sites are unaffected:** the setting is only persisted when an admin explicitly saves a value; otherwise `Settings::get()` resolves the field default (`Map::DEFAULT_ZOOM`) at read time. So sites that saved a custom Default Zoom Level keep it, and everyone else picks up 16 with no migration.

## Tests

- Updated the settings-default assertion (`Test_Venues`) and the venue-map edit-test default-attribute fixture to 16.
- `Test_Venues` / `Test_Prewarm` / `Test_Map` green (39 tests); venue-map JS suite green (45 tests). The `18x300`-keyed descriptor fixtures in `helpers.test.js` are arbitrary cache-key test data, not the default, and are intentionally left unchanged.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Changed

#### Message

Lowered the default Venue Map zoom level from 18 to 16 so new venue maps show more neighborhood context. Sites that already set a custom Default Zoom Level are unaffected.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)