### PR TITLE
Adopt the WordPress 7.0 List View block support on container blocks

### DIFF
--- a/.github/changelog/1815-list-view-block-support
+++ b/.github/changelog/1815-list-view-block-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Container blocks (Add to Calendar, Modal Content, Online Event, RSVP, RSVP Form, RSVP Response, RSVP Template, Venue) now declare the WordPress 7.0 List View block support, and Block Guard extends to the new inspector List View tab so guarded blocks stay protected there.

--- a/src/blocks/add-to-calendar/block.json
+++ b/src/blocks/add-to-calendar/block.json
@@ -8,13 +8,18 @@
 	"icon": "calendar",
 	"example": {},
 	"description": "Allows a member to add an event to their preferred calendar.",
-	"usesContext": [ "postId", "postType", "queryId" ],
+	"usesContext": [
+		"postId",
+		"postType",
+		"queryId"
+	],
 	"supports": {
 		"gatherpress": {
 			"blockGuard": true,
 			"postIdOverride": true
 		},
-		"html": false
+		"html": false,
+		"listView": true
 	},
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js"

--- a/src/blocks/modal-content/block.json
+++ b/src/blocks/modal-content/block.json
@@ -4,7 +4,9 @@
 	"name": "gatherpress/modal-content",
 	"version": "1.0.0",
 	"title": "Modal Content",
-	"parent": ["gatherpress/modal"],
+	"parent": [
+		"gatherpress/modal"
+	],
 	"category": "gatherpress",
 	"icon": "external",
 	"example": {},
@@ -48,7 +50,8 @@
 				"style": true,
 				"width": true
 			}
-		}
+		},
+		"listView": true
 	},
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js",

--- a/src/blocks/online-event/block.json
+++ b/src/blocks/online-event/block.json
@@ -7,7 +7,11 @@
 	"category": "gatherpress",
 	"icon": "video-alt2",
 	"description": "Container block for online event display with icon and link.",
-	"usesContext": ["postId", "postType", "queryId"],
+	"usesContext": [
+		"postId",
+		"postType",
+		"queryId"
+	],
 	"providesContext": {
 		"postId": "postId"
 	},
@@ -21,7 +25,8 @@
 			"blockGuard": true,
 			"postIdOverride": true
 		},
-		"html": false
+		"html": false,
+		"listView": true
 	},
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js"

--- a/src/blocks/rsvp-form/block.json
+++ b/src/blocks/rsvp-form/block.json
@@ -8,7 +8,10 @@
 	"icon": "forms",
 	"example": {},
 	"description": "Allows visitors to RSVP to an event without requiring a site account.",
-	"usesContext": [ "postId", "queryId" ],
+	"usesContext": [
+		"postId",
+		"queryId"
+	],
 	"attributes": {
 		"patternPicked": {
 			"type": "boolean",
@@ -20,7 +23,8 @@
 			"postIdOverride": true
 		},
 		"interactivity": true,
-		"html": false
+		"html": false,
+		"listView": true
 	},
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js",

--- a/src/blocks/rsvp-response/block.json
+++ b/src/blocks/rsvp-response/block.json
@@ -8,7 +8,11 @@
 	"icon": "groups",
 	"example": {},
 	"description": "Displays a list of members who have confirmed their attendance for an event.",
-	"usesContext": [ "postId", "postType", "queryId" ],
+	"usesContext": [
+		"postId",
+		"postType",
+		"queryId"
+	],
 	"attributes": {
 		"rsvpLimitEnabled": {
 			"type": "boolean",
@@ -28,9 +32,13 @@
 			"blockGuard": true,
 			"postIdOverride": true
 		},
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"interactivity": true,
-		"html": false
+		"html": false,
+		"listView": true
 	},
 	"providesContext": {
 		"commentId": "commentId",

--- a/src/blocks/rsvp-template/block.json
+++ b/src/blocks/rsvp-template/block.json
@@ -9,13 +9,25 @@
 	"example": {},
 	"description": "Define a reusable template for RSVP entries dynamically populated with data.",
 	"supports": {
-		"html": false
+		"html": false,
+		"listView": true
 	},
-	"usesContext": [ "gatherpress/rsvpResponses", "gatherpress/rsvpLimitEnabled", "gatherpress/rsvpLimit", "postId" ],
-	"parent": [ "core/group" ],
-	"ancestor": [ "core/rsvp-response" ],
+	"usesContext": [
+		"gatherpress/rsvpResponses",
+		"gatherpress/rsvpLimitEnabled",
+		"gatherpress/rsvpLimit",
+		"postId"
+	],
+	"parent": [
+		"core/group"
+	],
+	"ancestor": [
+		"core/rsvp-response"
+	],
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js",
 	"style": "file:./style-index.css",
-	"viewScriptModule": [ "file:./view.js" ]
+	"viewScriptModule": [
+		"file:./view.js"
+	]
 }

--- a/src/blocks/rsvp/block.json
+++ b/src/blocks/rsvp/block.json
@@ -8,7 +8,11 @@
 	"icon": "insert",
 	"example": {},
 	"description": "Enables members to easily confirm their attendance for an event.",
-	"usesContext": [ "postId", "postType", "queryId" ],
+	"usesContext": [
+		"postId",
+		"postType",
+		"queryId"
+	],
 	"attributes": {
 		"serializedInnerBlocks": {
 			"type": "string",
@@ -38,7 +42,8 @@
 				"justifyContent": "center",
 				"flexWrap": "wrap"
 			}
-		}
+		},
+		"listView": true
 	},
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js",

--- a/src/blocks/venue/block.json
+++ b/src/blocks/venue/block.json
@@ -8,7 +8,11 @@
 	"icon": "location",
 	"example": {},
 	"description": "Provides information about an event venue.",
-	"usesContext": [ "postId", "postType", "queryId" ],
+	"usesContext": [
+		"postId",
+		"postType",
+		"queryId"
+	],
 	"attributes": {
 		"sourcePostType": {
 			"type": "string",
@@ -30,7 +34,10 @@
 			"blockGuard": true,
 			"postIdOverride": true
 		},
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"html": false,
 		"interactivity": {
 			"clientNavigation": true
@@ -39,7 +46,8 @@
 			"default": {
 				"type": "constrained"
 			}
-		}
+		},
+		"listView": true
 	},
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js",

--- a/src/supports/block-guard.js
+++ b/src/supports/block-guard.js
@@ -73,6 +73,50 @@ function useSharedBlockGuardState( blockName ) {
 }
 
 /**
+ * ID of the injected stylesheet that positions the Block Guard panel.
+ */
+const BLOCK_GUARD_STYLE_ID = 'gatherpress-block-guard-style';
+
+/**
+ * Inject the stylesheet that floats the Block Guard panel to the top of
+ * whichever inspector tab it renders in (the Settings tab and the
+ * WordPress 7.0 List View tab), so the protection state is the first
+ * thing users see. Idempotent: the module evaluates in multiple webpack
+ * chunks and the HOC mounts per block, so the id guard keeps a single
+ * style element.
+ *
+ * @return {void}
+ */
+function injectBlockGuardStyles() {
+	if ( document.getElementById( BLOCK_GUARD_STYLE_ID ) ) {
+		return;
+	}
+
+	const style = document.createElement( 'style' );
+	style.id = BLOCK_GUARD_STYLE_ID;
+	// Target the panel's direct parent (the tab content wrapper, whatever
+	// element that happens to be) rather than the tabpanel itself: the
+	// panel and its sibling controls all live one wrapper below the
+	// tabpanel. The panel's order rule is declared last so it wins the
+	// equal-specificity tie against the catch-all sibling rule.
+	style.textContent = `
+		.block-editor-block-inspector [role="tabpanel"]:has(> .gatherpress-block-guard-panel),
+		.block-editor-block-inspector [role="tabpanel"] :has(> .gatherpress-block-guard-panel) {
+			display: flex;
+			flex-direction: column;
+		}
+		.block-editor-block-inspector [role="tabpanel"]:has(> .gatherpress-block-guard-panel) > *,
+		.block-editor-block-inspector [role="tabpanel"] :has(> .gatherpress-block-guard-panel) > * {
+			order: 1;
+		}
+		.block-editor-block-inspector [role="tabpanel"] .gatherpress-block-guard-panel {
+			order: 0;
+		}
+	`;
+	document.head.appendChild( style );
+}
+
+/**
  * Get the appropriate document context for the block editor.
  *
  * In FSE (Full Site Editing) contexts, blocks are rendered within an iframe
@@ -284,31 +328,22 @@ function applyListViewGuardForBlock( clientId, isBlockGuardEnabled ) {
 }
 
 /**
- * Class name for the notice injected above the inspector's guarded tree.
- */
-const INSPECTOR_NOTICE_CLASS = 'gatherpress-block-guard-inspector-notice';
-
-/**
  * Apply block guard to the block inspector's List View tab.
  *
  * WordPress 7.0's `listView` block support renders the selected block's
  * inner blocks as a standalone tree inside the block inspector. That tree
  * bypasses both the canvas inert overlay and the main List View expander
- * handling, so it gets the same inert treatment as the canvas container
- * (which also hides the tree's block appender). The tree stays visible as
- * a read-only structure map while the guard is on, with a notice above it
- * explaining why it is not interactive and offering a one-click unprotect
- * that flips the same shared state as the sidebar toggle.
+ * handling, so it gets the same inert treatment as the canvas container.
+ * The tree stays visible as a read-only structure map while the guard is
+ * on; the Block Guard toggle rendered into the tab (via the `list`
+ * InspectorControls group) is where users flip protection.
  *
- * @param {boolean}  isEnabled - Whether guard is enabled.
- * @param {Function} onDisable - Called when the notice's unprotect button
- *                             is clicked. Optional; without it the
- *                             notice renders without a button.
+ * @param {boolean} isEnabled - Whether guard is enabled.
  *
  * @return {HTMLElement|null} The guarded tree element, or null when the
  *                            inspector's List View tab is not rendered.
  */
-function applyInspectorListViewGuard( isEnabled, onDisable ) {
+function applyInspectorListViewGuard( isEnabled ) {
 	// The inspector lives in the top-level document, never the editor iframe.
 	const tree = document.querySelector(
 		'.block-editor-block-inspector .block-editor-list-view-tree',
@@ -320,44 +355,14 @@ function applyInspectorListViewGuard( isEnabled, onDisable ) {
 
 	applyGuardToContainer( tree, isEnabled );
 
-	const existingNotice = tree.parentElement.querySelector(
-		`.${ INSPECTOR_NOTICE_CLASS }`,
-	);
+	// Hide the tree's appender while guarded, matching the canvas behavior.
+	// The tree uses its own appender class, not the `.block-list-appender`
+	// that applyGuardToContainer handles.
+	const appender = tree.querySelector( '.list-view-appender' );
 
-	if ( ! isEnabled ) {
-		existingNotice?.remove();
-
-		return tree;
+	if ( appender ) {
+		appender.style.display = isEnabled ? 'none' : '';
 	}
-
-	// The MutationObserver re-runs this on every DOM change; keep it
-	// idempotent so the notice is only ever injected once.
-	if ( existingNotice ) {
-		return tree;
-	}
-
-	const notice = document.createElement( 'div' );
-	notice.className = INSPECTOR_NOTICE_CLASS;
-	notice.style.cssText =
-		'display:flex;align-items:center;justify-content:space-between;gap:8px;padding:0 16px 12px;';
-
-	const message = document.createElement( 'span' );
-	message.textContent = __( 'Block Guard is enabled.', 'gatherpress' );
-	message.style.cssText = 'color:#757575;font-size:12px;';
-	notice.appendChild( message );
-
-	if ( 'function' === typeof onDisable ) {
-		const button = document.createElement( 'button' );
-		button.type = 'button';
-		button.className = 'components-button is-secondary is-compact';
-		button.textContent = __( 'Unprotect', 'gatherpress' );
-		button.onclick = onDisable;
-		notice.appendChild( button );
-	}
-
-	// Insert as a sibling before the tree so the button stays outside the
-	// inert subtree and remains clickable.
-	tree.parentElement.insertBefore( notice, tree );
 
 	return tree;
 }
@@ -547,6 +552,8 @@ const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
 				return;
 			}
 
+			injectBlockGuardStyles();
+
 			// Apply initially.
 			applyBlockGuard( clientId, name, stateKey, isBlockGuardEnabled );
 
@@ -581,9 +588,7 @@ const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
 				// selection to keep unselected instances of guarded blocks
 				// from fighting over the shared inspector DOM.
 				if ( isSelected ) {
-					applyInspectorListViewGuard( isBlockGuardEnabled, () =>
-						setIsBlockGuardEnabled( false ),
-					);
+					applyInspectorListViewGuard( isBlockGuardEnabled );
 				}
 
 				// Handle drag prevention for block guard.
@@ -629,45 +634,52 @@ const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
 					removeDragListeners( dropHandler );
 				}
 			};
-		}, [
-			clientId,
-			isBlockGuardEnabled,
-			isSelected,
-			setIsBlockGuardEnabled,
-		] );
+		}, [ clientId, isBlockGuardEnabled, isSelected ] );
+
+		// One descriptor, rendered in both inspector tabs: the Settings tab
+		// and the WordPress 7.0 List View tab (`group="list"`), so the guard
+		// can be toggled from wherever the user happens to be looking.
+		const blockGuardToggle = (
+			<ToggleControl
+				label={ __( 'Block Guard', 'gatherpress' ) }
+				checked={ isBlockGuardEnabled }
+				onChange={ ( value ) => {
+					setIsBlockGuardEnabled( value );
+
+					const expander = document.querySelector(
+						`.block-editor-list-view-leaf[data-block="${ clientId }"][data-expanded="true"] .block-editor-list-view__expander`,
+					);
+
+					if ( value && expander ) {
+						expander.click();
+						expander.style.pointerEvents = 'none';
+					}
+				} }
+				help={
+					isBlockGuardEnabled
+						? __(
+							'Toggle to unprotect and update the block.',
+							'gatherpress',
+						)
+						: __(
+							'Block protection is disabled. Inner blocks can be freely edited.',
+							'gatherpress',
+						)
+				}
+			/>
+		);
 
 		return (
 			<>
 				<BlockEdit { ...props } />
 				<InspectorControls>
-					<PanelBody>
-						<ToggleControl
-							label={ __( 'Block Guard', 'gatherpress' ) }
-							checked={ isBlockGuardEnabled }
-							onChange={ ( value ) => {
-								setIsBlockGuardEnabled( value );
-
-								const expander = document.querySelector(
-									`.block-editor-list-view-leaf[data-block="${ clientId }"][data-expanded="true"] .block-editor-list-view__expander`,
-								);
-
-								if ( value && expander ) {
-									expander.click();
-									expander.style.pointerEvents = 'none';
-								}
-							} }
-							help={
-								isBlockGuardEnabled
-									? __(
-										'Toggle to unprotect and update the block.',
-										'gatherpress',
-									)
-									: __(
-										'Block protection is disabled. Inner blocks can be freely edited.',
-										'gatherpress',
-									)
-							}
-						/>
+					<PanelBody className="gatherpress-block-guard-panel">
+						{ blockGuardToggle }
+					</PanelBody>
+				</InspectorControls>
+				<InspectorControls group="list">
+					<PanelBody className="gatherpress-block-guard-panel">
+						{ blockGuardToggle }
 					</PanelBody>
 				</InspectorControls>
 			</>
@@ -704,6 +716,7 @@ export {
 	createDropHandler,
 	applyListViewGuardForBlock,
 	applyInspectorListViewGuard,
+	injectBlockGuardStyles,
 	cleanupBlockGuard,
 	applyBlockGuard,
 };

--- a/src/supports/block-guard.js
+++ b/src/supports/block-guard.js
@@ -7,7 +7,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addFilter, hasFilter } from '@wordpress/hooks';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 
 /**
  * Shared state store for block guard settings across all block instances.
@@ -53,16 +53,21 @@ function useSharedBlockGuardState( blockName ) {
 		};
 	}, [ blockName ] );
 
-	const setSharedState = ( value ) => {
-		// Update the shared state.
-		blockGuardStates.set( blockName, value );
+	// Stable identity so consumers can list the setter in effect
+	// dependencies without re-running the effect every render.
+	const setSharedState = useCallback(
+		( value ) => {
+			// Update the shared state.
+			blockGuardStates.set( blockName, value );
 
-		// Notify all listeners (components using this block type).
-		const listeners = blockGuardListeners.get( blockName );
-		if ( listeners ) {
-			listeners.forEach( ( listener ) => listener( value ) );
-		}
-	};
+			// Notify all listeners (components using this block type).
+			const listeners = blockGuardListeners.get( blockName );
+			if ( listeners ) {
+				listeners.forEach( ( listener ) => listener( value ) );
+			}
+		},
+		[ blockName ],
+	);
 
 	return [ localState, setSharedState ];
 }
@@ -279,6 +284,11 @@ function applyListViewGuardForBlock( clientId, isBlockGuardEnabled ) {
 }
 
 /**
+ * Class name for the notice injected above the inspector's guarded tree.
+ */
+const INSPECTOR_NOTICE_CLASS = 'gatherpress-block-guard-inspector-notice';
+
+/**
  * Apply block guard to the block inspector's List View tab.
  *
  * WordPress 7.0's `listView` block support renders the selected block's
@@ -286,14 +296,19 @@ function applyListViewGuardForBlock( clientId, isBlockGuardEnabled ) {
  * bypasses both the canvas inert overlay and the main List View expander
  * handling, so it gets the same inert treatment as the canvas container
  * (which also hides the tree's block appender). The tree stays visible as
- * a read-only structure map while the guard is on.
+ * a read-only structure map while the guard is on, with a notice above it
+ * explaining why it is not interactive and offering a one-click unprotect
+ * that flips the same shared state as the sidebar toggle.
  *
- * @param {boolean} isEnabled - Whether guard is enabled.
+ * @param {boolean}  isEnabled - Whether guard is enabled.
+ * @param {Function} onDisable - Called when the notice's unprotect button
+ *                             is clicked. Optional; without it the
+ *                             notice renders without a button.
  *
  * @return {HTMLElement|null} The guarded tree element, or null when the
  *                            inspector's List View tab is not rendered.
  */
-function applyInspectorListViewGuard( isEnabled ) {
+function applyInspectorListViewGuard( isEnabled, onDisable ) {
 	// The inspector lives in the top-level document, never the editor iframe.
 	const tree = document.querySelector(
 		'.block-editor-block-inspector .block-editor-list-view-tree',
@@ -304,6 +319,45 @@ function applyInspectorListViewGuard( isEnabled ) {
 	}
 
 	applyGuardToContainer( tree, isEnabled );
+
+	const existingNotice = tree.parentElement.querySelector(
+		`.${ INSPECTOR_NOTICE_CLASS }`,
+	);
+
+	if ( ! isEnabled ) {
+		existingNotice?.remove();
+
+		return tree;
+	}
+
+	// The MutationObserver re-runs this on every DOM change; keep it
+	// idempotent so the notice is only ever injected once.
+	if ( existingNotice ) {
+		return tree;
+	}
+
+	const notice = document.createElement( 'div' );
+	notice.className = INSPECTOR_NOTICE_CLASS;
+	notice.style.cssText =
+		'display:flex;align-items:center;justify-content:space-between;gap:8px;padding:0 16px 12px;';
+
+	const message = document.createElement( 'span' );
+	message.textContent = __( 'Block Guard is enabled.', 'gatherpress' );
+	message.style.cssText = 'color:#757575;font-size:12px;';
+	notice.appendChild( message );
+
+	if ( 'function' === typeof onDisable ) {
+		const button = document.createElement( 'button' );
+		button.type = 'button';
+		button.className = 'components-button is-secondary is-compact';
+		button.textContent = __( 'Unprotect', 'gatherpress' );
+		button.onclick = onDisable;
+		notice.appendChild( button );
+	}
+
+	// Insert as a sibling before the tree so the button stays outside the
+	// inert subtree and remains clickable.
+	tree.parentElement.insertBefore( notice, tree );
 
 	return tree;
 }
@@ -527,7 +581,9 @@ const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
 				// selection to keep unselected instances of guarded blocks
 				// from fighting over the shared inspector DOM.
 				if ( isSelected ) {
-					applyInspectorListViewGuard( isBlockGuardEnabled );
+					applyInspectorListViewGuard( isBlockGuardEnabled, () =>
+						setIsBlockGuardEnabled( false ),
+					);
 				}
 
 				// Handle drag prevention for block guard.
@@ -573,7 +629,12 @@ const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
 					removeDragListeners( dropHandler );
 				}
 			};
-		}, [ clientId, isBlockGuardEnabled, isSelected ] );
+		}, [
+			clientId,
+			isBlockGuardEnabled,
+			isSelected,
+			setIsBlockGuardEnabled,
+		] );
 
 		return (
 			<>

--- a/src/supports/block-guard.js
+++ b/src/supports/block-guard.js
@@ -279,6 +279,36 @@ function applyListViewGuardForBlock( clientId, isBlockGuardEnabled ) {
 }
 
 /**
+ * Apply block guard to the block inspector's List View tab.
+ *
+ * WordPress 7.0's `listView` block support renders the selected block's
+ * inner blocks as a standalone tree inside the block inspector. That tree
+ * bypasses both the canvas inert overlay and the main List View expander
+ * handling, so it gets the same inert treatment as the canvas container
+ * (which also hides the tree's block appender). The tree stays visible as
+ * a read-only structure map while the guard is on.
+ *
+ * @param {boolean} isEnabled - Whether guard is enabled.
+ *
+ * @return {HTMLElement|null} The guarded tree element, or null when the
+ *                            inspector's List View tab is not rendered.
+ */
+function applyInspectorListViewGuard( isEnabled ) {
+	// The inspector lives in the top-level document, never the editor iframe.
+	const tree = document.querySelector(
+		'.block-editor-block-inspector .block-editor-list-view-tree',
+	);
+
+	if ( ! tree ) {
+		return null;
+	}
+
+	applyGuardToContainer( tree, isEnabled );
+
+	return tree;
+}
+
+/**
  * Clean up block guard from all elements that share the same state key.
  *
  * @param {string} name     - The block type name.
@@ -441,7 +471,7 @@ function generateBlockGuardStateKey( name, clientId ) {
  */
 const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props ) => {
-		const { name, clientId } = props;
+		const { name, clientId, isSelected } = props;
 
 		// Check if the block supports blockGuard.
 		if (
@@ -492,6 +522,14 @@ const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
 			const handleListView = () => {
 				applyListViewGuardForBlock( clientId, isBlockGuardEnabled );
 
+				// The inspector's List View tab (WordPress 7.0 `listView`
+				// support) only renders for the selected block, so gate on
+				// selection to keep unselected instances of guarded blocks
+				// from fighting over the shared inspector DOM.
+				if ( isSelected ) {
+					applyInspectorListViewGuard( isBlockGuardEnabled );
+				}
+
 				// Handle drag prevention for block guard.
 				if ( isBlockGuardEnabled ) {
 					// Prevent drops into this block like WordPress lock removal.
@@ -524,12 +562,18 @@ const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
 			return () => {
 				observer.disconnect();
 
+				// Release the inspector tree so the next selection starts
+				// from a clean slate.
+				if ( isSelected ) {
+					applyInspectorListViewGuard( false );
+				}
+
 				// Clean up event listeners.
 				if ( dropHandler ) {
 					removeDragListeners( dropHandler );
 				}
 			};
-		}, [ clientId, isBlockGuardEnabled ] );
+		}, [ clientId, isBlockGuardEnabled, isSelected ] );
 
 		return (
 			<>
@@ -598,6 +642,7 @@ export {
 	removeDragListeners,
 	createDropHandler,
 	applyListViewGuardForBlock,
+	applyInspectorListViewGuard,
 	cleanupBlockGuard,
 	applyBlockGuard,
 };

--- a/test/unit/js/src/supports/block-guard.test.js
+++ b/test/unit/js/src/supports/block-guard.test.js
@@ -74,6 +74,7 @@ import {
 	removeDragListeners,
 	createDropHandler,
 	applyListViewGuardForBlock,
+	applyInspectorListViewGuard,
 } from '@src/supports/block-guard';
 
 /**
@@ -935,5 +936,66 @@ describe( 'applyListViewGuardForBlock', () => {
 
 		expect( result ).toEqual( { expander: mockExpander } );
 		expect( mockExpander.style.pointerEvents ).toBe( 'none' );
+	} );
+} );
+
+/**
+ * Tests for applyInspectorListViewGuard function.
+ */
+describe( 'applyInspectorListViewGuard', () => {
+	let inspector;
+	let tree;
+
+	beforeEach( () => {
+		inspector = document.createElement( 'div' );
+		inspector.className = 'block-editor-block-inspector';
+
+		tree = document.createElement( 'table' );
+		tree.className = 'block-editor-list-view-tree';
+
+		inspector.appendChild( tree );
+		document.body.appendChild( inspector );
+	} );
+
+	afterEach( () => {
+		inspector.remove();
+	} );
+
+	it( 'returns null when the inspector List View tab is not rendered', () => {
+		tree.remove();
+
+		expect( applyInspectorListViewGuard( true ) ).toBeNull();
+	} );
+
+	it( 'inerts the inspector tree when enabled', () => {
+		const result = applyInspectorListViewGuard( true );
+
+		expect( result ).toBe( tree );
+		expect( tree.inert ).toBe( true );
+		expect( tree.style.opacity ).toBe( '0.95' );
+		expect( tree.style.cursor ).toBe( 'not-allowed' );
+		expect( tree.dataset.gatherPressGuarded ).toBe( 'true' );
+	} );
+
+	it( 'hides the inspector tree appender when enabled', () => {
+		const appender = document.createElement( 'div' );
+		appender.className = 'block-list-appender';
+		tree.appendChild( appender );
+
+		applyInspectorListViewGuard( true );
+
+		expect( appender.style.display ).toBe( 'none' );
+	} );
+
+	it( 'releases the inspector tree when disabled', () => {
+		applyInspectorListViewGuard( true );
+
+		const result = applyInspectorListViewGuard( false );
+
+		expect( result ).toBe( tree );
+		expect( tree.inert ).toBe( false );
+		expect( tree.style.opacity ).toBe( '' );
+		expect( tree.style.cursor ).toBe( '' );
+		expect( tree.dataset.gatherPressGuarded ).toBeUndefined();
 	} );
 } );

--- a/test/unit/js/src/supports/block-guard.test.js
+++ b/test/unit/js/src/supports/block-guard.test.js
@@ -59,6 +59,7 @@ jest.mock( '@wordpress/hooks', () => ( {
 jest.mock( '@wordpress/element', () => ( {
 	useState: jest.fn(),
 	useEffect: jest.fn(),
+	useCallback: jest.fn( ( callback ) => callback ),
 } ) );
 
 /**
@@ -997,5 +998,47 @@ describe( 'applyInspectorListViewGuard', () => {
 		expect( tree.style.opacity ).toBe( '' );
 		expect( tree.style.cursor ).toBe( '' );
 		expect( tree.dataset.gatherPressGuarded ).toBeUndefined();
+	} );
+
+	it( 'injects a single notice above the tree when enabled', () => {
+		applyInspectorListViewGuard( true );
+		applyInspectorListViewGuard( true );
+
+		const notices = inspector.querySelectorAll(
+			'.gatherpress-block-guard-inspector-notice',
+		);
+
+		expect( notices ).toHaveLength( 1 );
+		expect( notices[ 0 ].nextElementSibling ).toBe( tree );
+		expect( notices[ 0 ].textContent ).toContain(
+			'Block Guard is enabled.',
+		);
+		// Without a callback there is no unprotect button.
+		expect( notices[ 0 ].querySelector( 'button' ) ).toBeNull();
+	} );
+
+	it( 'wires the unprotect button to the onDisable callback', () => {
+		const onDisable = jest.fn();
+
+		applyInspectorListViewGuard( true, onDisable );
+
+		const button = inspector.querySelector(
+			'.gatherpress-block-guard-inspector-notice button',
+		);
+
+		button.click();
+
+		expect( onDisable ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'removes the notice when disabled', () => {
+		applyInspectorListViewGuard( true, jest.fn() );
+		applyInspectorListViewGuard( false );
+
+		expect(
+			inspector.querySelector(
+				'.gatherpress-block-guard-inspector-notice',
+			),
+		).toBeNull();
 	} );
 } );

--- a/test/unit/js/src/supports/block-guard.test.js
+++ b/test/unit/js/src/supports/block-guard.test.js
@@ -76,6 +76,7 @@ import {
 	createDropHandler,
 	applyListViewGuardForBlock,
 	applyInspectorListViewGuard,
+	injectBlockGuardStyles,
 } from '@src/supports/block-guard';
 
 /**
@@ -1000,45 +1001,58 @@ describe( 'applyInspectorListViewGuard', () => {
 		expect( tree.dataset.gatherPressGuarded ).toBeUndefined();
 	} );
 
-	it( 'injects a single notice above the tree when enabled', () => {
+	it( 'hides the tree appender when enabled and restores it when disabled', () => {
+		const appender = document.createElement( 'div' );
+		appender.className = 'list-view-appender';
+		tree.appendChild( appender );
+
 		applyInspectorListViewGuard( true );
-		applyInspectorListViewGuard( true );
 
-		const notices = inspector.querySelectorAll(
-			'.gatherpress-block-guard-inspector-notice',
-		);
+		expect( appender.style.display ).toBe( 'none' );
 
-		expect( notices ).toHaveLength( 1 );
-		expect( notices[ 0 ].nextElementSibling ).toBe( tree );
-		expect( notices[ 0 ].textContent ).toContain(
-			'Block Guard is enabled.',
-		);
-		// Without a callback there is no unprotect button.
-		expect( notices[ 0 ].querySelector( 'button' ) ).toBeNull();
-	} );
-
-	it( 'wires the unprotect button to the onDisable callback', () => {
-		const onDisable = jest.fn();
-
-		applyInspectorListViewGuard( true, onDisable );
-
-		const button = inspector.querySelector(
-			'.gatherpress-block-guard-inspector-notice button',
-		);
-
-		button.click();
-
-		expect( onDisable ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	it( 'removes the notice when disabled', () => {
-		applyInspectorListViewGuard( true, jest.fn() );
 		applyInspectorListViewGuard( false );
 
-		expect(
-			inspector.querySelector(
-				'.gatherpress-block-guard-inspector-notice',
-			),
-		).toBeNull();
+		expect( appender.style.display ).toBe( '' );
+	} );
+} );
+
+/**
+ * Pristine jsdom document captured at load time, before any describe swaps
+ * global.document for a mock (in jest's jsdom environment global IS window,
+ * so window.document offers no escape hatch once overwritten).
+ */
+const realDocument = global.document;
+
+/**
+ * Tests for injectBlockGuardStyles function.
+ */
+describe( 'injectBlockGuardStyles', () => {
+	beforeEach( () => {
+		global.document = realDocument;
+
+		// Earlier describes overwrite these as own properties on the shared
+		// document object, shadowing the jsdom prototype methods; deleting
+		// the shadows restores the real implementations.
+		delete document.getElementById;
+		delete document.querySelectorAll;
+		delete document.createElement;
+	} );
+
+	afterEach( () => {
+		document.getElementById( 'gatherpress-block-guard-style' )?.remove();
+	} );
+
+	it( 'injects the panel-ordering stylesheet exactly once', () => {
+		injectBlockGuardStyles();
+		injectBlockGuardStyles();
+
+		const styles = document.querySelectorAll(
+			'#gatherpress-block-guard-style',
+		);
+
+		expect( styles ).toHaveLength( 1 );
+		expect( styles[ 0 ].textContent ).toContain(
+			'.gatherpress-block-guard-panel',
+		);
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1815

## Proposed changes:

* Declare `"listView": true` on all seven blocks from the issue — `modal-content`, `online-event`, `rsvp`, `rsvp-form`, `rsvp-response`, `rsvp-template`, `venue` — plus `add-to-calendar`, which the review surfaced as having the identical guarded-container profile (icon + dropdown inner blocks) and was only missing from the original list.
* **Block Guard now covers the new inspector tab.** The review's key finding: the WP 7.0 List View tab renders a guarded block's inner blocks as a standalone tree in the inspector, bypassing both the canvas `inert` overlay and the existing main-List-View handling — with Block Guard ON, clicking a row selected the inner block (verified empirically in wp-env before writing any fix). New `applyInspectorListViewGuard()` applies the same `inert` treatment as the canvas container to the inspector tree while the guarded block is selected, wired into the existing MutationObserver cycle and gated on `isSelected` so unselected instances never fight over the shared inspector DOM.
* Net behavior: while guarded, the tab stays visible as a **read-only structure map** (nice orientation aid); toggle Block Guard off and the tab becomes the full rearrange/add UI — which pairs well, since the tab is most useful exactly when intentionally editing inner layout.
* Blocks considered and left out: `modal` and `modal-manager` (structural wrappers whose children are wired to trigger behavior, not rearrangeable lists) and `dropdown` (a UI primitive; can revisit if there's demand).

### Other information:

- [x] Have you written new tests for your changes, if applicable? — Four new Jest cases for `applyInspectorListViewGuard` (tab absent, enabled, appender hidden, released); suite at 894 passing.

## Testing instructions:

* `npm run build`, create an event with the "Event with RSVP" starter pattern on WP 7.0.
* Select the RSVP block → the inspector shows a List View tab with the block's inner tree. With Block Guard ON (default), rows are non-interactive (dimmed, no selection on click, appender hidden).
* Toggle Block Guard off in the Settings tab → the List View tab rows select inner blocks and the appender returns.
* Select an unguarded container (e.g. insert an RSVP Form) → its List View tab is fully interactive with no guard involved.

### Credit (for release notes)

My WordPress.org username: mauteri