### PR TITLE
Give every RSVP-supporting post type its own scoped RSVPs admin page

### DIFF
--- a/.github/changelog/1849-rsvp-menu-per-post-type
+++ b/.github/changelog/1849-rsvp-menu-per-post-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Each post type supporting RSVPs now gets its own RSVPs admin page, scoped to that post type.

--- a/.github/changelog/1849-rsvp-menu-requires-support
+++ b/.github/changelog/1849-rsvp-menu-requires-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide the RSVPs admin menu when no post type supports the RSVP feature.

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -45,6 +45,18 @@ class List_Table extends WP_List_Table {
 	const STATUS_LINK_TEMPLATE = '<a href="%s"%s>%s <span class="count">(%s)</span></a>';
 
 	/**
+	 * Post type whose RSVPs this table lists.
+	 *
+	 * Each RSVP-supporting post type gets its own RSVPs admin page, and
+	 * the table only shows RSVPs belonging to that page's post type (#1849).
+	 *
+	 * @since 0.34.0
+	 *
+	 * @var string
+	 */
+	protected string $post_type;
+
+	/**
 	 * Initializes the RSVP list table.
 	 *
 	 * Sets up the table with appropriate labels and configuration options.
@@ -54,9 +66,13 @@ class List_Table extends WP_List_Table {
 	 * @since 0.34.0
 	 *
 	 * @param array $args Optional. Additional arguments to configure the list table.
-	 *                    Supports 'screen' to specify a particular screen context.
+	 *                    Supports 'screen' to specify a particular screen context and
+	 *                    'post_type' to scope the table to one RSVP-supporting post
+	 *                    type (defaults to the event post type).
 	 */
 	public function __construct( $args = array() ) {
+		$this->post_type = ! empty( $args['post_type'] ) ? (string) $args['post_type'] : Event::POST_TYPE;
+
 		parent::__construct(
 			array(
 				'plural'   => __( 'RSVPs', 'gatherpress' ),
@@ -88,7 +104,7 @@ class List_Table extends WP_List_Table {
 			'cb'       => '<input type="checkbox" />',
 			'attendee' => __( 'Attendee', 'gatherpress' ),
 			'response' => __( 'Response', 'gatherpress' ),
-			'event'    => __( 'Event', 'gatherpress' ),
+			'event'    => Utility::post_type_label( 'singular_name', $this->post_type ),
 			'approved' => __( 'Status', 'gatherpress' ),
 			'date'     => __( 'Date', 'gatherpress' ),
 		);
@@ -276,9 +292,10 @@ class List_Table extends WP_List_Table {
 		$offset = ( $page_number - 1 ) * $per_page;
 
 		$args = array(
-			'number' => $per_page,
-			'offset' => $offset,
-			'status' => 'all',
+			'number'    => $per_page,
+			'offset'    => $offset,
+			'status'    => 'all',
+			'post_type' => $this->post_type,
 		);
 
 		if ( isset( $_REQUEST['s'] ) && ! empty( $_REQUEST['s'] ) ) {
@@ -369,8 +386,9 @@ class List_Table extends WP_List_Table {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$rsvp_query = Query::get_instance();
 		$args       = array(
-			'count'  => true,
-			'status' => 'all',
+			'count'     => true,
+			'status'    => 'all',
+			'post_type' => $this->post_type,
 		);
 
 		if ( isset( $_REQUEST['user_id'] ) && ! empty( $_REQUEST['user_id'] ) ) {
@@ -569,7 +587,7 @@ class List_Table extends WP_List_Table {
 
 		$ip_search_url = add_query_arg(
 			array(
-				'post_type' => Event::POST_TYPE,
+				'post_type' => $this->post_type,
 				'page'      => Rsvp::COMMENT_TYPE,
 				's'         => $item['comment_author_IP'],
 			),
@@ -767,7 +785,7 @@ class List_Table extends WP_List_Table {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		$base_url_args = array(
-			'post_type' => Event::POST_TYPE,
+			'post_type' => $this->post_type,
 			'page'      => Rsvp::COMMENT_TYPE,
 			'_wpnonce'  => wp_create_nonce( Rsvp::COMMENT_TYPE ),
 		);
@@ -779,8 +797,11 @@ class List_Table extends WP_List_Table {
 
 		$base_url = add_query_arg( $base_url_args, admin_url( 'edit.php' ) );
 
-		// Base args for count queries.
-		$count_base_args = array( 'count' => true );
+		// Base args for count queries, scoped to this table's post type.
+		$count_base_args = array(
+			'count'     => true,
+			'post_type' => $this->post_type,
+		);
 
 		if ( $post_id ) {
 			$count_base_args['post_id'] = $post_id;

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -117,9 +117,14 @@ class Query {
 	 */
 	public function get_rsvps( array $args ) {
 		$args['type']         = Rsvp::COMMENT_TYPE;
-		$args['post_type']    = array_values( get_post_types_by_support( 'gatherpress-rsvp' ) );
 		$args['type__in']     = array();
 		$args['type__not_in'] = array();
+
+		// Default to every RSVP-supporting post type; callers may narrow
+		// this down, like the per-post-type RSVPs admin pages do (#1849).
+		if ( empty( $args['post_type'] ) ) {
+			$args['post_type'] = array_values( get_post_types_by_support( 'gatherpress-rsvp' ) );
+		}
 
 		remove_action( 'pre_get_comments', array( $this, 'exclude_rsvp_from_comment_query' ) );
 

--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -303,44 +303,74 @@ class Setup {
 	}
 
 	/**
-	 * Adds a submenu page for managing GatherPress RSVPs.
+	 * Adds an RSVPs submenu page to every RSVP-supporting post type's menu.
 	 *
-	 * This method adds a submenu page under the Events menu in the WordPress admin.
-	 * The page provides a dedicated interface for viewing and managing RSVPs
-	 * to GatherPress events, with capabilities similar to the WordPress comments
-	 * page but specifically tailored for RSVPs.
+	 * Each post type declaring `gatherpress-rsvp` support gets its own
+	 * RSVPs page under its admin menu, scoped to that post type's RSVPs —
+	 * the same way WordPress scopes post lists per type (#1849). The page
+	 * provides a dedicated interface for viewing and managing RSVPs, with
+	 * capabilities similar to the WordPress comments page but specifically
+	 * tailored for RSVPs.
 	 *
 	 * @since 0.34.0
 	 *
 	 * @return void
 	 */
 	public function add_rsvp_submenu_page(): void {
-		// Do not show the RSVPs submenu when RSVP is globally disabled or
-		// when no post type declares `gatherpress-rsvp` support — e.g. a
-		// companion plugin removed it from the event post type (#1849).
-		if (
-			'disabled' === Settings::get_instance()->get( 'rsvp_mode' ) ||
-			empty( get_post_types_by_support( 'gatherpress-rsvp' ) )
-		) {
+		// Do not show any RSVPs submenu when RSVP is globally disabled.
+		if ( 'disabled' === Settings::get_instance()->get( 'rsvp_mode' ) ) {
 			return;
 		}
 
-		$hook = add_submenu_page(
-			sprintf( 'edit.php?post_type=%s', Event::POST_TYPE ),
-			__( 'RSVPs', 'gatherpress' ),
-			__( 'RSVPs', 'gatherpress' ),
-			Rsvp::CAPABILITY,
-			Rsvp::COMMENT_TYPE,
-			array( $this, 'render_rsvp_admin_page' ),
-			2
-		);
+		// When no post type declares `gatherpress-rsvp` support — e.g. a
+		// companion plugin removed it from the event post type — the loop
+		// simply adds nothing (#1849).
+		foreach ( get_post_types_by_support( 'gatherpress-rsvp' ) as $post_type ) {
+			$hook = add_submenu_page(
+				sprintf( 'edit.php?post_type=%s', $post_type ),
+				__( 'RSVPs', 'gatherpress' ),
+				__( 'RSVPs', 'gatherpress' ),
+				Rsvp::CAPABILITY,
+				Rsvp::COMMENT_TYPE,
+				array( $this, 'render_rsvp_admin_page' ),
+				2
+			);
 
-		$this->list_table = new List_Table();
+			if ( false === $hook ) {
+				continue;
+			}
 
-		add_action(
-			sprintf( 'load-%s', $hook ),
-			array( $this, 'setup_rsvp_list_table_screen_options' )
-		);
+			add_action(
+				sprintf( 'load-%s', $hook ),
+				array( $this, 'prepare_rsvp_admin_page' )
+			);
+		}
+	}
+
+	/**
+	 * Prepares the RSVP admin page for the post type being viewed.
+	 *
+	 * Runs on the `load-{$hook}` action of each per-post-type RSVPs page.
+	 * Instantiates the list table scoped to the current screen's post type
+	 * and registers its screen options (#1849).
+	 *
+	 * @since 0.34.0
+	 *
+	 * @return void
+	 */
+	public function prepare_rsvp_admin_page(): void {
+		$screen_post_type = get_current_screen()->post_type ?? '';
+
+		// Fall back to the event post type when the screen doesn't carry a
+		// supporting post type (defensive; the submenu is only registered
+		// for supporting post types).
+		if ( ! post_type_supports( $screen_post_type, 'gatherpress-rsvp' ) ) {
+			$screen_post_type = Event::POST_TYPE;
+		}
+
+		$this->list_table = new List_Table( array( 'post_type' => $screen_post_type ) );
+
+		$this->setup_rsvp_list_table_screen_options();
 	}
 
 	/**
@@ -383,7 +413,10 @@ class Setup {
 			wp_die( esc_html__( 'Sorry, you are not allowed to manage RSVPs.', 'gatherpress' ), 403 );
 		}
 
-		$rsvp_table  = new List_Table();
+		// The load-{$hook} action has already scoped the list table to the
+		// current screen's post type; fall back to a default instance when
+		// called outside that flow (#1849).
+		$rsvp_table  = $this->list_table ?? new List_Table();
 		$search_term = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) : '';
 		$status      = isset( $_REQUEST['status'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['status'] ) ) : '';
 		$event       = isset( $_REQUEST['event'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['event'] ) ) : '';
@@ -498,12 +531,18 @@ class Setup {
 	 * @return string Modified parent file path to highlight the correct menu item.
 	 */
 	public function highlight_admin_menu( string $parent_file ): string {
-		global $plugin_page;
+		global $plugin_page, $typenow;
 
 		if ( isset( $plugin_page ) && Rsvp::COMMENT_TYPE === $plugin_page ) {
 			add_filter( 'submenu_file', array( $this, 'set_submenu_file' ) );
 
-			return sprintf( 'edit.php?post_type=%s', Event::POST_TYPE );
+			// Each RSVP-supporting post type has its own RSVPs page, so
+			// highlight whichever post type menu the page lives under (#1849).
+			$post_type = ( ! empty( $typenow ) && post_type_supports( $typenow, 'gatherpress-rsvp' ) )
+				? $typenow
+				: Event::POST_TYPE;
+
+			return sprintf( 'edit.php?post_type=%s', $post_type );
 		}
 
 		return $parent_file;

--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -315,8 +315,13 @@ class Setup {
 	 * @return void
 	 */
 	public function add_rsvp_submenu_page(): void {
-		// Do not show the RSVPs submenu when RSVP is globally disabled.
-		if ( 'disabled' === Settings::get_instance()->get( 'rsvp_mode' ) ) {
+		// Do not show the RSVPs submenu when RSVP is globally disabled or
+		// when no post type declares `gatherpress-rsvp` support — e.g. a
+		// companion plugin removed it from the event post type (#1849).
+		if (
+			'disabled' === Settings::get_instance()->get( 'rsvp_mode' ) ||
+			empty( get_post_types_by_support( 'gatherpress-rsvp' ) )
+		) {
 			return;
 		}
 

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
@@ -95,6 +95,115 @@ class Test_List_Table extends Base {
 	}
 
 	/**
+	 * The table defaults to the event post type and honors a `post_type`
+	 * constructor argument (#1849).
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_scopes_post_type(): void {
+		$this->assertSame(
+			Event::POST_TYPE,
+			Utility::get_hidden_property( new List_Table(), 'post_type' ),
+			'Table should default to the event post type.'
+		);
+
+		$scoped = new List_Table( array( 'post_type' => 'gatherpress_probe' ) );
+
+		$this->assertSame(
+			'gatherpress_probe',
+			Utility::get_hidden_property( $scoped, 'post_type' ),
+			'Table should honor the post_type constructor argument.'
+		);
+	}
+
+	/**
+	 * The table only counts RSVPs belonging to its scoped post type (#1849).
+	 *
+	 * @covers ::get_rsvp_count
+	 *
+	 * @return void
+	 */
+	public function test_get_rsvp_count_only_counts_scoped_post_type(): void {
+		register_post_type(
+			'gatherpress_probe',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'gatherpress-rsvp' ),
+			)
+		);
+
+		$probe_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'gatherpress_probe',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->factory->comment->create(
+			array(
+				'comment_post_ID' => $probe_id,
+				'comment_type'    => Rsvp::COMMENT_TYPE,
+			)
+		);
+
+		// One RSVP on the probe post plus the event RSVP from set_up().
+		$scoped = new List_Table( array( 'post_type' => 'gatherpress_probe' ) );
+
+		$this->assertSame(
+			1,
+			Utility::invoke_hidden_method( $scoped, 'get_rsvp_count' ),
+			'Scoped table should only count RSVPs of its own post type.'
+		);
+
+		$this->assertSame(
+			1,
+			Utility::invoke_hidden_method( new List_Table(), 'get_rsvp_count' ),
+			'Default table should only count event RSVPs.'
+		);
+
+		unregister_post_type( 'gatherpress_probe' );
+	}
+
+	/**
+	 * The event column header uses the scoped post type's singular label (#1849).
+	 *
+	 * @covers ::get_columns
+	 *
+	 * @return void
+	 */
+	public function test_get_columns_uses_scoped_post_type_label(): void {
+		register_post_type(
+			'gatherpress_probe',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'gatherpress-rsvp' ),
+				'labels'   => array(
+					'name'          => 'Probes',
+					'singular_name' => 'Probe',
+				),
+			)
+		);
+
+		$scoped = new List_Table( array( 'post_type' => 'gatherpress_probe' ) );
+
+		$this->assertSame(
+			'Probe',
+			$scoped->get_columns()['event'],
+			'Event column header should use the scoped post type singular label.'
+		);
+
+		$this->assertSame(
+			'Event',
+			( new List_Table() )->get_columns()['event'],
+			'Event column header should default to the event post type singular label.'
+		);
+
+		unregister_post_type( 'gatherpress_probe' );
+	}
+
+	/**
 	 * Tests get_columns method.
 	 *
 	 * @covers ::get_columns

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
@@ -698,6 +698,66 @@ class Test_Query extends Base {
 	}
 
 	/**
+	 * `get_rsvps()` honors a caller-provided `post_type` so per-post-type
+	 * callers (like the RSVPs admin pages) can narrow results, while still
+	 * defaulting to every RSVP-supporting post type (#1849).
+	 *
+	 * @covers ::get_rsvps
+	 *
+	 * @return void
+	 */
+	public function test_get_rsvps_honors_post_type_argument(): void {
+		register_post_type(
+			'gatherpress_probe',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'gatherpress-rsvp' ),
+			)
+		);
+
+		$instance = Query::get_instance();
+		$event    = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+		$probe_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'gatherpress_probe',
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_insert_comment(
+			array(
+				'comment_post_ID' => $event->ID,
+				'comment_type'    => Rsvp::COMMENT_TYPE,
+			)
+		);
+		wp_insert_comment(
+			array(
+				'comment_post_ID' => $probe_id,
+				'comment_type'    => Rsvp::COMMENT_TYPE,
+			)
+		);
+
+		$this->assertSame(
+			1,
+			$instance->get_rsvps(
+				array(
+					'count'     => true,
+					'post_type' => 'gatherpress_probe',
+				)
+			),
+			'A provided post_type should narrow results to that post type.'
+		);
+
+		$this->assertSame(
+			2,
+			$instance->get_rsvps( array( 'count' => true ) ),
+			'Without a post_type, every RSVP-supporting post type is included.'
+		);
+
+		unregister_post_type( 'gatherpress_probe' );
+	}
+
+	/**
 	 * Test get_rsvps with count parameter returns integer.
 	 *
 	 * @covers ::get_rsvps

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-setup.php
@@ -772,6 +772,27 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * Returns whether the RSVPs submenu is registered under a post type's menu.
+	 *
+	 * @param string $post_type Post type slug.
+	 *
+	 * @return bool True when the RSVPs submenu exists for the post type.
+	 */
+	protected function has_rsvp_submenu_for_post_type( string $post_type ): bool {
+		global $submenu;
+
+		$parent = sprintf( 'edit.php?post_type=%s', $post_type );
+
+		foreach ( $submenu[ $parent ] ?? array() as $item ) {
+			if ( Rsvp::COMMENT_TYPE === ( $item[2] ?? '' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * The RSVPs submenu is not added when no post type supports
 	 * `gatherpress-rsvp` — e.g. a companion plugin removed the support
 	 * from the event post type (#1849).
@@ -781,16 +802,22 @@ class Test_Setup extends Base {
 	 * @return void
 	 */
 	public function test_add_rsvp_submenu_page_bails_without_supporting_post_type(): void {
+		global $submenu;
+
+		$submenu = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
 		$instance = Setup::get_instance();
 
-		Utility::set_and_get_hidden_property( $instance, 'list_table', null );
 		remove_post_type_support( Event::POST_TYPE, 'gatherpress-rsvp' );
 
 		$instance->add_rsvp_submenu_page();
 
-		$this->assertNull(
-			Utility::get_hidden_property( $instance, 'list_table' ),
-			'List table should not be instantiated when no post type supports gatherpress-rsvp.'
+		$this->assertFalse(
+			$this->has_rsvp_submenu_for_post_type( Event::POST_TYPE ),
+			'No RSVPs submenu should be added when no post type supports gatherpress-rsvp.'
 		);
 
 		// Restore the support for subsequent tests.
@@ -798,11 +825,98 @@ class Test_Setup extends Base {
 
 		$instance->add_rsvp_submenu_page();
 
-		$this->assertInstanceOf(
-			List_Table::class,
-			Utility::get_hidden_property( $instance, 'list_table' ),
-			'List table should be instantiated once a post type supports gatherpress-rsvp again.'
+		$this->assertTrue(
+			$this->has_rsvp_submenu_for_post_type( Event::POST_TYPE ),
+			'RSVPs submenu should be added once a post type supports gatherpress-rsvp again.'
 		);
+	}
+
+	/**
+	 * Every post type declaring `gatherpress-rsvp` support gets its own
+	 * RSVPs submenu (#1849).
+	 *
+	 * @covers ::add_rsvp_submenu_page
+	 *
+	 * @return void
+	 */
+	public function test_add_rsvp_submenu_page_adds_menu_for_each_supporting_post_type(): void {
+		global $submenu;
+
+		$submenu = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		register_post_type(
+			'gatherpress_probe',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'gatherpress-rsvp' ),
+			)
+		);
+
+		Setup::get_instance()->add_rsvp_submenu_page();
+
+		$this->assertTrue(
+			$this->has_rsvp_submenu_for_post_type( Event::POST_TYPE ),
+			'RSVPs submenu should be added under the event post type menu.'
+		);
+		$this->assertTrue(
+			$this->has_rsvp_submenu_for_post_type( 'gatherpress_probe' ),
+			'RSVPs submenu should be added under every other supporting post type menu.'
+		);
+
+		unregister_post_type( 'gatherpress_probe' );
+	}
+
+	/**
+	 * The load-hook handler scopes the list table to the current screen's
+	 * post type, falling back to the event post type for screens without a
+	 * supporting post type (#1849).
+	 *
+	 * @covers ::prepare_rsvp_admin_page
+	 *
+	 * @return void
+	 */
+	public function test_prepare_rsvp_admin_page_scopes_list_table_to_screen_post_type(): void {
+		register_post_type(
+			'gatherpress_probe',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'gatherpress-rsvp' ),
+			)
+		);
+
+		$instance = Setup::get_instance();
+
+		set_current_screen( sprintf( 'probes_page_%s', Rsvp::COMMENT_TYPE ) );
+		get_current_screen()->post_type = 'gatherpress_probe';
+
+		$instance->prepare_rsvp_admin_page();
+
+		$list_table = Utility::get_hidden_property( $instance, 'list_table' );
+
+		$this->assertSame(
+			'gatherpress_probe',
+			Utility::get_hidden_property( $list_table, 'post_type' ),
+			'List table should be scoped to the screen post type.'
+		);
+
+		// A screen without a supporting post type falls back to the event post type.
+		get_current_screen()->post_type = 'post';
+
+		$instance->prepare_rsvp_admin_page();
+
+		$list_table = Utility::get_hidden_property( $instance, 'list_table' );
+
+		$this->assertSame(
+			Event::POST_TYPE,
+			Utility::get_hidden_property( $list_table, 'post_type' ),
+			'List table should fall back to the event post type for non-supporting screens.'
+		);
+
+		unregister_post_type( 'gatherpress_probe' );
+		set_current_screen( 'front' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-setup.php
@@ -721,6 +721,52 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * The highlighted parent follows the RSVP-supporting post type whose
+	 * menu the current RSVPs page lives under (#1849).
+	 *
+	 * @covers ::highlight_admin_menu
+	 *
+	 * @return void
+	 */
+	public function test_highlight_admin_menu_follows_supporting_post_type(): void {
+		global $plugin_page, $typenow;
+
+		register_post_type(
+			'gatherpress_probe',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'gatherpress-rsvp' ),
+			)
+		);
+
+		$instance = Setup::get_instance();
+
+		$plugin_page = Rsvp::COMMENT_TYPE; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$typenow     = 'gatherpress_probe'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$this->assertSame(
+			'edit.php?post_type=gatherpress_probe',
+			$instance->highlight_admin_menu( 'index.php' ),
+			'Highlighted parent should follow the supporting post type.'
+		);
+
+		// A non-supporting post type falls back to the event post type.
+		$typenow = 'post'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$this->assertSame(
+			sprintf( 'edit.php?post_type=%s', Event::POST_TYPE ),
+			$instance->highlight_admin_menu( 'index.php' ),
+			'Highlighted parent should fall back to the event post type.'
+		);
+
+		// Clean up.
+		remove_filter( 'submenu_file', array( $instance, 'set_submenu_file' ) );
+		unregister_post_type( 'gatherpress_probe' );
+		$plugin_page = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$typenow     = ''; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+
+	/**
 	 * Coverage for set_submenu_file method.
 	 *
 	 * @covers ::set_submenu_file

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-setup.php
@@ -772,6 +772,40 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * The RSVPs submenu is not added when no post type supports
+	 * `gatherpress-rsvp` — e.g. a companion plugin removed the support
+	 * from the event post type (#1849).
+	 *
+	 * @covers ::add_rsvp_submenu_page
+	 *
+	 * @return void
+	 */
+	public function test_add_rsvp_submenu_page_bails_without_supporting_post_type(): void {
+		$instance = Setup::get_instance();
+
+		Utility::set_and_get_hidden_property( $instance, 'list_table', null );
+		remove_post_type_support( Event::POST_TYPE, 'gatherpress-rsvp' );
+
+		$instance->add_rsvp_submenu_page();
+
+		$this->assertNull(
+			Utility::get_hidden_property( $instance, 'list_table' ),
+			'List table should not be instantiated when no post type supports gatherpress-rsvp.'
+		);
+
+		// Restore the support for subsequent tests.
+		add_post_type_support( Event::POST_TYPE, 'gatherpress-rsvp' );
+
+		$instance->add_rsvp_submenu_page();
+
+		$this->assertInstanceOf(
+			List_Table::class,
+			Utility::get_hidden_property( $instance, 'list_table' ),
+			'List table should be instantiated once a post type supports gatherpress-rsvp again.'
+		);
+	}
+
+	/**
 	 * Test setup_rsvp_list_table_screen_options method.
 	 *
 	 * @covers ::setup_rsvp_list_table_screen_options


### PR DESCRIPTION
Fixes #1849.

## What happened

`Rsvp\Setup::add_rsvp_submenu_page()` bailed when RSVP was globally disabled (`rsvp_mode === 'disabled'`) but never consulted the post-type-supports system, and the page itself was hardwired under the Events menu. A companion plugin that removes `gatherpress-rsvp` support from the event post type — like the [Productions & Seasons demo](https://github.com/carstingaxion/gatherpress-demos) — correctly lost every other piece of RSVP UI, yet the "RSVPs" submenu stayed under Events.

## Changes

Rather than only hiding the menu, this follows the supports architecture the whole way: **every post type declaring `gatherpress-rsvp` support gets its own RSVPs admin page under its own menu, scoped to that post type's RSVPs** — mirroring how WordPress scopes post lists per type. When no post type supports RSVPs (or RSVP is globally disabled), no menu is added anywhere.

- **`Rsvp\Setup`**: `add_rsvp_submenu_page()` loops `get_post_types_by_support( 'gatherpress-rsvp' )` and registers one submenu per type. A new `prepare_rsvp_admin_page()` runs on each page's `load-{$hook}` and builds the list table scoped to the current screen's post type; `render_rsvp_admin_page()` reuses that instance. `highlight_admin_menu()` highlights whichever post type menu the page lives under (via `$typenow`) instead of always Events.
- **`Rsvp\List_Table`**: accepts a `post_type` constructor argument (defaults to the event post type) and constrains the items query, pagination count, status-view counts, and its self-referencing admin URLs to it. The "Event" column header now uses the scoped post type's `singular_name` label.
- **`Rsvp\Query::get_rsvps()`**: honors a caller-provided `post_type` instead of always overriding it; the default remains all supporting post types, so existing callers are unaffected.

## Testing

New unit tests:
- submenu appears under each supporting post type's menu; none when support is absent; restored when support returns
- `prepare_rsvp_admin_page()` scopes the list table to the screen's post type and falls back to the event post type for non-supporting screens
- `List_Table` constructor scoping, per-post-type count filtering, and the per-post-type column label
- `Query::get_rsvps()` narrowing with `post_type` and unchanged default behavior

Full RSVP test namespace: 285 tests / 585 assertions passing via wp-env. phpcs and PHPStan clean on all changed files.

## Behavior note

With per-post-type scoping there is no single "all RSVPs" view when multiple post types support RSVPs — each page shows only its own type, matching per-CPT post list behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
