### PR TITLE
Target screenshot PRs at develop with only .wordpress-org changes

### DIFF
--- a/.github/workflows/wordpress-org-screenshots.yml
+++ b/.github/workflows/wordpress-org-screenshots.yml
@@ -201,12 +201,12 @@ jobs:
       # Using "continue-on-error:true" results in 'conclusion' being a success in any case, while the 'outcome' can differ.
       # And, as you already guessed, if: failure() looks at 'conclusion'.
       #
-      # The PR branch is cut from origin/main and carries over ONLY the
-      # screenshot directory. The run's own checkout is develop-based, and a
-      # branch created from it drags every develop-not-in-main commit into the
-      # main-targeted PR — with develop ~1000 commits ahead, that made every
-      # screenshot PR conflict with main (and, via `git add -A` picking up the
-      # repo-wide image recompression, with each other).
+      # The PR branch is cut from origin/develop (screenshots flow into
+      # develop like all other work; main only moves on release) and carries
+      # over ONLY the screenshot directory. Branching straight off the run's
+      # checkout is wrong twice: a run dispatched from any other ref would
+      # leak that ref's commits into the PR, and the earlier main-targeted
+      # variant dragged the whole develop delta into main and conflicted.
       if: ${{ github.event.inputs.updateAllSnapshots || steps.screenshot-tests.outcome == 'failure' }}
       run: |
         # Remove untracked, temporary file
@@ -220,8 +220,8 @@ jobs:
         # switch branches over dirty files that differ between the branches.
         git reset --hard HEAD
 
-        git fetch --no-tags --depth=1 origin main
-        git checkout -B fix/wp-org-screenshots-${{ matrix.locale }}-${{ github.sha }} origin/main
+        git fetch --no-tags --depth=1 origin develop
+        git checkout -B fix/wp-org-screenshots-${{ matrix.locale }}-${{ github.sha }} origin/develop
 
         rm -rf .wordpress-org
         cp -r "${RUNNER_TEMP}/wordpress-org-screenshots" .wordpress-org
@@ -235,8 +235,8 @@ jobs:
         git config --local user.name "GitHub Action"
 
         # Scope the commit to the screenshots: everything else in the working
-        # tree is either develop-only state left over from the run checkout or
-        # incidental recompression of unrelated images.
+        # tree is either leftover state from the run checkout or incidental
+        # recompression of unrelated images.
         git add .wordpress-org
         git commit -m "Screenshots for ${{ matrix.locale }} updated!"
       env:
@@ -267,8 +267,12 @@ jobs:
       # which terminated the quoted --body argument and crashed the shell with
       # a syntax error (and expression interpolation into run scripts is a
       # script-injection surface besides).
+      # Targets develop (main only moves on release). The Skip Changelog
+      # label is required because the changelog check enforces an entry on
+      # every develop-targeted PR, and screenshot regen doesn't warrant one.
       run: |
-        gh pr create -B main -H fix/wp-org-screenshots-${{ matrix.locale }}-${{ github.sha }} \
+        gh pr create -B develop -H fix/wp-org-screenshots-${{ matrix.locale }}-${{ github.sha }} \
+          --label 'Skip Changelog' \
           --title 'Update ${{ matrix.locale }} screenshots for wordpress.org' \
           --body "Created with ❤️ by WordPress Playground, Playwright & GitHub action <br /><br />${COMPRESS_MARKDOWN}"
       env:

--- a/.github/workflows/wordpress-org-screenshots.yml
+++ b/.github/workflows/wordpress-org-screenshots.yml
@@ -186,15 +186,6 @@ jobs:
         # DEBUG=pw:api,pw:webserver \
         npm run screenshots:wporg -- --update-snapshots
 
-    - name: Checkout new branch
-      # Using "continue-on-error:true" results in 'conclusion' being a success in any case, while the 'outcome' can differ.
-      # And, as you already guessed, if: failure() looks at 'conclusion'.
-      if: ${{ github.event.inputs.updateAllSnapshots || steps.screenshot-tests.outcome == 'failure' }}
-      run: |
-        # Remove untracked, temporary file
-        rm -f ./localized_blueprint.json
-        git checkout -b fix/wp-org-screenshots-${{ matrix.locale }}-${{ github.sha }}
-
     - name: Compress Images
       if: ${{ github.event.inputs.updateAllSnapshots || steps.screenshot-tests.outcome == 'failure' }}
       id: compress-images
@@ -206,6 +197,35 @@ jobs:
         # ignorePaths accepts a comma-separated string with globbing support # https://www.npmjs.com/package/glob
         ignorePaths: 'artifacts,build,node_modules/**'
 
+    - name: Checkout new branch
+      # Using "continue-on-error:true" results in 'conclusion' being a success in any case, while the 'outcome' can differ.
+      # And, as you already guessed, if: failure() looks at 'conclusion'.
+      #
+      # The PR branch is cut from origin/main and carries over ONLY the
+      # screenshot directory. The run's own checkout is develop-based, and a
+      # branch created from it drags every develop-not-in-main commit into the
+      # main-targeted PR — with develop ~1000 commits ahead, that made every
+      # screenshot PR conflict with main (and, via `git add -A` picking up the
+      # repo-wide image recompression, with each other).
+      if: ${{ github.event.inputs.updateAllSnapshots || steps.screenshot-tests.outcome == 'failure' }}
+      run: |
+        # Remove untracked, temporary file
+        rm -f ./localized_blueprint.json
+
+        # Preserve the (compressed) screenshots across the branch switch.
+        cp -r .wordpress-org "${RUNNER_TEMP}/wordpress-org-screenshots"
+
+        # Drop every working-tree modification (screenshots are safe in the
+        # copy above; the rest is incidental recompression) — git refuses to
+        # switch branches over dirty files that differ between the branches.
+        git reset --hard HEAD
+
+        git fetch --no-tags --depth=1 origin main
+        git checkout -B fix/wp-org-screenshots-${{ matrix.locale }}-${{ github.sha }} origin/main
+
+        rm -rf .wordpress-org
+        cp -r "${RUNNER_TEMP}/wordpress-org-screenshots" .wordpress-org
+
     - name: Commit updated screenshots
       # Using "continue-on-error:true" results in 'conclusion' being a success in any case, while the 'outcome' can differ.
       # And, as you already guessed, if: failure() looks at 'conclusion'.
@@ -214,7 +234,10 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
 
-        git add -A
+        # Scope the commit to the screenshots: everything else in the working
+        # tree is either develop-only state left over from the run checkout or
+        # incidental recompression of unrelated images.
+        git add .wordpress-org
         git commit -m "Screenshots for ${{ matrix.locale }} updated!"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to #1856. That PR got the screenshot workflow to run end to end for the first time, which exposed the next latent bug: **all six generated screenshot PRs (#1857–#1862) have merge conflicts.**

## Why

The per-locale branch was created with `git checkout -b` from the workflow run's own checkout — which is develop-based — while `gh pr create -B main` targeted main. Develop is currently ~1,080 commits ahead of main (main only moves on release), so every screenshot PR dragged the entire develop delta into a main-targeted PR, and main's own unique commits conflicted. On top of that, `git add -A` also committed the repo-wide image recompression that the Compress step performs, meaning the six PRs would conflict with *each other* after the first merge.

## Changes

- **Screenshot PRs now target `develop`**, matching the repo's branching model (main is release-only); the images reach main with the next release like everything else.
- The Compress step runs **before** the branch switch, so the committed screenshots are the compressed ones.
- The PR branch is cut from `origin/develop` (`git checkout -B … origin/develop` after a shallow fetch), with the generated `.wordpress-org/` directory preserved across the switch via a temp copy and a `git reset --hard` to clear incidental compression modifications that would block the branch switch. This also means a run dispatched from any other ref can't leak that ref's commits into the PR.
- The commit is scoped to `git add .wordpress-org` — each PR contains exactly its locale's screenshot diff and nothing else.
- The generated PRs get the **Skip Changelog** label, since the changelog check enforces an entry on every develop-targeted PR.

## After merge

Re-dispatch the workflow, close #1857–#1862 in favor of the clean replacements, and delete their branches plus the stray `fix/wp-org-screenshots-fr_FR-f944f336…` branch from the earlier quoting-bug run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
