### PR TITLE
Props bot: queue concurrent runs instead of cancelling them

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -29,12 +29,17 @@ on:
         types:
             - created
 
-# Cancels all previous workflow runs for pull requests that have not completed.
+# Serializes runs per pull request without cancelling in-flight ones.
 concurrency:
     # The concurrency group contains the workflow name and the branch name for pull requests
     # or the commit hash for any other events.
     group: ${{ github.workflow }}-${{ contains( fromJSON( '["pull_request_target", "pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && github.head_ref || github.sha }}
-    cancel-in-progress: true
+    # Queue instead of cancel: a review that contains an inline comment fires
+    # two simultaneous events (pull_request_review + pull_request_review_comment),
+    # and cancel-in-progress turned one of each pair into a red X on the PR's
+    # checks — alarming but meaningless, since its twin succeeded. Queued runs
+    # just update the same props comment idempotently a few seconds apart.
+    cancel-in-progress: false
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.


### PR DESCRIPTION
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* One-line behavior change in `.github/workflows/props-bot.yml`: `cancel-in-progress: true` → `false` (with a comment explaining why).

A review that contains an inline comment fires two events in the same second (`pull_request_review` + `pull_request_review_comment`). With cancel-in-progress, one of each pair gets cancelled and shows as a **red ✗ on the PR's checks** — alarming but meaningless, since its twin succeeds seconds later and keeps the props comment current. This has now caused two separate "props bot failed?" investigations (#1923's review, #1927's review), both false alarms.

Queueing serializes the pair instead: the first run executes, the second waits ~12s and then updates the same comment idempotently. No tombstones, no cried wolf. (With three-plus rapid events the middle queued run can still be superseded, but the common review-with-comment case — the one that keeps happening — is fully fixed.)

### Other information:

- [ ] Have you written new tests for your changes, if applicable? *(Not applicable — one-line workflow config.)*

## Testing instructions:

* After merge, leave a review containing an inline comment on any PR: both props-bot runs should complete green, one after the other, with no cancelled run on the checks list.

### Credit (for release notes)

My WordPress.org username:

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

*Carries the "Skip Changelog" label — CI config only.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)