### PR TITLE
Fix dropdown not resetting label when default selected item is deleted

### DIFF
--- a/.github/changelog/1826-from-description
+++ b/.github/changelog/1826-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Dropdown block not resetting the trigger label or selected index when the default selected item is deleted in Select Mode.

--- a/src/blocks/dropdown/edit.js
+++ b/src/blocks/dropdown/edit.js
@@ -35,7 +35,10 @@ import { dispatch, select, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { useIsBlockOrDescendantSelected } from './helpers';
+import {
+	getSelectedItemReset,
+	useIsBlockOrDescendantSelected,
+} from './helpers';
 
 /**
  * Edit component for the GatherPress Dropdown block.
@@ -127,6 +130,21 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 			} );
 		}
 	}, [ label, clientId ] );
+
+	// Recover from a deleted "Default Selected Item": fall back to the first item,
+	// or switch select mode off entirely once every item has been removed.
+	useEffect( () => {
+		const reset = getSelectedItemReset(
+			actAsSelect,
+			innerBlocks,
+			selectedIndex,
+			__( 'Dropdown', 'gatherpress' )
+		);
+
+		if ( reset ) {
+			setAttributes( reset );
+		}
+	}, [ actAsSelect, innerBlocks, selectedIndex, setAttributes ] );
 
 	useEffect( () => {
 		// Ensure this effect only runs when `actAsSelect` is enabled.

--- a/src/blocks/dropdown/helpers.js
+++ b/src/blocks/dropdown/helpers.js
@@ -4,6 +4,55 @@
 import { useSelect } from '@wordpress/data';
 
 /**
+ * Computes the attribute updates needed when a dropdown's "Default Selected Item"
+ * is removed while "Select Mode" is enabled.
+ *
+ * When an item set as the default selection is deleted, `selectedIndex` is left
+ * pointing at an item that no longer exists, which keeps the stale label on the
+ * trigger. This resolves that state:
+ *
+ * - Select mode off, or the selection still points at a real item: no change.
+ * - The selected item was removed but others remain: fall back to the first item.
+ * - Every item removed: turn select mode off and reset the label, so the block
+ *   behaves like a fresh, empty dropdown.
+ *
+ * @since 0.34.0
+ *
+ * @param {boolean} actAsSelect   Whether "Select Mode" is enabled.
+ * @param {Array}   innerBlocks   The dropdown's inner item blocks.
+ * @param {number}  selectedIndex The currently selected item index.
+ * @param {string}  defaultLabel  Label to fall back to when all items are removed.
+ *
+ * @return {Object|null} Attribute updates to apply, or null when nothing changes.
+ */
+export function getSelectedItemReset(
+	actAsSelect,
+	innerBlocks,
+	selectedIndex,
+	defaultLabel
+) {
+	// Only relevant while the dropdown is acting as a select.
+	if ( ! actAsSelect ) {
+		return null;
+	}
+
+	const itemCount = Array.isArray( innerBlocks ) ? innerBlocks.length : 0;
+
+	// All items removed: behave like an empty dropdown and switch select mode off.
+	if ( ! itemCount ) {
+		return { actAsSelect: false, selectedIndex: 0, label: defaultLabel };
+	}
+
+	// Selected item removed but others remain: fall back to the first item.
+	if ( 0 > selectedIndex || selectedIndex >= itemCount ) {
+		return { selectedIndex: 0 };
+	}
+
+	// Selection still points at a valid item: nothing to do.
+	return null;
+}
+
+/**
  * Custom hook to detect if a block or any of its children are currently selected.
  *
  * This hook is useful for UI components that need to show/hide based on whether

--- a/test/unit/js/src/blocks/dropdown/helpers.test.js
+++ b/test/unit/js/src/blocks/dropdown/helpers.test.js
@@ -12,7 +12,10 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { useIsBlockOrDescendantSelected } from '@src/blocks/dropdown/helpers';
+import {
+	getSelectedItemReset,
+	useIsBlockOrDescendantSelected,
+} from '@src/blocks/dropdown/helpers';
 
 // Mock @wordpress/data.
 jest.mock( '@wordpress/data', () => ( {
@@ -163,5 +166,54 @@ describe( 'useIsBlockOrDescendantSelected', () => {
 		);
 
 		expect( result.current ).toBe( true );
+	} );
+} );
+
+describe( 'getSelectedItemReset', () => {
+	const items = ( count ) =>
+		Array.from( { length: count }, ( _, index ) => ( {
+			attributes: { text: `Item ${ index + 1 }` },
+		} ) );
+
+	it( 'returns null when select mode is disabled', () => {
+		expect(
+			getSelectedItemReset( false, items( 3 ), 5, 'Dropdown' )
+		).toBeNull();
+	} );
+
+	it( 'returns null when the selected index still points at a valid item', () => {
+		expect(
+			getSelectedItemReset( true, items( 3 ), 2, 'Dropdown' )
+		).toBeNull();
+	} );
+
+	it( 'falls back to the first item when the selected item was removed but others remain', () => {
+		expect(
+			getSelectedItemReset( true, items( 3 ), 4, 'Dropdown' )
+		).toEqual( { selectedIndex: 0 } );
+	} );
+
+	it( 'falls back to the first item when the selected index is negative', () => {
+		expect(
+			getSelectedItemReset( true, items( 3 ), -1, 'Dropdown' )
+		).toEqual( { selectedIndex: 0 } );
+	} );
+
+	it( 'switches select mode off and resets the label when all items are removed', () => {
+		expect( getSelectedItemReset( true, [], 2, 'Dropdown' ) ).toEqual( {
+			actAsSelect: false,
+			selectedIndex: 0,
+			label: 'Dropdown',
+		} );
+	} );
+
+	it( 'treats a non-array innerBlocks value as an empty dropdown', () => {
+		expect(
+			getSelectedItemReset( true, undefined, 0, 'Dropdown' )
+		).toEqual( {
+			actAsSelect: false,
+			selectedIndex: 0,
+			label: 'Dropdown',
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #1822

## Proposed changes:

When **Enable Select Mode** is on and the item set as the **Default Selected Item** is deleted, `selectedIndex` was left pointing at an item that no longer exists. Both existing label-update effects bail on their bounds guard (`selectedIndex >= innerBlocks.length`), so the deleted item's text persisted as the trigger label in the editor, the inspector's "Default Selected Item" control, and on the frontend (PHP renders the stale saved `label`).

This PR adds a pure `getSelectedItemReset()` helper in `src/blocks/dropdown/helpers.js`, wired into an effect in `edit.js`, that recovers from the deleted-selection state:

* **Selected item removed, others remain** → reset `selectedIndex` to `0` (first item). The existing label effects then re-derive the label from index 0. This matches what the inspector control already falls back to displaying.
* **All items removed** → switch select mode off and reset the label to the default `Dropdown`, so the block behaves like a fresh, empty dropdown. Re-adding an item requires re-toggling select mode and choosing an item again.
* **Selection still valid** → no change.

The reset logic is extracted as a pure function (i18n-free, default label passed in) to keep the component thin and the logic fully unit-testable, per the project's testing philosophy.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Added 6 unit tests covering every branch of `getSelectedItemReset()`. `test:unit:js` passes with 100% statement/branch/function/line coverage on `helpers.js`; `lint-js` is clean on all changed files.

## Testing instructions:

* Add a `gatherpress/dropdown` block to a post or event.
* Add several dropdown items (e.g. `One`, `Two`, `Three`, `Four`, `Five`).
* In the block inspector **Advanced** panel, enable **Enable Select Mode**.
* Set **Default Selected Item** to the last item (`Five`).
* Delete the `Five` dropdown-item block from the editor.
* **Expected:** the trigger label and the "Default Selected Item" control immediately fall back to the first item (`One`); index 0 is shown as selected. Save and view on the frontend — the trigger shows `One`, not `Five`.
* Now delete every remaining item.
* **Expected:** Select Mode toggles off and the label resets to `Dropdown`, like an empty dropdown. Adding a new item requires re-enabling Select Mode and re-selecting an item.

### Credit (for release notes)

My WordPress.org username:

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch

#### Type

-   [x] Fixed - for any bug fixes

#### Message

Fix Dropdown block not resetting the trigger label or selected index when the default selected item is deleted in Select Mode.

</details>