### PR TITLE
Remove shipped features from the roadmap ideas section

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,7 +16,4 @@ These are the upcoming features we're actively developing or planning for future
 ## Ideas Under Exploration
 
 - Custom RSVP fields (e.g., dietary preferences, accessibility needs)
-- Email verification + token expiration for Open RSVPs
 - Role-based permissions for blocks and RSVP features
-- Frontend RSVP submission forms
-- Calendar integration (iCal/ICS feeds, Google/Yahoo Calendar support)


### PR DESCRIPTION
Fixes #1899.

The issue asks to remove **calendar integration (iCal/ICS feeds)** from the ideas section, since it shipped. While verifying, two more listed ideas turned out to have shipped in the 0.34.0 cycle as well, so they're removed in the same pass:

- **Calendar integration (iCal/ICS feeds, Google/Yahoo Calendar support)** — the add-to-calendar block, `.ics` downloads, and event feeds.
- **Frontend RSVP submission forms** — the `rsvp-form` block.
- **Email verification + token expiration for Open RSVPs** — the `enable_open_rsvp` setting (email verification) plus the scheduled cleanup of unverified RSVPs.

Kept, since they haven't shipped as described: **custom RSVP fields** (the generic form-field block exists, but purpose-built RSVP fields like dietary/accessibility preferences don't) and **role-based permissions for blocks and RSVP features** (the Roles tab covers organizer assignment, not block/feature permissions). Happy to trim further if either of those is considered covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)