### PR TITLE
Harden RSVP frontend against missing state markup

### DIFF
--- a/.github/changelog/1851-center-rsvp-display-name
+++ b/.github/changelog/1851-center-rsvp-display-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Center the RSVP Response display name again on WordPress versions where the comment author name block moved text alignment to the typography block support.

--- a/.github/changelog/1851-rsvp-missing-state-markup
+++ b/.github/changelog/1851-rsvp-missing-state-markup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent a successful RSVP from showing a false "RSVP API request failed" alert and a broken modal when the block's state markup is malformed or incomplete.

--- a/src/blocks/modal-manager/view.js
+++ b/src/blocks/modal-manager/view.js
@@ -18,7 +18,13 @@ const { actions } = store( 'gatherpress', {
 				event.preventDefault();
 			}
 
-			element = element ?? event.target;
+			element = element ?? event?.target;
+
+			// Bail when called with neither an event nor an element (e.g. a
+			// querySelector miss at the call site) instead of throwing (#1719).
+			if ( ! element ) {
+				return;
+			}
 
 			const modalManager = element.closest(
 				'.wp-block-gatherpress-modal-manager',

--- a/src/blocks/rsvp-template/template.js
+++ b/src/blocks/rsvp-template/template.js
@@ -38,8 +38,18 @@ const TEMPLATE = [
 							'gatherpress',
 						),
 					},
+					// Centering is declared both ways on purpose: newer
+					// WordPress moved the block's text alignment from the
+					// `textAlign` attribute to the typography block support
+					// (`style.typography.textAlign`) and silently drops the
+					// legacy attribute on insert, while our WP 6.7 floor
+					// still reads the attribute. Each version keeps the one
+					// it understands.
 					textAlign: 'center',
 					style: {
+						typography: {
+							textAlign: 'center',
+						},
 						spacing: {
 							margin: {
 								top: '0',

--- a/src/blocks/rsvp/view.js
+++ b/src/blocks/rsvp/view.js
@@ -129,15 +129,26 @@ const { state, actions } = store( 'gatherpress', {
 								'[data-rsvp-status="attending"] .gatherpress-rsvp--trigger-update',
 							);
 
-						actions.openModal( null, attendingStatusButton );
+						if ( attendingStatusButton ) {
+							actions.openModal( null, attendingStatusButton );
 
-						/**
-						 * When keeping a modal open after an action, use findActiveSibling=false
-						 * to prevent focus from moving to a different modal manager.
-						 */
-						setTimeout( () => {
-							actions.closeModal( null, element.ref, false );
-						}, 10 );
+							/**
+							 * When keeping a modal open after an action, use findActiveSibling=false
+							 * to prevent focus from moving to a different modal manager.
+							 */
+							setTimeout( () => {
+								actions.closeModal( null, element.ref, false );
+							}, 10 );
+						} else {
+							/**
+							 * The attending state's markup is missing (malformed or
+							 * partial block content), so there is no modal to switch
+							 * to — fully close the current one instead (#1719).
+							 */
+							setTimeout( () => {
+								actions.closeModal( null, element.ref, true );
+							}, 10 );
+						}
 					} else {
 						/**
 						 * When fully closing a modal, use findActiveSibling=true

--- a/src/blocks/rsvp/view.js
+++ b/src/blocks/rsvp/view.js
@@ -131,24 +131,23 @@ const { state, actions } = store( 'gatherpress', {
 
 						if ( attendingStatusButton ) {
 							actions.openModal( null, attendingStatusButton );
-
-							/**
-							 * When keeping a modal open after an action, use findActiveSibling=false
-							 * to prevent focus from moving to a different modal manager.
-							 */
-							setTimeout( () => {
-								actions.closeModal( null, element.ref, false );
-							}, 10 );
-						} else {
-							/**
-							 * The attending state's markup is missing (malformed or
-							 * partial block content), so there is no modal to switch
-							 * to — fully close the current one instead (#1719).
-							 */
-							setTimeout( () => {
-								actions.closeModal( null, element.ref, true );
-							}, 10 );
 						}
+
+						/**
+						 * When switching to the attending modal, close with
+						 * findActiveSibling=false so focus stays on the newly
+						 * opened modal manager. When the attending state's
+						 * markup is missing (malformed or partial block
+						 * content), there is no modal to switch to, so fully
+						 * close the current one instead (#1719).
+						 */
+						setTimeout( () => {
+							actions.closeModal(
+								null,
+								element.ref,
+								! attendingStatusButton,
+							);
+						}, 10 );
 					} else {
 						/**
 						 * When fully closing a modal, use findActiveSibling=true

--- a/src/helpers/interactivity.js
+++ b/src/helpers/interactivity.js
@@ -267,7 +267,18 @@ export async function sendRsvpApiRequest(
 			}
 
 			if ( 'function' === typeof onSuccess ) {
-				onSuccess( res );
+				try {
+					onSuccess( res );
+				} catch ( error ) {
+					// The RSVP request itself succeeded — a failure while
+					// updating the UI afterward must not be reported to the
+					// user as a failed request (#1719).
+					// eslint-disable-next-line no-console
+					console.warn(
+						'RSVP post-success UI update failed:',
+						error,
+					);
+				}
 			}
 		} else {
 			notifyRsvpFailure();

--- a/test/unit/js/src/blocks/modal-manager/view.test.js
+++ b/test/unit/js/src/blocks/modal-manager/view.test.js
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+
+/**
+ * Mock the Interactivity API with a namespace-merging store so every
+ * module contributing to the `gatherpress` namespace (modal-manager,
+ * helpers) shares one registry, mirroring the real runtime.
+ */
+jest.mock(
+	'@wordpress/interactivity',
+	() => {
+		const registries = {};
+
+		return {
+			store: ( name, config = {} ) => {
+				if ( ! registries[ name ] ) {
+					registries[ name ] = {
+						state: {},
+						actions: {},
+						callbacks: {},
+					};
+				}
+
+				const registry = registries[ name ];
+
+				Object.assign( registry.state, config.state );
+				Object.assign( registry.actions, config.actions );
+				Object.assign( registry.callbacks, config.callbacks );
+
+				return registry;
+			},
+			getElement: jest.fn(),
+			getContext: jest.fn(),
+		};
+	},
+	{ virtual: true }
+);
+
+/**
+ * WordPress dependencies
+ */
+import { store } from '@wordpress/interactivity';
+
+/**
+ * Internal dependencies
+ */
+// Import the actual module so its actions register on the shared store.
+import '@src/blocks/modal-manager/view';
+
+/**
+ * Regression coverage for #1719 — openModal must not throw when it is
+ * called with neither an event nor an element (e.g. a `querySelector`
+ * miss at the call site used to produce `openModal( null, null )` and
+ * a "Cannot read properties of null (reading 'target')" TypeError).
+ */
+describe( 'modal-manager openModal', () => {
+	let actions;
+
+	beforeEach( () => {
+		( { actions } = store( 'gatherpress' ) );
+		document.body.innerHTML = '';
+	} );
+
+	it( 'bails without throwing when called with no event and no element (#1719)', () => {
+		expect( () => actions.openModal( null, null ) ).not.toThrow();
+	} );
+
+	it( 'falls back to event.target when no element is given', () => {
+		document.body.innerHTML = `
+			<div class="wp-block-gatherpress-modal-manager">
+				<button type="button">Open</button>
+				<div class="wp-block-gatherpress-modal"></div>
+			</div>
+		`;
+
+		const button = document.querySelector( 'button' );
+		const event = { preventDefault: jest.fn(), target: button };
+
+		actions.openModal( event );
+
+		expect( event.preventDefault ).toHaveBeenCalled();
+		expect(
+			document
+				.querySelector( '.wp-block-gatherpress-modal' )
+				.classList.contains( 'gatherpress--is-visible' )
+		).toBe( true );
+	} );
+
+	it( 'uses the explicit element when one is given', () => {
+		document.body.innerHTML = `
+			<div class="wp-block-gatherpress-modal-manager">
+				<button type="button">Open</button>
+				<div class="wp-block-gatherpress-modal"></div>
+			</div>
+		`;
+
+		const button = document.querySelector( 'button' );
+
+		actions.openModal( null, button );
+
+		expect(
+			document
+				.querySelector( '.wp-block-gatherpress-modal' )
+				.classList.contains( 'gatherpress--is-visible' )
+		).toBe( true );
+	} );
+} );

--- a/test/unit/js/src/blocks/rsvp/view.test.js
+++ b/test/unit/js/src/blocks/rsvp/view.test.js
@@ -1,0 +1,201 @@
+/**
+ * External dependencies
+ */
+import {
+	describe,
+	expect,
+	it,
+	jest,
+	beforeEach,
+	afterEach,
+} from '@jest/globals';
+
+/**
+ * Mock the Interactivity API with a namespace-merging store so every
+ * module contributing to the `gatherpress` namespace (rsvp view,
+ * modal-manager view, helpers) shares one registry, mirroring the
+ * real runtime.
+ */
+jest.mock(
+	'@wordpress/interactivity',
+	() => {
+		const registries = {};
+
+		return {
+			store: ( name, config = {} ) => {
+				if ( ! registries[ name ] ) {
+					registries[ name ] = {
+						state: {},
+						actions: {},
+						callbacks: {},
+					};
+				}
+
+				const registry = registries[ name ];
+
+				Object.assign( registry.state, config.state );
+				Object.assign( registry.actions, config.actions );
+				Object.assign( registry.callbacks, config.callbacks );
+
+				return registry;
+			},
+			getElement: jest.fn(),
+			getContext: jest.fn(),
+		};
+	},
+	{ virtual: true }
+);
+
+/**
+ * WordPress dependencies
+ */
+import { store, getElement, getContext } from '@wordpress/interactivity';
+
+/**
+ * Internal dependencies
+ */
+import { getNonce } from '@src/helpers/interactivity';
+// Import the actual modules so their actions register on the shared store.
+import '@src/blocks/rsvp/view';
+import '@src/blocks/modal-manager/view';
+
+/**
+ * Waits long enough for the fire-and-forget sendRsvpApiRequest promise
+ * chain and the 10ms closeModal timeout inside updateRsvp to settle.
+ *
+ * @return {Promise<void>} Resolves after the RSVP flow settles.
+ */
+function flushRsvpFlow() {
+	return new Promise( ( resolve ) => {
+		setTimeout( resolve, 30 );
+	} );
+}
+
+/**
+ * Regression coverage for #1719 — after a successful RSVP from the
+ * `no_status` state, updateRsvp switches to the attending state's modal.
+ * When the attending state markup is missing (malformed or partial block
+ * content), it used to call `openModal( null, null )` and throw, which
+ * surfaced a bogus "RSVP API request failed" alert even though the RSVP
+ * was saved.
+ */
+describe( 'rsvp updateRsvp post-success modal switch', () => {
+	let state;
+	let actions;
+
+	beforeEach( () => {
+		( { state, actions } = store( 'gatherpress' ) );
+
+		// Reset shared registry state between tests.
+		delete state.posts;
+		state.eventApiUrl = 'https://example.test/wp-json/gatherpress/v1';
+
+		// The modal actions' own behavior is covered in the modal-manager
+		// tests; here only the call routing matters.
+		actions.openModal = jest.fn();
+		actions.closeModal = jest.fn();
+
+		getNonce.clearCache();
+
+		window.alert = jest.fn();
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+		global.fetch = jest.fn( ( url ) => {
+			if ( url.endsWith( '/nonce' ) ) {
+				return Promise.resolve( {
+					json: () => Promise.resolve( { nonce: 'test-nonce' } ),
+				} );
+			}
+
+			// POST /rsvp.
+			return Promise.resolve( {
+				status: 200,
+				json: () =>
+					Promise.resolve( {
+						success: true,
+						status: 'attending',
+						guests: 0,
+						anonymous: false,
+					} ),
+			} );
+		} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+		delete global.fetch;
+	} );
+
+	/**
+	 * Builds the RSVP block DOM and wires getElement/getContext to the
+	 * `no_status` trigger button.
+	 *
+	 * @param {boolean} withAttendingState - Whether to include the attending
+	 *                                     state's container in the markup.
+	 * @return {Object} The trigger button and (possibly null) attending button.
+	 */
+	function setupDom( withAttendingState ) {
+		const attendingMarkup = withAttendingState
+			? `<div data-rsvp-status="attending">
+					<button type="button" class="gatherpress-rsvp--trigger-update">Edit RSVP</button>
+				</div>`
+			: '';
+
+		document.body.innerHTML = `
+			<div class="wp-block-gatherpress-rsvp">
+				<div data-rsvp-status="no_status">
+					<button type="button" class="gatherpress-rsvp--trigger-update">Attend</button>
+				</div>
+				${ attendingMarkup }
+			</div>
+		`;
+
+		const trigger = document.querySelector(
+			'[data-rsvp-status="no_status"] button'
+		);
+
+		getElement.mockReturnValue( { ref: trigger } );
+		getContext.mockReturnValue( { postId: 123 } );
+
+		return {
+			trigger,
+			attendingButton: document.querySelector(
+				'[data-rsvp-status="attending"] button'
+			),
+		};
+	}
+
+	it( 'switches to the attending modal when its markup is present', async () => {
+		const { trigger, attendingButton } = setupDom( true );
+
+		actions.updateRsvp( { preventDefault: jest.fn() } );
+		await flushRsvpFlow();
+
+		expect( actions.openModal ).toHaveBeenCalledWith(
+			null,
+			attendingButton
+		);
+		expect( actions.closeModal ).toHaveBeenCalledWith(
+			null,
+			trigger,
+			false
+		);
+		expect( window.alert ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fully closes the modal instead of throwing when the attending markup is missing (#1719)', async () => {
+		const { trigger } = setupDom( false );
+
+		actions.updateRsvp( { preventDefault: jest.fn() } );
+		await flushRsvpFlow();
+
+		expect( actions.openModal ).not.toHaveBeenCalled();
+		expect( actions.closeModal ).toHaveBeenCalledWith(
+			null,
+			trigger,
+			true
+		);
+		// The RSVP succeeded; no failure alert may fire.
+		expect( window.alert ).not.toHaveBeenCalled();
+	} );
+} );

--- a/test/unit/js/src/helpers/interactivity.test.js
+++ b/test/unit/js/src/helpers/interactivity.test.js
@@ -118,6 +118,58 @@ describe( 'sendRsvpApiRequest', () => {
 		expect( window.alert ).not.toHaveBeenCalled();
 	} );
 
+	it( 'invokes onSuccess with the response payload on success', async () => {
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 0,
+			anonymous: false,
+		};
+
+		const onSuccess = jest.fn();
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 0, anonymous: false },
+			state,
+			onSuccess
+		);
+
+		expect( onSuccess ).toHaveBeenCalledWith( rsvpPayload );
+		expect( window.alert ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not report a successful request as failed when onSuccess throws (#1719)', async () => {
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 0,
+			anonymous: false,
+		};
+
+		const onSuccess = jest.fn( () => {
+			throw new TypeError( 'UI update failed' );
+		} );
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 0, anonymous: false },
+			state,
+			onSuccess
+		);
+
+		// The request succeeded, so the user-facing failure alert must not
+		// fire; the UI error is only logged for debugging.
+		expect( window.alert ).not.toHaveBeenCalled();
+		// eslint-disable-next-line no-console
+		expect( console.warn ).toHaveBeenCalledWith(
+			'RSVP post-success UI update failed:',
+			expect.any( TypeError )
+		);
+		// State was still updated before the callback threw.
+		expect( state.posts[ 123 ].currentUser.status ).toBe( 'attending' );
+	} );
+
 	it( 'falls back to 0 only for the missing sub-keys of a partial responses object', async () => {
 		rsvpPayload = {
 			success: true,


### PR DESCRIPTION
Fixes the frontend half of #1719.

## What happened

On the reporter's site, the RSVP block's `serializedInnerBlocks` attribute is corrupted by a platform-level content filter (one level of backslash escaping stripped on every save), so `json_decode` fails server side and only the currently selected status container renders. The RSVP REST request itself succeeds, but the success handler then does:

```js
actions.openModal( null, rsvpContainer.querySelector( '[data-rsvp-status="attending"] ...' ) );
```

With the attending container missing, that is `openModal( null, null )`, which threw `TypeError: Cannot read properties of null (reading 'target')`, and the catch-all in `sendRsvpApiRequest` reported it as "RSVP API request failed" even though the RSVP was saved. Reproducible with the existing e2e fixture `test/e2e/helpers/create-event-with-rsvp.php` (its `serializedInnerBlocks:""` yields the same single-state DOM), no corrupted content needed.

## Changes

- **modal-manager/view.js**: `openModal` mirrors `closeModal`'s null handling (`event?.target` plus a bail when no element resolves) instead of throwing.
- **rsvp/view.js**: when the attending state's trigger is absent, fully close the current modal (`closeModal( null, ref, true )`) instead of calling `openModal` with null.
- **helpers/interactivity.js**: `onSuccess` runs in its own try/catch; a UI-update failure after a successful request logs `RSVP post-success UI update failed:` instead of firing the request-failure alert. The alert still fires for genuine request failures.
- **rsvp-template/template.js**: restore the centered display name. Newer WordPress moved `core/comment-author-name` text alignment from the `textAlign` attribute to the typography block support, so the template's `textAlign: 'center'` was silently dropped on insert and the name rendered left-aligned. The alignment is now declared both ways (legacy attribute for the WP 6.7 floor, `style.typography.textAlign` for current WordPress); verified via `wp.blocks.createBlock` attribute validation that the new form survives where the old one was stripped. Existing events keep their saved (left-aligned) markup; re-centering there is a one-click toolbar change or a block reinsert.

## Testing

- New unit tests for the `rsvp` and `modal-manager` view stores using a namespace-merging `@wordpress/interactivity` store mock (first tests for these view files), covering all new branches, plus two new `sendRsvpApiRequest` cases (onSuccess invoked; onSuccess throwing does not alert).
- Full Jest suite: 890 passing. Lint clean. `npm run build` (experimental modules) compiles.
- Verified end to end in a browser against a single-state event: one click produces one POST, the RSVP saves as attending, no alert, no console error, modal closes cleanly. Before this change the same click threw the TypeError above and showed the false-failure alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
