### PR TITLE
Minor label adjustments to better support renaming post types & taxonomies

### DIFF
--- a/.extract-wp-hooks.json
+++ b/.extract-wp-hooks.json
@@ -8,7 +8,9 @@
 		"test"
 	],
 	"ignore_filter": [
-		"determine_current_user"
+		"determine_current_user",
+		"post_type_labels_gatherpress_event",
+		"post_type_labels_gatherpress_venue"
 	],
 	"github_wiki": false
 }

--- a/.github/changelog/1834-fix-minor-label-adjustments-to-better-support-renaming-types
+++ b/.github/changelog/1834-fix-minor-label-adjustments-to-better-support-renaming-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated Settings screens and Editor UI to better reflect the registered post type & taxonomy labels.

--- a/.github/playground/PR-1834-blueprint-override.json
+++ b/.github/playground/PR-1834-blueprint-override.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://gatherpress.org/playground-preview/pr-override-schema.json",
+	"landingPage": "/wp-admin/edit.php?post_type=gatherpress_event",
+	"appendSteps": [
+		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/mu-plugins/happenings-at-spots.php",
+			"data": {
+				"resource": "url",
+				"url": "https://raw.githubusercontent.com/carstingaxion/gatherpress-demos/main/happenings-at-spots/happenings-at-spots.php"
+			}
+		}
+	]
+}

--- a/includes/core/classes/class-topic.php
+++ b/includes/core/classes/class-topic.php
@@ -146,8 +146,28 @@ class Topic {
 	 */
 	public static function get_localized_taxonomy_slug(): string {
 		$switched_locale = switch_to_locale( get_locale() );
-		$slug            = _x( 'Topic', 'Admin menu and taxonomy singular name', 'gatherpress' );
-		$slug            = sanitize_title( $slug );
+
+		// The taxonomy (to get the singular name from) is typically not registered, when this method is called.
+		// Using Utility::taxonomy_label() will not yet work.
+
+		// Prepare a default at first.
+		$default_labels                = new \stdClass();
+		$default_labels->singular_name = _x(
+			'Topic',
+			'Admin menu and taxonomy singular name',
+			'gatherpress'
+		);
+
+		// To ensure, we use the proper labels, we get them from the WordPress core filter.
+		$taxonomy_labels = apply_filters(
+			sprintf( // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
+				'taxonomy_labels_%s',
+				self::TAXONOMY
+			),
+			$default_labels
+		);
+
+		$slug = sanitize_title( $taxonomy_labels->singular_name );
 
 		if ( $switched_locale ) {
 			restore_previous_locale();

--- a/includes/core/classes/class-topic.php
+++ b/includes/core/classes/class-topic.php
@@ -14,6 +14,7 @@ namespace GatherPress\Core;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
+use stdClass;
 
 /**
  * Class Topic.
@@ -151,7 +152,7 @@ class Topic {
 		// Using Utility::taxonomy_label() will not yet work.
 
 		// Prepare a default at first.
-		$default_labels                = new \stdClass();
+		$default_labels                = new stdClass();
 		$default_labels->singular_name = _x(
 			'Topic',
 			'Admin menu and taxonomy singular name',

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -221,6 +221,34 @@ class Utility {
 	}
 
 	/**
+	 * Resolve a single label from a taxonomy's registered labels.
+	 *
+	 * Wraps `get_taxonomy()` so call sites don't have to defend
+	 * against unregistered taxonomies or missing label keys. Lets UI
+	 * strings reflect whatever a site builder filtered the labels to,
+	 * and lets extenders' event-supporting taxonomies surface their own
+	 * labels instead of GatherPress's defaults (#1612).
+	 *
+	 * @since 0.34.0
+	 *
+	 * @param string $key       Label key to read (e.g. `singular_name`,
+	 *                          `name`, `add_new_item`).
+	 * @param string $taxonomy  Taxonomy slug to read the label from.
+	 *
+	 * @return string The resolved label, or empty string when the taxonomy
+	 *                isn't registered or the key isn't set.
+	 */
+	public static function taxonomy_label( string $key, string $taxonomy ): string {
+		$object = get_taxonomy( $taxonomy );
+
+		if ( ! $object || empty( $object->labels->$key ) ) {
+			return '';
+		}
+
+		return (string) $object->labels->$key;
+	}
+
+	/**
 	 * Convert a snake_case string to camelCase.
 	 *
 	 * Expects standard snake_case input (lowercase words separated by single underscores).

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -219,7 +219,7 @@ class Setup {
 		// Using Utility::post_type_label() will not yet work.
 
 		// Prepare a default at first.
-		$default_labels                = new \stdClass;
+		$default_labels                = new \stdClass();
 		$default_labels->singular_name = _x(
 			'Event',
 			'Admin menu and post type singular name',
@@ -228,7 +228,7 @@ class Setup {
 
 		// To ensure, we use the proper labels, we get them from the WordPress core filter.
 		$post_type_labels = apply_filters(
-			sprintf(
+			sprintf( // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
 				'post_type_labels_%s',
 				Event::POST_TYPE
 			),

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -22,6 +22,7 @@ use GatherPress\Core\Settings;
 use GatherPress\Core\Starter_Pattern_Loader;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
+use stdClass;
 use WP_Block;
 use WP_Post;
 use WP_Query;
@@ -219,7 +220,7 @@ class Setup {
 		// Using Utility::post_type_label() will not yet work.
 
 		// Prepare a default at first.
-		$default_labels                = new \stdClass();
+		$default_labels                = new stdClass();
 		$default_labels->singular_name = _x(
 			'Event',
 			'Admin menu and post type singular name',

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -214,8 +214,29 @@ class Setup {
 	 */
 	public static function get_localized_post_type_slug(): string {
 		$switched_locale = switch_to_locale( get_locale() );
-		$slug            = _x( 'Event', 'Post Type Singular Name', 'gatherpress' );
-		$slug            = sanitize_title( $slug );
+
+		// The post type (to get the singular name from) is typically not registered, when this method is called.
+		// Using Utility::post_type_label() will not yet work.
+
+		// Prepare a default at first.
+		$default_labels                = new \stdClass;
+		$default_labels->singular_name = _x(
+			'Event',
+			'Admin menu and post type singular name',
+			'gatherpress'
+		);
+
+		// To ensure, we use the proper labels, we get them from the WordPress core filter.
+		$post_type_labels = apply_filters(
+			sprintf(
+				'post_type_labels_%s',
+				Event::POST_TYPE
+			),
+			$default_labels
+		);
+
+		$slug = sanitize_title( $post_type_labels->singular_name );
+
 		if ( $switched_locale ) {
 			restore_previous_locale();
 		}

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -88,7 +88,7 @@ class List_Table extends WP_List_Table {
 			'cb'       => '<input type="checkbox" />',
 			'attendee' => __( 'Attendee', 'gatherpress' ),
 			'response' => __( 'Response', 'gatherpress' ),
-			'event'    => __( 'Event', 'gatherpress' ),
+			'event'    => Utility::post_type_label( 'singular_name', Event::POST_TYPE ),
 			'approved' => __( 'Status', 'gatherpress' ),
 			'date'     => __( 'Date', 'gatherpress' ),
 		);

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -93,7 +93,14 @@ class Events extends Base {
 							'name' => __( 'Date Format', 'gatherpress' ),
 						),
 						'field'  => array(
-							'label'   => __( 'Format of date for scheduled events.', 'gatherpress' ),
+							'label'   => sprintf(
+								/* translators: %s: Plural post type label, e.g. "Events". */
+								__(
+									'Format of date for scheduled %s.',
+									'gatherpress'
+								),
+								Utility::post_type_label( 'name', Event::POST_TYPE )
+							),
 							'type'    => 'text',
 							'size'    => 'regular',
 							'options' => array(
@@ -109,7 +116,14 @@ class Events extends Base {
 							'name' => __( 'Time Format', 'gatherpress' ),
 						),
 						'field'  => array(
-							'label'   => __( 'Format of time for scheduled events.', 'gatherpress' ),
+							'label'   => sprintf(
+								/* translators: %s: Plural post type label, e.g. "Events". */
+								__(
+									'Format of time for scheduled %s.',
+									'gatherpress'
+								),
+								Utility::post_type_label( 'name', Event::POST_TYPE )
+							),
 							'type'    => 'text',
 							'size'    => 'regular',
 							'options' => array(
@@ -125,9 +139,13 @@ class Events extends Base {
 							'name' => __( 'Show Timezone', 'gatherpress' ),
 						),
 						'field'  => array(
-							'label'   => __(
-								'Display the timezone for scheduled events.',
-								'gatherpress'
+							'label'   => sprintf(
+								/* translators: %s: Plural post type label, e.g. "Events". */
+								__(
+									'Display the timezone for scheduled %s.',
+									'gatherpress'
+								),
+								Utility::post_type_label( 'name', Event::POST_TYPE )
 							),
 							'type'    => 'checkbox',
 							'options' => array(
@@ -143,9 +161,13 @@ class Events extends Base {
 					__( '%s Display', 'gatherpress' ),
 					Utility::post_type_label( 'singular_name', Event::POST_TYPE )
 				),
-				'description' => __(
-					'Configure how events are displayed on your site.',
-					'gatherpress'
+				'description' => sprintf(
+					/* translators: %s: Plural post type label, e.g. "Events". */
+					__(
+						'Configure how %s are displayed on your site.',
+						'gatherpress'
+					),
+					Utility::post_type_label( 'name', Event::POST_TYPE )
 				),
 				'options'     => array(
 					'post_or_event_date' => array(
@@ -153,9 +175,15 @@ class Events extends Base {
 							'name' => __( 'Publish Date', 'gatherpress' ),
 						),
 						'field'  => array(
-							'label'   => __(
-								'Display event date instead of publish date for events.',
-								'gatherpress'
+							'label'   => sprintf(
+								// phpcs:ignore Generic.Files.LineLength.TooLong
+								/* translators: %1$s: Singular post type label, e.g. "Event", %2$s: Plural post type label, e.g. "Events". */
+								__(
+									'Display %1$s date instead of publish date for %2$s.',
+									'gatherpress'
+								),
+								Utility::post_type_label( 'singular_name', Event::POST_TYPE ),
+								Utility::post_type_label( 'name', Event::POST_TYPE )
 							),
 							'type'    => 'checkbox',
 							'options' => array(

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -198,12 +198,12 @@ class Events extends Base {
 								'items'   => array(
 									'upcoming' => sprintf(
 										/* translators: %s: Plural post type label, e.g. "Events". */
-										__( 'Upcoming %s.', 'gatherpress' ),
+										__( 'Upcoming %s', 'gatherpress' ),
 										Utility::post_type_label( 'name', Event::POST_TYPE )
 									),
 									'past'     => sprintf(
 										/* translators: %s: Plural post type label, e.g. "Events". */
-										__( 'Past %s.', 'gatherpress' ),
+										__( 'Past %s', 'gatherpress' ),
 										Utility::post_type_label( 'name', Event::POST_TYPE )
 									),
 									'none'     => __( 'None (return 404)', 'gatherpress' ),
@@ -215,7 +215,7 @@ class Events extends Base {
 						'labels' => array(
 							'name' => sprintf(
 								/* translators: %s: Plural post type label, e.g. "Events". */
-								__( 'Upcoming %s.', 'gatherpress' ),
+								__( 'Upcoming %s', 'gatherpress' ),
 								Utility::post_type_label( 'name', Event::POST_TYPE )
 							),
 						),
@@ -237,7 +237,7 @@ class Events extends Base {
 						'labels' => array(
 							'name' => sprintf(
 								/* translators: %s: Plural post type label, e.g. "Events". */
-								__( 'Past %s.', 'gatherpress' ),
+								__( 'Past %s', 'gatherpress' ),
 								Utility::post_type_label( 'name', Event::POST_TYPE )
 							),
 						),

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -250,7 +250,11 @@ class Events extends Base {
 							'preview' => array(
 								'template' => 'url-rewrite-preview',
 								'suffix'   => _x(
-									'sample-event',
+									sprintf(
+										/* translators: %s: Singular post type label, e.g. "Event". */
+										__( 'sample-%s', 'gatherpress' ),
+										lcfirst( Utility::post_type_label( 'singular_name', Event::POST_TYPE ) )
+									),
 									'URL permalink structure example for events',
 									'gatherpress'
 								),

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -167,10 +167,14 @@ class Events extends Base {
 			),
 			'archive_pages' => array(
 				'name'        => __( 'Archive Pages', 'gatherpress' ),
-				'description' => __(
-					// phpcs:ignore Generic.Files.LineLength.TooLong -- Single translator-facing sentence; keep on one line for the .pot extractor.
-					'Choose what the event archive URL shows by default and optionally point custom pages at the upcoming or past archives.',
-					'gatherpress'
+				'description' => sprintf(
+					/* translators: %s: Singular post type label, e.g. "Event". */
+					__(
+						// phpcs:ignore Generic.Files.LineLength.TooLong -- Single translator-facing sentence; keep on one line for the .pot extractor.
+						'Choose what the %s archive URL shows by default and optionally point custom pages at the upcoming or past archives.',
+						'gatherpress'
+					),
+					Utility::post_type_label( 'singular_name', Event::POST_TYPE )
 				),
 				'options'     => array(
 					'event_archive'   => array(
@@ -181,9 +185,10 @@ class Events extends Base {
 								Utility::post_type_label( 'singular_name', Event::POST_TYPE )
 							),
 						),
-						'description' => __(
-							'What the events archive URL displays when no custom page is assigned.',
-							'gatherpress'
+						'description' => sprintf(
+							/* translators: %s: Plural post type label, e.g. "Events". */
+							__( 'What the %s archive URL displays when no custom page is assigned.', 'gatherpress' ),
+							Utility::post_type_label( 'name', Event::POST_TYPE )
 						),
 						'field'       => array(
 							'label'   => __( 'Default archive view:', 'gatherpress' ),
@@ -191,8 +196,16 @@ class Events extends Base {
 							'options' => array(
 								'default' => 'upcoming',
 								'items'   => array(
-									'upcoming' => __( 'Upcoming Events', 'gatherpress' ),
-									'past'     => __( 'Past Events', 'gatherpress' ),
+									'upcoming' => sprintf(
+										/* translators: %s: Plural post type label, e.g. "Events". */
+										__( 'Upcoming %s.', 'gatherpress' ),
+										Utility::post_type_label( 'name', Event::POST_TYPE )
+									),
+									'past'     => sprintf(
+										/* translators: %s: Plural post type label, e.g. "Events". */
+										__( 'Past %s.', 'gatherpress' ),
+										Utility::post_type_label( 'name', Event::POST_TYPE )
+									),
 									'none'     => __( 'None (return 404)', 'gatherpress' ),
 								),
 							),
@@ -200,13 +213,21 @@ class Events extends Base {
 					),
 					'upcoming_events' => array(
 						'labels' => array(
-							'name' => __( 'Upcoming Events', 'gatherpress' ),
+							'name' => sprintf(
+								/* translators: %s: Plural post type label, e.g. "Events". */
+								__( 'Upcoming %s.', 'gatherpress' ),
+								Utility::post_type_label( 'name', Event::POST_TYPE )
+							),
 						),
 						'field'  => array(
 							'type'    => 'autocomplete',
 							'options' => array(
 								'type'    => 'page',
-								'label'   => __( 'Select Upcoming Events Archive Page', 'gatherpress' ),
+								'label'   => sprintf(
+									/* translators: %s: Plural post type label, e.g. "Events". */
+									__( 'Select Upcoming %s Archive Page.', 'gatherpress' ),
+									Utility::post_type_label( 'name', Event::POST_TYPE )
+								),
 								'limit'   => 1,
 								'default' => '[]',
 							),
@@ -214,13 +235,21 @@ class Events extends Base {
 					),
 					'past_events'     => array(
 						'labels' => array(
-							'name' => __( 'Past Events', 'gatherpress' ),
+							'name' => sprintf(
+								/* translators: %s: Plural post type label, e.g. "Events". */
+								__( 'Past %s.', 'gatherpress' ),
+								Utility::post_type_label( 'name', Event::POST_TYPE )
+							),
 						),
 						'field'  => array(
 							'type'    => 'autocomplete',
 							'options' => array(
 								'type'    => 'page',
-								'label'   => __( 'Select Past Events Archive Page', 'gatherpress' ),
+								'label'   => sprintf(
+									/* translators: %s: Plural post type label, e.g. "Events". */
+									__( 'Select Past %s Archive Page.', 'gatherpress' ),
+									Utility::post_type_label( 'name', Event::POST_TYPE )
+								),
 								'limit'   => 1,
 								'default' => '[]',
 							),

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -316,21 +316,25 @@ class Events extends Base {
 					),
 					'topics_url' => array(
 						'labels' => array(
-							'name' => __( 'Topics', 'gatherpress' ),
+							'name' => Utility::taxonomy_label( 'name', Topic::TAXONOMY ),
 						),
 						'field'  => array(
 							'type'    => 'text',
 							'rewrite' => true,
 							'options' => array(
-								'label'   => __( 'Permalink base of Topics.', 'gatherpress' ),
+								'label'   => sprintf(
+									/* translators: %s: Plural post type label, e.g. "Topics". */
+									__( 'Permalink base of %s.', 'gatherpress' ),
+									Utility::taxonomy_label( 'name', Topic::TAXONOMY )
+								),
 								'default' => Topic::get_localized_taxonomy_slug(),
 							),
 							'preview' => array(
 								'template' => 'url-rewrite-preview',
-								'suffix'   => _x(
-									'sample-topic-term',
-									'URL permalink structure example for topics',
-									'gatherpress'
+								'suffix'   => sprintf(
+									/* translators: %s: Singular post type label, e.g. "Event". */
+									_x( 'sample-%s-term', 'URL permalink structure example for topics', 'gatherpress' ),
+									sanitize_title( Utility::taxonomy_label( 'singular_name', Topic::TAXONOMY ) )
 								),
 							),
 						),

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -323,7 +323,7 @@ class Events extends Base {
 							'rewrite' => true,
 							'options' => array(
 								'label'   => sprintf(
-									/* translators: %s: Plural post type label, e.g. "Topics". */
+									/* translators: %s: Plural taxonomy label, e.g. "Topics". */
 									__( 'Permalink base of %s.', 'gatherpress' ),
 									Utility::taxonomy_label( 'name', Topic::TAXONOMY )
 								),
@@ -332,7 +332,7 @@ class Events extends Base {
 							'preview' => array(
 								'template' => 'url-rewrite-preview',
 								'suffix'   => sprintf(
-									/* translators: %s: Singular post type label, e.g. "Event". */
+									/* translators: %s: Singular taxonomy label, e.g. "Topic". */
 									_x( 'sample-%s-term', 'URL permalink structure example for topics', 'gatherpress' ),
 									sanitize_title( Utility::taxonomy_label( 'singular_name', Topic::TAXONOMY ) )
 								),

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -249,14 +249,10 @@ class Events extends Base {
 							),
 							'preview' => array(
 								'template' => 'url-rewrite-preview',
-								'suffix'   => _x(
-									sprintf(
-										/* translators: %s: Singular post type label, e.g. "Event". */
-										__( 'sample-%s', 'gatherpress' ),
-										lcfirst( Utility::post_type_label( 'singular_name', Event::POST_TYPE ) )
-									),
-									'URL permalink structure example for events',
-									'gatherpress'
+								'suffix'   => sprintf(
+									/* translators: %s: Singular post type label, e.g. "Event". */
+									_x( 'sample-%s', 'URL permalink structure example for events', 'gatherpress' ),
+									sanitize_title( Utility::post_type_label( 'singular_name', Event::POST_TYPE ) )
 								),
 							),
 						),

--- a/includes/core/classes/settings/class-rsvp-settings.php
+++ b/includes/core/classes/settings/class-rsvp-settings.php
@@ -14,7 +14,9 @@ namespace GatherPress\Core\Settings;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Event;
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Utility;
 
 /**
  * Class Rsvp_Settings.
@@ -74,9 +76,15 @@ class Rsvp_Settings extends Base {
 		return array(
 			'rsvp_defaults' => array(
 				'name'        => __( 'RSVP Defaults', 'gatherpress' ),
-				'description' => __(
-					'Default RSVP settings for new events. These can be overridden per event.',
-					'gatherpress'
+				'description' => sprintf(
+					// phpcs:ignore Generic.Files.LineLength.TooLong
+					/* translators: %1$s: Singular post type label, e.g. "Event", %2$s: Plural post type label, e.g. "Events". */
+					__(
+						'Default RSVP settings for new %2$s. These can be overridden per %1$s.',
+						'gatherpress'
+					),
+					Utility::post_type_label( 'singular_name', Event::POST_TYPE ),
+					Utility::post_type_label( 'name', Event::POST_TYPE )
 				),
 				'options'     => array(
 					'rsvp_mode'             => array(
@@ -92,9 +100,17 @@ class Rsvp_Settings extends Base {
 							'options' => array(
 								'default' => 'all_on',
 								'items'   => array(
-									'all_on'        => __( 'All events', 'gatherpress' ),
-									'per_event_on'  => __( 'Per event (default on)', 'gatherpress' ),
-									'per_event_off' => __( 'Per event (default off)', 'gatherpress' ),
+									'all_on'        => Utility::post_type_label( 'all_items', Event::POST_TYPE ),
+									'per_event_on'  => sprintf(
+										/* translators: %s: Singular post type label, e.g. "Event". */
+										__( 'Per %s (default on)', 'gatherpress' ),
+										Utility::post_type_label( 'singular_name', Event::POST_TYPE )
+									),
+									'per_event_off' => sprintf(
+										/* translators: %s: Singular post type label, e.g. "Event". */
+										__( 'Per %s (default off)', 'gatherpress' ),
+										Utility::post_type_label( 'singular_name', Event::POST_TYPE )
+									),
 									'disabled'      => __( 'Disabled', 'gatherpress' ),
 								),
 							),
@@ -109,9 +125,10 @@ class Rsvp_Settings extends Base {
 							'gatherpress'
 						),
 						'field'       => array(
-							'label'   => __(
-								'Enable Open RSVP for events.',
-								'gatherpress'
+							'label'   => sprintf(
+								/* translators: %s: Plural post type label, e.g. "Events". */
+								__( 'Enable Open RSVP for %s.', 'gatherpress' ),
+								Utility::post_type_label( 'name', Event::POST_TYPE )
 							),
 							'type'    => 'checkbox',
 							'options' => array(
@@ -123,16 +140,16 @@ class Rsvp_Settings extends Base {
 						'labels'      => array(
 							'name' => __( 'Maximum Attendance Limit', 'gatherpress' ),
 						),
-						'description' => __(
-							// phpcs:disable Generic.Files.LineLength.TooLong
-							'The total number of people allowed at an event. Set to 0 for no limit.',
-							// phpcs:enable Generic.Files.LineLength.TooLong
-							'gatherpress'
+						'description' => sprintf(
+							/* translators: %s: Singular post type label, e.g. "Event". */
+							__( 'The total number of people allowed per %s. Set to 0 for no limit.', 'gatherpress' ), // phpcs:ignore Generic.Files.LineLength.TooLong
+							Utility::post_type_label( 'singular_name', Event::POST_TYPE )
 						),
 						'field'       => array(
-							'label'   => __(
-								'The default maximum limit of attendees to an event.',
-								'gatherpress'
+							'label'   => sprintf(
+								/* translators: %s: Singular post type label, e.g. "Event". */
+								__( 'The default maximum limit of attendees per %s.', 'gatherpress' ),
+								Utility::post_type_label( 'singular_name', Event::POST_TYPE )
 							),
 							'type'    => 'number',
 							'size'    => 'small',
@@ -172,9 +189,10 @@ class Rsvp_Settings extends Base {
 							'gatherpress'
 						),
 						'field'       => array(
-							'label'   => __(
-								'Enable Anonymous RSVP for new events.',
-								'gatherpress'
+							'label'   => sprintf(
+								/* translators: %s: Plural post type label, e.g. "Events". */
+								__( 'Enable Anonymous RSVP for new %s.', 'gatherpress' ),
+								Utility::post_type_label( 'name', Event::POST_TYPE )
 							),
 							'type'    => 'checkbox',
 							'options' => array(

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -315,14 +315,10 @@ class Venues extends Base {
 							),
 							'preview' => array(
 								'template' => 'url-rewrite-preview',
-								'suffix'   => _x(
-									sprintf(
-										/* translators: %s: Singular post type label, e.g. "Venue". */
-										__( 'sample-%s', 'gatherpress' ),
-										lcfirst( Utility::post_type_label( 'singular_name', Venue::POST_TYPE ) )
-									),
-									'URL permalink structure example for Venues.',
-									'gatherpress'
+								'suffix'   => sprintf(
+									/* translators: %s: Singular post type label, e.g. "Venue". */
+									_x( 'sample-%s', 'URL permalink structure example for Venues.', 'gatherpress' ),
+									sanitize_title( Utility::post_type_label( 'singular_name', Venue::POST_TYPE ) )
 								),
 							),
 						),

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -316,8 +316,12 @@ class Venues extends Base {
 							'preview' => array(
 								'template' => 'url-rewrite-preview',
 								'suffix'   => _x(
-									'sample-venue',
-									'URL permalink structure example for venues',
+									sprintf(
+										/* translators: %s: Singular post type label, e.g. "Venue". */
+										__( 'sample-%s.', 'gatherpress' ),
+										lcfirst( Utility::post_type_label( 'singular_name', Venue::POST_TYPE ) )
+									),
+									'URL permalink structure example for Venues.',
 									'gatherpress'
 								),
 							),

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -318,7 +318,7 @@ class Venues extends Base {
 								'suffix'   => _x(
 									sprintf(
 										/* translators: %s: Singular post type label, e.g. "Venue". */
-										__( 'sample-%s.', 'gatherpress' ),
+										__( 'sample-%s', 'gatherpress' ),
 										lcfirst( Utility::post_type_label( 'singular_name', Venue::POST_TYPE ) )
 									),
 									'URL permalink structure example for Venues.',

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -707,8 +707,28 @@ class Setup {
 	 */
 	public function get_localized_post_type_slug(): string {
 		$switched_locale = switch_to_locale( get_locale() );
-		$slug            = _x( 'Venue', 'Admin menu and post type singular name', 'gatherpress' );
-		$slug            = sanitize_title( $slug );
+
+		// The post type (to get the singular name from) is typically not registered, when this method is called.
+		// Using Utility::post_type_label() will not yet work.
+
+		// Prepare a default at first.
+		$default_labels                = new \stdClass;
+		$default_labels->singular_name = _x(
+			'Venue',
+			'Admin menu and post type singular name',
+			'gatherpress'
+		);
+
+		// To ensure, we use the proper labels, we get them from the WordPress core filter.
+		$post_type_labels = apply_filters(
+			sprintf(
+				'post_type_labels_%s',
+				Venue::POST_TYPE
+			),
+			$default_labels
+		);
+
+		$slug = sanitize_title( $post_type_labels->singular_name );
 
 		if ( $switched_locale ) {
 			restore_previous_locale();

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -26,6 +26,7 @@ use GatherPress\Core\Starter_Pattern_Loader;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Venue\Map\Setup as Map_Setup;
+use stdClass;
 use WP_Block_Patterns_Registry;
 use WP_Post;
 
@@ -712,7 +713,7 @@ class Setup {
 		// Using Utility::post_type_label() will not yet work.
 
 		// Prepare a default at first.
-		$default_labels                = new \stdClass();
+		$default_labels                = new stdClass();
 		$default_labels->singular_name = _x(
 			'Venue',
 			'Admin menu and post type singular name',

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -712,7 +712,7 @@ class Setup {
 		// Using Utility::post_type_label() will not yet work.
 
 		// Prepare a default at first.
-		$default_labels                = new \stdClass;
+		$default_labels                = new \stdClass();
 		$default_labels->singular_name = _x(
 			'Venue',
 			'Admin menu and post type singular name',
@@ -721,7 +721,7 @@ class Setup {
 
 		// To ensure, we use the proper labels, we get them from the WordPress core filter.
 		$post_type_labels = apply_filters(
-			sprintf(
+			sprintf( // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
 				'post_type_labels_%s',
 				Venue::POST_TYPE
 			),

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -16,13 +16,13 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import TEMPLATE from './template';
-import { hasValidBlockContext, isInFSETemplate } from '../../helpers/editor';
+import { hasValidBlockContext, isInFSETemplate, usePostTypeLabel } from '../../helpers/editor';
 import { isPostTypeSupporting, usePostTypeSupports, DISABLED_FIELD_OPACITY } from '../../helpers/event';
 import { getVenuePostType, getVenueTaxonomy, useVenueTaxonomyIds } from '../../helpers/venue';
 
@@ -67,6 +67,16 @@ const Edit = ( { attributes, context } ) => {
 			};
 		},
 		[]
+	);
+
+	// Read the singular label so the panel title reflects what the post type
+	// is actually called — a renamed event post type with
+	// `singular_name => 'Happening'` shows "This is an online Happening" without any
+	// extra wiring (#1612).
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		currentPostType,
+		__( 'Event', 'gatherpress' )
 	);
 
 	const isEditingEvent = isPostTypeSupporting( 'gatherpress-online-event', currentPostType );
@@ -219,14 +229,19 @@ const Edit = ( { attributes, context } ) => {
 			{ showControls && (
 				<InspectorControls>
 					<PanelBody
-						title={ __( 'Online Event Settings', 'gatherpress' ) }
+						title={ sprintf(
+							/* translators: %s: Singular post type label, e.g. "Event". */
+							__( 'Online %s Settings', 'gatherpress' ),
+							singularLabel
+						) }
 						initialOpen={ true }
 					>
 						<VStack spacing={ 3 }>
 							<ToggleControl
-								label={ __(
-									'This is an online event',
-									'gatherpress'
+								label={ sprintf(
+									/* translators: %s: Singular post type label, e.g. "Event". */
+									__( 'This is an online %s', 'gatherpress' ),
+									singularLabel
 								) }
 								checked={ isOnlineEvent }
 								onChange={ toggleOnlineEvent }
@@ -234,14 +249,16 @@ const Edit = ( { attributes, context } ) => {
 							{ isOnlineEvent && (
 								<TextControl
 									type="url"
-									label={ __(
-										'Online event link',
-										'gatherpress'
+									label={ sprintf(
+										/* translators: %s: Singular post type label, e.g. "Event". */
+										__( 'Online %s link', 'gatherpress' ),
+										singularLabel
 									) }
 									value={ onlineEventLink }
-									placeholder={ __(
-										'Add link to online event',
-										'gatherpress'
+									placeholder={ sprintf(
+										/* translators: %s: Singular post type label, e.g. "Event". */
+										__( 'Add link to online %s', 'gatherpress' ),
+										singularLabel
 									) }
 									onChange={ updateOnlineEventLink }
 								/>

--- a/src/blocks/venue/edit.js
+++ b/src/blocks/venue/edit.js
@@ -9,7 +9,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 import {
 	PanelBody,
@@ -24,7 +24,7 @@ import { useMemo, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { getCurrentContextualPostId, hasValidBlockContext, isInFSETemplate } from '../../helpers/editor';
+import { getCurrentContextualPostId, hasValidBlockContext, isInFSETemplate, usePostTypeLabel } from '../../helpers/editor';
 import { usePostTypeSupports, findEventPostById, DISABLED_FIELD_OPACITY } from '../../helpers/event';
 import { useVenuePostFromTermId, GetVenuePostFromEventId, findVenuePostById, getVenuePostType, getVenueTaxonomy, useVenueTaxonomyIds } from '../../helpers/venue';
 import VenueNavigator from '../../components/VenueNavigator';
@@ -364,6 +364,16 @@ const Edit = ( props ) => {
 		},
 	} );
 
+	// Read the singular label so the panel title reflects what the post type
+	// is actually called — a custom venue post type with
+	// `singular_name => 'Location'` shows "Location settings" without any
+	// extra wiring (#1612).
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		venuePostType,
+		__( 'Venue', 'gatherpress' )
+	);
+
 	return (
 		<div { ...blockProps }>
 			{ ! showPatternPicker && (
@@ -391,11 +401,12 @@ const Edit = ( props ) => {
 			>
 				{ showPatternPicker && (
 					<PatternPicker
-						label={ __( 'Venue', 'gatherpress' ) }
+						label={ singularLabel }
 						icon="location"
-						instructions={ __(
-							'Choose a pattern for the venue.',
-							'gatherpress'
+						instructions={ sprintf(
+							/* translators: %s: Singular post type label, e.g. "Venue". */
+							__( 'Choose a pattern for the %s.', 'gatherpress' ),
+							singularLabel
 						) }
 						patterns={ patterns }
 						showStartBlank={ false }
@@ -415,7 +426,11 @@ const Edit = ( props ) => {
 			<InspectorControls>
 				{ isVenueSource && ! isDescendentOfQueryLoop && ! isInFSETemplate() && isEventContext && (
 					<PanelBody
-						title={ __( 'Venue settings', 'gatherpress' ) }
+						title={ sprintf(
+							/* translators: %s: Singular post type label, e.g. "Venue". */
+							__( '%s settings', 'gatherpress' ),
+							singularLabel
+						) }
 						initialOpen={ true }
 					>
 						<PanelRow>

--- a/src/components/OnlineEvent.js
+++ b/src/components/OnlineEvent.js
@@ -8,13 +8,14 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { getVenuePostType, getVenueTaxonomy } from '../helpers/venue';
+import { usePostTypeLabel } from '../helpers/editor';
+import { getVenueTaxonomy } from '../helpers/venue';
 
 /**
  * OnlineEvent component for GatherPress.
@@ -38,10 +39,24 @@ const OnlineEvent = () => {
 	);
 
 	// Derive the venue taxonomy from the current editor post type.
-	const venueTaxonomy = useSelect( ( select ) => {
-		const editorPostType = select( 'core/editor' )?.getCurrentPostType();
-		return getVenueTaxonomy( getVenuePostType( editorPostType ) );
+	const { venueTaxonomy, editorPostType } = useSelect( ( select ) => {
+		const currentEditorPostType = select( 'core/editor' )?.getCurrentPostType();
+		const currentVenueTaxonomy = getVenueTaxonomy( currentEditorPostType );
+		return {
+			editorPostType: currentEditorPostType,
+			venueTaxonomy: currentVenueTaxonomy,
+		};
 	}, [] );
+
+	// Read the singular label so the panel title reflects what the post type
+	// is actually called — a custom venue post type with
+	// `singular_name => 'Location'` shows "Location settings" without any
+	// extra wiring (#1612).
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		editorPostType,
+		__( 'Venue', 'gatherpress' )
+	);
 
 	// Get current venue taxonomy terms.
 	const venueTermIds = useSelect( ( select ) =>
@@ -141,16 +156,28 @@ const OnlineEvent = () => {
 	return (
 		<VStack spacing={ 3 }>
 			<ToggleControl
-				label={ __( 'This is an online event', 'gatherpress' ) }
+				label={ sprintf(
+					/* translators: %s: Singular post type label, e.g. "Venue". */
+					__( 'This is an online %s', 'gatherpress' ),
+					singularLabel
+				) }
 				checked={ isOnlineEvent }
 				onChange={ handleToggleChange }
 			/>
 			{ isOnlineEvent && (
 				<TextControl
 					type="url"
-					label={ __( 'Online event link', 'gatherpress' ) }
+					label={ sprintf(
+						/* translators: %s: Singular post type label, e.g. "Venue". */
+						__( 'Online %s link', 'gatherpress' ),
+						singularLabel
+					) }
 					value={ onlineEventLink }
-					placeholder={ __( 'Add link to online event', 'gatherpress' ) }
+					placeholder={ sprintf(
+						/* translators: %s: Singular post type label, e.g. "Venue". */
+						__( 'Add link to online %s', 'gatherpress' ),
+						singularLabel
+					) }
 					onChange={ ( value ) => {
 						updateEventLink( value );
 					} }

--- a/src/components/OnlineEvent.js
+++ b/src/components/OnlineEvent.js
@@ -15,7 +15,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { usePostTypeLabel } from '../helpers/editor';
-import { getVenueTaxonomy } from '../helpers/venue';
+import { getVenuePostType, getVenueTaxonomy } from '../helpers/venue';
 
 /**
  * OnlineEvent component for GatherPress.
@@ -41,10 +41,9 @@ const OnlineEvent = () => {
 	// Derive the venue taxonomy from the current editor post type.
 	const { venueTaxonomy, editorPostType } = useSelect( ( select ) => {
 		const currentEditorPostType = select( 'core/editor' )?.getCurrentPostType();
-		const currentVenueTaxonomy = getVenueTaxonomy( currentEditorPostType );
 		return {
 			editorPostType: currentEditorPostType,
-			venueTaxonomy: currentVenueTaxonomy,
+			venueTaxonomy: getVenueTaxonomy( getVenuePostType( currentEditorPostType ) ),
 		};
 	}, [] );
 
@@ -55,7 +54,7 @@ const OnlineEvent = () => {
 	const singularLabel = usePostTypeLabel(
 		'singular_name',
 		editorPostType,
-		__( 'Venue', 'gatherpress' )
+		__( 'Event', 'gatherpress' )
 	);
 
 	// Get current venue taxonomy terms.

--- a/src/components/OnlineEvent.js
+++ b/src/components/OnlineEvent.js
@@ -48,8 +48,8 @@ const OnlineEvent = () => {
 	}, [] );
 
 	// Read the singular label so the panel title reflects what the post type
-	// is actually called — a custom venue post type with
-	// `singular_name => 'Location'` shows "Location settings" without any
+	// is actually called — a renamed event post type with
+	// `singular_name => 'Happening'` shows "This is an online Happening" without any
 	// extra wiring (#1612).
 	const singularLabel = usePostTypeLabel(
 		'singular_name',
@@ -156,7 +156,7 @@ const OnlineEvent = () => {
 		<VStack spacing={ 3 }>
 			<ToggleControl
 				label={ sprintf(
-					/* translators: %s: Singular post type label, e.g. "Venue". */
+					/* translators: %s: Singular post type label, e.g. "Event". */
 					__( 'This is an online %s', 'gatherpress' ),
 					singularLabel
 				) }
@@ -167,13 +167,13 @@ const OnlineEvent = () => {
 				<TextControl
 					type="url"
 					label={ sprintf(
-						/* translators: %s: Singular post type label, e.g. "Venue". */
+						/* translators: %s: Singular post type label, e.g. "Event". */
 						__( 'Online %s link', 'gatherpress' ),
 						singularLabel
 					) }
 					value={ onlineEventLink }
 					placeholder={ sprintf(
-						/* translators: %s: Singular post type label, e.g. "Venue". */
+						/* translators: %s: Singular post type label, e.g. "Event". */
 						__( 'Add link to online %s', 'gatherpress' ),
 						singularLabel
 					) }

--- a/src/components/PopularVenues.js
+++ b/src/components/PopularVenues.js
@@ -8,6 +8,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
+import { usePostTypeLabel } from '../helpers/editor';
 import { usePopularVenues, getVenueTitle } from '../helpers/venue';
 
 /**
@@ -28,15 +29,31 @@ import { usePopularVenues, getVenueTitle } from '../helpers/venue';
 export default function PopularVenues( { onSelect, currentId, venuePostType } ) {
 	const popularVenues = usePopularVenues( 3, venuePostType );
 
+	// Read the plural label so the panel title reflects what the post type
+	// is actually called — a custom venue post type with
+	// `name => 'Location'` shows "Popular Locations" without any
+	// extra wiring (#1612).
+	const pluralLabel = usePostTypeLabel(
+		'name',
+		venuePostType,
+		__( 'Venue', 'gatherpress' )
+	);
+
 	// Don't render if there are no popular venues.
 	if ( ! popularVenues || 0 === popularVenues.length ) {
 		return null;
 	}
 
+	const popularVenuesLabel = sprintf(
+		/* translators: %s: Plural post type label, e.g. "Venues". */
+		__( 'Popular %s:', 'gatherpress' ),
+		pluralLabel
+	);
+
 	return (
 		<div className="gatherpress-popular-venues">
 			<p className="gatherpress-popular-venues__label">
-				{ __( 'Popular venues:', 'gatherpress' ) }{ ' ' }
+				{ popularVenuesLabel }{ ' ' }
 				{ popularVenues.map( ( venue ) => {
 					const isSelected = currentId === venue.id;
 					const venueName = decodeEntities(

--- a/src/components/PopularVenues.js
+++ b/src/components/PopularVenues.js
@@ -36,7 +36,7 @@ export default function PopularVenues( { onSelect, currentId, venuePostType } ) 
 	const pluralLabel = usePostTypeLabel(
 		'name',
 		venuePostType,
-		__( 'Venue', 'gatherpress' )
+		__( 'Venues', 'gatherpress' )
 	);
 
 	// Don't render if there are no popular venues.

--- a/src/components/VenueForm.js
+++ b/src/components/VenueForm.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Spinner,
 	Button,
@@ -18,6 +18,7 @@ import { store as coreDataStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
+import { usePostTypeLabel } from '../helpers/editor';
 import { getVenuePostType, getVenueTaxonomy } from '../helpers/venue';
 import { isPostTypeSupporting } from '../helpers/event';
 import { geocodeAddress } from '../helpers/geocoding';
@@ -32,6 +33,7 @@ import AddressAutocompleteField from './AddressAutocompleteField';
  * @since 0.34.0
  *
  * @param {Object}   props                     Component props.
+ * @param {string}   props.newTitleLabel       The label for the venue title.
  * @param {string}   props.title               The venue title.
  * @param {Function} props.onChangeTitle       Callback when title changes.
  * @param {string}   props.titleError          Error message for title validation.
@@ -47,6 +49,7 @@ import AddressAutocompleteField from './AddressAutocompleteField';
  * @return {JSX.Element} The venue form component.
  */
 function VenueForm( {
+	newTitleLabel,
 	title,
 	onChangeTitle,
 	titleError,
@@ -64,7 +67,7 @@ function VenueForm( {
 			<div className="gatherpress-new-venue-form">
 				<TextControl
 					__next40pxDefaultSize
-					label={ __( 'Venue name', 'gatherpress' ) }
+					label={ newTitleLabel }
 					value={ title }
 					onChange={ onChangeTitle }
 					help={ titleError }
@@ -141,6 +144,21 @@ function CreateVenueForm( { search, ...props } ) {
 	const venuePostType = getVenuePostType( currentPostType );
 	const venueTaxonomy = getVenueTaxonomy( venuePostType );
 
+	// Read the singular label so the input-label reflects what the post type
+	// is actually called — a custom venue post type with
+	// `singular_name => 'Location'` shows "Location name" without any
+	// extra wiring (#1612).
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		venuePostType,
+		__( 'Venue', 'gatherpress' )
+	);
+	const newTitleLabel = sprintf(
+		/* translators: %s: Singular post type label, e.g. "Venue". */
+		__( '%s name', 'gatherpress' ),
+		singularLabel
+	);
+
 	const { lastError, isSaving } = useSelect(
 		( select ) => ( {
 			lastError: select( coreDataStore ).getLastEntitySaveError(
@@ -164,12 +182,17 @@ function CreateVenueForm( { search, ...props } ) {
 	 */
 	const validateTitle = ( value ) => {
 		if ( ! value || '' === value.trim() ) {
-			return __( 'Venue name is required.', 'gatherpress' );
+			return sprintf(
+				/* translators: %s: Singular post type label, e.g. "Venue". */
+				__( '%s name is required.', 'gatherpress' ),
+				singularLabel
+			);
 		}
 		if ( 2 > value.trim().length ) {
-			return __(
-				'Venue name must be at least 2 characters.',
-				'gatherpress'
+			return sprintf(
+				/* translators: %s: Singular post type label, e.g. "Venue". */
+				__( '%s name must be at least 2 characters.', 'gatherpress' ),
+				singularLabel
 			);
 		}
 		return '';
@@ -357,6 +380,7 @@ function CreateVenueForm( { search, ...props } ) {
 
 	return (
 		<VenueForm
+			newTitleLabel={ newTitleLabel }
 			title={ title ?? '' }
 			onChangeTitle={ handleTitleChange }
 			titleError={ titleError }

--- a/src/components/VenueNavigator.js
+++ b/src/components/VenueNavigator.js
@@ -42,7 +42,7 @@ export default function VenueNavigator( props = null ) {
 	const addNewItemLabel = usePostTypeLabel(
 		'add_new_item',
 		venuePostType,
-		__( 'Venue', 'gatherpress' )
+		__( 'Add New Venue', 'gatherpress' )
 	);
 
 	/**

--- a/src/components/VenueNavigator.js
+++ b/src/components/VenueNavigator.js
@@ -15,7 +15,7 @@ import CreateVenueForm from './VenueForm';
 import { VenueComboboxProvider } from './VenueComboboxProvider';
 import PopularVenues from './PopularVenues';
 import { isPostTypeSupporting } from '../helpers/event';
-import { getCurrentContextualPostId } from '../helpers/editor';
+import { getCurrentContextualPostId, usePostTypeLabel } from '../helpers/editor';
 
 /**
  *
@@ -24,8 +24,6 @@ import { getCurrentContextualPostId } from '../helpers/editor';
  * @return {Component} A Navigator component to be rendered.
  */
 export default function VenueNavigator( props = null ) {
-	const addNewItemLabel = __( 'Add New Venue', 'gatherpress' );
-
 	// Use context post type if provided, otherwise fall back to the editor's current post type.
 	// This is necessary because VenueNavigator can be rendered from slotfill.js without any props.
 	const currentPostType = useSelect(
@@ -36,6 +34,16 @@ export default function VenueNavigator( props = null ) {
 	);
 	const venuePostType = getVenuePostType( currentPostType );
 	const venueTaxonomy = getVenueTaxonomy( venuePostType );
+
+	// Read the "Add new Venue" label so the panel title reflects what the post type
+	// is actually called — a custom venue post type with
+	// `singular_name => 'Location'` shows "Add New Location" without any
+	// extra wiring (#1612).
+	const addNewItemLabel = usePostTypeLabel(
+		'add_new_item',
+		venuePostType,
+		__( 'Venue', 'gatherpress' )
+	);
 
 	/**
 	 * Check if user can CREATE new venues.

--- a/src/components/VenuePostsCombobox.js
+++ b/src/components/VenuePostsCombobox.js
@@ -4,11 +4,12 @@
 import { ComboboxControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { usePostTypeLabel } from '../helpers/editor';
 import { useVenueOptions, getVenuePostType } from '../helpers/venue';
 
 /**
@@ -31,6 +32,21 @@ export const VenuePostsCombobox = ( { search, setSearch, ...props } ) => {
 	const venueId = props?.attributes?.selectedPostId;
 
 	const venuePostType = getVenuePostType( props?.context?.postType );
+
+	// Read the singular label so the panel title reflects what the post type
+	// is actually called — a custom venue post type with
+	// `singular_name => 'Location'` shows "Add New Location" without any
+	// extra wiring (#1612).
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		venuePostType,
+		__( 'Venue', 'gatherpress' )
+	);
+	const comboBoxLabel = sprintf(
+		/* translators: %s: Singular post type label, e.g. "Venue". */
+		__( 'Choose a %s', 'gatherpress' ),
+		singularLabel
+	);
 
 	// Fetch available venue options using a custom query hook.
 	const { venueOptions } = useVenueOptions(
@@ -79,7 +95,7 @@ export const VenuePostsCombobox = ( { search, setSearch, ...props } ) => {
 
 	return (
 		<ComboboxControl
-			label={ __( 'Choose a venue', 'gatherpress' ) }
+			label={ comboBoxLabel }
 			__next40pxDefaultSize
 			onChange={ update }
 			onFilterValueChange={ setSearchDebounced }

--- a/src/components/VenueTermsCombobox.js
+++ b/src/components/VenueTermsCombobox.js
@@ -5,12 +5,12 @@ import { ComboboxControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { getCurrentContextualPostId } from '../helpers/editor';
+import { getCurrentContextualPostId, usePostTypeLabel } from '../helpers/editor';
 import { getVenuePostType, getVenueTaxonomy, useVenueOptions, useVenueTaxonomyIds } from '../helpers/venue';
 
 /**
@@ -43,8 +43,25 @@ export const VenueTermsCombobox = ( { search, setSearch, ...props } ) => {
 		[ props?.context?.postType ]
 	);
 
+	const venuePostType = getVenuePostType( currentPostType );
+
+	// Read the singular label so the panel title reflects what the post type
+	// is actually called — a custom venue post type with
+	// `singular_name => 'Location'` shows "Add New Location" without any
+	// extra wiring (#1612).
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		venuePostType,
+		__( 'Venue', 'gatherpress' )
+	);
+	const comboBoxLabel = sprintf(
+		/* translators: %s: Singular post type label, e.g. "Venue". */
+		__( 'Choose a %s', 'gatherpress' ),
+		singularLabel
+	);
+
 	// Derive the venue taxonomy from the event post type.
-	const venueTaxonomy = getVenueTaxonomy( getVenuePostType( currentPostType ) );
+	const venueTaxonomy = getVenueTaxonomy( venuePostType );
 
 	const { editPost } = useDispatch( 'core/editor' );
 
@@ -129,7 +146,7 @@ export const VenueTermsCombobox = ( { search, setSearch, ...props } ) => {
 
 	return (
 		<ComboboxControl
-			label={ __( 'Choose a venue', 'gatherpress' ) }
+			label={ comboBoxLabel }
 			__next40pxDefaultSize
 			onChange={ update }
 			onFilterValueChange={ setSearchDebounced }

--- a/src/panels/venue-settings/fill.js
+++ b/src/panels/venue-settings/fill.js
@@ -6,18 +6,21 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { VenuePluginDocumentSettings } from './slot';
 import { isPostTypeSupporting } from '../../helpers/event';
+import { usePostTypeLabel } from '../../helpers/editor';
+import { getVenuePostType } from '../../helpers/venue';
 import OnlineEventPanel from './online-event';
 
 export default function VenuePluginFill() {
@@ -25,11 +28,40 @@ export default function VenuePluginFill() {
 	const showOnlineEventSection = isPostTypeSupporting( 'gatherpress-online-event' );
 	const showPanel = showVenueSection || showOnlineEventSection;
 
+	// Get the current post type and its related venue post type.
+	// In general, there should (!) be no need to look up the post type dynamically,
+	// as this only renders for gatherpress_event|s related to gatherpress_venue|s.
+	// But just in case, let's be consistent to stay safe.
+	const { venuePostType } = useSelect(
+		( select ) => {
+			const editorPostType = select( 'core/editor' )?.getCurrentPostType();
+			const currentVenuePostType = getVenuePostType( editorPostType );
+			return {
+				venuePostType: currentVenuePostType,
+			};
+		},
+		[]
+	);
+
+	// Read the singular label so the panel title reflects what the post type
+	// is actually called — a custom venue post type with
+	// `singular_name => 'Location'` shows "Location settings" without any
+	// extra wiring (#1612).
+	const singularLabel = usePostTypeLabel(
+		'singular_name',
+		venuePostType,
+		__( 'Venue', 'gatherpress' )
+	);
+
 	return (
 		showPanel && (
 			<PluginDocumentSettingPanel
 				name="gatherpress-venue-settings-at-events"
-				title={ __( 'Venue settings', 'gatherpress' ) }
+				title={ sprintf(
+					/* translators: %s: Singular post type label, e.g. "Venue". */
+					__( '%s settings', 'gatherpress' ),
+					singularLabel
+				) }
 				className="gatherpress-venue-settings"
 			>
 				<VStack spacing={ 6 }>

--- a/test/e2e/event-tests/datetime-picker-regression.spec.js
+++ b/test/e2e/event-tests/datetime-picker-regression.spec.js
@@ -84,7 +84,7 @@ test.describe( '#1607 datetime picker year-down regression', () => {
 			// it by default on first load, but a previous visit could have
 			// collapsed it via persisted UI state.
 			const eventSettingsButton = page
-				.getByRole( 'button', { name: /event settings/i } )
+				.getByRole( 'button', { name: /Event settings/i } )
 				.first();
 			if ( 0 < ( await eventSettingsButton.count() ) ) {
 				const expanded =

--- a/test/unit/php/includes/tests/core/classes/class-test-utility.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-utility.php
@@ -399,6 +399,74 @@ class Test_Utility extends Base {
 	}
 
 	/**
+	 * `Utility::taxonomy_label()` reads a single label off a registered
+	 * taxonomy so admin UI strings reflect whatever a site builder
+	 * filtered the labels to (#1612).
+	 *
+	 * @covers ::taxonomy_label
+	 *
+	 * @return void
+	 */
+	public function test_taxonomy_label_returns_registered_label(): void {
+		register_taxonomy(
+			'shindig_type',
+			'post',
+			array(
+				'public' => false,
+				'labels' => array(
+					'name'          => 'Shindig Types',
+					'singular_name' => 'Shindig Type',
+					'add_new_item'  => 'Add New Shindig Type',
+				),
+			)
+		);
+
+		$this->assertSame( 'Shindig Types', Utility::taxonomy_label( 'name', 'shindig_type' ) );
+		$this->assertSame( 'Shindig Type', Utility::taxonomy_label( 'singular_name', 'shindig_type' ) );
+		$this->assertSame( 'Add New Shindig Type', Utility::taxonomy_label( 'add_new_item', 'shindig_type' ) );
+
+		unregister_taxonomy( 'shindig_type' );
+	}
+
+	/**
+	 * `Utility::taxonomy_label()` returns an empty string for an
+	 * unregistered taxonomy rather than warning. Lets call sites fall
+	 * back gracefully when the taxonomy isn't (or isn't yet)
+	 * registered.
+	 *
+	 * @covers ::taxonomy_label
+	 *
+	 * @return void
+	 */
+	public function test_taxonomy_label_unregistered_taxonomy_returns_empty_string(): void {
+		$this->assertSame( '', Utility::taxonomy_label( 'name', 'definitely_not_a_taxonomy' ) );
+	}
+
+	/**
+	 * `Utility::taxonomy_label()` returns an empty string when the
+	 * label key isn't set on the taxonomy, instead of triggering a
+	 * notice on the missing dynamic property.
+	 *
+	 * @covers ::taxonomy_label
+	 *
+	 * @return void
+	 */
+	public function test_taxonomy_label_missing_key_returns_empty_string(): void {
+		register_taxonomy(
+			'shindig_type',
+			'post',
+			array(
+				'public' => false,
+				'labels' => array(
+					'name' => 'Shindig Types',
+				),
+			)
+		);
+
+		$this->assertSame( '', Utility::taxonomy_label( 'no_such_label_key', 'shindig_type' ) );
+	}
+
+	/**
 	 * Coverage for snake_to_camel method.
 	 *
 	 * @covers ::snake_to_camel

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -419,7 +419,7 @@ class Test_Setup extends Base {
 		// This also checks that the post type is still registered with the same 'Post Type Singular Name' label,
 		// which is used by the method under test and the test itself.
 		$filter = static function ( string $translation, string $text, string $context ): string {
-			if ( 'Event' !== $text || 'Post Type Singular Name' !== $context ) {
+			if ( 'Event' !== $text || 'Admin menu and post type singular name' !== $context ) {
 				return $translation;
 			}
 			return 'Ünit Tést';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes a lot of little strings to use the properly registered post type or taxonomy labels instead of hardcoded Event, Venue & Topic strings.

Besides the changes, this PR introduces `Utility::taxonomy_label()`, which works exact same, as the existing `Utility::post_type_label()`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
| **BEFORE** | **AFTER** |
|--------|--------|
| <img width="2048" height="1536" alt="image" src="https://github.com/user-attachments/assets/fe7ff786-d035-45d5-aaa6-9e370b71c269" /> | <img width="2314" height="1911" alt="image" src="https://github.com/user-attachments/assets/407f7f3b-f28b-4cc5-8880-b6f4817bf78e" /> |
| <img width="2048" height="1536" alt="image" src="https://github.com/user-attachments/assets/971fcb14-8313-4a7e-a6a3-1789afe041df" /> | <img width="1790" height="723" alt="image" src="https://github.com/user-attachments/assets/a4b7b681-7f1c-4da2-aef0-3a7ffea6f5d5" /> |
| <img width="2048" height="1536" alt="image" src="https://github.com/user-attachments/assets/0fce3830-6afa-4408-a071-926443428f60" /> | <img width="1790" height="723" alt="image" src="https://github.com/user-attachments/assets/48c7f095-2c8c-40b5-ba26-ef3a4f235c84" /> |
| <img width="2048" height="1536" alt="image" src="https://github.com/user-attachments/assets/7f2fcdfa-c788-4696-81fe-5640798ee09e" /> | <img width="2312" height="1910" alt="image" src="https://github.com/user-attachments/assets/8151a75d-cc2f-4941-9633-97ed3c74a2c4" /> |
| ... | <img width="452" height="239" alt="image" src="https://github.com/user-attachments/assets/d6c4dc58-6da9-4949-baf6-3b3a8cde126a" /> |
| ... | <img width="452" height="467" alt="image" src="https://github.com/user-attachments/assets/b6c0141d-e00b-4b16-a8e9-f9cead5a70ab" /> | 

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

>[!NOTE]
> This PR does not change any post type or taxonomy labels, it JUST prepares GatherPress core to work with renamed types. The actual renaming is only be applied to this PR Playground.

* Open the generated PR Playground
* Go to Happenings > Settings
* **Confirm**: Every label speaks either: Happening, Spot and Type, instead of Event, Venue and Topic
* Open some Happening
* **Confirm**: The main editing UI controls do speak either: Happening, Spot and Type, instead of Event, Venue and Topic


### Credit (for release notes)

<!-- First time contributing? Add your WordPress.org profile so we can credit you in the -->
<!-- release and on the in-plugin Credits screen. -->
<!-- Your profile URL looks like: https://profiles.wordpress.org/USERNAME/ -->
<!-- Enter just the USERNAME (the last part of that URL) below. -->
<!-- Please open the link first to confirm it loads — credits are generated from this exact -->
<!-- username, so a typo or a non-existent profile gets skipped. -->
<!-- Don't have a WordPress.org account? Create a free one at https://login.wordpress.org/register -->

My WordPress.org username:

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs created from a fork under GitHub organizations. -->
<!-- In this case, you can create the entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
