### PR TITLE
Add GDPR steps for event update emails to privacy.md

### DIFF
--- a/.github/changelog/1897-gdpr-privacy-docs
+++ b/.github/changelog/1897-gdpr-privacy-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Documented the GDPR opt-in steps for event update emails in the privacy docs.

--- a/docs/user/privacy.md
+++ b/docs/user/privacy.md
@@ -16,6 +16,22 @@ With the help of contributors this prepared text may even be already translated 
 
 Go to `Settings > Privacy > Policy Guide` to find a new '*GatherPress*' dropdown in the 'Policies' list
 
+## Event update emails and GDPR consent
+
+GatherPress can [email members about event updates](./emails.md). Out of the box, every user is treated as **opted in** to these emails until they uncheck "*Yes, I want to receive updates and information about events from the organizers.*" in the **Notifications** section of their user profile.
+
+The GDPR — the European Union's privacy regulation, known in Germany as the DSGVO — requires affirmative consent for this kind of communication. An opt-out default generally does not qualify, so if your site operates under the GDPR or a similar privacy law, you should flip the default so users are **opted out** until they actively opt in:
+
+```php
+add_filter( 'gatherpress_event_updates_default_opt_in', static function () {
+    return '0';
+} );
+```
+
+Drop the snippet into a must-use plugin, a site-specific plugin, or your theme's `functions.php`.
+
+The filter only controls the default for users who have never touched the setting — anyone who has explicitly saved a preference in their profile keeps it. See the [`gatherpress_event_updates_default_opt_in`](../developer/hooks/gatherpress_event_updates_default_opt_in.md) hook reference for details.
+
 ## Redacting RSVP IP addresses and user agents
 
 RSVPs are stored as WordPress comments, so the visitor's IP address and browser user agent are recorded by default. To help comply with GDPR/DSGVO or other privacy regulations, you can redact this information with the same WordPress-native filters that apply to regular comments:

--- a/includes/core/classes/class-user.php
+++ b/includes/core/classes/class-user.php
@@ -165,8 +165,8 @@ class User {
 			 * Filters the default state of the event updates opt-in.
 			 *
 			 * This filter allows modification of the default opt-in state for compliance
-			 * with regional privacy laws (e.g., GDPR in Germany) that may require
-			 * opt-in consent to be unchecked by default.
+			 * with privacy laws such as the European Union's GDPR (known in Germany
+			 * as the DSGVO) that may require opt-in consent to be unchecked by default.
 			 *
 			 * @since 0.28.0
 			 *


### PR DESCRIPTION
Fixes #1897

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add an "Event update emails and GDPR consent" section to `docs/user/privacy.md`:
    * Explains that every user is treated as opted in to event update emails until they uncheck the setting in the Notifications section of their profile.
    * Explains that the GDPR requires affirmative consent, with the `gatherpress_event_updates_default_opt_in` filter snippet to flip the default to opted out.
    * Notes that explicitly saved user preferences always win over the filtered default, and links to the hook reference.
* Correct the filter's docblock in `includes/core/classes/class-user.php`, which described GDPR as a German law ("GDPR in Germany"). GDPR is European Union law; the German pendant is the DSGVO. The change is made in the PHP docblock rather than `docs/developer/hooks/` since that folder is regenerated from docblocks by CI.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? *(Not applicable — docs and a docblock comment only, no behavior change.)*

## Testing instructions:

* Read `docs/user/privacy.md` and confirm the new section accurately describes the opt-in default and the filter.
* Optionally verify the default behavior: on a fresh user, `Users > Profile` shows the "Yes, I want to receive updates…" checkbox checked; with the documented filter snippet active, it shows unchecked.
* Confirm the docblock over the `gatherpress_event_updates_default_opt_in` filter in `includes/core/classes/class-user.php` no longer calls GDPR a German law.

### Credit (for release notes)

My WordPress.org username:

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

*Changelog entry already committed to the branch (`.github/changelog/1897-gdpr-privacy-docs`).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)