### PR TITLE
Raise minimum PHP requirement from 7.4 to 8.1

### DIFF
--- a/.github/changelog/1602-php-81-floor
+++ b/.github/changelog/1602-php-81-floor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Raised the minimum required PHP version from 7.4 to 8.1.

--- a/.github/changelog/1602-php-81-floor
+++ b/.github/changelog/1602-php-81-floor
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: major
 Type: changed
 
 Raised the minimum required PHP version from 7.4 to 8.1.

--- a/.github/scripts/release/generate-version.php
+++ b/.github/scripts/release/generate-version.php
@@ -153,11 +153,16 @@ function fold_unreleased_credits( $entry, $credits_file, $version ) {
 		fail( "Failed to fold unreleased contributors into credits/{$version}.json." );
 	}
 
-	if ( file_put_contents( $unreleased_file, json_encode( array( 'contributors' => array() ), $json_flags ) . "\n" ) === false ) {
+	$reset_json = json_encode( array( 'contributors' => array() ), $json_flags ) . "\n";
+
+	if ( file_put_contents( $unreleased_file, $reset_json ) === false ) {
 		fail( 'Failed to reset credits/unreleased.json.' );
 	}
 
-	success( 'Folded ' . count( $new ) . " unreleased contributor(s) into credits/{$version}.json: " . implode( ', ', $new ) . '.' );
+	success(
+		'Folded ' . count( $new ) . " unreleased contributor(s) into credits/{$version}.json: "
+		. implode( ', ', $new ) . '.'
+	);
 
 	return $entry;
 }

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           coverage: none
           tools: composer, cs2pr
 

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -6,10 +6,14 @@ on:
   pull_request:
     paths:
     - '.github/workflows/coding-standards.yml'
+    - '.github/scripts/**'
     - 'includes/**'
     - 'src/**'
     - 'test/**'
     - 'package.*'
+    - 'composer.*'
+    - 'phpcs.ruleset.xml'
+    - '*.php'
     - '*.js'
     - '*.php'
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           coverage: xdebug
 
       - name: Install NodeJS

--- a/.github/workflows/extract-wp-hooks-as-docs.yml
+++ b/.github/workflows/extract-wp-hooks-as-docs.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.4
+        php-version: 8.1
         extensions: dom, iconv, json, libxml, zip
         coverage: none
 

--- a/.github/workflows/phpmd-tests.yml
+++ b/.github/workflows/phpmd-tests.yml
@@ -25,7 +25,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           # phpstan requires PHP 7.1+.
-          php-version: 7.4
+          php-version: 8.1
           extensions: dom, iconv, json, libxml, zip
           coverage: none
           tools: cs2pr

--- a/.github/workflows/phpstan-tests.yml
+++ b/.github/workflows/phpstan-tests.yml
@@ -27,7 +27,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           # phpstan requires PHP 7.1+.
-          php-version: 7.4
+          php-version: 8.1
           extensions: dom, iconv, json, libxml, zip
           coverage: none
           tools: cs2pr

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -29,7 +29,7 @@ jobs:
       max-parallel: 2
       matrix:
         os: [ ubuntu-latest ]
-        php_versions: [ '7.4', '8.2', '8.4' ]
+        php_versions: [ '8.1', '8.2', '8.4' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
         if: ${{ success() || failure() }}
 
   test-php-multisite:
-    name: Multisite Tests (PHP 7.4)
+    name: Multisite Tests (PHP 8.1)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -78,7 +78,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           coverage: xdebug
 
       - name: Composer Install

--- a/.github/workflows/playground-preview-comment.yml
+++ b/.github/workflows/playground-preview-comment.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Add Preview Links comment
         uses: actions/github-script@v7
         env:
-          PHP_VERSIONS: '["8.4","8.2","7.4"]'
+          PHP_VERSIONS: '["8.4","8.2","8.1"]'
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           tools: composer
 
       - name: Composer install

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           coverage: xdebug
 
       - name: Composer Install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,7 +276,7 @@ Apply to PHP PHPDoc blocks and JS JSDoc blocks alike.
         ```
 
     - ❌ Bad: `class Setup {` immediately followed by `\t/**` on the next line.
-- **Prefer `str_contains` / `str_starts_with` / `str_ends_with` over `strpos`**: WordPress ships polyfills for these PHP 8 string helpers back to PHP 7.0, so they're safe under our PHP 7.4 floor. They read better than the `false ===` / `0 ===` dance and SonarCloud flags the legacy form.
+- **Prefer `str_contains` / `str_starts_with` / `str_ends_with` over `strpos`**: native in PHP 8 (the plugin's floor is 8.1). They read better than the `false ===` / `0 ===` dance and SonarCloud flags the legacy form.
     - ✅ Good: `if ( str_contains( $haystack, $needle ) )` / `if ( str_starts_with( $key, 'gatherpress_' ) )` / `if ( ! str_contains( $content, $token ) )`
     - ❌ Bad: `if ( false !== strpos( $haystack, $needle ) )` / `if ( 0 === strpos( $key, 'gatherpress_' ) )` / `if ( false === strpos( $content, $token ) )`
 - **Every `switch` needs a `default` case**: SonarCloud (`php:S131`) flags any switch missing a `default` branch, even when the listed cases cover the expected values. Add `default: break;` with a one-line comment explaining what falls through (e.g. "Field types without extra params render with the base $params.") — that way the reader sees the intent rather than wondering whether a case was forgotten.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	],
 	"require": {
 		"pmc/unit-test": "dev-main",
-		"php": ">=7.4"
+		"php": ">=8.1"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
@@ -62,7 +62,7 @@
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		},
 		"platform": {
-			"php": "7.4"
+			"php": "8.1"
 		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "321600136728d0c050ae71787daf9547",
+    "content-hash": "bcc6063287c5e415dcb902d655fae4fd",
     "packages": [
         {
             "name": "hamcrest/hamcrest-php",
@@ -4566,11 +4566,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=8.1"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.4"
+        "php": "8.1"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -6,7 +6,7 @@
  * Author:            The GatherPress Community
  * Author URI:        https://gatherpress.org/
  * Version:           0.34.0
- * Requires PHP:      7.4
+ * Requires PHP:      8.1
  * Requires at least: 6.7
  * Text Domain:       gatherpress
  * License:           GNU General Public License v2.0 or later

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -25,7 +25,7 @@
 
 	<!-- Rules: Check PHP version compatibility -->
 	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="7.4-"/>
+	<config name="testVersion" value="8.1-"/>
 	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP"/>
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,6 +15,9 @@ parameters:
         maximumNumberOfProcesses: 1
         processTimeout: 300.0
 
+    # Analyze as PHP 8.1 — the plugin's minimum supported version.
+    phpVersion: 80100
+
     # the analysis level, from 0 (loose) to 9 (strict)
     # https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 Contributors: mauteri, patricia70, hrmervin, jmarx75, stephenerdelyi, carstenbach, jordanpak, mahimadave, tusharaddweb, pkbhatt, supernovia
 Tags: events, event, meetup, community
 Tested up to: 7.0
+Requires PHP: 8.1
 Stable tag: 0.34.0
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Fixes #1602

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The full checklist from the issue, plus stragglers that postdate it:

* `gatherpress.php` — `Requires PHP: 8.1`. The runtime deactivation check (`requirements-check.php`) reads `GATHERPRESS_REQUIRES_PHP` from this header via `get_file_data()`, so it updates automatically — no separate edit needed.
* `readme.txt` — gains an explicit `Requires PHP: 8.1` line (it never had one; wp.org was falling back to the plugin header).
* `composer.json` — `require.php >=8.1` and `config.platform.php 8.1`; lock refreshed with `--lock` (no dependency changes; all locked packages already support 8.1).
* `phpstan.neon.dist` — `phpVersion: 80100` added (the issue assumed 70400 was set; nothing was). **Analysis is clean at 8.1.**
* `phpcs.ruleset.xml` — PHPCompatibility `testVersion 8.1-`. **Lint is clean.**
* CI matrices — 7.4 → 8.1 in all seven workflows from the issue, plus two the issue predates: `release.yml`'s changelogger job and `playground-preview-comment.yml`'s PHP matrix.
* `AGENTS.md` — the `str_contains` guidance no longer cites the 7.4 floor/polyfill rationale.
* Codebase modernization (enums, nullsafe, readonly, constructor promotion, `GdImage` hints) is **deliberately not in this PR**, per the issue's own scoping — follow-ups.

### Other information:

- [ ] Have you written new tests for your changes, if applicable? *(Not applicable — requirement/config change; full test matrix runs in CI on the new floor.)*
- Verified locally: `composer validate` ✓, `npm run lint:php` zero errors/warnings under `testVersion 8.1-`, `npm run lint:phpstan` zero errors at `phpVersion 80100`.
- Companion plugins: gatherpress-alpha's header bump is a separate lockstep PR; gatherpress-awesome still declares 7.4 and can follow at its own pace (it simply won't run alongside a deactivated core anyway, since core self-deactivates below 8.1).
- The issue's 0.34.0 release-note callout never happened before 0.34.0 shipped — being handled by amending the 0.34.0 release notes with a heads-up (see issue comment).

## Testing instructions:

* On a PHP ≥ 8.1 site: normal operation.
* On PHP < 8.1: activating the plugin shows the "GatherPress requires 8.1 or higher" admin notice and self-deactivates (the `requirements-check.php` flow, driven by the bumped header).
* CI: the PHPUnit matrix now runs 8.1/8.2/8.4; multisite runs on 8.1.

### Credit (for release notes)

My WordPress.org username:

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

*Changelog entry committed to the branch (`.github/changelog/1602-php-81-floor`, minor/changed) — this one is user-visible.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)