### PR TITLE
Add TEMPORARY PATCH for Playgrounds

### DIFF
--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -236,6 +236,17 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion, override) 
 				},
 			},
 			{
+				step: 'writeFile',
+				path: '/wordpress/wp-content/mu-plugins/gatherpress-do-not-rewrite-urls-on-import.php',
+				data: {
+					resource: 'url',
+					url: 'https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/blueprints/gatherpress-do-not-rewrite-urls-on-import.php'
+				},
+				progress: {
+					caption: 'TEMPORARY PATCH, see https://github.com/GatherPress/gatherpress/issues/1842'
+				}
+			},
+			{
 				step: 'importWxr',
 				file: {
 					resource: 'url',

--- a/.github/scripts/wordpress-org-screenshots/blueprint.json
+++ b/.github/scripts/wordpress-org-screenshots/blueprint.json
@@ -50,6 +50,17 @@
 			}
 		},
 		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/mu-plugins/gatherpress-do-not-rewrite-urls-on-import.php",
+			"data": {
+				"resource": "url",
+				"url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/blueprints/gatherpress-do-not-rewrite-urls-on-import.php"
+			},
+			"progress": {
+				"caption": "TEMPORARY PATCH, see https://github.com/GatherPress/gatherpress/issues/1842"
+			}
+		},
+		{
 			"step": "importWxr",
 			"file": {
 				"resource": "url",

--- a/.wordpress-org/blueprints/blueprint-nightly.json
+++ b/.wordpress-org/blueprints/blueprint-nightly.json
@@ -48,6 +48,17 @@
       }
     },
     {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/gatherpress-do-not-rewrite-urls-on-import.php",
+      "data": {
+        "resource": "url",
+        "url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/blueprints/gatherpress-do-not-rewrite-urls-on-import.php"
+      },
+      "progress": {
+        "caption": "TEMPORARY PATCH, see https://github.com/GatherPress/gatherpress/issues/1842"
+      }
+    },
+    {
       "step": "importWxr",
       "file": {
         "resource": "url",

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -48,6 +48,17 @@
       }
     },
     {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/gatherpress-do-not-rewrite-urls-on-import.php",
+      "data": {
+        "resource": "url",
+        "url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/blueprints/gatherpress-do-not-rewrite-urls-on-import.php"
+      },
+      "progress": {
+        "caption": "TEMPORARY PATCH, see https://github.com/GatherPress/gatherpress/issues/1842"
+      }
+    },
+    {
       "step": "importWxr",
       "file": {
         "resource": "url",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://github.com/GatherPress/gatherpress/issues/1840#issuecomment-4847606624

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
>The Importer does rewrite URLs by default to the new home, see https://make.wordpress.org/core/2025/11/27/wordpress-importer-can-now-migrate-urls-in-your-content/. This is problematic for all blocks, that add "#" or "#...." as <a href=""> value, because on import, WP adds its Playground scope before that hashtags, resulting in broken block validation.

**The fix (for now): Disable URL rewriting using a mu-plugin!**

>Doing so, can safe people testing GatherPress (on w.org or using the nightly builds) from annoying experiences, but as soon as someone creates themselves a site with Playground, exports and re-imports it live, the mess will be there too.
>
>Disabling the URL rewriting feature, which was requested for years, can't be a good way long term.

That's why this PR already has an issue in place to revert it later: #1842

### Other information:

- [ ] Have you written new tests for your changes, if applicable? _**NO**_

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use one of the existing Playgrounds and confirm, that all blocks, especially "Add-to-calendar" and "RSVP-Response" blocks, work and none shows `Block contains invalid content`


### Credit (for release notes)

<!-- First time contributing? Add your WordPress.org profile so we can credit you in the -->
<!-- release and on the in-plugin Credits screen. -->
<!-- Your profile URL looks like: https://profiles.wordpress.org/USERNAME/ -->
<!-- Enter just the USERNAME (the last part of that URL) below. -->
<!-- Please open the link first to confirm it loads — credits are generated from this exact -->
<!-- username, so a typo or a non-existent profile gets skipped. -->
<!-- Don't have a WordPress.org account? Create a free one at https://login.wordpress.org/register -->

My WordPress.org username:

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs created from a fork under GitHub organizations. -->
<!-- In this case, you can create the entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
