### PR TITLE
Add WordPress Props Bot action for contributor attribution

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -3,7 +3,7 @@ name: Props Bot
 on:
     # This event runs anytime a PR is (re)opened, updated, marked ready for review, or labeled.
     # GitHub does not allow filtering the `labeled` event by a specific label.
-    # However, the logic below will short-circuit the workflow when the `props-bot` label is not the one being added.
+    # However, the logic below will short-circuit the workflow when the `Props Bot` label is not the one being added.
     # Note: The pull_request_target event is used instead of pull_request because this workflow needs permission to comment
     # on the pull request. Because this event grants extra permissions to `GITHUB_TOKEN`, any code changes within the PR
     # should be considered untrusted. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
@@ -45,7 +45,7 @@ jobs:
     #
     # Performs the following steps:
     # - Collects a list of contributor props and leaves a comment.
-    # - Removes the props-bot label, if necessary.
+    # - Removes the Props Bot label, if necessary.
     props-bot:
         name: Generate a list of props
         runs-on: ubuntu-latest
@@ -58,13 +58,13 @@ jobs:
         # - A comment is added to the pull request.
         # - A review is created or commented on (unless PR originates from a fork).
         # - The pull request is opened, synchronized, marked ready for review, or reopened.
-        # - The `props-bot` label is added to the pull request.
+        # - The `Props Bot` label is added to the pull request.
         if: |
             (
               github.event_name == 'issue_comment' && github.event.issue.pull_request ||
               ( contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && ! github.event.pull_request.head.repo.fork ) ||
               github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
-              'props-bot' == github.event.label.name
+              'Props Bot' == github.event.label.name
             ) &&
             ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
 
@@ -78,9 +78,9 @@ jobs:
                   # `svn` value only describes the output style.
                   format: 'svn'
 
-            - name: Remove the props-bot label
+            - name: Remove the Props Bot label
               uses: actions/github-script@v7
-              if: ${{ github.event.action == 'labeled' && 'props-bot' == github.event.label.name }}
+              if: ${{ github.event.action == 'labeled' && 'Props Bot' == github.event.label.name }}
               with:
                   retries: 2
                   retry-exempt-status-codes: 418
@@ -89,5 +89,5 @@ jobs:
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: '${{ github.event.number }}',
-                        name: 'props-bot'
+                        name: 'Props Bot'
                       });

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -1,0 +1,93 @@
+name: Props Bot
+
+on:
+    # This event runs anytime a PR is (re)opened, updated, marked ready for review, or labeled.
+    # GitHub does not allow filtering the `labeled` event by a specific label.
+    # However, the logic below will short-circuit the workflow when the `props-bot` label is not the one being added.
+    # Note: The pull_request_target event is used instead of pull_request because this workflow needs permission to comment
+    # on the pull request. Because this event grants extra permissions to `GITHUB_TOKEN`, any code changes within the PR
+    # should be considered untrusted. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
+    pull_request_target:
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - labeled
+            - ready_for_review
+    # This event runs anytime a comment is added or deleted.
+    # You cannot filter this event for PR comments only.
+    # However, the logic below does short-circuit the workflow for issues.
+    issue_comment:
+        types:
+            - created
+    # This event will run everytime a new PR review is initially submitted.
+    pull_request_review:
+        types:
+            - submitted
+    # This event runs anytime a PR review comment is created or deleted.
+    pull_request_review_comment:
+        types:
+            - created
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ contains( fromJSON( '["pull_request_target", "pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && github.head_ref || github.sha }}
+    cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+    # Compiles a list of props for a pull request.
+    #
+    # Performs the following steps:
+    # - Collects a list of contributor props and leaves a comment.
+    # - Removes the props-bot label, if necessary.
+    props-bot:
+        name: Generate a list of props
+        runs-on: ubuntu-latest
+        permissions:
+            # The action needs `write` permission for PRs in order to add a comment.
+            pull-requests: write
+        timeout-minutes: 20
+        # The job will run when pull requests are open, ready for review and:
+        #
+        # - A comment is added to the pull request.
+        # - A review is created or commented on (unless PR originates from a fork).
+        # - The pull request is opened, synchronized, marked ready for review, or reopened.
+        # - The `props-bot` label is added to the pull request.
+        if: |
+            (
+              github.event_name == 'issue_comment' && github.event.issue.pull_request ||
+              ( contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && ! github.event.pull_request.head.repo.fork ) ||
+              github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
+              'props-bot' == github.event.label.name
+            ) &&
+            ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
+
+        steps:
+            - name: Gather a list of contributors
+              uses: WordPress/props-bot-action@trunk
+              with:
+                  # Resolve contributors to their WordPress.org usernames and render them
+                  # as a `Props <wporg-username>` list, which is what feeds the
+                  # data/credits.php + generate_version flow. We do not use SVN; the
+                  # `svn` value only describes the output style.
+                  format: 'svn'
+
+            - name: Remove the props-bot label
+              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+              if: ${{ github.event.action == 'labeled' && 'props-bot' == github.event.label.name }}
+              with:
+                  retries: 2
+                  retry-exempt-status-codes: 418
+                  script: |
+                      github.rest.issues.removeLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: '${{ github.event.number }}',
+                        name: 'props-bot'
+                      });

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -79,7 +79,7 @@ jobs:
                   format: 'svn'
 
             - name: Remove the props-bot label
-              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+              uses: actions/github-script@v7
               if: ${{ github.event.action == 'labeled' && 'props-bot' == github.event.label.name }}
               with:
                   retries: 2

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,6 +38,14 @@ Draft PRs and PRs not targeting `develop` are exempt from the check.
 
 - For access to infrastructure (SSH or WP Admin on gatherpress.org), contact [@MervinHernandez](https://github.com/MervinHernandez)
 
+## 🏷️ Contributor Credits
+
+GatherPress credits contributors by their **WordPress.org username**, both on the in-plugin Credits screen and in the WordPress.org attribution. A [Props Bot](https://github.com/WordPress/props-bot-action) runs on every pull request and posts a maintained comment listing the PR's contributors (including authors of any linked issues), resolved to their wp.org usernames.
+
+For the bot to resolve you correctly, **link your GitHub account on your [profiles.wordpress.org](https://profiles.wordpress.org/) profile**. If you don't have a WordPress.org account yet, create a free one at [login.wordpress.org/register](https://login.wordpress.org/register). Contributors who haven't linked their accounts won't resolve cleanly and may need to be credited by hand.
+
+Maintainers can force the bot to refresh its list by adding the `props-bot` label to a pull request.
+
 ---
 
 Thanks for helping make GatherPress better! 💜

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -44,7 +44,7 @@ GatherPress credits contributors by their **WordPress.org username**, both on th
 
 For the bot to resolve you correctly, **link your GitHub account on your [profiles.wordpress.org](https://profiles.wordpress.org/) profile**. If you don't have a WordPress.org account yet, create a free one at [login.wordpress.org/register](https://login.wordpress.org/register). Contributors who haven't linked their accounts won't resolve cleanly and may need to be credited by hand.
 
-Maintainers can force the bot to refresh its list by adding the `props-bot` label to a pull request.
+Maintainers can force the bot to refresh its list by adding the `Props Bot` label to a pull request.
 
 ---
 


### PR DESCRIPTION
Fixes #1811

## Proposed changes:

* Add `.github/workflows/props-bot.yml` — the upstream [`WordPress/props-bot-action`](https://github.com/WordPress/props-bot-action) example workflow (the same bot WordPress core uses). On every PR it posts and maintains a comment listing the PR's contributors, including authors of any linked issues, resolved to their **WordPress.org usernames**.
* Configured with **`format: svn`**, which renders the `Props <wporg-username>` list. We do **not** use SVN (GatherPress deploys to WordPress.org via GitHub Actions); the `svn` value only describes the output style. Those usernames are exactly what feed the `data/credits.php` + `generate_version` flow that powers the in-plugin Credits screen and wp.org attribution.
* Runs on `pull_request_target` so it can comment on fork PRs, with job-level `permissions: pull-requests: write`. Maintainers/contributors can force a refresh by adding the `props-bot` label (created in the repo; the action removes it after running).
* Documents wp.org profile linkage in `docs/contributing.md` so contributors resolve cleanly.

### Other information:

- [x] Have you written new tests for your changes, if applicable? _N/A — CI/workflow-only change._

## Testing instructions:

> [!NOTE]
> Because the workflow triggers on `pull_request_target`, GitHub runs the workflow definition from the **base branch**. This file doesn't exist on `develop` yet, so the bot will **not** run on this PR — it activates on PRs opened after this merges. That's expected.

After merge, on any new PR:

* Confirm the **Props Bot** workflow runs and posts a comment listing contributors as a `Props ...` list of WordPress.org usernames.
* Add the `props-bot` label and confirm the bot refreshes its comment and the label is removed automatically.

### Notes

- **wp.org profile linkage is required for accurate resolution.** The bot maps a GitHub account to a wp.org username via the contributor's profiles.wordpress.org profile with GitHub linked. Contributors who haven't linked won't resolve cleanly and may need manual crediting — now documented in the contributing guide.
- This complements (does not replace) the `data/credits.php` + `generate_version` credits flow; it makes gathering the correct usernames much easier. Follow-up automation to auto-add merged-PR contributors to credits is tracked in #1828.