### PR TITLE
Replace custom "Start blank" logic with registerBlockVariation() calls

### DIFF
--- a/.github/changelog/1801-fix-start-blank-patterns
+++ b/.github/changelog/1801-fix-start-blank-patterns
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Replace custom-made "Start blank" logic with registerBlockVariation() calls, like it is intended by WP core.

--- a/src/variations/core/query/constants.js
+++ b/src/variations/core/query/constants.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { NAME } from './name';
+
+export const QUERY_ATTRIBUTES = {
+	namespace: NAME,
+	query: {
+		perPage: 5,
+		pages: 0,
+		offset: 0,
+		postType: 'gatherpress_event',
+		gatherpress_event_query: 'upcoming',
+		include_unfinished: 1,
+		order: 'asc',
+		orderBy: 'datetime',
+		inherit: false,
+	},
+};
+
+export const VARIATION_ATTRIBUTES = {
+	category: 'gatherpress',
+	keywords: [ __( 'Events', 'gatherpress' ), __( 'Dates', 'gatherpress' ) ],
+	// Gate on `namespace` only. Including `query.postType` here would
+	// drop the variation match the moment a user picks a custom event-
+	// supporting post type, which in turn drops the "Event Card with
+	// RSVP" starter pattern out of the Change design picker since that
+	// pattern is scoped to this variation.
+	isActive: [ 'namespace' ],
+	attributes: {
+		...QUERY_ATTRIBUTES,
+		className: 'gatherpress-event-query',
+	},
+	// Disabling irrelevant or unsupported query controls
+	// @see https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#disabling-irrelevant-or-unsupported-query-controls
+	allowedControls: [ 'inherit', 'postType', 'taxQuery', 'author', 'search' ],
+};

--- a/src/variations/core/query/icons.js
+++ b/src/variations/core/query/icons.js
@@ -1,0 +1,54 @@
+/**
+ * This file replicates how WP core provides icons for its "Start blank" variations picker.
+ * Inspired by: https://raw.githubusercontent.com/WordPress/gutenberg/b08653ae83a20f69f4657f1da11b2e3d27683f5a/packages/block-library/src/query/icons.js
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+/**
+ * Event Date + Title
+ *
+ * Layout per card:
+ *   - Short bar (date): y=9, h=1, partial width
+ *   - Tall bar (title): y=12, h=3, full width
+ * Repeated for second card at y=27.
+ */
+export const eventDateTitle = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+		<Path d="M19 9H7v1h12V9zm22 3H7v3h34v-3zM19 27H7v1h12v-1zm22 3H7v3h34v-3z" />
+	</SVG>
+);
+
+/**
+ * Event Date + Title + Excerpt
+ *
+ * Layout per card:
+ *   - Two thin bars (excerpt): y=17 and y=19, near-full width
+ */
+export const eventDateTitleExcerpt = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+		<Path d="M19 9H7v1h12V9zm22 3H7v3h34v-3zm-4 5H7v1h30v-1zm4 2H7v1h34v-1zM19 27H7v1h12v-1zm22 3H7v3h34v-3zm-4 5H7v1h30v-1zm4 2H7v1h34v-1z" />
+	</SVG>
+);
+
+/**
+ * Image + Event Date + Title
+ */
+export const imageEventDateTitle = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+		<Path d="M7 9h18v8H7V9zM7 9l18 8M29 10h10v1H29v-1zm0 3h12v4H29v-4zM7 27h18v8H7V27zM7 27l18 8M29 28h10v1H29v-1zm0 3h12v4H29v-4z" />
+	</SVG>
+);
+
+/**
+ * Event Date + Title + Venue + Map
+ */
+export const eventDateTitleVenueMap = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+		<Path d="M7 8h14v1H7V8zm0 3h24v3H7v-3zm0 7h18v1H7v-1zm0 3h34v14H7V21z" />
+		<Path d="M24 25a2 2 0 100 4 2 2 0 000-4zm0 7c-2-2-4-4-4-6a4 4 0 118 0c0 2-2 4-4 6z" />
+	</SVG>
+);

--- a/src/variations/core/query/index.js
+++ b/src/variations/core/query/index.js
@@ -3,14 +3,17 @@
  */
 import { registerBlockVariation } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
 /**
  * Internal dependencies
  */
 import { NAME } from './name';
 import './controls';
 import './patterns';
-import './start-blank';
+// import './start-blank';
 
 export { NAME };
 
@@ -98,4 +101,60 @@ registerBlockVariation( 'core/query', {
 			},
 		],
 	},
+} );
+
+const { attributes, ...VARIATION_ATTRIBUTES_WITHOUT_ATTRIBUTES } = VARIATION_ATTRIBUTES;
+
+const START_BLANK_QUERY_ATTRIBUTES = {
+	namespace: [ NAME ],
+	query: {
+		...QUERY_ATTRIBUTES.query
+	},
+}
+
+const START_BLANK_VARIATION_ATTRIBUTES = {
+	...VARIATION_ATTRIBUTES_WITHOUT_ATTRIBUTES,
+	attributes: {
+		...VARIATION_ATTRIBUTES.attributes.className,
+		...START_BLANK_QUERY_ATTRIBUTES
+	},
+};
+
+/**
+ * "Start blank" pattern "..."
+ *
+ * To connect this variation to the "Event Query" "Start blank" patterns, it defines the namespace attribute as array,
+ * that contains the name property of the visible variation this one wants to connect to.
+ */
+registerBlockVariation( 'core/query', {
+	...START_BLANK_VARIATION_ATTRIBUTES,
+	name: NAME + 'start-blank-1',
+	title: __( 'Event Query Loop (Start blank 1)', 'gatherpress' ),
+	description: __( 'Create event queries', 'gatherpress' ),
+	icon: (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			width="48"
+			height="48"
+			viewBox="0 0 48 48"
+		>
+			<Path d="M0 10a2 2 0 0 1 2-2h44a2 2 0 0 1 2 2v28a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V10Z" />
+		</SVG>
+	),
+	/*
+	 * Intentionally with `innerBlocks` here, because this variation powers the "Start blank" patterns.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#customize-your-variation-layout
+	 */
+	innerBlocks: [
+		{
+			name: 'core/post-template',
+			attributes: {},
+			innerBlocks: [
+				{
+					name: 'core/post-title',
+				},
+			],
+		},
+	],
 } );

--- a/src/variations/core/query/index.js
+++ b/src/variations/core/query/index.js
@@ -3,53 +3,17 @@
  */
 import { registerBlockVariation } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-/**
- * WordPress dependencies
- */
-import { Path, SVG } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
 import { NAME } from './name';
+import { QUERY_ATTRIBUTES, VARIATION_ATTRIBUTES } from './constants';
 import './controls';
 import './patterns';
-// import './start-blank';
+import './start-blank';
 
-export { NAME };
-
-const QUERY_ATTRIBUTES = {
-	namespace: NAME,
-	query: {
-		perPage: 5,
-		pages: 0,
-		offset: 0,
-		postType: 'gatherpress_event',
-		gatherpress_event_query: 'upcoming',
-		include_unfinished: 1,
-		order: 'asc',
-		orderBy: 'datetime',
-		inherit: false,
-	},
-};
-
-const VARIATION_ATTRIBUTES = {
-	category: 'gatherpress',
-	keywords: [ __( 'Events', 'gatherpress' ), __( 'Dates', 'gatherpress' ) ],
-	// Gate on `namespace` only. Including `query.postType` here would
-	// drop the variation match the moment a user picks a custom event-
-	// supporting post type, which in turn drops the "Event Card with
-	// RSVP" starter pattern out of the Change design picker since that
-	// pattern is scoped to this variation.
-	isActive: [ 'namespace' ],
-	attributes: {
-		...QUERY_ATTRIBUTES,
-		className: 'gatherpress-event-query',
-	},
-	// Disabling irrelevant or unsupported query controls
-	// @see https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#disabling-irrelevant-or-unsupported-query-controls
-	allowedControls: [ 'inherit', 'postType', 'taxQuery', 'author', 'search' ],
-	scope: [ 'block' ],
-};
+// export { NAME };
 
 /**
  * Docs about the Query block.
@@ -101,60 +65,4 @@ registerBlockVariation( 'core/query', {
 			},
 		],
 	},
-} );
-
-const { attributes, ...VARIATION_ATTRIBUTES_WITHOUT_ATTRIBUTES } = VARIATION_ATTRIBUTES;
-
-const START_BLANK_QUERY_ATTRIBUTES = {
-	namespace: [ NAME ],
-	query: {
-		...QUERY_ATTRIBUTES.query
-	},
-}
-
-const START_BLANK_VARIATION_ATTRIBUTES = {
-	...VARIATION_ATTRIBUTES_WITHOUT_ATTRIBUTES,
-	attributes: {
-		...VARIATION_ATTRIBUTES.attributes.className,
-		...START_BLANK_QUERY_ATTRIBUTES
-	},
-};
-
-/**
- * "Start blank" pattern "..."
- *
- * To connect this variation to the "Event Query" "Start blank" patterns, it defines the namespace attribute as array,
- * that contains the name property of the visible variation this one wants to connect to.
- */
-registerBlockVariation( 'core/query', {
-	...START_BLANK_VARIATION_ATTRIBUTES,
-	name: NAME + 'start-blank-1',
-	title: __( 'Event Query Loop (Start blank 1)', 'gatherpress' ),
-	description: __( 'Create event queries', 'gatherpress' ),
-	icon: (
-		<SVG
-			xmlns="http://www.w3.org/2000/svg"
-			width="48"
-			height="48"
-			viewBox="0 0 48 48"
-		>
-			<Path d="M0 10a2 2 0 0 1 2-2h44a2 2 0 0 1 2 2v28a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V10Z" />
-		</SVG>
-	),
-	/*
-	 * Intentionally with `innerBlocks` here, because this variation powers the "Start blank" patterns.
-	 *
-	 * @see https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#customize-your-variation-layout
-	 */
-	innerBlocks: [
-		{
-			name: 'core/post-template',
-			attributes: {},
-			innerBlocks: [
-				{
-					name: 'core/post-title',
-				},
-			],
-		},
-	],
 } );

--- a/src/variations/core/query/index.js
+++ b/src/variations/core/query/index.js
@@ -13,8 +13,6 @@ import './controls';
 import './patterns';
 import './start-blank';
 
-// export { NAME };
-
 /**
  * Docs about the Query block.
  *

--- a/src/variations/core/query/start-blank.js
+++ b/src/variations/core/query/start-blank.js
@@ -32,7 +32,7 @@ const START_BLANK_VARIATION_ATTRIBUTES = {
 	...VARIATION_ATTRIBUTES_WITHOUT_ATTRIBUTES,
 	scope: [ 'block' ],
 	attributes: {
-		...VARIATION_ATTRIBUTES.attributes.className,
+		...attributes,
 		...START_BLANK_QUERY_ATTRIBUTES,
 	},
 };

--- a/src/variations/core/query/start-blank.js
+++ b/src/variations/core/query/start-blank.js
@@ -1,168 +1,182 @@
 /**
  * WordPress dependencies
  */
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock, getBlockType } from '@wordpress/blocks';
-import { dispatch, select, subscribe } from '@wordpress/data';
-import domReady from '@wordpress/dom-ready';
-
-const NAMESPACE = 'gatherpress-event-query';
+import { registerBlockVariation } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 
 /**
- * Recognizes any of WP core's "Start blank" scoped-variation scaffolds.
- *
- * The QueryPlaceholder's "Start blank" button doesn't insert a single shape —
- * it opens a sub-picker of four scoped Query Loop variations (Title & Date,
- * Title & Excerpt, Title/Date/Excerpt, Image/Date/Title). All four drop in a
- * `core/post-template` whose children are core post blocks, never our
- * `gatherpress/event-date`. We treat "post-template present and no event-date
- * anywhere in its subtree" as the signal that the user just picked a WP
- * scaffold rather than our event pattern (which threads event-date through
- * its media-text wrapper).
- *
- * @param {Array} innerBlocks Inner blocks of a `core/query` block.
- *
- * @return {boolean} True when the inner-block tree looks like a WP scoped-variation scaffold.
+ * Internal dependencies
  */
-function isWpStartBlankShape( innerBlocks ) {
-	const postTemplate = innerBlocks.find(
-		( block ) => 'core/post-template' === block.name
-	);
+import { NAME } from './name';
+import { QUERY_ATTRIBUTES, VARIATION_ATTRIBUTES } from './constants';
 
-	if ( ! postTemplate || 0 === postTemplate.innerBlocks.length ) {
-		return false;
-	}
+import {
+	eventDateTitle,
+	eventDateTitleExcerpt,
+	imageEventDateTitle,
+	eventDateTitleVenueMap,
+} from './icons';
+import { QUERY_NO_RESULTS_VARIATION } from '../query-no-results';
+import { QUERY_PAGINATION_VARIATION } from '../query-pagination';
 
-	return ! treeContainsBlock(
-		postTemplate.innerBlocks,
-		'gatherpress/event-date'
-	);
-}
+const { attributes, ...VARIATION_ATTRIBUTES_WITHOUT_ATTRIBUTES } = VARIATION_ATTRIBUTES;
+
+const START_BLANK_QUERY_ATTRIBUTES = {
+	namespace: [ NAME ],
+	query: {
+		...QUERY_ATTRIBUTES.query,
+	},
+};
+
+const START_BLANK_VARIATION_ATTRIBUTES = {
+	...VARIATION_ATTRIBUTES_WITHOUT_ATTRIBUTES,
+	scope: [ 'block' ],
+	attributes: {
+		...VARIATION_ATTRIBUTES.attributes.className,
+		...START_BLANK_QUERY_ATTRIBUTES,
+	},
+};
 
 /**
- * Depth-first check for a block name anywhere in a block tree.
+ * "Start blank" pattern "Event Date & Title"
  *
- * @param {Array}  blocks    Block tree to search.
- * @param {string} blockName Name to look for, e.g. `gatherpress/event-date`.
- *
- * @return {boolean} True if any node in the tree matches.
+ * To connect this variation to the "Event Query" "Start blank" patterns,
+ * it defines the namespace attribute as array,
+ * that contains the name property of the visible variation this one wants to connect to.
  */
-function treeContainsBlock( blocks, blockName ) {
-	for ( const block of blocks ) {
-		if ( block.name === blockName ) {
-			return true;
-		}
-		if (
-			block.innerBlocks &&
-			treeContainsBlock( block.innerBlocks, blockName )
-		) {
-			return true;
-		}
-	}
-
-	return false;
-}
+registerBlockVariation( 'core/query', {
+	...START_BLANK_VARIATION_ATTRIBUTES,
+	name: NAME + 'start-blank-1',
+	title: __( 'Event Date & Title', 'gatherpress' ),
+	icon: eventDateTitle,
+	/*
+	 * Intentionally with `innerBlocks` here, because this variation powers the "Start blank" patterns.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#customize-your-variation-layout
+	 */
+	innerBlocks: [
+		{
+			name: 'core/post-template',
+			attributes: {
+				metadata: {
+					name: __( 'Events Template', 'gatherpress' ),
+				},
+			},
+			innerBlocks: [
+				[ 'gatherpress/event-date' ],
+				[ 'core/post-title' ],
+			],
+		},
+		QUERY_PAGINATION_VARIATION,
+		QUERY_NO_RESULTS_VARIATION,
+	],
+} );
 
 /**
- * Walk the picked WP scaffold and convert any `core/post-date` block into a
- * `gatherpress/event-date` block, leaving every other block (title, excerpt,
- * image) untouched. Returns the rebuilt block tree.
+ * "Start blank" pattern "Event Date, Title & Excerpt"
  *
- * Driven this way the "Title & Excerpt" scaffold — which has no date — is
- * left alone, while "Title & Date" / "Title, Date & Excerpt" /
- * "Image, Date & Title" all swap out their `post-date` for an event date.
- *
- * @param {Array} blocks Inner blocks to rebuild.
- *
- * @return {Array} Created block instances ready for `replaceInnerBlocks()`.
+ * To connect this variation to the "Event Query" "Start blank" patterns,
+ * it defines the namespace attribute as array,
+ * that contains the name property of the visible variation this one wants to connect to.
  */
-function rebuildWithEventDate( blocks ) {
-	return blocks.map( ( block ) => {
-		if ( 'core/post-date' === block.name ) {
-			return createBlock( 'gatherpress/event-date', {
-				displayType: 'start',
-				startDateFormat: ' D, M j, Y, g:i a ',
-			} );
-		}
-
-		return createBlock(
-			block.name,
-			block.attributes,
-			rebuildWithEventDate( block.innerBlocks || [] )
-		);
-	} );
-}
+registerBlockVariation( 'core/query', {
+	...START_BLANK_VARIATION_ATTRIBUTES,
+	name: NAME + 'start-blank-2',
+	title: __( 'Event Date, Title & Excerpt', 'gatherpress' ),
+	icon: eventDateTitleExcerpt,
+	/*
+	 * Intentionally with `innerBlocks` here, because this variation powers the "Start blank" patterns.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#customize-your-variation-layout
+	 */
+	innerBlocks: [
+		{
+			name: 'core/post-template',
+			attributes: {
+				metadata: {
+					name: __( 'Events Template', 'gatherpress' ),
+				},
+			},
+			innerBlocks: [
+				[ 'gatherpress/event-date' ],
+				[ 'core/post-title' ],
+				[ 'core/post-excerpt' ],
+			],
+		},
+		QUERY_PAGINATION_VARIATION,
+		QUERY_NO_RESULTS_VARIATION,
+	],
+} );
 
 /**
- * Swap WP core's hardcoded "Start blank" scaffold's `core/post-date` for our
- * `gatherpress/event-date`.
+ * "Start blank" pattern "Image, Event Date & Title"
  *
- * The Query Loop block's placeholder modal exposes a "Start blank" button that
- * is bound to a private handler in `@wordpress/block-library` — there's no
- * filter to override its inner blocks. Instead, we subscribe to the block
- * editor store and post-swap: when an Event Query Loop block ends up
- * containing one of WP's scoped-variation scaffolds, walk the post-template
- * tree and replace any `post-date` with `event-date`. Pagination/no-results
- * siblings stay intact, and scaffolds without a date (Title & Excerpt) pass
- * through unchanged so we don't add a date the user didn't ask for.
- *
- * Per-`clientId` guarding via `swappedClientIds` keeps the swap one-shot per
- * block — a user who later edits back to the WP scaffold isn't fought with.
+ * To connect this variation to the "Event Query" "Start blank" patterns,
+ * it defines the namespace attribute as array,
+ * that contains the name property of the visible variation this one wants to connect to.
  */
-domReady( () => {
-	if (
-		! getBlockType( 'core/post-template' ) ||
-		! getBlockType( 'gatherpress/event-date' )
-	) {
-		return;
-	}
+registerBlockVariation( 'core/query', {
+	...START_BLANK_VARIATION_ATTRIBUTES,
+	name: NAME + 'start-blank-3',
+	title: __( 'Image, Event Date & Title', 'gatherpress' ),
+	icon: imageEventDateTitle,
+	/*
+	 * Intentionally with `innerBlocks` here, because this variation powers the "Start blank" patterns.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#customize-your-variation-layout
+	 */
+	innerBlocks: [
+		{
+			name: 'core/post-template',
+			attributes: {
+				metadata: {
+					name: __( 'Events Template', 'gatherpress' ),
+				},
+			},
+			innerBlocks: [
+				[ 'core/media-text', { useFeaturedImage: true }, [
+					[ 'gatherpress/event-date' ],
+					[ 'core/post-title' ],
+				] ],
+			],
+		},
+		QUERY_PAGINATION_VARIATION,
+		QUERY_NO_RESULTS_VARIATION,
+	],
+} );
 
-	const swappedClientIds = new Set();
-
-	subscribe( () => {
-		const blocks = select( blockEditorStore ).getBlocks();
-		const eventQueryBlocks = [];
-
-		const walk = ( list ) => {
-			for ( const block of list ) {
-				if (
-					'core/query' === block.name &&
-					NAMESPACE === block.attributes?.namespace
-				) {
-					eventQueryBlocks.push( block );
-				}
-				walk( block.innerBlocks );
-			}
-		};
-
-		walk( blocks );
-
-		for ( const block of eventQueryBlocks ) {
-			if ( swappedClientIds.has( block.clientId ) ) {
-				continue;
-			}
-
-			if ( ! isWpStartBlankShape( block.innerBlocks ) ) {
-				continue;
-			}
-
-			const postTemplate = block.innerBlocks.find(
-				( child ) => 'core/post-template' === child.name
-			);
-
-			swappedClientIds.add( block.clientId );
-
-			// If the picked scaffold has no `post-date` (Title & Excerpt),
-			// rebuilding is a no-op shape-wise — skip the dispatch to avoid
-			// a pointless undo entry.
-			if ( ! treeContainsBlock( postTemplate.innerBlocks, 'core/post-date' ) ) {
-				continue;
-			}
-
-			dispatch( blockEditorStore ).replaceInnerBlocks(
-				postTemplate.clientId,
-				rebuildWithEventDate( postTemplate.innerBlocks )
-			);
-		}
-	} );
+/**
+ * "Start blank" pattern "Event Date, Title, Venue & Map"
+ *
+ * To connect this variation to the "Event Query" "Start blank" patterns,
+ * it defines the namespace attribute as array,
+ * that contains the name property of the visible variation this one wants to connect to.
+ */
+registerBlockVariation( 'core/query', {
+	...START_BLANK_VARIATION_ATTRIBUTES,
+	name: NAME + 'start-blank-4',
+	title: __( 'Event Date, Title, Venue & Map', 'gatherpress' ),
+	icon: eventDateTitleVenueMap,
+	/*
+	 * Intentionally with `innerBlocks` here, because this variation powers the "Start blank" patterns.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/extending-the-query-loop-block/#customize-your-variation-layout
+	 */
+	innerBlocks: [
+		{
+			name: 'core/post-template',
+			attributes: {
+				metadata: {
+					name: __( 'Events Template', 'gatherpress' ),
+				},
+			},
+			innerBlocks: [
+				[ 'gatherpress/event-date' ],
+				[ 'core/post-title' ],
+				[ 'gatherpress/venue', { patternPicked: true } ],
+			],
+		},
+		QUERY_PAGINATION_VARIATION,
+		QUERY_NO_RESULTS_VARIATION,
+	],
 } );

--- a/src/variations/core/query/start-blank.js
+++ b/src/variations/core/query/start-blank.js
@@ -46,7 +46,7 @@ const START_BLANK_VARIATION_ATTRIBUTES = {
  */
 registerBlockVariation( 'core/query', {
 	...START_BLANK_VARIATION_ATTRIBUTES,
-	name: NAME + 'start-blank-1',
+	name: NAME + '-start-blank-1',
 	title: __( 'Event Date & Title', 'gatherpress' ),
 	icon: eventDateTitle,
 	/*
@@ -81,7 +81,7 @@ registerBlockVariation( 'core/query', {
  */
 registerBlockVariation( 'core/query', {
 	...START_BLANK_VARIATION_ATTRIBUTES,
-	name: NAME + 'start-blank-2',
+	name: NAME + '-start-blank-2',
 	title: __( 'Event Date, Title & Excerpt', 'gatherpress' ),
 	icon: eventDateTitleExcerpt,
 	/*
@@ -117,7 +117,7 @@ registerBlockVariation( 'core/query', {
  */
 registerBlockVariation( 'core/query', {
 	...START_BLANK_VARIATION_ATTRIBUTES,
-	name: NAME + 'start-blank-3',
+	name: NAME + '-start-blank-3',
 	title: __( 'Image, Event Date & Title', 'gatherpress' ),
 	icon: imageEventDateTitle,
 	/*
@@ -154,7 +154,7 @@ registerBlockVariation( 'core/query', {
  */
 registerBlockVariation( 'core/query', {
 	...START_BLANK_VARIATION_ATTRIBUTES,
-	name: NAME + 'start-blank-4',
+	name: NAME + '-start-blank-4',
 	title: __( 'Event Date, Title, Venue & Map', 'gatherpress' ),
 	icon: eventDateTitleVenueMap,
 	/*

--- a/test/unit/js/src/variations/core/query/start-blank.test.js
+++ b/test/unit/js/src/variations/core/query/start-blank.test.js
@@ -1,0 +1,130 @@
+/**
+ * Tests for the "Start blank" connected block variations.
+ *
+ * Guards the fix for #1801: every "Start blank" option must scaffold a
+ * GatherPress event template (`gatherpress/event-date`) AND carry our own
+ * pagination ("Event Pagination") and no-results ("No Event Results")
+ * variations, instead of WP core's plain post blocks.
+ */
+
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+
+const registered = [];
+
+jest.mock( '@wordpress/blocks', () => {
+	const actual = jest.requireActual( '@wordpress/blocks' );
+	return {
+		...actual,
+		registerBlockVariation: ( blockName, variation ) => {
+			registered.push( { blockName, variation } );
+		},
+	};
+} );
+
+const {
+	createBlocksFromInnerBlocksTemplate,
+	registerBlockType,
+	getBlockType,
+} = jest.requireActual( '@wordpress/blocks' );
+
+/**
+ * Register a throwaway block type so createBlocksFromInnerBlocksTemplate can
+ * instantiate the templates without a full WordPress environment.
+ *
+ * @param {string} name Block name to stub-register.
+ */
+const ensureBlock = ( name ) => {
+	if ( ! getBlockType( name ) ) {
+		registerBlockType( name, {
+			apiVersion: 3,
+			title: name,
+			category: 'widgets',
+			attributes: {},
+			save: () => null,
+			edit: () => null,
+		} );
+	}
+};
+
+[
+	'core/query',
+	'core/post-template',
+	'core/post-title',
+	'core/post-excerpt',
+	'core/paragraph',
+	'core/media-text',
+	'core/query-pagination',
+	'core/query-pagination-previous',
+	'core/query-pagination-numbers',
+	'core/query-pagination-next',
+	'core/query-no-results',
+	'gatherpress/event-date',
+	'gatherpress/venue',
+].forEach( ensureBlock );
+
+// Importing the module triggers its registerBlockVariation() side effects.
+require( '@src/variations/core/query/start-blank' );
+
+// Only the four start-blank variations target core/query; the pagination and
+// no-results modules imported as a side effect register against their own
+// core blocks, so filter those out.
+const startBlankVariations = registered
+	.filter( ( r ) => 'core/query' === r.blockName )
+	.map( ( r ) => r.variation );
+
+const flattenNames = ( blocks ) => {
+	const out = [];
+	const walk = ( list ) => {
+		for ( const block of list ) {
+			out.push( block.name );
+			walk( block.innerBlocks || [] );
+		}
+	};
+	walk( blocks );
+	return out;
+};
+
+describe( 'core/query "Start blank" variations', () => {
+	it( 'registers four scoped variations against core/query', () => {
+		expect( startBlankVariations ).toHaveLength( 4 );
+	} );
+
+	it( 'scopes every variation to the block (Start blank) picker only', () => {
+		startBlankVariations.forEach( ( variation ) => {
+			expect( variation.scope ).toEqual( [ 'block' ] );
+		} );
+	} );
+
+	it( 'gives every variation a unique name and a title', () => {
+		const names = startBlankVariations.map( ( v ) => v.name );
+		expect( new Set( names ).size ).toBe( names.length );
+		startBlankVariations.forEach( ( variation ) => {
+			expect( typeof variation.title ).toBe( 'string' );
+			expect( variation.title.length ).toBeGreaterThan( 0 );
+		} );
+	} );
+
+	it( 'scaffolds an event template with pagination and no-results in each variation', () => {
+		startBlankVariations.forEach( ( variation ) => {
+			const blocks = createBlocksFromInnerBlocksTemplate(
+				variation.innerBlocks
+			);
+			const all = flattenNames( blocks );
+
+			// Top level holds the post-template plus the two query siblings.
+			expect( blocks.map( ( b ) => b.name ) ).toEqual( [
+				'core/post-template',
+				'core/query-pagination',
+				'core/query-no-results',
+			] );
+
+			// The regression guard: our blocks, not core's plain post blocks.
+			expect( all ).toContain( 'gatherpress/event-date' );
+			expect( all ).toContain( 'core/query-pagination' );
+			expect( all ).toContain( 'core/query-no-results' );
+		} );
+	} );
+} );

--- a/test/unit/js/src/variations/core/query/start-blank.test.js
+++ b/test/unit/js/src/variations/core/query/start-blank.test.js
@@ -107,6 +107,20 @@ describe( 'core/query "Start blank" variations', () => {
 		} );
 	} );
 
+	it( 'carries the event-query className without leaking string-spread keys', () => {
+		startBlankVariations.forEach( ( variation ) => {
+			expect( variation.attributes.className ).toBe(
+				'gatherpress-event-query'
+			);
+			// A regression guard against spreading the className *string*,
+			// which would scatter numeric-index keys ("0","1",...) across
+			// the attributes object.
+			Object.keys( variation.attributes ).forEach( ( key ) => {
+				expect( key ).not.toMatch( /^\d+$/ );
+			} );
+		} );
+	} );
+
 	it( 'scaffolds an event template with pagination and no-results in each variation', () => {
 		startBlankVariations.forEach( ( variation ) => {
 			const blocks = createBlocksFromInnerBlocksTemplate(

--- a/test/unit/js/src/variations/core/query/start-blank.test.js
+++ b/test/unit/js/src/variations/core/query/start-blank.test.js
@@ -101,6 +101,11 @@ describe( 'core/query "Start blank" variations', () => {
 	it( 'gives every variation a unique name and a title', () => {
 		const names = startBlankVariations.map( ( v ) => v.name );
 		expect( new Set( names ).size ).toBe( names.length );
+		names.forEach( ( name ) => {
+			expect( name ).toMatch(
+				/^gatherpress-event-query-start-blank-\d+$/
+			);
+		} );
 		startBlankVariations.forEach( ( variation ) => {
 			expect( typeof variation.title ).toBe( 'string' );
 			expect( variation.title.length ).toBeGreaterThan( 0 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

BEFORE 
<img width="1062" height="311" alt="image" src="https://github.com/user-attachments/assets/a191a4cb-35ef-4bdd-9c97-ec88882f7d43" />

AFTER
<img width="1063" height="322" alt="image" src="https://github.com/user-attachments/assets/ac16d9bf-b699-49ec-bb38-6acf81b3d9ec" />


Fixes #1801

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
>... replace all or almost all code of /src/variations/core/query/start-blank.js by 4 calls to registerBlockVariation() and [...] done!

### Other information:

- [ ] Have you written new tests for your changes, if applicable? _**No**_

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
1. Insert an "Event Query" block anywhere
2. Use "Start blank" and choose any option
3. The blocks being inserted DO contain our block variations for pagination & no-results

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs created from a fork under GitHub organizations. -->
<!-- In this case, you can create the entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
