### PR TITLE
Install Playwright ffmpeg so e2e retries can record video

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -91,6 +91,16 @@ jobs:
           fi
           "$BIN" --version
 
+      # Playwright records a video on the first retry of a failing test, and
+      # video capture needs Playwright's bundled ffmpeg — which the skipped
+      # browser install would normally provide. Without it, EVERY retry dies
+      # instantly with "Executable doesn't exist at .../ffmpeg-linux", so a
+      # flaky test can never recover. This downloads only ffmpeg (a few MB),
+      # not the browsers, so it doesn't reopen the 2026-05-30 hang above.
+      - name: Install Playwright ffmpeg for retry videos
+        timeout-minutes: 5
+        run: npx playwright install ffmpeg
+
       - name: Build plugin assets
         run: npm run build
 


### PR DESCRIPTION
Spotted while triaging a flaky e2e failure on #1891: the retry never re-ran the test — it crashed instantly with `browserContext.newPage: Executable doesn't exist at /home/runner/.cache/ms-playwright/ffmpeg-1011/ffmpeg-linux`.

Since the e2e workflow switched to the runner's preinstalled Chrome (`channel: 'chrome'`) and stopped running `playwright install`, nothing provides Playwright's bundled ffmpeg. The Gutenberg base config records **video on first retry**, which needs it — so every retry of any failing e2e test dies immediately, and the retry mechanism has been effectively disabled since the switch. Flaky tests that would recover on a second attempt fail the job instead (that's exactly what happened to the datetime-picker test on #1891, which passed on re-run).

Fix: `npx playwright install ffmpeg` — downloads only ffmpeg (a few MB, no browsers), so it doesn't reopen the 2026-05-30 chromium-download hang that motivated the Chrome-channel switch. With it, retries record their videos and can actually retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)