### PR TITLE
Add "Experiments" tab

### DIFF
--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -119,6 +119,7 @@ class Settings {
 	protected function instantiate_classes(): void {
 		Settings\Credits::get_instance();
 		Settings\Events::get_instance();
+		Settings\Experiments::get_instance();
 		Settings\Network::get_instance();
 		Settings\Roles::get_instance();
 		Settings\Rsvp_Settings::get_instance();

--- a/includes/core/classes/settings/class-experiments.php
+++ b/includes/core/classes/settings/class-experiments.php
@@ -1,0 +1,367 @@
+<?php
+/**
+ * Experiments settings page for GatherPress.
+ *
+ * Registers a "GatherPress Experiments" sub-page inside the GatherPress
+ * settings area and renders a card list of experiments sourced from the
+ * static data file at includes/data/experiments.php.
+ *
+ * For each experiment the page fetches the 👍 reaction count from the
+ * GitHub REST API (cached in a transient for 1 hour) and renders links
+ * to the GitHub Discussion and to the WordPress Playground blueprint.
+ *
+ * @package GatherPress\Core\Settings
+ * @since 0.34.0
+ */
+
+namespace GatherPress\Core\Settings;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Settings;
+use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Utility;
+
+/**
+ * Class Experiments.
+ *
+ * @since 0.34.0
+ */
+class Experiments extends Base {
+
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Transient key prefix used to cache vote counts per discussion URL.
+	 *
+	 * @since 0.34.0
+	 * @var string
+	 */
+	const TRANSIENT_PREFIX = 'gatherpress_exp_votes_';
+
+	/**
+	 * How long (in seconds) to cache vote counts fetched from GitHub.
+	 *
+	 * @since 0.34.0
+	 * @var int
+	 */
+	const CACHE_TTL = HOUR_IN_SECONDS;
+
+	/**
+	 * Set up hooks for various purposes.
+	 *
+	 * @since 0.34.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks(): void {
+		parent::setup_hooks();
+
+		add_action( 'gatherpress_settings_section', array( $this, 'settings_section' ), 9 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+	}
+
+	/**
+	 * Get the slug for the experiments settings page.
+	 *
+	 * @since 0.34.0
+	 *
+	 * @return string
+	 */
+	protected function get_slug(): string {
+		return 'experiments';
+	}
+
+	/**
+	 * Get the name for the experiments settings page.
+	 *
+	 * @since 0.34.0
+	 *
+	 * @return string
+	 */
+	protected function get_name(): string {
+		return __( 'Experiments', 'gatherpress' );
+	}
+
+	/**
+	 * Get the priority for displaying the experiments settings page.
+	 *
+	 * Sits just before Credits (PHP_INT_MAX) and after Tools (PHP_INT_MAX - 1).
+	 *
+	 * @since 0.34.0
+	 *
+	 * @return int
+	 */
+	protected function get_priority(): int {
+		return PHP_INT_MAX - 2;
+	}
+
+	/**
+	 * Enqueue inline styles only on our settings sub-page.
+	 *
+	 * @since 0.34.0
+	 *
+	 * @param string $hook The current admin page hook suffix.
+	 *
+	 * @return void
+	 */
+	public function enqueue_assets( string $hook ): void {
+		// GatherPress settings pages share a single hook suffix.
+		if ( ! str_contains( $hook, 'gatherpress' ) ) {
+			return;
+		}
+
+		// Only inject when our sub-page is active.
+		$page = Utility::get_http_input( INPUT_GET, 'page' );
+		if ( Utility::unprefix_key( (string) $page ) !== $this->get_slug() ) {
+			return;
+		}
+
+		wp_add_inline_style( 'wp-admin', $this->inline_styles() );
+	}
+
+	/**
+	 * Render the custom experiments section instead of the default settings form.
+	 *
+	 * @since 0.34.0
+	 *
+	 * @param string $page The current settings page slug.
+	 *
+	 * @return void
+	 */
+	public function settings_section( string $page ): void {
+		if ( Utility::unprefix_key( $page ) !== $this->get_slug() ) {
+			return;
+		}
+
+		remove_action(
+			'gatherpress_settings_section',
+			array( Settings::get_instance(), 'render_settings_form' )
+		);
+
+		$experiments = $this->get_experiments();
+
+		Utility::render_template(
+			sprintf( '%s/includes/templates/admin/settings/experiments.php', GATHERPRESS_CORE_PATH ),
+			array( 'experiments' => $experiments ),
+			true
+		);
+	}
+
+	/**
+	 * Load the static experiments list and enrich each item with live discussion
+	 * stats (votes, comments) and a resolved Playground launch URL.
+	 *
+	 * @since 0.34.0
+	 *
+	 * @return array
+	 */
+	public function get_experiments(): array {
+		$raw = require GATHERPRESS_CORE_PATH . '/includes/data/experiments.php';
+
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		foreach ( $raw as &$experiment ) {
+			$stats                        = $this->get_discussion_stats( $experiment['discussion'] ?? '' );
+			$experiment['reactions']      = $stats['reactions'];
+			$experiment['comments']       = $stats['comments'];
+			$experiment['playground_url'] = $this->build_playground_url( $experiment['blueprint'] ?? '' );
+		}
+		unset( $experiment );
+
+		return $raw;
+	}
+
+	/**
+	 * Build the WordPress Playground launch URL from an external blueprint.json URL.
+	 *
+	 * @since 0.34.0
+	 *
+	 * @param string $blueprint_url Raw URL to an external blueprint.json file.
+	 *
+	 * @return string Full Playground launch URL, or empty string when no blueprint URL is given.
+	 */
+	public function build_playground_url( string $blueprint_url ): string {
+		if ( empty( $blueprint_url ) ) {
+			return '';
+		}
+
+		return add_query_arg(
+			'blueprint-url',
+			rawurlencode( $blueprint_url ),
+			'https://playground.wordpress.net/'
+		);
+	}
+
+	/**
+	 * Reaction types tracked by GitHub, mapped to their display emoji.
+	 *
+	 * @since 0.34.0
+	 * @var array<string,string>
+	 */
+	const REACTION_EMOJI = array(
+		'+1'       => '&#x1F44D;',
+		'-1'       => '&#x1F44E;',
+		'laugh'    => '&#x1F604;',
+		'hooray'   => '&#x1F389;',
+		'confused' => '&#x1F615;',
+		'heart'    => '&#x2764;&#xFE0F;',
+		'rocket'   => '&#x1F680;',
+		'eyes'     => '&#x1F440;',
+	);
+
+	/**
+	 * Fetch per-type reaction counts and comment count for a GitHub Discussion URL.
+	 *
+	 * Results are cached in a transient for {@see self::CACHE_TTL} seconds.
+	 * Returns an array with:
+	 *   'reactions' => array<string,int>  only types with count > 0, keyed by GitHub type slug
+	 *   'comments'  => int|null
+	 *
+	 * @since 0.34.0
+	 *
+	 * @param string $discussion_url Full URL of the GitHub Discussion.
+	 *
+	 * @return array{ reactions: array<string,int>, comments: int|null }
+	 */
+	public function get_discussion_stats( string $discussion_url ): array {
+		$empty = array( 'reactions' => array(), 'comments' => null );
+
+		if ( empty( $discussion_url ) ) {
+			return $empty;
+		}
+
+		$transient_key = self::TRANSIENT_PREFIX . substr( md5( $discussion_url ), 0, 16 );
+		$cached        = get_transient( $transient_key );
+
+		if ( is_array( $cached ) && array_key_exists( 'reactions', $cached ) ) {
+			return $cached;
+		}
+
+		$stats = $this->fetch_discussion_stats_from_github( $discussion_url );
+
+		set_transient( $transient_key, $stats ?? $empty, self::CACHE_TTL );
+
+		return $stats ?? $empty;
+	}
+
+	/**
+	 * Call the GitHub REST API to fetch reaction and comment counts for a discussion.
+	 *
+	 * Uses GET /repos/{owner}/{repo}/discussions/{id} which returns both a
+	 * `reactions` object (with per-type counts) and a top-level `comments`
+	 * integer in a single request. Only non-zero reaction types are returned.
+	 *
+	 * @since 0.34.0
+	 *
+	 * @param string $discussion_url Full GitHub Discussion URL.
+	 *
+	 * @return array{ reactions: array<string,int>, comments: int|null }|null Null on request failure.
+	 */
+	protected function fetch_discussion_stats_from_github( string $discussion_url ): ?array {
+		if ( ! preg_match( '#^https://github\.com/([^/]+/[^/]+)/discussions/(\d+)#', $discussion_url, $m ) ) {
+			return null;
+		}
+
+		$api_url = sprintf(
+			'https://api.github.com/repos/%s/discussions/%d',
+			$m[1],
+			(int) $m[2]
+		);
+
+		$response = wp_remote_get(
+			$api_url,
+			array(
+				'timeout' => 5,
+				'headers' => array(
+					'Accept'     => 'application/vnd.github+json',
+					'User-Agent' => 'GatherPress/' . GATHERPRESS_VERSION,
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( ! is_array( $data ) ) {
+			return null;
+		}
+
+		// Keep only known reaction types with a non-zero count.
+		$raw       = is_array( $data['reactions'] ?? null ) ? $data['reactions'] : array();
+		$reactions = array();
+		foreach ( array_keys( self::REACTION_EMOJI ) as $type ) {
+			if ( ! empty( $raw[ $type ] ) ) {
+				$reactions[ $type ] = (int) $raw[ $type ];
+			}
+		}
+
+		$comments = isset( $data['comments'] ) ? (int) $data['comments'] : null;
+
+		return array( 'reactions' => $reactions, 'comments' => $comments );
+	}
+
+	/**
+	 * Return the inline CSS for the Experiments page.
+	 *
+	 * @since 0.34.0
+	 *
+	 * @return string
+	 */
+	protected function inline_styles(): string {
+		return '
+.gp-experiments-wrap .gp-exp-intro { color: #646970; margin-bottom: 1.5em; }
+.gp-experiments-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+	gap: 1.25rem;
+	margin-top: 1rem;
+}
+.gp-exp-card {
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	padding: 1.25rem 1.25rem 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: .6rem;
+	box-shadow: 0 1px 1px rgba(0,0,0,.04);
+}
+.gp-exp-card h3 { margin: 0; font-size: 1rem; line-height: 1.4; }
+.gp-exp-card p  { margin: 0; color: #646970; font-size: .875rem; flex: 1; }
+.gp-exp-meta { display: flex; align-items: center; gap: .5rem; font-size: .8rem; color: #646970; }
+.gp-exp-reaction,
+.gp-exp-comments {
+	display: inline-flex;
+	align-items: center;
+	gap: .25rem;
+	border-radius: 2em;
+	padding: .15em .65em;
+	font-weight: 600;
+}
+.gp-exp-reaction {
+	background: #f0f6ff;
+	border: 1px solid #c2dbff;
+	color: #2271b1;
+	font-size: .8rem;
+}
+.gp-exp-comments {
+	background: #f6f7f7;
+	border: 1px solid #c3c4c7;
+	color: #3c434a;
+}
+.gp-exp-comments .dashicons { font-size: 14px; width: 14px; height: 14px; margin-top: 1px; }
+.gp-exp-actions { display: flex; gap: .5rem; flex-wrap: wrap; margin-top: .25rem; }
+.gp-exp-actions .button { font-size: .8rem; line-height: 2; height: auto; padding: 0 .75rem; }
+		';
+	}
+}

--- a/includes/data/experiments.php
+++ b/includes/data/experiments.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Static list of GatherPress experiments.
+ *
+ * Each entry represents an experimental feature tracked via a GitHub Discussion.
+ * Keys per item:
+ *   - title        (string)  Human-readable experiment name.
+ *   - description  (string)  Short description shown on the card.
+ *   - discussion   (string)  Full URL of the GitHub Discussion.
+ *   - blueprint    (string)  Raw URL to an external blueprint.json file
+ *                            (e.g. https://raw.githubusercontent.com/…/blueprint.json).
+ *                            The Experiments class builds the full Playground launch URL from this.
+ *
+ * @package GatherPress\Core
+ * @since 0.34.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+return array(
+	// array(
+	// 	'title'       => 'Tickets & Paid RSVP',
+	// 	'description' => 'Explore a first draft of ticketing support with paid and free tiers for GatherPress events.',
+	// 	'discussion'  => 'https://github.com/GatherPress/gatherpress/discussions/1',
+	// 	'blueprint'   => 'https://playground.wordpress.net/#%7B%22steps%22:%5B%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22gatherpress%22%7D%7D%5D%7D',
+	// ),
+	// array(
+	// 	'title'       => 'Venue Hierarchy',
+	// 	'description' => 'Nest venues inside parent venues to model multi-room or multi-floor event spaces.',
+	// 	'discussion'  => 'https://github.com/GatherPress/gatherpress/discussions/2',
+	// 	'blueprint'   => 'https://playground.wordpress.net/#%7B%22steps%22:%5B%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22gatherpress%22%7D%7D%5D%7D',
+	// ),
+	// array(
+	// 	'title'       => 'Event Series / Seasons',
+	// 	'description' => 'Group recurring events into a named series and let attendees subscribe to the whole run.',
+	// 	'discussion'  => 'https://github.com/GatherPress/gatherpress/discussions/3',
+	// 	'blueprint'   => 'https://playground.wordpress.net/#%7B%22steps%22:%5B%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22gatherpress%22%7D%7D%5D%7D',
+	// ),
+	// array(
+	// 	'title'       => 'Add-to-Calendar Buttons',
+	// 	'description' => 'One-click buttons that let attendees export events to Google, Apple, and Outlook calendars.',
+	// 	'discussion'  => 'https://github.com/GatherPress/gatherpress/discussions/4',
+	// 	'blueprint'   => 'https://playground.wordpress.net/#%7B%22steps%22:%5B%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22gatherpress%22%7D%7D%5D%7D',
+	// ),
+	// array(
+	// 	'title'       => 'Attendee Statistics Dashboard',
+	// 	'description' => 'A per-event and site-wide dashboard showing RSVP trends, no-show rates, and capacity charts.',
+	// 	'discussion'  => 'https://github.com/GatherPress/gatherpress/discussions/5',
+	// 	'blueprint'   => 'https://playground.wordpress.net/#%7B%22steps%22:%5B%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22gatherpress%22%7D%7D%5D%7D',
+	// ),
+	array(
+		'title'       => 'Planning: Venue Block Architecture - Inline Creation, Query Loop Support, & Hybrid Events',
+		'description' => '...',
+		'discussion'  => 'https://github.com/GatherPress/gatherpress/discussions/1349',
+		'blueprint'   => 'https://raw.githubusercontent.com/carstingaxion/gatherpress-demos/refs/heads/main/happenings-at-spots/blueprint.json',
+	),
+	array(
+		'title'       => 'Organizers: Use Custom Post Type to be future proof.',
+		'description' => '...',
+		'discussion'  => 'https://github.com/GatherPress/gatherpress/discussions/1638',
+		'blueprint'   => 'https://raw.githubusercontent.com/carstingaxion/gatherpress-demos/refs/heads/main/happenings-at-spots/blueprint.json',
+	),
+);

--- a/includes/templates/admin/settings/experiments.php
+++ b/includes/templates/admin/settings/experiments.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Template: Tools > GatherPress Experiments admin page.
+ *
+ * Available variables:
+ *   $experiments  array  List of experiment items from Experiments::get_experiments().
+ *
+ * @package GatherPress\Core
+ * @since 0.34.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+?>
+<div class="wrap gp-experiments-wrap">
+	<h1>
+		<?php esc_html_e( 'GatherPress Experiments', 'gatherpress' ); ?>
+	</h1>
+
+	<p class="gp-exp-intro">
+		<?php
+		echo wp_kses(
+			sprintf(
+				/* translators: %s: URL to GitHub Discussions */
+				__( 'These are active experiments being discussed in the <a href="%s" target="_blank" rel="noopener noreferrer">GatherPress GitHub Discussions</a>. Try each one in a Playground sandbox and cast your vote on GitHub to shape the roadmap.', 'gatherpress' ),
+				'https://github.com/GatherPress/gatherpress/discussions'
+			),
+			array( 'a' => array( 'href' => array(), 'target' => array(), 'rel' => array() ) )
+		);
+		?>
+	</p>
+
+	<?php if ( empty( $experiments ) ) : ?>
+		<p><?php esc_html_e( 'No experiments found.', 'gatherpress' ); ?></p>
+	<?php else : ?>
+		<div class="gp-experiments-grid">
+			<?php foreach ( $experiments as $experiment ) :
+				$title          = isset( $experiment['title'] )          ? (string) $experiment['title']          : '';
+				$description    = isset( $experiment['description'] )    ? (string) $experiment['description']    : '';
+				$discussion     = isset( $experiment['discussion'] )     ? (string) $experiment['discussion']     : '';
+				$playground_url = isset( $experiment['playground_url'] ) ? (string) $experiment['playground_url'] : '';
+				$reactions      = isset( $experiment['reactions'] ) && is_array( $experiment['reactions'] ) ? $experiment['reactions'] : array();
+				$comments       = isset( $experiment['comments'] )       ? $experiment['comments']               : null;
+			?>
+			<div class="gp-exp-card">
+				<h3><?php echo esc_html( $title ); ?></h3>
+
+				<p><?php echo esc_html( $description ); ?></p>
+
+				<div class="gp-exp-meta">
+					<?php
+					$reaction_emoji = GatherPress\Core\Settings\Experiments::REACTION_EMOJI;
+					foreach ( $reaction_emoji as $type => $emoji ) :
+						if ( empty( $reactions[ $type ] ) ) continue;
+						$count = (int) $reactions[ $type ];
+					?>
+						<span class="gp-exp-reaction" title="<?php echo esc_attr( $type ); ?>">
+							<span aria-hidden="true"><?php echo $emoji; // HTML entities, safe ?></span>
+							<?php echo esc_html( number_format_i18n( $count ) ); ?>
+						</span>
+					<?php endforeach; ?>
+
+					<?php if ( null !== $comments && $comments >= 0 ) : ?>
+						<span class="gp-exp-comments">
+							<span class="dashicons dashicons-admin-comments" aria-hidden="true"></span>
+							<?php
+							echo esc_html(
+								sprintf(
+									/* translators: %d: number of comments */
+									_n( '%d comment', '%d comments', $comments, 'gatherpress' ),
+									$comments
+								)
+							);
+							?>
+						</span>
+					<?php endif; ?>
+				</div>
+
+				<div class="gp-exp-actions">
+					<?php if ( ! empty( $discussion ) ) : ?>
+						<a
+							href="<?php echo esc_url( $discussion ); ?>"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="button button-secondary"
+						>
+							<?php esc_html_e( 'View Discussion', 'gatherpress' ); ?>
+							<span class="screen-reader-text"><?php esc_html_e( '(opens in new tab)', 'gatherpress' ); ?></span>
+						</a>
+					<?php endif; ?>
+
+					<?php if ( ! empty( $playground_url ) ) : ?>
+						<a
+							href="<?php echo esc_url( $playground_url ); ?>"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="button button-primary"
+						>
+							<?php esc_html_e( '▶ Try in Playground', 'gatherpress' ); ?>
+							<span class="screen-reader-text"><?php esc_html_e( '(opens in new tab)', 'gatherpress' ); ?></span>
+						</a>
+					<?php endif; ?>
+				</div>
+			</div>
+			<?php endforeach; ?>
+		</div>
+	<?php endif; ?>
+</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes the long lasting idea of having an "Experiments" area somewhere.

Lets take this as ONE possible solution, not a final proposal.

<img width="1519" height="818" alt="image" src="https://github.com/user-attachments/assets/91a644e2-2b72-44f5-b259-3edc8ebdb0d0" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

### Credit (for release notes)

<!-- First time contributing? Add your WordPress.org profile so we can credit you in the -->
<!-- release and on the in-plugin Credits screen. -->
<!-- Your profile URL looks like: https://profiles.wordpress.org/USERNAME/ -->
<!-- Enter just the USERNAME (the last part of that URL) below. -->
<!-- Please open the link first to confirm it loads — credits are generated from this exact -->
<!-- username, so a typo or a non-existent profile gets skipped. -->
<!-- Don't have a WordPress.org account? Create a free one at https://login.wordpress.org/register -->

My WordPress.org username:

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs created from a fork under GitHub organizations. -->
<!-- In this case, you can create the entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
