### PR TITLE
Add user docs for subscribable calendar feeds

### DIFF
--- a/.github/changelog/1848-calendar-feeds-user-docs
+++ b/.github/changelog/1848-calendar-feeds-user-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added user documentation for the subscribable iCal calendar feeds.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -17,6 +17,7 @@
 * [Topics](./topics.md)
 * [RSVP system](./rsvp-system.md)
 * [Emails](./emails.md)
+* [Calendar feeds](./calendar-feeds.md)
 * [Venues](./venues.md)
 * [Blocks](./blocks/README.md)
 * [User roles and permissions](./user-roles-and-permissions.md)

--- a/docs/user/blocks/README.md
+++ b/docs/user/blocks/README.md
@@ -8,7 +8,7 @@ Event List (will be deprecated in the next version, 0.34)
 
 [RSVP Response and its inner blocks](./rsvp-response-and-inner-blocks.md) (RSVP Response Toggle, Avatar Display Name, RSVP Guest Count Display, etc)
 
-Add to Calendar: Allows a user to add an event to their preferred calendar application.
+Add to Calendar: Allows a user to add an event to their preferred calendar application. This saves a one-time copy of the event; for live, auto-updating subscriptions by venue, topic, or site, see [Calendar feeds](../calendar-feeds.md).
 
 ## Other blocks used in an event
 

--- a/docs/user/calendar-feeds.md
+++ b/docs/user/calendar-feeds.md
@@ -1,0 +1,48 @@
+# Calendar feeds
+
+Subscribe once, never miss an event.
+
+GatherPress publishes subscribable calendar feeds in the widely supported iCalendar (`.ics`) format. Attendees can follow a venue, a topic, or all of a site's events in their own calendar app, and the calendar stays up to date automatically — new events appear, and changes to dates, times, or venues flow through without anyone having to download anything again.
+
+## Download once vs. subscribe
+
+There are two ways to get GatherPress events into a calendar app, and they behave differently:
+
+* **Add to Calendar** (the [block](./blocks/README.md) on a single event) saves a *one-time snapshot* of that event, or hands it off to Google Calendar or Yahoo Calendar. If the event is rescheduled afterwards, the entry in the attendee's calendar does not update.
+* **Calendar feeds** (this page) are a *live subscription*. The calendar app checks the feed URL periodically and keeps every event in it current.
+
+If someone cares about one event, the Add to Calendar block is enough. If they care about your community, hand them a feed.
+
+## Available feeds
+
+Each feed is a URL that can be pasted into any calendar app that supports iCalendar subscriptions:
+
+| Feed | URL |
+| --- | --- |
+| All events on the site | `example.org/feed/ical` |
+| The events archive | `example.org/event/feed/ical` |
+| Events at one venue | `example.org/venue/my-venue/feed/ical` |
+| Events in one topic | `example.org/topic/my-topic/feed/ical` |
+
+Replace `example.org` with your site address, and `my-venue` / `my-topic` with the slug of the venue or topic — the same slug that appears in the venue's or topic's own web address. If you have customized the event, venue, or topic permalink bases in the GatherPress settings, the feed URLs follow your custom slugs.
+
+So a community site could offer, for example:
+
+* "Follow everything we do" → `example.org/feed/ical`
+* "Only interested in our meetups at the library?" → `example.org/venue/city-library/feed/ical`
+* "Just the workshops, please" → `example.org/topic/workshops/feed/ical`
+
+## Subscribing in common calendar apps
+
+* **Google Calendar:** `Other calendars > + > From URL`, then paste the feed URL.
+* **Apple Calendar:** `File > New Calendar Subscription…`, then paste the feed URL.
+* **Outlook:** `Add calendar > Subscribe from web`, then paste the feed URL.
+* **Thunderbird:** `New Calendar > On the Network`, then paste the feed URL.
+
+## Automatic discovery
+
+The feeds are also advertised in the site's HTML (as `<link rel="alternate">` tags), so calendar-aware browsers, apps, and services can find the right feed on their own. Visiting a venue page advertises that venue's feed, a topic page advertises that topic's feed, and so on — often subscribing is as simple as pointing a calendar app at the page URL itself.
+
+## For developers
+
+The feeds are built on GatherPress' custom URL endpoint API, which companion plugins can use to register their own endpoints for any post type or taxonomy. See [Custom URL Endpoints](../developer/custom-url-endpoints/README.md) for the technical details.

--- a/docs/user/creating-and-managing-events.md
+++ b/docs/user/creating-and-managing-events.md
@@ -84,5 +84,7 @@ When publishing or updating an event:
 * Existing RSVPs are preserved when editing events.
 * A Compose message prompt appears at the top of the event to invite you to inform users, see [more on Emails](./emails.md)
 
+Published events automatically appear in the site's subscribable [calendar feeds](./calendar-feeds.md), so attendees following a venue, topic, or the whole site see new and updated events in their own calendar apps.
+
 
 


### PR DESCRIPTION
Fixes #1848

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `docs/user/calendar-feeds.md`, user-facing documentation for the subscribable iCal feeds that shipped in 0.34.0:
    * Leads with the attendee benefit ("subscribe once, never miss an event") and explains the difference between the one-time Add to Calendar download and a live subscription.
    * Lists the four feed URLs (site-wide `/feed/ical`, event archive `/event/feed/ical`, per-venue `/venue/{slug}/feed/ical`, per-topic `/topic/{slug}/feed/ical`), matching `docs/developer/custom-url-endpoints/`, with a note that customized permalink bases carry through.
    * Gives paste-the-URL subscribe steps for Google Calendar, Apple Calendar, Outlook, and Thunderbird.
    * Notes the `<link rel="alternate">` auto-discovery so calendar-aware apps can find feeds from a page URL alone.
    * Points developers at the custom URL endpoint API docs.
* Cross-references: user docs TOC (`docs/user/README.md`), the Add to Calendar entry in `docs/user/blocks/README.md`, and a note in `docs/user/creating-and-managing-events.md` that published events flow into the feeds automatically.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? *(Not applicable — docs only.)*

## Testing instructions:

* Read `docs/user/calendar-feeds.md` and check the framing and app instructions.
* On a site running 0.34.0 with pretty permalinks, verify each documented URL responds with an iCal payload: `/feed/ical`, `/event/feed/ical`, `/venue/{existing-venue-slug}/feed/ical`, `/topic/{existing-topic-slug}/feed/ical`.
* View source on a venue or topic page and confirm the `<link rel="alternate">` tags advertise the corresponding feed.
* Follow the cross-links from `docs/user/README.md`, `docs/user/blocks/README.md`, and `docs/user/creating-and-managing-events.md`.

### Credit (for release notes)

My WordPress.org username:

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

*Changelog entry already committed to the branch (`.github/changelog/1848-calendar-feeds-user-docs`).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)