### PR TITLE
Remove unused public events-list REST endpoint

### DIFF
--- a/.github/changelog/remove-events-list-endpoint
+++ b/.github/changelog/remove-events-list-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove the unused public `event/events-list` REST endpoint (and its `events_list`/`max_number` handlers). The route had no callers in the plugin or build output and exposed event RSVP data on a public, unauthenticated GET; the same data is already rendered on public event pages, so nothing relied on it.

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -113,7 +113,6 @@ class Rest_Api {
 			$this->rsvp_form_route(),
 			$this->rsvp_status_html_route(),
 			$this->rsvp_responses_route(),
-			$this->events_list_route(),
 			$this->nonce_route(),
 		);
 	}
@@ -363,42 +362,6 @@ class Rest_Api {
 					'post_id' => array(
 						'required'          => true,
 						'validate_callback' => array( Validate::class, 'event_post_id' ),
-					),
-				),
-			),
-		);
-	}
-
-	/**
-	 * Define the REST route for retrieving a list of events.
-	 *
-	 * This method sets up the REST route for retrieving a list of events based on specified parameters.
-	 *
-	 * @since 0.34.0
-	 *
-	 * @return array The REST route configuration.
-	 */
-	protected function events_list_route(): array {
-		return array(
-			'route' => 'events-list',
-			'args'  => array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'events_list' ),
-				'permission_callback' => '__return_true',
-				'args'                => array(
-					'event_list_type' => array(
-						'required'          => true,
-						'validate_callback' => array( Validate::class, 'event_list_type' ),
-					),
-					'max_number'      => array(
-						'required'          => true,
-						'validate_callback' => array( Validate::class, 'positive_number' ),
-					),
-					'datetime_format' => array(
-						'required' => false,
-					),
-					'topics'          => array(
-						'required' => false,
 					),
 				),
 			),
@@ -678,112 +641,6 @@ class Rest_Api {
 			'email'      => $email,
 			'name'       => $name,
 		);
-	}
-
-	/**
-	 * Retrieve a list of events based on specified criteria.
-	 *
-	 * This method handles the retrieval of a list of events based on the parameters provided in the REST API request.
-	 * It takes the `event_list_type` to determine whether to fetch upcoming or past events, the `max_number` to
-	 * limit the number of events in the response, and optional `topics` and `venues` to filter events by specific
-	 * topic and venue slugs.
-	 *
-	 * @since 0.34.0
-	 *
-	 * @param WP_REST_Request $request Contains data from the REST API request.
-	 *
-	 * @return WP_REST_Response The REST API response containing an array of event data.
-	 *
-	 * @throws Exception If there is an issue while retrieving the list of events.
-	 */
-	public function events_list( WP_REST_Request $request ): WP_REST_Response {
-		$params          = $request->get_params();
-		$event_list_type = $params['event_list_type'];
-		$max_number      = $this->max_number( (int) $params['max_number'], 5 );
-		$datetime_format = ! empty( $params['datetime_format'] ) ? $params['datetime_format'] : 'D, M j, Y, g:i a T';
-		$posts           = array();
-		$topics          = array();
-		$venues          = array();
-
-		if ( ! empty( $params['topics'] ) ) {
-			$topics = array_map(
-				static function ( $slug ): string {
-					return sanitize_key( $slug );
-				},
-				explode( ',', $params['topics'] )
-			);
-		}
-
-		if ( ! empty( $params['venues'] ) ) {
-			$venues = array_map(
-				static function ( $slug ): string {
-					return sanitize_key( $slug );
-				},
-				explode( ',', $params['venues'] )
-			);
-		}
-
-		$query = Query::get_instance()->get_events_list( $event_list_type, $max_number, $topics, $venues );
-
-		if ( $query->have_posts() ) {
-			foreach ( $query->posts as $post_id ) {
-				$event             = new Event( $post_id );
-				$venue_information = $event->get_venue_information();
-				$user_identifier   = Setup::get_instance()->get_user_identifier();
-				// Rsvp::get() is typed `: array` — an empty array when there's
-				// no RSVP, a populated record otherwise. Mirror that with an
-				// empty-array fallback so `current_user` is always an array
-				// rather than flipping between '' and an object (#1766).
-				$current_user_rsvp = ( $event->rsvp ) ? $event->rsvp->get( $user_identifier ) : array();
-				$posts[]           = array(
-					'ID'                       => $post_id,
-					'datetime_start'           => $event->get_datetime_start( $datetime_format ),
-					'datetime_end'             => $event->get_datetime_end( $datetime_format ),
-					'permalink'                => get_the_permalink( $post_id ),
-					'title'                    => get_the_title( $post_id ),
-					'excerpt'                  => get_the_excerpt( $post_id ),
-					'featured_image'           => get_the_post_thumbnail( $post_id, 'medium' ),
-					'featured_image_large'     => get_the_post_thumbnail( $post_id, 'large' ),
-					'featured_image_thumbnail' => get_the_post_thumbnail( $post_id, 'thumbnail' ),
-					'enable_rsvp'              => ( new Rsvp( $post_id ) )->is_enabled(),
-					'enable_anonymous_rsvp'    => (bool) get_post_meta(
-						$post_id,
-						'gatherpress_enable_anonymous_rsvp',
-						true
-					),
-					'responses'                => ( $event->rsvp ) ? $event->rsvp->responses() : array(),
-					'current_user'             => $current_user_rsvp,
-					'venue'                    => ( $venue_information['name'] )
-						? $event->get_venue_information()
-						: null,
-				);
-			}
-		}
-
-		wp_reset_postdata();
-
-		return new WP_REST_Response( $posts );
-	}
-
-	/**
-	 * Ensure that the provided number does not exceed the maximum number allowed.
-	 *
-	 * This method checks if the provided `$number` is greater than the specified `$max_number` and
-	 * returns the lower of the two values to ensure it does not exceed the maximum limit.
-	 *
-	 * @since 0.34.0
-	 *
-	 * @param int $number     The actual number.
-	 * @param int $max_number The maximum number allowed.
-	 *
-	 * @return int The sanitized number, ensuring it does not exceed the maximum limit.
-	 */
-	protected function max_number( int $number, int $max_number ): int {
-		if ( $max_number < $number ) {
-			$number = $max_number;
-		}
-
-		return $number;
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -116,11 +116,6 @@ class Test_Rest_Api extends Base {
 			$namespace[ sprintf( '/%s/event/rsvp', GATHERPRESS_REST_NAMESPACE ) ],
 			'Failed to assert rsvp endpoint is registered'
 		);
-		$this->assertEquals(
-			1,
-			$namespace[ sprintf( '/%s/event/events-list', GATHERPRESS_REST_NAMESPACE ) ],
-			'Failed to assert events-list endpoint is registered'
-		);
 	}
 
 	/**
@@ -129,7 +124,6 @@ class Test_Rest_Api extends Base {
 	 * @covers ::get_event_routes
 	 * @covers ::email_route
 	 * @covers ::rsvp_route
-	 * @covers ::events_list_route
 	 *
 	 * @return void
 	 */
@@ -165,12 +159,6 @@ class Test_Rest_Api extends Base {
 		$this->assertSame(
 			WP_REST_Server::READABLE,
 			$routes[4]['args']['methods'],
-			'Failed to assert methods is GET.'
-		);
-		$this->assertSame( 'events-list', $routes[5]['route'], 'Failed to assert route is events-list.' );
-		$this->assertSame(
-			WP_REST_Server::READABLE,
-			$routes[5]['args']['methods'],
 			'Failed to assert methods is GET.'
 		);
 	}
@@ -520,171 +508,6 @@ class Test_Rest_Api extends Base {
 				return $recipient['email'];
 			},
 			$recipients
-		);
-	}
-
-	/**
-	 * Coverage for events_list method.
-	 *
-	 * @covers ::events_list
-	 *
-	 * @return void
-	 */
-	public function test_events_list(): void {
-		$instance          = Rest_Api::get_instance();
-		$request           = new WP_REST_Request( 'POST' );
-		$upcoming_event_id = $this->mock->post(
-			array( 'post_type' => Event::POST_TYPE )
-		)->get()->ID;
-		$past_event_id     = $this->mock->post(
-			array( 'post_type' => Event::POST_TYPE )
-		)->get()->ID;
-		$upcoming_event    = new Event( $upcoming_event_id );
-		$past_event        = new Event( $past_event_id );
-
-		$request->set_query_params(
-			array(
-				'event_list_type' => 'upcoming',
-			)
-		);
-
-		$upcoming_event->save_datetimes(
-			array(
-				'datetime_start' => gmdate( Event::DATETIME_FORMAT, strtotime( '+1 day' ) ),
-				'datetime_end'   => gmdate( Event::DATETIME_FORMAT, strtotime( '+2 day' ) ),
-				'timezone'       => 'America/New_York',
-			)
-		);
-
-		$past_event->save_datetimes(
-			array(
-				'datetime_start' => gmdate( Event::DATETIME_FORMAT, strtotime( '-2 day' ) ),
-				'datetime_end'   => gmdate( Event::DATETIME_FORMAT, strtotime( '-1 day' ) ),
-				'timezone'       => 'America/New_York',
-			)
-		);
-
-		$response  = $instance->events_list( $request );
-		$event_ids = $this->get_event_ids( $response->data );
-
-		$this->assertContains( $upcoming_event_id, $event_ids, 'Failed to assert event ID is in array.' );
-		$this->assertNotContains( $past_event_id, $event_ids, 'Failed to assert event ID is not in array.' );
-
-		$request->set_query_params(
-			array(
-				'event_list_type' => 'past',
-			)
-		);
-
-		$response  = $instance->events_list( $request );
-		$event_ids = $this->get_event_ids( $response->data );
-
-		$this->assertContains( $past_event_id, $event_ids, 'Failed to assert event ID is in array.' );
-		$this->assertNotContains( $upcoming_event_id, $event_ids, 'Failed to assert event ID is not in array.' );
-	}
-
-	/**
-	 * Coverage for the current_user field type stability in events_list.
-	 *
-	 * Regression for #1766: current_user previously returned '' when there was
-	 * no RSVP and an array when one existed. It should always be an array so JS
-	 * consumers can safely read current_user.status.
-	 *
-	 * @covers ::events_list
-	 *
-	 * @return void
-	 */
-	public function test_events_list_current_user_is_always_array(): void {
-		$instance = Rest_Api::get_instance();
-		$event_id = $this->mock->post(
-			array( 'post_type' => Event::POST_TYPE )
-		)->get()->ID;
-		$event    = new Event( $event_id );
-
-		$event->save_datetimes(
-			array(
-				'datetime_start' => gmdate( Event::DATETIME_FORMAT, strtotime( '+1 day' ) ),
-				'datetime_end'   => gmdate( Event::DATETIME_FORMAT, strtotime( '+2 day' ) ),
-				'timezone'       => 'America/New_York',
-			)
-		);
-
-		$request = new WP_REST_Request( 'POST' );
-		$request->set_query_params( array( 'event_list_type' => 'upcoming' ) );
-
-		// Logged-out, no RSVP: current_user should be an empty array, not ''.
-		wp_set_current_user( 0 );
-		$response = $instance->events_list( $request );
-		$current  = $this->find_event_in_list( $response->data, $event_id )['current_user'];
-
-		$this->assertIsArray( $current, 'current_user should be an array with no RSVP.' );
-		$this->assertSame( array(), $current, 'current_user should be empty with no RSVP.' );
-
-		// Logged-in with an RSVP: current_user should still be an array, now populated.
-		$user_id = $this->factory->user->create();
-		wp_set_current_user( $user_id );
-		$event->rsvp->save( $user_id, 'attending' );
-
-		$response = $instance->events_list( $request );
-		$current  = $this->find_event_in_list( $response->data, $event_id )['current_user'];
-
-		$this->assertIsArray( $current, 'current_user should be an array with an RSVP.' );
-		$this->assertSame( 'attending', $current['status'], 'current_user should carry the RSVP status.' );
-	}
-
-	/**
-	 * Helper to find a single event entry in an events_list response.
-	 *
-	 * @param array $events   Response data from events_list.
-	 * @param int   $event_id The event ID to locate.
-	 *
-	 * @return array The matching event entry, or an empty array if not found.
-	 */
-	private function find_event_in_list( array $events, int $event_id ): array {
-		foreach ( $events as $event ) {
-			if ( isset( $event['ID'] ) && $event_id === $event['ID'] ) {
-				return $event;
-			}
-		}
-
-		return array();
-	}
-
-	/**
-	 * Helper to get members IDs for test.
-	 *
-	 * @param array $events Response from events_list.
-	 *
-	 * @return array
-	 */
-	protected function get_event_ids( array $events ): array {
-		return array_map(
-			static function ( $event ): int {
-				return $event['ID'];
-			},
-			$events
-		);
-	}
-
-	/**
-	 * Coverage for max_number method.
-	 *
-	 * @covers ::max_number
-	 *
-	 * @return void
-	 */
-	public function test_max_number(): void {
-		$instance = Rest_Api::get_instance();
-
-		$this->assertEquals(
-			5,
-			Utility::invoke_hidden_method( $instance, 'max_number', array( 6, 5 ) ),
-			'Failed to assert that numbers are equal.'
-		);
-		$this->assertEquals(
-			3,
-			Utility::invoke_hidden_method( $instance, 'max_number', array( 3, 5 ) ),
-			'Failed to assert that numbers are equal.'
 		);
 	}
 
@@ -1255,122 +1078,6 @@ class Test_Rest_Api extends Base {
 			$result->data,
 			'No meta should be injected when id is absent.'
 		);
-	}
-
-	/**
-	 * Coverage for events_list with topics filter.
-	 *
-	 * @covers ::events_list
-	 *
-	 * @return void
-	 */
-	public function test_events_list_with_topics(): void {
-		$instance = Rest_Api::get_instance();
-		$post_id  = $this->factory()->post->create(
-			array(
-				'post_type' => Event::POST_TYPE,
-			)
-		);
-
-		$event = new Event( $post_id );
-		$event->save_datetimes(
-			array(
-				'datetime_start' => '2099-01-01 10:00:00',
-				'datetime_end'   => '2099-01-01 14:00:00',
-				'timezone'       => 'America/New_York',
-			)
-		);
-
-		// Create a topic term.
-		$term = wp_insert_term( 'Test Topic', Topic::TAXONOMY );
-		wp_set_post_terms( $post_id, array( $term['term_id'] ), Topic::TAXONOMY );
-
-		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'event_list_type', 'upcoming' );
-		$request->set_param( 'max_number', 5 );
-		$request->set_param( 'topics', 'test-topic' );
-
-		$response = $instance->events_list( $request );
-		$data     = $response->get_data();
-
-		$this->assertIsArray( $data );
-	}
-
-	/**
-	 * Coverage for events_list with venues filter.
-	 *
-	 * @covers ::events_list
-	 *
-	 * @return void
-	 */
-	public function test_events_list_with_venues(): void {
-		$instance = Rest_Api::get_instance();
-		$post_id  = $this->factory()->post->create(
-			array(
-				'post_type' => Event::POST_TYPE,
-			)
-		);
-
-		$event = new Event( $post_id );
-		$event->save_datetimes(
-			array(
-				'datetime_start' => '2099-01-01 10:00:00',
-				'datetime_end'   => '2099-01-01 14:00:00',
-				'timezone'       => 'America/New_York',
-			)
-		);
-
-		// Create a venue term.
-		$term = wp_insert_term( 'Test Venue', Venue::TAXONOMY );
-		wp_set_post_terms( $post_id, array( $term['term_id'] ), Venue::TAXONOMY );
-
-		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'event_list_type', 'upcoming' );
-		$request->set_param( 'max_number', 5 );
-		$request->set_param( 'venues', 'test-venue' );
-
-		$response = $instance->events_list( $request );
-		$data     = $response->get_data();
-
-		$this->assertIsArray( $data );
-	}
-
-	/**
-	 * Coverage for events_list with custom datetime format.
-	 *
-	 * @covers ::events_list
-	 *
-	 * @return void
-	 */
-	public function test_events_list_custom_datetime_format(): void {
-		$instance = Rest_Api::get_instance();
-		$post_id  = $this->factory()->post->create(
-			array(
-				'post_type' => Event::POST_TYPE,
-			)
-		);
-
-		$event = new Event( $post_id );
-		$event->save_datetimes(
-			array(
-				'datetime_start' => '2099-01-01 10:00:00',
-				'datetime_end'   => '2099-01-01 14:00:00',
-				'timezone'       => 'America/New_York',
-			)
-		);
-
-		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'event_list_type', 'upcoming' );
-		$request->set_param( 'max_number', 5 );
-		$request->set_param( 'datetime_format', 'Y-m-d H:i:s' );
-
-		$response = $instance->events_list( $request );
-		$data     = $response->get_data();
-
-		$this->assertIsArray( $data );
-		if ( ! empty( $data ) ) {
-			$this->assertArrayHasKey( 'datetime_start', $data[0] );
-		}
 	}
 
 	/**


### PR DESCRIPTION
## What

Removes the `event/events-list` REST endpoint and its supporting code:
- `events_list_route()` registration + the `events_list()` handler
- the now-orphaned `max_number()` helper (only the handler used it)
- the related tests (`test_events_list*`, `test_max_number`) and test-only helpers (`find_event_in_list()`, `get_event_ids()`), plus the `events-list` assertions in the route-registration tests

## Why

The route is **dead code**: a repo-wide search (source + compiled `build/`) found no callers anywhere. Git history shows it backed a legacy "event list" block that has since been removed.

It was also registered as a **public, unauthenticated GET** (`WP_REST_Server::READABLE`, `permission_callback => '__return_true'`) that returned full RSVP `responses()` data (attendee `userId`, name, profile URL, avatar, role, timestamp, guest count) for every event. A recent security-audit pass flagged this. Because that exact data is already rendered on the public event page via the same `responses()` method, removing the unused route is cleaner than hardening an endpoint nobody calls.

## Verification

- Repo-wide grep: no references to `events-list` / `events_list` outside the route + its tests.
- `php -l` and `phpcs` clean on both changed files.
- `phpunit --filter Rest_Api` (wp-env tests instance): **60 tests, 183 assertions, OK**.

## Notes

- `Validate::event_list_type` is now unused (it was only referenced by this route) but is left in place — it lives in the shared `Validate` class with its own test coverage. Flagged for a separate cleanup rather than widening this PR.
- Technically a public REST surface change, but for a pre-1.0 line with no internal callers this is a safe removal. Changelog entry marked `Type: removed`, `Significance: minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)