### PR TITLE
Bound and split the screenshot workflow's Playwright install

### DIFF
--- a/.github/workflows/wordpress-org-screenshots.yml
+++ b/.github/workflows/wordpress-org-screenshots.yml
@@ -238,6 +238,16 @@ jobs:
       # Using GitHub CLI in Workflows
       # https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows
       # https://cli.github.com/manual/gh_pr_create
-      run: gh pr create -B main -H fix/wp-org-screenshots-${{ matrix.locale }}-${{ github.sha }} --title 'Update ${{ matrix.locale }} screenshots for wordpress.org' --body 'Created with ❤️ by WordPress Playground, Playwright & GitHub action <br /><br />${{ steps.compress-images.outputs.markdown }}'
+      #
+      # The compression markdown is passed through an env var, NOT interpolated
+      # into the run script: it always contains a single quote ("Calibre's"),
+      # which terminated the quoted --body argument and crashed the shell with
+      # a syntax error (and expression interpolation into run scripts is a
+      # script-injection surface besides).
+      run: |
+        gh pr create -B main -H fix/wp-org-screenshots-${{ matrix.locale }}-${{ github.sha }} \
+          --title 'Update ${{ matrix.locale }} screenshots for wordpress.org' \
+          --body "Created with ❤️ by WordPress Playground, Playwright & GitHub action <br /><br />${COMPRESS_MARKDOWN}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COMPRESS_MARKDOWN: ${{ steps.compress-images.outputs.markdown }}

--- a/.github/workflows/wordpress-org-screenshots.yml
+++ b/.github/workflows/wordpress-org-screenshots.yml
@@ -22,6 +22,10 @@ permissions:
 jobs:
   screenshot:
     runs-on: ubuntu-latest
+    # Backstop against hangs: with max-parallel 1, a job silently stuck at
+    # GitHub's 6h default limit stalls every locale behind it — one hung
+    # apt phase turned into ~48h of dead runner time (run 27881952586).
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       max-parallel: 1 # Prevent parallel runs to make use of the caching for node_modules and playwright browsers
@@ -81,11 +85,23 @@ jobs:
           ./node_modules
         key: ${{ steps.node_modules-cache.outputs.cache-primary-key }}
 
-    - name: Install Playwright dependencies
-      run: npx playwright install --with-deps chromium
+    # The browser download and the apt-based system-dependency install are
+    # deliberately separate steps with their own timeouts: the combined
+    # `install --with-deps` hung indefinitely inside its apt phase (after the
+    # browser download had already completed) and every locale job burned
+    # GitHub's 6h limit — see run 27881952586. Step-level timeouts fail fast
+    # AND keep the post-job cache save alive, so the next locale job can hit
+    # the browser cache instead of repeating the download.
+    - name: Install Playwright browser
+      timeout-minutes: 10
+      run: npx playwright install chromium
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-    - run: npx playwright install-deps chromium
-      if: steps.playwright-cache.outputs.cache-hit == 'true'
+
+    - name: Install Playwright system dependencies
+      timeout-minutes: 10
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: npx playwright install-deps chromium
 
     - name: Prepare localized blueprint
       # en_US should not get any additional steps added, as this will result in errors!

--- a/.typos.toml
+++ b/.typos.toml
@@ -19,6 +19,8 @@ locale = "en-us"
 extend-ignore-re = [
     "\\biMatix\\b",
     "\\bEvent Organiser\\b",
+    # Calibre (calibreapp.com) builds the image-actions image compressor.
+    "\\bCalibre\\b",
 ]
 
 [default.extend-identifiers]


### PR DESCRIPTION
Unblocks screenshot regeneration for #1845.

## What happened

[Run 27881952586](https://github.com/GatherPress/gatherpress/actions/runs/27881952586) hung at `npx playwright install --with-deps chromium`: the Chromium download completed to 100%, then the apt system-dependency phase stalled indefinitely (the orphan processes at cancellation were the playwright installer plus stuck apt machinery). Because the matrix runs with `max-parallel: 1` and had no timeout, all eight locale jobs serially burned GitHub's 6-hour job limit — about 48 hours of dead runner time over two days. And since cancelled jobs skip the post-job cache save, every job repeated the identical download-then-hang instead of hitting the browser cache the serialization was designed around.

## Changes

- **`timeout-minutes: 40`** on the job as a backstop — a hang now costs minutes, not days.
- **Split `install --with-deps` into two steps with 10-minute timeouts**: browser download (which demonstrably worked) and `install-deps` (the part that hung). A *step* timeout fails the job fast while still letting the post-job cache save run, so the next locale job hits the browser cache.
- `install-deps` now runs unconditionally with `DEBIAN_FRONTEND=noninteractive` (previously it ran via `--with-deps` on cache miss and standalone on cache hit — same coverage, one code path).

## Second bug found once the hang was cleared

With the install phase fixed, the first verification run got all the way to the final step and hit a pre-existing bug nobody could reach before: `gh pr create` interpolated the image-compression markdown directly into a single-quoted `--body` shell argument. That markdown always contains a single quote ("Calibre's"), which terminated the quote and crashed the step with a shell syntax error -- every locale would have pushed its screenshots branch and then failed to open its PR. Fixed by passing the markdown through an env var (which also closes the script-injection surface of interpolating step output into a run script).

## Verification

[Run 28670362520](https://github.com/GatherPress/gatherpress/actions/runs/28670362520) dispatched from this branch. The previously hanging install phase now completes in under two minutes per job (first attempt: fr_FR went checkout -> screenshots -> compression -> branch push in ~4 minutes).

## Testing

- YAML lints clean.
- Will dispatch a run from this branch to verify end to end — if the apt phase still misbehaves, it now fails within 10 minutes with a clear step failure instead of a silent 6-hour cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
