### PR TITLE
Auto-credit merged-PR contributors via props-bot

### DIFF
--- a/.github/scripts/release/README.md
+++ b/.github/scripts/release/README.md
@@ -15,6 +15,7 @@ The full release runbook lives at
 | --- | --- |
 | `generate-version.php` | The version bump: regenerates credits, patches version strings in place. |
 | `credits/<version>.json` | **Source of truth** for per-version credits, one file per version (full history). Hand-edited. |
+| `credits/unreleased.json` | Staging file for the Credits Sync automation (#1828): contributors accumulate here as PRs merge, and the next version bump folds them into the release's credits file. |
 
 ## What is generated vs hand-edited
 

--- a/.github/scripts/release/credits/unreleased.json
+++ b/.github/scripts/release/credits/unreleased.json
@@ -1,0 +1,3 @@
+{
+    "contributors": []
+}

--- a/.github/scripts/release/generate-version.php
+++ b/.github/scripts/release/generate-version.php
@@ -106,6 +106,63 @@ function fetch_wporg_profile( $username ) {
 }
 
 /**
+ * Fold pending credits/unreleased.json contributors into the version entry.
+ *
+ * The credits-sync automation (#1828) accumulates newly-merged contributors
+ * in credits/unreleased.json between releases. At bump time they move into
+ * the target version's file (which stays the source of truth) and the
+ * staging file is emptied — both writes land in the version-bump commit.
+ *
+ * @param array  $entry        The decoded credits entry for the version.
+ * @param string $credits_file Absolute path to the version's credits file.
+ * @param string $version      The plugin version (for messages).
+ * @return array The entry with pending contributors folded in.
+ */
+function fold_unreleased_credits( $entry, $credits_file, $version ) {
+	$unreleased_file = SCRIPT_ROOT . '/credits/unreleased.json';
+
+	if ( ! file_exists( $unreleased_file ) ) {
+		return $entry;
+	}
+
+	$unreleased = json_decode( file_get_contents( $unreleased_file ), true );
+	$pending    = isset( $unreleased['contributors'] ) && is_array( $unreleased['contributors'] )
+		? $unreleased['contributors']
+		: array();
+
+	// Already-credited people (any group) don't get re-added.
+	$credited = array_merge(
+		isset( $entry['leads'] ) ? $entry['leads'] : array(),
+		isset( $entry['team'] ) ? $entry['team'] : array(),
+		isset( $entry['contributors'] ) ? $entry['contributors'] : array()
+	);
+	$new      = array_values( array_diff( array_unique( $pending ), $credited ) );
+
+	if ( empty( $new ) ) {
+		return $entry;
+	}
+
+	$entry['contributors'] = array_merge(
+		isset( $entry['contributors'] ) ? $entry['contributors'] : array(),
+		$new
+	);
+
+	$json_flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
+
+	if ( file_put_contents( $credits_file, json_encode( $entry, $json_flags ) . "\n" ) === false ) {
+		fail( "Failed to fold unreleased contributors into credits/{$version}.json." );
+	}
+
+	if ( file_put_contents( $unreleased_file, json_encode( array( 'contributors' => array() ), $json_flags ) . "\n" ) === false ) {
+		fail( 'Failed to reset credits/unreleased.json.' );
+	}
+
+	success( 'Folded ' . count( $new ) . " unreleased contributor(s) into credits/{$version}.json: " . implode( ', ', $new ) . '.' );
+
+	return $entry;
+}
+
+/**
  * Generate includes/data/credits.php from the source credits entry.
  *
  * @param string $version The plugin version.
@@ -125,6 +182,8 @@ function generate_credits( $version ) {
 	if ( ! is_array( $entry ) ) {
 		fail( "credits/{$version}.json is not valid JSON." );
 	}
+
+	$entry = fold_unreleased_credits( $entry, $credits_file, $version );
 
 	$data['version'] = $version;
 	$contributors    = array();

--- a/.github/workflows/credits-sync.yml
+++ b/.github/workflows/credits-sync.yml
@@ -1,0 +1,167 @@
+name: Credits Sync
+
+# Auto-credit merged-PR contributors (#1828).
+#
+# When a PR into develop merges, the props-bot comment on it already resolves
+# every participant to a wp.org username (the hard part). This workflow takes
+# those usernames, drops anyone already credited for the current cycle, and
+# appends the rest to .github/scripts/release/credits/unreleased.json on a
+# fixed branch via a standing, auto-merging PR. At the next version bump,
+# `npm run version:bump` folds unreleased.json into the new version's credits
+# file and empties it.
+#
+# Design notes:
+# - The commit is created through the GraphQL API (createCommitOnBranch), so
+#   it is signed by GitHub and satisfies develop's signed-commit protection —
+#   that's what lets the standing PR auto-merge with no human step.
+# - Membership is checked against the newest credits file (leads + team +
+#   contributors) plus any pending entries already on the standing branch, so
+#   double-crediting can't happen even while the standing PR is open.
+# - Leads and team stay hand-curated; this only ever appends to the
+#   contributors long tail via unreleased.json.
+# - Contributors props-bot can't resolve (no GitHub link on their wp.org
+#   profile) are skipped with a log line — see docs/contributing.md for the
+#   manual fallback.
+#
+# Security: pull_request_target grants a write token, so this workflow never
+# checks out or executes code from the PR head — it checks out develop and
+# only reads PR metadata/comments via the API. Parsed usernames are
+# charset-validated before they touch a file.
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - develop
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: credits-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Credit merged-PR contributors
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Collect new contributors and update the standing PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SYNC_BRANCH: credits/unreleased-sync
+          UNRELEASED_PATH: .github/scripts/release/credits/unreleased.json
+        run: |
+          set -euo pipefail
+
+          # 1. Parse the props-bot comment for resolved wp.org usernames.
+          props_line=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]") | .body] | join("\n")' \
+            | grep -E '^Props .+\.$' | head -1 || true)
+
+          if [[ -z "${props_line}" ]]; then
+            echo "::notice::No props-bot props line found on PR #${PR_NUMBER}; nothing to credit."
+            exit 0
+          fi
+
+          echo "${props_line}" | sed 's/^Props //; s/\.$//' | tr ',' '\n' | tr -d ' ' \
+            | grep -E '^[a-z0-9._-]+$' | grep -v -- '-bot$' | sort -u > /tmp/props.txt
+
+          if [[ ! -s /tmp/props.txt ]]; then
+            echo "::notice::Props line contained no valid usernames; nothing to credit."
+            exit 0
+          fi
+          echo "Props usernames: $(paste -sd, /tmp/props.txt)"
+
+          # 2. Base state: if the standing branch exists, its unreleased.json
+          # (with pending, not-yet-merged additions) is the base; otherwise
+          # develop's copy is.
+          if gh api "repos/${REPO}/git/ref/heads/${SYNC_BRANCH}" > /dev/null 2>&1; then
+            branch_exists=1
+            gh api "repos/${REPO}/contents/${UNRELEASED_PATH}?ref=${SYNC_BRANCH}" \
+              --jq .content | base64 -d > /tmp/unreleased.json
+          else
+            branch_exists=0
+            cp "${UNRELEASED_PATH}" /tmp/unreleased.json
+          fi
+
+          # 3. Membership: newest version file's full roster + pending entries.
+          newest=$(ls .github/scripts/release/credits/*.json | grep -v unreleased | sort -V | tail -1)
+          echo "Roster source: ${newest}"
+          jq -r '[(.leads // [])[], (.team // [])[], (.contributors // [])[]] | .[]' "${newest}" > /tmp/roster.txt
+          jq -r '(.contributors // [])[]' /tmp/unreleased.json >> /tmp/roster.txt
+          sort -u /tmp/roster.txt -o /tmp/roster.txt
+
+          new_contributors=$(comm -23 /tmp/props.txt /tmp/roster.txt || true)
+
+          if [[ -z "${new_contributors}" ]]; then
+            echo "::notice::Everyone on PR #${PR_NUMBER} is already credited for this cycle."
+            exit 0
+          fi
+          echo "New contributors: $(echo "${new_contributors}" | paste -sd, -)"
+
+          # 4. Append and write the updated staging file.
+          jq --argjson add "$(echo "${new_contributors}" | jq -R . | jq -s .)" \
+            '.contributors = ((.contributors // []) + $add | unique)' \
+            /tmp/unreleased.json > /tmp/unreleased.new.json
+          printf '%s\n' "$(jq --indent 4 . /tmp/unreleased.new.json)" > /tmp/unreleased.final.json
+
+          # 5. Ensure the standing branch exists (created from develop's head).
+          develop_sha=$(gh api "repos/${REPO}/git/ref/heads/develop" --jq .object.sha)
+
+          if [[ "${branch_exists}" == "0" ]]; then
+            gh api "repos/${REPO}/git/refs" \
+              -f ref="refs/heads/${SYNC_BRANCH}" -f sha="${develop_sha}" > /dev/null
+            head_sha="${develop_sha}"
+          else
+            head_sha=$(gh api "repos/${REPO}/git/ref/heads/${SYNC_BRANCH}" --jq .object.sha)
+          fi
+
+          # 6. Commit via GraphQL so GitHub signs it (develop requires signed
+          # commits; an unsigned CLI commit would block auto-merge).
+          contents_b64=$(base64 < /tmp/unreleased.final.json | tr -d '\n')
+          names=$(echo "${new_contributors}" | paste -sd, - | sed 's/,/, /g')
+
+          gh api graphql \
+            -f query='mutation ($repo: String!, $branch: String!, $oid: GitObjectID!, $headline: String!, $path: String!, $contents: Base64String!) {
+              createCommitOnBranch(input: {
+                branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                expectedHeadOid: $oid,
+                message: { headline: $headline },
+                fileChanges: { additions: [ { path: $path, contents: $contents } ] }
+              }) { commit { oid } }
+            }' \
+            -f repo="${REPO}" \
+            -f branch="${SYNC_BRANCH}" \
+            -f oid="${head_sha}" \
+            -f headline="Credit ${names} (PR #${PR_NUMBER})" \
+            -f path="${UNRELEASED_PATH}" \
+            -f contents="${contents_b64}" > /dev/null
+          echo "Signed commit pushed to ${SYNC_BRANCH}."
+
+          # 7. Open the standing PR when none exists, and keep auto-merge on.
+          pr_number=$(gh pr list --head "${SYNC_BRANCH}" --base develop --state open \
+            --json number --jq '.[0].number // empty')
+
+          if [[ -z "${pr_number}" ]]; then
+            pr_url=$(gh pr create \
+              --base develop \
+              --head "${SYNC_BRANCH}" \
+              --title "Credit new contributors" \
+              --body "Automated credits sync (#1828): appends newly-merged contributors to \`credits/unreleased.json\`. The next \`npm run version:bump\` folds these into the release's credits file. Commits are API-signed and this PR auto-merges once checks pass." \
+              --label "Skip Changelog")
+            pr_number=$(basename "${pr_url}")
+            echo "Opened standing PR #${pr_number}."
+          fi
+
+          gh pr merge "${pr_number}" --auto --squash
+          echo "Auto-merge enabled on PR #${pr_number}."

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -46,6 +46,8 @@ For the bot to resolve you correctly, **link your GitHub account on your [profil
 
 Maintainers can force the bot to refresh its list by adding the `Props Bot` label to a pull request.
 
+Crediting is automated from there: when a pull request merges into `develop`, the Credits Sync workflow reads the Props Bot comment and appends anyone not yet credited for the current release cycle to `.github/scripts/release/credits/unreleased.json`, via a small auto-merging PR. At the next version bump those names move into the release's credits file and appear on the in-plugin Credits screen. Contributors the bot couldn't resolve (no linked GitHub account) are skipped by the automation — maintainers add them by hand to `unreleased.json` or the version's credits file.
+
 ---
 
 Thanks for helping make GatherPress better! 💜


### PR DESCRIPTION
Fixes #1828

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* **`.github/workflows/credits-sync.yml`** — on every merged PR into develop: parses the props-bot comment for its resolved wp.org usernames (reusing the bot's GitHub→wp.org mapping rather than reimplementing it), drops anyone already credited for the current cycle, and appends newcomers to `credits/unreleased.json` on a fixed `credits/unreleased-sync` branch via a **standing, auto-merging PR** (Skip Changelog label, native auto-merge).
    * The commit is created through GraphQL's `createCommitOnBranch`, so **GitHub signs it** — satisfying develop's signed-commit protection with zero human steps (the lesson from the 0.34.0 rollup PR that needed admin overrides; see #1921).
    * Membership is checked against the newest credits file's full roster **plus pending entries already on the standing branch**, so rapid consecutive merges can't double-credit; a concurrency group serializes runs.
    * `pull_request_target` safety: the workflow never checks out or executes PR-head code — it checks out develop and reads only PR metadata via the API; parsed usernames are charset-validated (`[a-z0-9._-]`, bots excluded) before touching any file.
* **`.github/scripts/release/credits/unreleased.json`** — the staging file. Contributors accumulate here between releases; keying off "the in-dev version from package.json" (the issue's original sketch) would mis-credit, since package.json holds the *last released* version for most of the cycle.
* **`generate-version.php`** — `npm run version:bump` now folds `unreleased.json` into the target version's credits file (which stays the source of truth) and empties the staging file, all in the version-bump commit.
* **`docs/contributing.md`** — the Contributor Credits section now explains the automation and the manual fallback for contributors props-bot can't resolve.
* Leads and team stay hand-curated, per the issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? *(`.github/` is outside the coverage scope; verification below.)*
- **Verification**: the props-parsing and membership pipeline was exercised against live data (PR #1923's actual props-bot comment → `mauteri, carstenbach` → correctly identified as already-credited); the jq append reproduces the file's exact 4-space format; the bump-time fold was tested end to end (a pending contributor folded into `credits/0.35.0-alpha.1.json`, staging emptied, name present in the generated in-plugin credits and correctly **absent** from readme.txt's leads+team-only `Contributors:` line, then fully restored). YAML validated; `lint:php` / `lint:md:docs` pass. Repo `allow_auto_merge` confirmed enabled.
- First live run happens on whichever PR merges into develop next — worth watching its Actions run once as a smoke test.
- Parsing accepts dotted usernames and skips `*-bot` names; if props-bot posted no props line (nobody resolvable), the run exits with a notice and no PR.

## Testing instructions:

* Review the workflow's security posture: no PR-head checkout, API-only reads, charset validation.
* After merge: merge any small PR into develop and watch the Credits Sync run — for an already-credited author it should log "already credited" and exit; for a new contributor it should open the standing PR with a one-line diff and auto-merge it.
* Locally: add a name to `credits/unreleased.json`, run `npm run version:bump -- --version=0.35.0-alpha.1`, and confirm it folds into `credits/0.35.0-alpha.1.json` with the staging file emptied.

### Credit (for release notes)

My WordPress.org username:

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

*Carries the "Skip Changelog" label — repo automation only, nothing shipped in the plugin.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)