### PR TITLE
Ship playground preview artifact as a single plugin zip

### DIFF
--- a/.gatherpress-org/playground-preview/plugin-proxy.php
+++ b/.gatherpress-org/playground-preview/plugin-proxy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * https://gatherpress.org/some-random-chars/plugin-proxy.php?org=GatherPress&repo=gatherpress&workflow=Build%20GatherPress%20Plugin%20Zip&artifact=gatherpress-pr&pr=666
+ * https://gatherpress.org/some-random-chars/plugin-proxy.php?org=GatherPress&repo=gatherpress&workflow=Playground%20Preview&artifact=gatherpress-pr-666&pr=666
  * 
  * 
  * Based on: https://github.com/WordPress/wordpress-playground/blob/ca759ee3281837596bfdd9736bbea205104741b2/packages/playground/website/public/plugin-proxy.php
@@ -100,7 +100,9 @@ class PluginDownloader {
 			// server-level .htaccess `Header set Content-Disposition` rule.
 			if ( ! headers_sent() ) {
 				header( 'Content-Type: application/zip' );
-				header( 'Content-Disposition: attachment; filename="gatherpress-pr.zip"' );
+				// Match the artifact naming so proxy downloads and direct
+				// workflow-page downloads produce the same filename.
+				header( 'Content-Disposition: attachment; filename="gatherpress-pr-' . (int) $pr . '.zip"' );
 			}
 
 			// die(var_export($artifact_res['headers'],true));
@@ -255,7 +257,9 @@ try {
 				'org'      => 'GatherPress',
 				'repo'     => 'gatherpress',
 				'workflow' => 'Playground Preview',
-				'artifact' => '#gatherpress-pr#',
+				// The `Playground Preview` workflow encodes the PR number in
+				// the artifact name: gatherpress-pr-<number>.
+				'artifact' => '#^gatherpress-pr-\d+$#',
 			],
 		];
 		$allowed       = false;

--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -196,7 +196,7 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion, override) 
 			*/
 			{
 				step: 'writeFile',
-				path: '/wordpress/pr/pr.zip',
+				path: '/wordpress/pr/gatherpress-pr.zip',
 				data: {
 					resource: 'url',
 					url: zipArtifactUrl,
@@ -212,7 +212,7 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion, override) 
 			 * directory, so the downloaded artifact is a single zip that
 			 * unpacks straight to `gatherpress/`:
 			 *
-			 * pr.zip
+			 * gatherpress-pr.zip
 			 *    gatherpress/
 			 *       gatherpress.php
 			 *       ... other files ...
@@ -223,7 +223,7 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion, override) 
 				step: 'installPlugin',
 				pluginData: {
 					resource: 'vfs',
-					path: '/wordpress/pr/pr.zip',
+					path: '/wordpress/pr/gatherpress-pr.zip',
 				},
 			},
 			{

--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -133,7 +133,7 @@ function mergeOverride(template, override) {
 function createBlueprintUrl(context, number) {
 	const { repo, owner } = context;
 	const workflow = encodeURI('Playground Preview');  // Encode the workflow name
-	const artifact = 'gatherpress-pr'; // GitHub Actions artifact name
+	const artifact = `gatherpress-pr-${number}`; // GitHub Actions artifact name (PR number encoded)
 	const proxy = 'https://gatherpress.org/playground-preview/plugin-proxy.php';
 
 	return `${proxy}?org=${owner}&repo=${repo}&workflow=${workflow}&artifact=${artifact}&pr=${number}`;
@@ -208,31 +208,22 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion, override) 
 				},
 			},
 			/**
-			 * GitHub CI artifacts are doubly zipped:
-			*
-			* pr.zip
-			*    gatherpress.zip
-			*       gatherpress/
-			*          gatherpress.php
-			*          ... other files ...
-			*
-			* This step extracts the inner zip file so that we get
-			* access directly to gatherpress.zip and can use it to
-			* install the plugin.
-			*/
-			{
-				step: 'unzip',
-				zipFile: {
-					resource: 'vfs',
-					path: '/wordpress/pr/pr.zip',
-				},
-				extractToPath: '/wordpress/pr',
-			},
+			 * The `Playground Preview` workflow uploads the extracted plugin
+			 * directory, so the downloaded artifact is a single zip that
+			 * unpacks straight to `gatherpress/`:
+			 *
+			 * pr.zip
+			 *    gatherpress/
+			 *       gatherpress.php
+			 *       ... other files ...
+			 *
+			 * That makes it directly installable — no inner-zip extraction.
+			 */
 			{
 				step: 'installPlugin',
 				pluginData: {
 					resource: 'vfs',
-					path: '/wordpress/pr/gatherpress.zip',
+					path: '/wordpress/pr/pr.zip',
 				},
 			},
 			{

--- a/.github/workflows/playground-preview-comment.yml
+++ b/.github/workflows/playground-preview-comment.yml
@@ -28,16 +28,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Download build artifact from upstream workflow
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ github.event.repository.name }}-pr
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Read PR number from artifact
+      # The upstream workflow encodes the PR number in the artifact name
+      # (`gatherpress-pr-<number>`), so listing the run's artifacts is
+      # enough — no artifact download or pr-number.txt payload file needed.
+      - name: Read PR number from artifact name
         id: pr
-        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
+            });
+            const prefix = `${context.repo.repo}-pr-`;
+            const artifact = data.artifacts.find(
+                (a) => a.name.startsWith(prefix) && /^\d+$/.test(a.name.slice(prefix.length))
+            );
+            if (!artifact) {
+                core.setFailed(`No ${prefix}<number> artifact found on run ${context.payload.workflow_run.id}`);
+                return;
+            }
+            core.setOutput('number', artifact.name.slice(prefix.length));
 
       # Check out the base repo at the default branch (trusted code) so the
       # github-script step below can require .github/scripts/playground-preview

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -82,13 +82,23 @@ jobs:
           npm run build
           wp dist-archive . ./${{ github.event.repository.name }}.zip
 
-      - name: Save PR number for downstream comment workflow
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+      # dist-archive is kept as the single source of truth for what ships
+      # (.distignore), but its zip is re-extracted so the *artifact itself*
+      # is the one and only zip: downloading it yields
+      # `gatherpress-pr-<number>.zip`, which unzips straight to a
+      # `gatherpress/` directory. Without this, GitHub wraps the uploaded
+      # files in an artifact zip and users get a zip inside a zip.
+      - name: Stage plugin directory for artifact
+        run: |
+          mkdir staging
+          unzip -q ./${{ github.event.repository.name }}.zip -d staging
 
+      # The PR number is encoded in the artifact name (instead of a
+      # pr-number.txt payload file) so the downstream `Playground Preview
+      # Comment` workflow can read it via the artifact-listing API and the
+      # downloaded zip stays clean.
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}-pr
-          path: |
-            ./${{ github.event.repository.name }}.zip
-            pr-number.txt
+          name: ${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
+          path: staging


### PR DESCRIPTION
Downloading the playground preview build used to be awkward: the artifact zip contained `gatherpress.zip` plus a `pr-number.txt`, so you unzipped twice and got a stray text file. After this change the artifact download is a single `gatherpress-pr-<number>.zip` that unzips straight to a `gatherpress/` directory, and the PR number is carried by the artifact name itself.

## Changes

- **playground-preview.yml**: still builds through `wp dist-archive` (so `.distignore` stays the single source of truth for what ships), but re-extracts that zip into a staging directory and uploads the files. GitHub's artifact wrapper zip therefore *is* the plugin zip. Artifact name is now `gatherpress-pr-<number>`; `pr-number.txt` is gone.
- **playground-preview-comment.yml**: gets the PR number by listing the run's artifacts and parsing the name, instead of downloading the artifact to read `pr-number.txt`. No artifact download at all in the privileged workflow anymore.
- **.github/scripts/playground-preview/index.js**: the blueprint requests the per-PR artifact name and feeds the downloaded zip directly to `installPlugin`; the "GitHub CI artifacts are doubly zipped" workaround (`unzip` step) is removed.
- **.gatherpress-org/playground-preview/plugin-proxy.php**: the existing unanchored allowlist regex `#gatherpress-pr#` already matched the new names, but it is now anchored to `#^gatherpress-pr-\d+$#`, and the `Content-Disposition` filename includes the PR number (`gatherpress-pr-<number>.zip`) so proxy downloads match direct artifact downloads.

## Heads up: deployment

The proxy source lives in this repo, but the running copy at `https://gatherpress.org/playground-preview/plugin-proxy.php` is deployed separately (it carries a real GitHub token in place of the placeholder). After merge, the deployed copy needs to be refreshed from this version. Until then the old deployed proxy keeps working with the new artifact names (its unanchored regex matches them), just with the old fixed `gatherpress-pr.zip` download filename.

Also expected: this PR's own preview comment run fails, because the `workflow_run`-triggered comment workflow executes the old code from `develop` (fixed artifact name + `pr-number.txt`). It resolves once merged.

## Testing

- YAML lints clean; `node --check` passes on the script.
- The blueprint change matches the new artifact layout one-to-one (single zip with `gatherpress/` root, which is the standard shape `installPlugin` accepts).
- Needs one live PR run to confirm end to end, which this PR itself provides once CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
