### PR TITLE
Start 0.34.0 Beta 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ or the assembly in classes/class-cli.php, then regenerate.
 
 **GatherPress is a flexible, community-powered event management plugin for WordPress.**
 
-[![Try it in WordPress Playground](https://img.shields.io/badge/Try_it-in_WordPress_Playground-blue?logo=wordpress&logoColor=%23fff&labelColor=%233858e9&color=%233858e9)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/GatherPress/gatherpress/main/.wordpress-org/blueprints/blueprint-nightly.json) ![Version](https://img.shields.io/static/v1?label=version&message=0.34.0-beta.1&color=blue)
+[![Try it in WordPress Playground](https://img.shields.io/badge/Try_it-in_WordPress_Playground-blue?logo=wordpress&logoColor=%23fff&labelColor=%233858e9&color=%233858e9)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/GatherPress/gatherpress/develop/.wordpress-org/blueprints/blueprint-nightly.json) ![Version](https://img.shields.io/static/v1?label=version&message=0.34.0-beta.2&color=blue)
 
 [![GPLv2 License](https://img.shields.io/github/license/GatherPress/gatherpress)](https://github.com/GatherPress/gatherpress/blob/main/LICENSE) [![Coding Standards](https://github.com/GatherPress/gatherpress/actions/workflows/coding-standards.yml/badge.svg)](https://github.com/GatherPress/gatherpress/actions/workflows/coding-standards.yml) [![PHPUnit Tests](https://github.com/GatherPress/gatherpress/actions/workflows/phpunit-tests.yml/badge.svg)](https://github.com/GatherPress/gatherpress/actions/workflows/phpunit-tests.yml) [![JavaScript Unit Tests](https://github.com/GatherPress/gatherpress/actions/workflows/jest-tests.yml/badge.svg)](https://github.com/GatherPress/gatherpress/actions/workflows/jest-tests.yml) [![E2E Tests](https://github.com/GatherPress/gatherpress/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/GatherPress/gatherpress/actions/workflows/e2e-tests.yml)
 
@@ -40,7 +40,7 @@ or the assembly in classes/class-cli.php, then regenerate.
 
 ### Try it instantly
 
-Use the [Playground Environment](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/GatherPress/gatherpress/main/.wordpress-org/blueprints/blueprint-nightly.json) to test the latest GatherPress nightly build with real data -- no setup required.
+Use the [Playground Environment](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/GatherPress/gatherpress/develop/.wordpress-org/blueprints/blueprint-nightly.json) to test the latest GatherPress nightly build with real data -- no setup required.
 
 [Watch the intro demo](https://gatherpress.org/demovideo) | [Learn more about Playground](https://github.com/GatherPress/gatherpress/blob/main/docs/playground.md)
 

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -5,7 +5,7 @@
  * Description:       Powering Communities with WordPress.
  * Author:            The GatherPress Community
  * Author URI:        https://gatherpress.org/
- * Version:           0.34.0-beta.1
+ * Version:           0.34.0-beta.2
  * Requires PHP:      7.4
  * Requires at least: 6.7
  * Text Domain:       gatherpress

--- a/includes/data/credits.php
+++ b/includes/data/credits.php
@@ -4,7 +4,7 @@
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 return array (
-  'version' => '0.34.0-beta.1',
+  'version' => '0.34.0-beta.2',
   'project-leaders' => 
   array (
     0 => 
@@ -219,6 +219,19 @@ return array (
         24 => '//www.gravatar.com/avatar/fa01ba22f1911653a65d50ccb265ba5d?s=24&#038;r=g&#038;d=mm',
         48 => '//www.gravatar.com/avatar/fa01ba22f1911653a65d50ccb265ba5d?s=48&#038;r=g&#038;d=mm',
         96 => '//www.gravatar.com/avatar/fa01ba22f1911653a65d50ccb265ba5d?s=96&#038;r=g&#038;d=mm',
+      ),
+    ),
+    5 => 
+    array (
+      'id' => 13804324,
+      'name' => 'Vineet Talwar',
+      'link' => 'https://profiles.wordpress.org/vineettalwar/',
+      'slug' => 'vineettalwar',
+      'avatar_urls' => 
+      array (
+        24 => '//www.gravatar.com/avatar/80b2864ad2ab0b704caee3c1495cf0ba?s=24&#038;r=g&#038;d=mm',
+        48 => '//www.gravatar.com/avatar/80b2864ad2ab0b704caee3c1495cf0ba?s=48&#038;r=g&#038;d=mm',
+        96 => '//www.gravatar.com/avatar/80b2864ad2ab0b704caee3c1495cf0ba?s=96&#038;r=g&#038;d=mm',
       ),
     ),
   ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gatherpress",
-	"version": "0.34.0-beta.1",
+	"version": "0.34.0-beta.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gatherpress",
-			"version": "0.34.0-beta.1",
+			"version": "0.34.0-beta.2",
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gatherpress",
-	"version": "0.34.0-beta.1",
+	"version": "0.34.0-beta.2",
 	"description": "Powering Communities with WordPress",
 	"author": "",
 	"license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mauteri, patricia70, hrmervin, jmarx75, stephenerdelyi, carstenbach, jordanpak, mahimadave, tusharaddweb, pkbhatt, supernovia
 Tags: events, event, meetup, community
 Tested up to: 7.0
-Stable tag: 0.34.0-beta.1
+Stable tag: 0.34.0-beta.2
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Prepares the 0.34.0-beta.2 prerelease. Generated with `wp gatherpress develop generate_version --version=0.34.0-beta.2` plus the host-side `npm i --package-lock-only` refresh:

- Version bump: `gatherpress.php` header, `package.json` + `package-lock.json`, `readme.txt` stable tag, README version badge.
- Regenerated `includes/data/credits.php`, adding **vineettalwar** to contributors (#1743 merged before the beta.1 tag but was missed in its credits, same correction pattern as #1809).
- README's Playground link now points at the develop nightly blueprint (upstream template fix in gatherpress-develop riding along).
- SECURITY.md unchanged (already reflects 0.34.x).

Companion PRs: version sync in gatherpress-alpha and the credits data entry in gatherpress-develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)