### PR TITLE
Fix Event Query listing past events on the front end (#1806)

### DIFF
--- a/.github/changelog/1806-fix-event-query-frontend-past-events
+++ b/.github/changelog/1806-fix-event-query-frontend-past-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Event Query block no longer lists past events on the front end when its saved query omits the event type; it now defaults to upcoming, matching the editor. [#1806]

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -41,6 +41,26 @@ class Event_Query {
 	 * @var string
 	 */
 	const BLOCK_NAME = 'gatherpress-event-query';
+
+	/**
+	 * Resolved event-query type ('upcoming', 'past' or 'all') keyed by the
+	 * `queryId` of each event-query block seen during the render pass.
+	 *
+	 * Populated in `pre_render_block`, where the block's `namespace` attribute
+	 * confirms it is one of ours, and consumed in `query_loop_block_query_vars`,
+	 * which only sees the descendant (post-template / pagination) block context
+	 * and therefore cannot tell our blocks from a sibling plain Query Loop. The
+	 * map lets the front-end filter scope strictly to the blocks we registered
+	 * and fall back to the same 'upcoming' default the REST collection params
+	 * apply, so a block whose saved query predates the `gatherpress_event_query`
+	 * attribute still scopes to upcoming events on the front end instead of
+	 * listing every event (#1806).
+	 *
+	 * @since 0.34.0
+	 * @var array<int, string>
+	 */
+	protected array $event_query_types = array();
+
 	/**
 	 * Class constructor.
 	 *
@@ -142,56 +162,64 @@ class Event_Query {
 	 * @return string|null The pre-rendered content. Default null.
 	 */
 	public function pre_render_block( ?string $pre_render, array $parsed_block ): ?string {
-		// Check if this is our event query block by verifying the namespace attribute.
+		// Bail unless this is our event query block, verified via the namespace attribute.
 		if (
-			isset( $parsed_block['attrs']['namespace'] ) &&
-			self::BLOCK_NAME === $parsed_block['attrs']['namespace']
+			! isset( $parsed_block['attrs']['namespace'] ) ||
+			self::BLOCK_NAME !== $parsed_block['attrs']['namespace']
 		) {
-			if (
-				isset( $parsed_block['attrs']['query']['inherit'] ) &&
-				true === $parsed_block['attrs']['query']['inherit']
-			) {
-				global $wp_query;
+			return $pre_render;
+		}
 
-				$query_args = array_merge(
-					$wp_query->query_vars,
-					array(
-						'posts_per_page' => $parsed_block['attrs']['query']['perPage'],
-						'order'          => $parsed_block['attrs']['query']['order'],
-						'orderby'        => $parsed_block['attrs']['query']['orderBy'],
-					)
-				);
+		if (
+			isset( $parsed_block['attrs']['query']['inherit'] ) &&
+			true === $parsed_block['attrs']['query']['inherit']
+		) {
+			global $wp_query;
 
-				/**
-				 * Filter the query vars.
-				 *
-				 * Allows filtering query params when the query is being inherited.
-				 *
-				 * @since 0.33.0
-				 *
-				 * @param array   $query_args  Arguments to be passed to WP_Query.
-				 * @param array   $block_query The query attribute retrieved from the block.
-				 * @param boolean $inherited   Whether the query is being inherited.
-				 *
-				 * @return array $filtered_query_args Final arguments list.
-				 */
-				$filtered_query_args = apply_filters(
-					'gatherpress_query_vars',
-					$query_args,
-					$parsed_block['attrs']['query'],
-					true,
-				);
-				// "Hijack the global query. It's a hack, but it works." Ryan Welcher.
-				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$wp_query = new WP_Query( $filtered_query_args );
-			} else {
-				add_filter(
-					'query_loop_block_query_vars',
-					array( $this, 'query_loop_block_query_vars' ),
-					10,
-					2
-				);
-			}
+			$query_args = array_merge(
+				$wp_query->query_vars,
+				array(
+					'posts_per_page' => $parsed_block['attrs']['query']['perPage'],
+					'order'          => $parsed_block['attrs']['query']['order'],
+					'orderby'        => $parsed_block['attrs']['query']['orderBy'],
+				)
+			);
+
+			/**
+			 * Filter the query vars.
+			 *
+			 * Allows filtering query params when the query is being inherited.
+			 *
+			 * @since 0.33.0
+			 *
+			 * @param array   $query_args  Arguments to be passed to WP_Query.
+			 * @param array   $block_query The query attribute retrieved from the block.
+			 * @param boolean $inherited   Whether the query is being inherited.
+			 *
+			 * @return array $filtered_query_args Final arguments list.
+			 */
+			$filtered_query_args = apply_filters(
+				'gatherpress_query_vars',
+				$query_args,
+				$parsed_block['attrs']['query'],
+				true,
+			);
+			// "Hijack the global query. It's a hack, but it works." Ryan Welcher.
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$wp_query = new WP_Query( $filtered_query_args );
+		} else {
+			// Record this query's event type, defaulting to 'upcoming' to
+			// match the REST collection params when the block omits it (#1806).
+			$query_id                             = $parsed_block['attrs']['queryId'] ?? 0;
+			$this->event_query_types[ $query_id ] =
+				$parsed_block['attrs']['query']['gatherpress_event_query'] ?? 'upcoming';
+
+			add_filter(
+				'query_loop_block_query_vars',
+				array( $this, 'query_loop_block_query_vars' ),
+				10,
+				2
+			);
 		}
 
 		return $pre_render;
@@ -244,7 +272,19 @@ class Event_Query {
 		// Retrieve the query from the passed block context.
 		$block_query = $block->context['query'];
 
-		if ( ! is_array( $block_query ) || ! isset( $block_query['gatherpress_event_query'] ) ) {
+		if ( ! is_array( $block_query ) ) {
+			return $query;
+		}
+
+		// Prefer the type recorded in pre_render_block, then one set directly on
+		// the block query. A query with neither is not ours, so leave it untouched.
+		$query_id = $block->context['queryId'] ?? 0;
+
+		if ( array_key_exists( $query_id, $this->event_query_types ) ) {
+			$event_query_type = $this->event_query_types[ $query_id ];
+		} elseif ( isset( $block_query['gatherpress_event_query'] ) ) {
+			$event_query_type = $block_query['gatherpress_event_query'];
+		} else {
 			return $query;
 		}
 
@@ -261,7 +301,7 @@ class Event_Query {
 
 		// Type of event list: 'upcoming', 'past', or 'all',
 		// @see wp-content/plugins/gatherpress/includes/core/classes/class-event-query.php.
-		$query_args['gatherpress_event_query'] = $block_query['gatherpress_event_query'];
+		$query_args['gatherpress_event_query'] = $event_query_type;
 
 		// Exclude Posts.
 		$exclude_ids = $this->get_exclude_ids( $block_query );
@@ -278,12 +318,10 @@ class Event_Query {
 			$query_args['shadow_filter'] = $block_query['shadow_filter'];
 		}
 
-		// Editor-preview context — the editor writes these into the block's
-		// `query` attribute when the contextual toggle is enabled, so the
-		// REST-side preview can scope to the same shadow-source post the
-		// frontend `is_singular()` path scopes to. Frontend `pre_get_posts`
-		// ignores these (it has the queried object); the REST path uses them
-		// as a fallback when `is_singular()` is false.
+		// Editor-preview context: lets the REST preview scope to the same
+		// shadow-source post the frontend resolves from the queried object.
+		// Frontend pre_get_posts ignores these; the REST path uses them as a
+		// fallback when is_singular() is false.
 		if ( ! empty( $block_query['gatherpress_shadow_source_post_id'] ) ) {
 			$query_args['gatherpress_shadow_source_post_id'] = (int) $block_query['gatherpress_shadow_source_post_id'];
 		}

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-query.php
@@ -11,6 +11,7 @@ namespace GatherPress\Tests\Core\Blocks;
 use GatherPress\Core\Blocks\Event_Query;
 use GatherPress\Core\Event;
 use GatherPress\Tests\Base;
+use PMC\Unit_Test\Utility;
 
 /**
  * Class Test_Event_Query.
@@ -18,6 +19,20 @@ use GatherPress\Tests\Base;
  * @coversDefaultClass \GatherPress\Core\Blocks\Event_Query
  */
 class Test_Event_Query extends Base {
+
+	/**
+	 * Reset the per-request event-query type map between tests.
+	 *
+	 * The map is request-scoped singleton state in production, but the
+	 * singleton persists across test methods, so clear it to keep the
+	 * `query_loop_block_query_vars` tests isolated from each other.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Utility::set_and_get_hidden_property( Event_Query::get_instance(), 'event_query_types', array() );
+	}
 
 	/**
 	 * Tests the setup_hooks method.
@@ -486,6 +501,128 @@ class Test_Event_Query extends Base {
 		$result = $instance->query_loop_block_query_vars( $query, $block );
 
 		$this->assertSame( $query, $result, 'Should return unchanged query without gatherpress_event_query.' );
+	}
+
+	/**
+	 * Test pre_render_block records the default 'upcoming' type for a block
+	 * whose saved query omits gatherpress_event_query.
+	 *
+	 * Regression coverage for #1806: such a block rendered every event on the
+	 * front end because no event type reached the query. The recorded default
+	 * is what lets the front-end filter scope it to upcoming events.
+	 *
+	 * @since 0.34.0
+	 * @covers ::pre_render_block
+	 *
+	 * @return void
+	 */
+	public function test_pre_render_block_records_default_event_query_type(): void {
+		$instance = Event_Query::get_instance();
+
+		remove_all_filters( 'query_loop_block_query_vars' );
+
+		$parsed_block = array(
+			'attrs' => array(
+				'namespace' => Event_Query::BLOCK_NAME,
+				'queryId'   => 6,
+				'query'     => array(
+					'inherit'  => false,
+					'postType' => Event::POST_TYPE,
+					'order'    => 'desc',
+					'orderBy'  => 'date',
+				),
+			),
+		);
+
+		$instance->pre_render_block( null, $parsed_block );
+
+		$types = Utility::get_hidden_property( $instance, 'event_query_types' );
+
+		$this->assertSame(
+			'upcoming',
+			$types[6] ?? null,
+			'A block whose saved query omits gatherpress_event_query should default to upcoming.'
+		);
+
+		remove_filter( 'query_loop_block_query_vars', array( $instance, 'query_loop_block_query_vars' ) );
+	}
+
+	/**
+	 * Test query_loop_block_query_vars applies the recorded 'upcoming' default
+	 * when the block context omits gatherpress_event_query.
+	 *
+	 * Mirrors the #1806 front-end path: pre_render_block records the default
+	 * keyed by queryId, then the descendant post-template context (which lacks
+	 * gatherpress_event_query) resolves to that default instead of leaving the
+	 * query unfiltered.
+	 *
+	 * @since 0.34.0
+	 * @covers ::query_loop_block_query_vars
+	 *
+	 * @return void
+	 */
+	public function test_query_loop_block_query_vars_applies_registered_default(): void {
+		$instance = Event_Query::get_instance();
+
+		Utility::set_and_get_hidden_property( $instance, 'event_query_types', array( 6 => 'upcoming' ) );
+
+		$query = array( 'posts_per_page' => 5 );
+		$block = $this->createMock( \WP_Block::class );
+
+		$block->context = array(
+			'queryId' => 6,
+			'query'   => array(
+				'postType' => Event::POST_TYPE,
+				'order'    => 'desc',
+			),
+		);
+
+		$result = $instance->query_loop_block_query_vars( $query, $block );
+
+		$this->assertSame(
+			'upcoming',
+			$result['gatherpress_event_query'],
+			'A registered query without an explicit type should default to upcoming.'
+		);
+		$this->assertSame( Event::POST_TYPE, $result['post_type'] );
+	}
+
+	/**
+	 * Test query_loop_block_query_vars leaves an unregistered sibling query
+	 * untouched.
+	 *
+	 * A plain Query Loop rendered after an event-query block can hit this
+	 * still-attached filter. Without a recorded type and without an explicit
+	 * gatherpress_event_query, its query must pass through unmodified so it is
+	 * not accidentally turned into an event query (#1806).
+	 *
+	 * @since 0.34.0
+	 * @covers ::query_loop_block_query_vars
+	 *
+	 * @return void
+	 */
+	public function test_query_loop_block_query_vars_skips_unregistered_query(): void {
+		$instance = Event_Query::get_instance();
+
+		Utility::set_and_get_hidden_property( $instance, 'event_query_types', array( 6 => 'upcoming' ) );
+
+		$query = array( 'posts_per_page' => 5 );
+		$block = $this->createMock( \WP_Block::class );
+
+		$block->context = array(
+			'queryId' => 99,
+			'query'   => array(
+				'postType' => 'post',
+			),
+		);
+
+		$result = $instance->query_loop_block_query_vars( $query, $block );
+
+		$this->assertSame(
+			$query,
+			$result,
+			'A sibling query with a different queryId and no explicit type should be untouched.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1806.

## Problem

An **Event Query** block whose saved `query` omits the `gatherpress_event_query` attribute lists **every** event (past and future) on the front end, while rendering correctly ("upcoming only") in the editor. This affects blocks created before the attribute existed, and blocks seeded by demo data — e.g. the Playground data referenced in the issue.

## Root cause

An editor/front-end asymmetry around the default value:

- **Editor (REST):** `rest_collection_params()` declares `gatherpress_event_query` with `'default' => 'upcoming'`, so a request that doesn't specify a value still resolves to `upcoming`.
- **Front end (`query_loop_block_query_vars()`):** bailed out early when the value was absent (`! isset(...) → return $query`), applying **no** event-type filtering, so the Query Loop returned all events.

That's why the bug is only visible when past events are present, and looks total when there are no upcoming events.

## Fix

Apply the same `'upcoming'` default on the front end.

The front-end filter only sees the descendant (post-template / pagination) block context, which carries no `namespace`, so it can't distinguish our block from a sibling plain Query Loop. So the resolved type is recorded in `pre_render_block()` — where the `namespace` attribute confirms the block is ours — keyed by `queryId`, and looked up at filter time. Scoping by `queryId` keeps a sibling plain Query Loop rendered later on the same page untouched, preserving the safety the old `isset` guard provided. An explicit type set directly on the block query is still honored.

## Testing

- Reproduced on a local page (a past event leaked into the front-end output); confirmed the fix removes it and only upcoming events render.
- `phpcs` and `phpstan` clean.
- `Test_Event_Query` passes (added 3 regression tests + a `setUp` that resets the per-request type map between tests); related `Test_Query` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)