### PR TITLE
Gate RSVP user enrollment behind promote_users capability

### DIFF
--- a/.github/changelog/security-rsvp-enroll-capability
+++ b/.github/changelog/security-rsvp-enroll-capability
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Require the `promote_users` capability (not just per-event `edit_post`) before adding another user to the site when RSVPing them into an event, so editors and authors cannot enroll arbitrary users as subscribers — most impactful on multisite. Self-RSVP auto-join is unchanged. [#1839]

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -673,6 +673,7 @@ class Rest_Api {
 		$event           = new Event( $post_id );
 
 		// If managing user is adding someone to an event.
+		$is_managing_other = false;
 		if (
 			$current_user_id &&
 			$user_id &&
@@ -682,14 +683,27 @@ class Rest_Api {
 			// RSVP someone else into it. The previous flat `edit_posts`
 			// check would have let any Author manage attendees on any
 			// event, including ones they don't own.
-			if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			if ( current_user_can( 'edit_post', $post_id ) ) {
+				$is_managing_other = true;
+			} else {
 				$user_id = 0;
 			}
 		} else {
 			$user_id = $current_user_id;
 		}
 
-		if ( intval( $user_id ) && ! is_user_member_of_blog( $user_id ) ) {
+		// Auto-join the current blog when the RSVP target is not yet a member.
+		// A user RSVPing *themselves* joins as a subscriber (the open-RSVP
+		// across-network flow). Enrolling *another* user is a higher-privilege
+		// action: `edit_post` lets an editor manage attendees, but adding users
+		// to a site is gated by `promote_users` in WordPress, so require that
+		// capability here and confirm the target is a real user before creating
+		// any membership.
+		if (
+			intval( $user_id )
+			&& ! is_user_member_of_blog( $user_id )
+			&& ( ! $is_managing_other || ( current_user_can( 'promote_users' ) && get_userdata( $user_id ) ) )
+		) {
 			add_user_to_blog( $blog_id, $user_id, 'subscriber' );
 		}
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -2043,6 +2043,131 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
+	 * Tests that a manager with edit_post but not promote_users cannot enroll others.
+	 *
+	 * Managing attendees is gated by `edit_post`, but adding a non-member user to
+	 * the blog is a `promote_users` action. An event author (has edit_post on
+	 * their own event, lacks promote_users) must not be able to add another user
+	 * to the site via the RSVP endpoint, and the RSVP for that non-member fails.
+	 *
+	 * @group multisite
+	 * @covers ::update_rsvp
+	 *
+	 * @return void
+	 */
+	public function test_update_rsvp_manager_without_promote_users_cannot_enroll_other_multisite(): void {
+		$instance = Rest_Api::get_instance();
+
+		// Target network user, not a member of site 2.
+		$target_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		$site_2_id = $this->factory->blog->create();
+		switch_to_blog( $site_2_id );
+
+		$setup = Setup::get_instance();
+		Utility::invoke_hidden_method( $setup, 'create_tables' );
+
+		// Author who owns the event on site 2: has edit_post on it, no promote_users.
+		$author_id = $this->factory->user->create();
+		add_user_to_blog( $site_2_id, $author_id, 'author' );
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_author' => $author_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_set_current_user( $author_id );
+
+		$this->assertFalse(
+			current_user_can( 'promote_users' ),
+			'Author should not have promote_users.'
+		);
+
+		$request = new WP_REST_Request( 'POST', '/gatherpress/v1/event/rsvp' );
+		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'user_id', $target_id );
+		$request->set_param( 'status', 'attending' );
+
+		$response = $instance->update_rsvp( $request );
+
+		$this->assertFalse(
+			is_user_member_of_blog( $target_id, $site_2_id ),
+			'Target must not be enrolled into site 2 by a manager lacking promote_users.'
+		);
+		$this->assertFalse(
+			$response->data['success'],
+			'RSVP for a non-member target should fail when the manager cannot enroll them.'
+		);
+
+		restore_current_blog();
+	}
+
+	/**
+	 * Tests that a manager with promote_users can enroll another user.
+	 *
+	 * A site administrator holds both edit_post and promote_users, so managing an
+	 * RSVP for a non-member network user enrolls them as a subscriber and the
+	 * RSVP succeeds.
+	 *
+	 * @group multisite
+	 * @covers ::update_rsvp
+	 *
+	 * @return void
+	 */
+	public function test_update_rsvp_admin_with_promote_users_enrolls_other_multisite(): void {
+		$instance = Rest_Api::get_instance();
+
+		// Target network user, not a member of site 2.
+		$target_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		$site_2_id = $this->factory->blog->create();
+		switch_to_blog( $site_2_id );
+
+		$setup = Setup::get_instance();
+		Utility::invoke_hidden_method( $setup, 'create_tables' );
+
+		// Administrator on site 2: has edit_post (edit_others_posts) and promote_users.
+		$admin_id = $this->factory->user->create();
+		add_user_to_blog( $site_2_id, $admin_id, 'administrator' );
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_author' => $admin_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_set_current_user( $admin_id );
+
+		$this->assertTrue(
+			current_user_can( 'promote_users' ),
+			'Administrator should have promote_users.'
+		);
+
+		$request = new WP_REST_Request( 'POST', '/gatherpress/v1/event/rsvp' );
+		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'user_id', $target_id );
+		$request->set_param( 'status', 'attending' );
+
+		$response = $instance->update_rsvp( $request );
+
+		$this->assertTrue(
+			is_user_member_of_blog( $target_id, $site_2_id ),
+			'Target should be enrolled into site 2 by a manager with promote_users.'
+		);
+		$this->assertTrue(
+			$response->data['success'],
+			'RSVP should succeed when the manager can enroll the target.'
+		);
+
+		restore_current_blog();
+	}
+
+	/**
 	 * `send_event_email_to_recipient` happy path for a WordPress user.
 	 * Direct-invokes the protected helper so xdebug traces every line —
 	 * the loop in `send_emails()` does call it, but xdebug's


### PR DESCRIPTION
## What

In `update_rsvp()`, the auto-join that calls `add_user_to_blog()` for a non-member RSVP target was only gated behind the per-event `edit_post` capability. This change splits self-RSVP from managing another user:

- **Self-RSVP** still auto-joins the current blog as `subscriber` (the open-RSVP-across-network flow is unchanged).
- **Enrolling another user** now requires `promote_users` *and* that the target is a real user (`get_userdata()`).

```php
if (
	intval( $user_id )
	&& ! is_user_member_of_blog( $user_id )
	&& ( ! $is_managing_other || ( current_user_can( 'promote_users' ) && get_userdata( $user_id ) ) )
) {
	add_user_to_blog( $blog_id, $user_id, 'subscriber' );
}
```

## Why

`edit_post` lets an event editor/author manage attendees, but **adding a user to a site is a `promote_users` action** in WordPress — a capability Editors and Authors do not have in wp-admin. Gating enrollment behind `edit_post` let them add arbitrary users to the blog as subscribers. On **multisite** this meant an editor could enroll any network user into the current site. (Came out of the SECURITY_AUDIT.md triage — the realistic core of findings #1/#3.)

The `get_userdata()` guard also closes the related gap where a non-existent `user_id` could be passed to `add_user_to_blog()`, creating stray usermeta.

When a manager lacks `promote_users`, enrollment is skipped and the existing membership check then drops the save for a non-member target — net effect: editors can still manage RSVPs for **existing** members, just not conjure new ones.

## Tests

- `test_update_rsvp_manager_without_promote_users_cannot_enroll_other_multisite` — author (edit_post, no promote_users) cannot enroll; RSVP fails.
- `test_update_rsvp_admin_with_promote_users_enrolls_other_multisite` — administrator enrolls; RSVP succeeds.
- Existing `test_update_rsvp_adds_user_to_blog_multisite` (self-RSVP) still passes.

Verified on wp-env: single-site `Rest_Api` 60 tests / 183 assertions OK; multisite `update_rsvp` 3 tests / 10 assertions OK. `phpcs` clean.

## Note

Single-site is effectively unaffected — `is_user_member_of_blog()` is always true for existing users there, so `add_user_to_blog()` only does real work on multisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)