### PR TITLE
Exclude .gatherpress-org from the PR coverage gate

### DIFF
--- a/.github/coverage-config.json
+++ b/.github/coverage-config.json
@@ -19,6 +19,7 @@
     "*/e2e/*",
     "*/endpoints/*",
     ".github/**",
+    ".gatherpress-org/**",
     "includes/data/*",
     "src/index.js",
     "src/editor.js",


### PR DESCRIPTION
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `".gatherpress-org/**"` to `excludePatterns` in `.github/coverage-config.json`, mirroring the existing `.github/**` exclusion.

`.gatherpress-org/playground-preview/plugin-proxy.php` is a standalone CORS proxy deployed to gatherpress.org for the Playground PR-preview system — it is never loaded by the plugin (zero references from `includes/` or `src/`) and sits outside PHPUnit's include-only coverage scope (`includes/core/classes`), so it can never have coverage data.

**Why it only surfaced now:** the coverage workflow's `paths:` trigger doesn't include `.gatherpress-org/`, so the PRs that touched the proxy (#1720, #1852) never triggered the workflow. But once the workflow runs for any other reason, the check script sweeps **every** changed `.php` file in the diff. Release PR #1917 (develop → main) is the first PR whose diff both contains the proxy and touches trigger paths — the gate flagged `plugin-proxy.php - No coverage data found` and failed, while all 76 other changed PHP files passed at 100% and the full test suites were green. This aligns the script-level exclusions with the trigger filter's existing treatment of `.gatherpress-org/` as non-plugin infrastructure.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? *(Not applicable — CI config; the file is untestable infrastructure by design.)*
- `.github/scripts/validate-coverage-config.php` passes with the new pattern (exit 0; the "missing in sonar-project.properties" line is a warning that also applies to the existing `.github/**` pattern).

## Testing instructions:

* After this merges, update `version-0.34.0` (merge develop into it) — the coverage check on #1917 should re-run and pass.
* Sanity check: a PR touching `includes/**` plus a `.gatherpress-org/*.php` file no longer fails on the proxy file.

### Credit (for release notes)

My WordPress.org username:

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

*Carries the "Skip Changelog" label — CI configuration only.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)