### PR TITLE
Add jobgaspersic and e1337geek to 0.34.0-beta.1 credits

### DIFF
--- a/includes/data/credits.php
+++ b/includes/data/credits.php
@@ -171,6 +171,32 @@ return array (
     ),
     1 => 
     array (
+      'id' => 23125819,
+      'name' => 'Brady Friedrich',
+      'link' => 'https://profiles.wordpress.org/e1337geek/',
+      'slug' => 'e1337geek',
+      'avatar_urls' => 
+      array (
+        24 => '//www.gravatar.com/avatar/ce53d88b81cc9af61e017eb89ce1e057?s=24&#038;r=g&#038;d=mm',
+        48 => '//www.gravatar.com/avatar/ce53d88b81cc9af61e017eb89ce1e057?s=48&#038;r=g&#038;d=mm',
+        96 => '//www.gravatar.com/avatar/ce53d88b81cc9af61e017eb89ce1e057?s=96&#038;r=g&#038;d=mm',
+      ),
+    ),
+    2 => 
+    array (
+      'id' => 23518518,
+      'name' => 'jobgaspersic',
+      'link' => 'https://profiles.wordpress.org/jobgaspersic/',
+      'slug' => 'jobgaspersic',
+      'avatar_urls' => 
+      array (
+        24 => '//www.gravatar.com/avatar/3bb9acfbf74fc17daada7eafee6dcae0?s=24&#038;r=g&#038;d=mm',
+        48 => '//www.gravatar.com/avatar/3bb9acfbf74fc17daada7eafee6dcae0?s=48&#038;r=g&#038;d=mm',
+        96 => '//www.gravatar.com/avatar/3bb9acfbf74fc17daada7eafee6dcae0?s=96&#038;r=g&#038;d=mm',
+      ),
+    ),
+    3 => 
+    array (
       'id' => 15768524,
       'name' => 'Kofi Mokome',
       'link' => 'https://profiles.wordpress.org/kofimokome/',
@@ -182,7 +208,7 @@ return array (
         96 => '//www.gravatar.com/avatar/35d97e8ebb19530c8cb46cb42f5e5c86?s=96&#038;r=g&#038;d=mm',
       ),
     ),
-    2 => 
+    4 => 
     array (
       'id' => 14685954,
       'name' => 'richsalvucci',


### PR DESCRIPTION
Regenerates `includes/data/credits.php` for `0.34.0-beta.1` via the gatherpress-develop `generate_version` CLI.

Adds two contributors to the credits screen / release attribution:
- **jobgaspersic**
- **e1337geek** (Brady Friedrich)

Both resolve to valid WordPress.org profiles, so the generated data contains real profile info (no error stubs).

Version, `readme.txt`, `package.json`, and `SECURITY.md` were already at `0.34.0-beta.1`, so this PR only touches the generated credits data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)