### PR TITLE
Add WordPress.org profile credit section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,18 @@ Fixes #
 * Go to '..'
 *
 
+### Credit (for release notes)
+
+<!-- First time contributing? Add your WordPress.org profile so we can credit you in the -->
+<!-- release and on the in-plugin Credits screen. -->
+<!-- Your profile URL looks like: https://profiles.wordpress.org/USERNAME/ -->
+<!-- Enter just the USERNAME (the last part of that URL) below. -->
+<!-- Please open the link first to confirm it loads — credits are generated from this exact -->
+<!-- username, so a typo or a non-existent profile gets skipped. -->
+<!-- Don't have a WordPress.org account? Create a free one at https://login.wordpress.org/register -->
+
+My WordPress.org username:
+
 ### Changelog entry
 
 <!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->


### PR DESCRIPTION
Adds a **Credit** section to the PR template so contributors can supply their WordPress.org username for release/Credits-screen attribution.

The wording:
- Shows the exact profile URL shape `https://profiles.wordpress.org/USERNAME/` and asks for just the `USERNAME`.
- Reminds contributors to confirm the profile loads — the credits generator (`wp gatherpress develop generate_version`) returns `404 rest_user_invalid_slug` for a non-existent username and skips it, so this prevents bad/missing credits.
- Points people without an account to the WordPress.org signup page.

Placed alongside the existing changelog bookkeeping section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)