### PR TITLE
Update the configuration guide for the 0.34.0 settings screens

### DIFF
--- a/.github/changelog/1845-configuration-docs-034
+++ b/.github/changelog/1845-configuration-docs-034
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated the configuration guide for the 0.34.0 settings screens.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,18 +2,85 @@
 
 Once activated, GatherPress can be configured from your WordPress dashboard under **Events > Settings**.
 
-## ⚙️ General Settings
+The settings screen is organized into tabs: **Events**, **Venues**, **RSVP**, **Roles**, **Tools**, and **Credits**. Each tab has its own **Save Settings** button, so save before switching tabs.
 
-Customize how GatherPress behaves across your site:
+> [!NOTE]
+> GatherPress requires pretty permalinks. If your site uses Plain permalinks, event pages will not resolve, and **Tools > Site Health** shows a warning until a different permalink structure is selected under **Settings > Permalinks**.
 
-- Use publish date as event date (optional)
-- **RSVP Mode** — choose between All events, Per event (default on), Per event (default off), or Disabled (see [RSVP system](user/rsvp-system.md#rsvp-mode))
-- Default RSVP limit
-- Enable or disable anonymous RSVPs
-- **Open RSVP** — allow visitors to RSVP without a site account using email verification (see [Open RSVP](user/rsvp-system.md#open-rsvp-without-an-account))
-- Date and time formats
-- Display timezone for events
-- Set pages for Upcoming and Past Events listings
+## 🗓️ Events tab
+
+![The Events tab of the GatherPress settings screen.](user/user-doc-media/settings-events-tab.png)
+
+### Date & Time
+
+- **Date Format** and **Time Format** control how event dates and times are displayed, using [WordPress date and time format strings](https://wordpress.org/documentation/article/customize-date-and-time-format/). A live preview appears under each field.
+- **Show Timezone** displays the timezone next to scheduled event times.
+
+### Event Display
+
+- **Publish Date** shows the event date instead of the publish date wherever WordPress would display a post date.
+
+### Archive Pages
+
+- **Event Archive** chooses what the events archive URL displays when no custom page is assigned: **Upcoming Events**, **Past Events**, or **None (return 404)**.
+- **Upcoming Events** and **Past Events** optionally point the corresponding archive at a custom page you have created.
+
+### Permalinks
+
+- **Events** and **Topics** set the permalink bases used in event and topic URLs, with a live preview of the resulting URL.
+
+## 📍 Venues tab
+
+![The Venues tab of the GatherPress settings screen.](user/user-doc-media/settings-venues-tab.png)
+
+### Maps
+
+These settings choose the mapping platform and the defaults applied to newly added venue map blocks. Changing a default does not alter maps already placed in your content.
+
+- **Mapping Platform** selects **OpenStreetMap** (the default, no account needed) or **Google Maps**. Selecting Google Maps reveals a field for your Google Maps API key.
+- **Default Render Mode** chooses between an interactive map and a static map image for new blocks.
+- **Default Zoom Level**, **Default Height**, **Default Width**, **Default Aspect Ratio**, and **Default Scale** set the initial appearance of new venue map blocks. Height and width can be left empty for automatic sizing derived from the aspect ratio.
+
+### Permalinks
+
+- **Venues** sets the permalink base used in venue URLs.
+
+## ✅ RSVP tab
+
+![The RSVP tab of the GatherPress settings screen, with the RSVP Mode field highlighted.](user/user-doc-media/settings-rsvp-tab.png)
+
+### RSVP Defaults
+
+Default RSVP settings for new events; most can be overridden per event.
+
+- **RSVP Mode** controls how RSVP works across your site (see [RSVP system](user/rsvp-system.md#rsvp-mode)):
+  - **All Events**: RSVP is enabled for every event.
+  - **Per event (default on)**: each event gets its own toggle in the editor; new events start with RSVP enabled.
+  - **Per event (default off)**: each event gets its own toggle; new events start with RSVP disabled.
+  - **Disabled**: RSVP is turned off sitewide, and the RSVP blocks and admin screens are hidden.
+- **Open RSVP** allows visitors to RSVP without a site account, using email verification (see [Open RSVP](user/rsvp-system.md#open-rsvp-without-an-account)).
+- **Maximum Attendance Limit** caps the total number of people per event. Set to 0 for no limit.
+- **Maximum Number of Guests** sets how many additional guests each attendee may bring.
+- **Anonymous RSVP** allows users to RSVP without revealing their identity.
+
+### Cleanup
+
+Unverified Open RSVPs can be removed automatically on a schedule.
+
+- **Toggle RSVP Cleanup** enables or disables the automatic cleanup.
+- **Cleanup Frequency** and **Cleanup Interval** control how often the cleanup runs.
+
+## 👥 Roles tab
+
+Assign users to GatherPress roles, such as **Organizer**. Organizers can manage events without needing broader site permissions.
+
+## 🧰 Tools tab
+
+Export your GatherPress settings to a file, or import settings from a previously exported file. Handy for copying a configuration between sites or keeping a backup before making changes.
+
+## 💙 Credits tab
+
+The people who contributed to the GatherPress release you are running.
 
 ## 🗓️ Creating an Event
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ The settings screen is organized into tabs: **Events**, **Venues**, **RSVP**, **
 - **Event Archive** chooses what the events archive URL displays when no custom page is assigned: **Upcoming Events**, **Past Events**, or **None (return 404)**.
 - **Upcoming Events** and **Past Events** optionally point the corresponding archive at a custom page you have created.
 
-### Permalinks
+### Event and topic permalinks
 
 - **Events** and **Topics** set the permalink bases used in event and topic URLs, with a live preview of the resulting URL.
 
@@ -41,7 +41,7 @@ These settings choose the mapping platform and the defaults applied to newly add
 - **Default Render Mode** chooses between an interactive map and a static map image for new blocks.
 - **Default Zoom Level**, **Default Height**, **Default Width**, **Default Aspect Ratio**, and **Default Scale** set the initial appearance of new venue map blocks. Height and width can be left empty for automatic sizing derived from the aspect ratio.
 
-### Permalinks
+### Venue permalink
 
 - **Venues** sets the permalink base used in venue URLs.
 
@@ -54,10 +54,10 @@ These settings choose the mapping platform and the defaults applied to newly add
 Default RSVP settings for new events; most can be overridden per event.
 
 - **RSVP Mode** controls how RSVP works across your site (see [RSVP system](user/rsvp-system.md#rsvp-mode)):
-  - **All Events**: RSVP is enabled for every event.
-  - **Per event (default on)**: each event gets its own toggle in the editor; new events start with RSVP enabled.
-  - **Per event (default off)**: each event gets its own toggle; new events start with RSVP disabled.
-  - **Disabled**: RSVP is turned off sitewide, and the RSVP blocks and admin screens are hidden.
+    - **All Events**: RSVP is enabled for every event.
+    - **Per event (default on)**: each event gets its own toggle in the editor; new events start with RSVP enabled.
+    - **Per event (default off)**: each event gets its own toggle; new events start with RSVP disabled.
+    - **Disabled**: RSVP is turned off sitewide, and the RSVP blocks and admin screens are hidden.
 - **Open RSVP** allows visitors to RSVP without a site account, using email verification (see [Open RSVP](user/rsvp-system.md#open-rsvp-without-an-account)).
 - **Maximum Attendance Limit** caps the total number of people per event. Set to 0 for no limit.
 - **Maximum Number of Guests** sets how many additional guests each attendee may bring.


### PR DESCRIPTION
Fixes #1845.

The configuration guide (`docs/configuration.md`) still described the single "General Settings" screen from 0.33. This rewrites it for the 0.34.0 tabbed layout:

- **Tab structure**: Events, Venues, RSVP, Roles, Tools, Credits — each documented section-by-section against the actual 0.34.0 UI.
- **New RSVP tab coverage**: RSVP Mode (All Events / Per event default on / Per event default off / Disabled) with per-value behavior, Open RSVP, attendance and guest limits, anonymous RSVP, and the unverified-RSVP cleanup schedule — cross-linked to the RSVP system doc.
- **New Venues tab coverage**: mapping platform (OpenStreetMap or Google Maps, with the API key field noted), and the default render mode / zoom / dimensions / aspect ratio / scale applied to new venue map blocks.
- **Events tab**: date/time formats, event-vs-publish date display, the archive default view (including "None (return 404)"), custom archive pages, and permalink bases.
- **Site Health note**: the 0.34.0 plain-permalinks warning, called out up top since events don't resolve without pretty permalinks.

The three settings-tab images are the **generated** screenshots from the docs screenshot suite (#1891) — `settings-events-tab.png`, `settings-rsvp-tab.png` (with the RSVP Mode field highlighted via the new helper), `settings-venues-tab.png` — so this page's imagery regenerates with the UI from now on.

Content cross-checked against `docs/developer/settings/README.md` (the source of truth per the issue) and the live 0.34.0 screens; the Venues tab documents the map-block defaults that exist in the UI beyond the developer table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)