### PR TITLE
Update features.md for 0.34.0

### DIFF
--- a/.github/changelog/1847-features-docs-034
+++ b/.github/changelog/1847-features-docs-034
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated the features list and static-map docs for 0.34.0.

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,17 +6,23 @@ GatherPress includes a growing list of features to help communities organize and
 
 - **Event scheduling**: Set dates, times, and detailed event information.
 - **Attendee registration**: Let users RSVP to events.
-- **Open RSVP support**: Allow non-logged-in users to RSVP to events.
+- **Configurable RSVP Mode**: Control RSVP sitewide with four modes — enabled for all events, per event (default on), per event (default off), or disabled entirely — with a per-event override toggle in the editor.
+- **Open RSVP support**: Allow non-logged-in users to RSVP to events, with a sitewide on/off control.
 - **Guest support**: Allow attendees to include additional guests.
 - **Anonymous RSVPs**: Optionally list attendees as anonymous (only visible to admins).
 - **Email notifications**: Send emails to all members, event attendees, non-attendees, or those on the waitlist.
+- **Subscribable calendar feeds**: Attendees can subscribe to a live, auto-updating calendar feed for a venue, a topic, the events archive, or the whole site — distinct from the one-time "Add to Calendar" download. See [Calendar feeds](./user/calendar-feeds.md).
 - **Online and in-person events**: Add venues with maps or online meeting links.
-- **Mapping**: Supports OpenStreetMap (via Leaflet) and Google Maps.
+- **Mapping**: Supports OpenStreetMap (via Leaflet) and Google Maps, rendered as interactive maps or as static map images.
+- **Static venue maps**: A server-rendered map image option alongside the interactive map — it loads faster and works without JavaScript.
+- **Venue address autocomplete**: The venue address field suggests real addresses as you type, powered by open geocoding.
 - **Multiple event management**: Handle multiple upcoming or past events simultaneously.
 - **Multisite-ready**: Centralized plugin support for networks, while allowing each site its own settings.
+- **Network-wide settings**: Multisite administrators can set GatherPress options once at the network level, with per-option control over what individual sites inherit.
 - **Block editor compatible**: Create and customize events using WordPress blocks.
 - **Internationalized**: Fully translatable and ready for global use.
 - **Layout flexibility**: Add or remove blocks as needed, or include synced patterns for reusable content across events.
+- **Extensible for developers**: Attach event capabilities (dates, RSVPs, venues) to your own post types via [post type supports](./developer/post-type-supports/README.md), and register [custom URL endpoints](./developer/custom-url-endpoints/README.md) with the same primitives that power the calendar feeds.
 
 ## In Development
 

--- a/docs/user/venues.md
+++ b/docs/user/venues.md
@@ -83,6 +83,16 @@ Changing a default only affects blocks added afterwards — existing blocks keep
 
 Static images regenerate automatically when any input the image depends on changes — venue address, coordinates, zoom level, or block height. Each `(zoom, height)` combination is cached separately, so two events showing the same venue at different sizes each get a crisp PNG. Old images are cleaned up when the venue is updated or deleted.
 
+### Disabling static map generation
+
+GatherPress pre-generates static map images in the background so they are ready before a visitor asks for one. If your site only uses interactive maps, those generated files are wasted disk space and server work — in that case it is best to switch the pre-generation off:
+
+```php
+add_filter( 'gatherpress_static_map_prewarm_pre_enqueue_job', '__return_false' );
+```
+
+Drop the snippet into a must-use plugin, a site-specific plugin, or your theme's `functions.php`. Any Venue Map block actually set to the static render mode still generates its image on demand; the filter only stops the speculative background generation.
+
 ### Privacy of static map URLs
 
 Because static maps live under `wp-content/uploads/gatherpress/static-maps/`, anyone with the direct URL can fetch one — the same is true of any image in your uploads directory. To keep those URLs from being guessable, each filename includes a random per-venue salt generated the first time a map is rendered; two different venues at the same address produce different filenames. If you need stronger isolation (for example, venues whose coordinates should stay hidden until the event is public), restrict access to the static-maps subdirectory with an `.htaccess` or Nginx rule, or keep the venue unpublished until you're ready.


### PR DESCRIPTION
Fixes #1847

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update `docs/features.md` for 0.34.0:
    * **Configurable RSVP Mode** — four sitewide modes plus the per-event override toggle. Framed as more control over RSVP; Open RSVP itself stays listed as the existing 0.33.0 feature, now noting the sitewide on/off control.
    * **Subscribable calendar feeds** — live, auto-updating feeds by venue, topic, event archive, or site-wide, distinguished from the one-time "Add to Calendar" download, linking to the new calendar feeds user doc.
    * **Static venue maps** — server-rendered image option alongside the interactive map; the existing **Mapping** entry is expanded to mention both render modes.
    * **Venue address autocomplete** — address suggestions while typing, powered by open geocoding.
    * **Network-wide settings** — network-level options with per-option inheritance, alongside the existing multisite bullet.
    * **Extensible for developers** — post type supports and the custom URL endpoint API (the primitive behind the calendar feeds), linking to both developer docs, per @carstingaxion's comment on the issue.
* Add a "Disabling static map generation" section to `docs/user/venues.md` with the `gatherpress_static_map_prewarm_pre_enqueue_job` snippet, also per @carstingaxion's comment — pre-generation runs for every venue-map block regardless of render mode, so sites using only interactive maps can and should switch it off. Blocks actually set to static render mode still generate their image on demand.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? *(Not applicable — docs only.)*
- The link to `docs/user/calendar-feeds.md` resolves once #1910 merges; merge that PR first (or together with this one).
- Per the issue comments, the README feature list is generated from the GatherPress/gatherpress-develop repo and needs a matching update there — that is out of scope for this PR and tracked as a follow-up.

## Testing instructions:

* Read `docs/features.md` and confirm each new bullet matches shipped 0.34.0 behavior (RSVP Mode names match the settings UI: All Events / Per event default on / Per event default off / Disabled).
* Confirm the developer links (`docs/developer/post-type-supports/`, `docs/developer/custom-url-endpoints/`) resolve.
* For the venues.md addition: with the filter snippet active, saving a venue or event no longer schedules `gatherpress_static_map_prewarm_run` cron jobs, while a Venue Map block set to the static render mode still produces its image on first render.

### Credit (for release notes)

My WordPress.org username:

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

*Changelog entry already committed to the branch (`.github/changelog/1847-features-docs-034`).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)