### PR TITLE
Fix the create-pull-request working base and image-actions token input

### DIFF
--- a/.github/workflows/wordpress-org-screenshots.yml
+++ b/.github/workflows/wordpress-org-screenshots.yml
@@ -160,6 +160,11 @@ jobs:
       #
       # Because it seems to be a problem to "wait on webServer.command" https://github.com/microsoft/playwright/issues/11811
       # & "it seems that globalSetup runs before webServer is started." https://github.com/microsoft/playwright/issues/11811#issuecomment-1040732201
+      #
+      # No retry here on purpose: this step failing is the SIGNAL that
+      # screenshots changed, which routes into the retry-hardened update
+      # step below. A transient Playground failure takes the same route and
+      # self-corrects there (identical regen produces no diff, so no PR).
       run: |
         npm run playground -- --blueprint=./localized_blueprint.json  & \
         sleep 60 && \
@@ -179,12 +184,26 @@ jobs:
         UPDATE_ALL_SNAPSHOTS: ${{ github.event.inputs.updateAllSnapshots }}
       # Important Documentation about this "run"
       # can be found on the "screenshot-tests" step!
+      #
+      # Playground's blueprint occasionally fails to download the WordPress
+      # core translations from translate.wordpress.org (transient; observed
+      # hitting random locales). Retry the whole playground + screenshots
+      # cycle a few times, killing any leftover playground on port 9400
+      # between attempts.
       run: |
-        npm run playground -- --blueprint=./localized_blueprint.json & \
-        sleep 60 && \
-        echo 'Playground is ready now, lets take some pictures.' && \
-        # DEBUG=pw:api,pw:webserver \
-        npm run screenshots:wporg -- --update-snapshots
+        for attempt in 1 2 3; do
+          npm run playground -- --blueprint=./localized_blueprint.json &
+          sleep 60
+          echo 'Playground is ready now, lets take some pictures.'
+          # For verbose output, prefix the next command with: DEBUG=pw:api,pw:webserver
+          if npm run screenshots:wporg -- --update-snapshots; then
+            exit 0
+          fi
+          echo "Attempt ${attempt} failed; restarting Playground."
+          fuser -k 9400/tcp || true
+          sleep 10
+        done
+        exit 1
 
     - name: Compress Images
       if: ${{ github.event.inputs.updateAllSnapshots || steps.screenshot-tests.outcome == 'failure' }}

--- a/.github/workflows/wordpress-org-screenshots.yml
+++ b/.github/workflows/wordpress-org-screenshots.yml
@@ -191,7 +191,10 @@ jobs:
       id: compress-images
       uses: calibreapp/image-actions@main
       with:
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
+        # The action renamed this input from `githubToken`; the old name is
+        # silently ignored ("Unexpected input(s)") and compression ran
+        # without a token.
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Use the compressOnly option with true value to skip the commit and summary comment.
         compressOnly: true
         # ignorePaths accepts a comma-separated string with globbing support # https://www.npmjs.com/package/glob
@@ -220,8 +223,12 @@ jobs:
         # switch branches over dirty files that differ between the branches.
         git reset --hard HEAD
 
+        # Check out develop itself as the local working base: peter-evans
+        # resolves the current branch as the PR's working base and resets it
+        # to its remote counterpart, so the branch must exist on origin — a
+        # local-only staging branch fails with "unknown revision".
         git fetch --no-tags --depth=1 origin develop
-        git checkout -B screenshots-staging-${{ matrix.locale }} origin/develop
+        git checkout -B develop origin/develop
 
         rm -rf .wordpress-org
         cp -r "${RUNNER_TEMP}/wordpress-org-screenshots" .wordpress-org


### PR DESCRIPTION
The first run after #1870 failed in the create-pull-request step: the action resolves the checked-out branch as the PR's working base and runs `git reset --hard origin/<branch>` on it, so the local-only `screenshots-staging-<locale>` branch died with `fatal: ambiguous argument 'origin/screenshots-staging-fr_FR': unknown revision`. The prepare step now checks out `develop` itself as the working base (it exists on origin), matching the shape the hook-docs workflow runs in.

Also from the same run's log: `calibreapp/image-actions@main` renamed its token input from `githubToken` to `GITHUB_TOKEN` — the old name was warned about as an unexpected input and the action ran without a token. Renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Added in follow-up commit:** the screenshot-update step now retries the Playground + Playwright cycle up to three times. Playground's blueprint intermittently fails downloading WordPress core translations from translate.wordpress.org, and the flake hits random locales (nl_BE and pt_BR in one run, de_DE in the next). The detection step intentionally keeps its single pass — its failure is the signal that screenshots changed, and a transient failure there self-corrects through the retry-hardened update step (identical regen → no diff → no PR).
