### PR TITLE
Add the isLink attribute to the event-date block

### DIFF
--- a/.github/changelog/1726-event-date-islink
+++ b/.github/changelog/1726-event-date-islink
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+The Event Date block supports a new isLink attribute, matching the core Post Date block: toggle "Link to event" in the block settings to render the date as a link to the event.

--- a/src/blocks/event-date/block.json
+++ b/src/blocks/event-date/block.json
@@ -22,6 +22,11 @@
 			"type": "string",
 			"default": "both"
 		},
+		"isLink": {
+			"type": "boolean",
+			"default": false,
+			"role": "content"
+		},
 		"startDateFormat": {
 			"type": "string",
 			"default": ""

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -292,7 +292,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 			</BlockControls>
 			{ isLink ? (
 				<a
-					href="#event-date-pseudo-link"
+					href="#gatherpress-event-date-pseudo-link"
 					onClick={ ( event ) => event.preventDefault() }
 				>
 					{ displayedDateTime }

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -195,6 +195,7 @@ const calculateDisplayType = ( toggleType, showStartTime, showEndTime ) => {
 const Edit = ( { attributes, setAttributes, context } ) => {
 	const {
 		displayType,
+		isLink,
 		startDateFormat,
 		endDateFormat,
 		separator,
@@ -245,6 +246,16 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 	const showStartTime = [ 'start', 'both' ].includes( displayType );
 	const showEndTime = [ 'end', 'both' ].includes( displayType );
 
+	const displayedDateTime = displayDateTime(
+		showStartTime ? finalDateTimeStart : null,
+		showEndTime ? finalDateTimeEnd : null,
+		finalTimezone,
+		startDateFormat,
+		endDateFormat,
+		separator,
+		showTimezone
+	);
+
 	return (
 		<div { ...blockProps }>
 			<BlockControls>
@@ -279,14 +290,15 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 					/>
 				</ToolbarGroup>
 			</BlockControls>
-			{ displayDateTime(
-				showStartTime ? finalDateTimeStart : null,
-				showEndTime ? finalDateTimeEnd : null,
-				finalTimezone,
-				startDateFormat,
-				endDateFormat,
-				separator,
-				showTimezone
+			{ isLink ? (
+				<a
+					href="#event-date-pseudo-link"
+					onClick={ ( event ) => event.preventDefault() }
+				>
+					{ displayedDateTime }
+				</a>
+			) : (
+				displayedDateTime
 			) }
 			{ isEventPostType() && (
 				<InspectorControls>
@@ -379,6 +391,13 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 							setAttributes( {
 								showTimezone: value ? 'yes' : 'no',
 							} )
+						}
+					/>
+					<ToggleControl
+						label={ __( 'Link to event', 'gatherpress' ) }
+						checked={ isLink }
+						onChange={ () =>
+							setAttributes( { isLink: ! isLink } )
 						}
 					/>
 				</PanelBody>

--- a/src/blocks/event-date/render.php
+++ b/src/blocks/event-date/render.php
@@ -16,17 +16,25 @@ use GatherPress\Core\Event;
 $gatherpress_block_instance = Setup::get_instance();
 $gatherpress_post_id        = $gatherpress_block_instance->get_post_id( $block->parsed_block );
 $gatherpress_event          = new Event( $gatherpress_post_id );
+$gatherpress_display        = esc_html(
+	$gatherpress_event->get_display_datetime(
+		$attributes['displayType'] ?? '',
+		$attributes['startDateFormat'] ?? '',
+		$attributes['endDateFormat'] ?? '',
+		$attributes['separator'] ?? '',
+		$attributes['showTimezone'] ?? ''
+	)
+);
+
+// Mirrors core/post-date's isLink attribute: link the datetime to the event.
+if ( ! empty( $attributes['isLink'] ) ) {
+	$gatherpress_display = sprintf(
+		'<a href="%s">%s</a>',
+		esc_url( get_permalink( $gatherpress_post_id ) ),
+		$gatherpress_display
+	);
+}
 ?>
 <div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
-	<?php
-	echo esc_html(
-		$gatherpress_event->get_display_datetime(
-			$attributes['displayType'] ?? '',
-			$attributes['startDateFormat'] ?? '',
-			$attributes['endDateFormat'] ?? '',
-			$attributes['separator'] ?? '',
-			$attributes['showTimezone'] ?? ''
-		)
-	);
-	?>
+	<?php echo wp_kses_post( $gatherpress_display ); ?>
 </div>

--- a/src/blocks/event-date/render.php
+++ b/src/blocks/event-date/render.php
@@ -36,5 +36,5 @@ if ( ! empty( $attributes['isLink'] ) ) {
 }
 ?>
 <div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
-	<?php echo wp_kses_post( $gatherpress_display ); ?>
+	<?php echo wp_kses( $gatherpress_display, array( 'a' => array( 'href' => true ) ) ); ?>
 </div>

--- a/test/unit/js/src/blocks/event-date/edit.test.js
+++ b/test/unit/js/src/blocks/event-date/edit.test.js
@@ -1,0 +1,156 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Mocks
+ */
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn( () => ( {
+		dateTimeStart: '2026-08-01 18:00:00',
+		dateTimeEnd: '2026-08-01 20:00:00',
+		timezone: 'UTC',
+		isLoading: false,
+		isValidEvent: true,
+	} ) ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	BlockControls: ( { children } ) => <div>{ children }</div>,
+	InspectorControls: ( { children } ) => <div>{ children }</div>,
+	useBlockProps: jest.fn( () => ( {} ) ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	__experimentalVStack: ( { children } ) => <div>{ children }</div>,
+	PanelBody: ( { children } ) => <div>{ children }</div>,
+	RadioControl: () => null,
+	Spinner: () => <div>spinner</div>,
+	TextControl: () => null,
+	ToggleControl: ( { label, checked, onChange } ) => (
+		<button
+			aria-pressed={ checked }
+			onClick={ () => onChange( ! checked ) }
+		>
+			{ label }
+		</button>
+	),
+	ToolbarButton: ( { text } ) => <button>{ text }</button>,
+	ToolbarGroup: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( '@src/components/DateTimeRange', () => () => null );
+
+jest.mock( '@src/helpers/editor-settings', () => ( {
+	getFromSettings: ( key ) =>
+		( {
+			dateFormat: 'F j, Y',
+			timeFormat: 'g:i a',
+			showTimezone: false,
+		} )[ key ],
+} ) );
+
+jest.mock( '@src/helpers/event', () => ( {
+	isEventPostType: () => false,
+	DISABLED_FIELD_OPACITY: 0.5,
+} ) );
+
+jest.mock( '@src/helpers/editor', () => ( {
+	isInFSETemplate: () => false,
+} ) );
+
+jest.mock( '@src/helpers/datetime', () => {
+	const actualMoment = jest.requireActual( 'moment' );
+
+	return {
+		convertPHPToMomentFormat: () => 'YYYY-MM-DD HH:mm',
+		createMomentWithTimezone: ( dateTime ) => actualMoment( dateTime ),
+		getTimezone: () => 'UTC',
+		getUtcOffset: () => '',
+		isManualOffset: () => false,
+		removeNonTimePHPFormatChars: ( format ) => format,
+	};
+} );
+
+jest.mock( '@src/blocks/event-date/helpers', () => ( {
+	resolveEventDateData: jest.fn(),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import Edit from '@src/blocks/event-date/edit';
+
+const baseAttributes = {
+	displayType: 'both',
+	isLink: false,
+	startDateFormat: '',
+	endDateFormat: '',
+	separator: 'to',
+	showTimezone: '',
+};
+
+const renderEdit = ( attributes = {}, setAttributes = jest.fn() ) =>
+	render(
+		<Edit
+			attributes={ { ...baseAttributes, ...attributes } }
+			setAttributes={ setAttributes }
+			context={ {} }
+		/>
+	);
+
+describe( 'Event Date Edit isLink', () => {
+	it( 'renders the datetime without a link by default', () => {
+		const { container } = renderEdit();
+
+		expect(
+			container.querySelector( 'a[href="#event-date-pseudo-link"]' )
+		).toBeNull();
+	} );
+
+	it( 'wraps the datetime in a pseudo-link when isLink is set', () => {
+		const { container } = renderEdit( { isLink: true } );
+
+		const anchor = container.querySelector(
+			'a[href="#event-date-pseudo-link"]'
+		);
+
+		expect( anchor ).not.toBeNull();
+		expect( anchor.textContent ).not.toBe( '' );
+	} );
+
+	it( 'prevents navigation when the pseudo-link is clicked', () => {
+		const { container } = renderEdit( { isLink: true } );
+
+		const anchor = container.querySelector(
+			'a[href="#event-date-pseudo-link"]'
+		);
+
+		// fireEvent returns false when preventDefault was called.
+		expect( fireEvent.click( anchor ) ).toBe( false );
+	} );
+
+	it( 'toggles the isLink attribute from the Link to event control', () => {
+		const setAttributes = jest.fn();
+		const { getByText } = renderEdit( {}, setAttributes );
+
+		fireEvent.click( getByText( 'Link to event' ) );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { isLink: true } );
+	} );
+
+	it( 'toggles the isLink attribute back off', () => {
+		const setAttributes = jest.fn();
+		const { getByText } = renderEdit( { isLink: true }, setAttributes );
+
+		fireEvent.click( getByText( 'Link to event' ) );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { isLink: false } );
+	} );
+} );

--- a/test/unit/js/src/blocks/event-date/edit.test.js
+++ b/test/unit/js/src/blocks/event-date/edit.test.js
@@ -110,7 +110,7 @@ describe( 'Event Date Edit isLink', () => {
 		const { container } = renderEdit();
 
 		expect(
-			container.querySelector( 'a[href="#event-date-pseudo-link"]' )
+			container.querySelector( 'a[href="#gatherpress-event-date-pseudo-link"]' )
 		).toBeNull();
 	} );
 
@@ -118,7 +118,7 @@ describe( 'Event Date Edit isLink', () => {
 		const { container } = renderEdit( { isLink: true } );
 
 		const anchor = container.querySelector(
-			'a[href="#event-date-pseudo-link"]'
+			'a[href="#gatherpress-event-date-pseudo-link"]'
 		);
 
 		expect( anchor ).not.toBeNull();
@@ -129,7 +129,7 @@ describe( 'Event Date Edit isLink', () => {
 		const { container } = renderEdit( { isLink: true } );
 
 		const anchor = container.querySelector(
-			'a[href="#event-date-pseudo-link"]'
+			'a[href="#gatherpress-event-date-pseudo-link"]'
 		);
 
 		// fireEvent returns false when preventDefault was called.

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-event-date.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-event-date.php
@@ -255,4 +255,59 @@ class Test_Event_Date extends Base {
 			'Empty content should be returned as-is when block content is empty'
 		);
 	}
+
+	/**
+	 * Coverage for the rendered block with the isLink attribute enabled.
+	 *
+	 * Mirrors core/post-date's isLink behavior: the datetime output is
+	 * wrapped in a link to the event.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return void
+	 */
+	public function test_render_links_datetime_to_event_when_islink_set(): void {
+		$event_post = $this->mock->post(
+			array(
+				'post_title' => 'Linked Unit Test Event',
+				'post_type'  => Event::POST_TYPE,
+			)
+		)->get();
+
+		$this->go_to( get_permalink( $event_post->ID ) );
+
+		$output = do_blocks( '<!-- wp:gatherpress/event-date {"isLink":true} /-->' );
+
+		$this->assertStringContainsString(
+			sprintf( '<a href="%s">', esc_url( get_permalink( $event_post->ID ) ) ),
+			$output,
+			'isLink should wrap the datetime in a link to the event.'
+		);
+	}
+
+	/**
+	 * Coverage for the rendered block without the isLink attribute.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return void
+	 */
+	public function test_render_does_not_link_datetime_by_default(): void {
+		$event_post = $this->mock->post(
+			array(
+				'post_title' => 'Unlinked Unit Test Event',
+				'post_type'  => Event::POST_TYPE,
+			)
+		)->get();
+
+		$this->go_to( get_permalink( $event_post->ID ) );
+
+		$output = do_blocks( '<!-- wp:gatherpress/event-date /-->' );
+
+		$this->assertStringNotContainsString(
+			'<a href=',
+			$output,
+			'The datetime should not be linked when isLink is not set.'
+		);
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1726

## Proposed changes:

* Add an `isLink` attribute to `gatherpress/event-date`, mirroring `core/post-date`: `boolean`, `default: false`, `"role": "content"` (matching core's attribute shape exactly, which also serves #1816's role-annotation effort for this block).
* **Frontend:** when set, `render.php` wraps the formatted datetime in `<a href="{event permalink}">`, resolved through the block's existing post-id handling (so post-id overrides and query-loop context both link to the right event).
* **Editor:** a "Link to event" toggle in the Display Settings panel, and the same pseudo-link treatment core uses (`href="#event-date-pseudo-link"` with `preventDefault`) so the date looks like a link without navigating the editor.
* The block already declares `color.link` support, so link color controls apply to the new anchor out of the box.
* Use case from the issue: shadow-source connected post types (e.g. a Workshop listing all its occurrences) can show bare linked dates without repeating the post title ten times.

### Other information:

- [x] Have you written new tests for your changes, if applicable? — Two PHP render tests (anchor present with `isLink`, absent by default) and five Jest cases for the Edit component (pseudo-link render both ways, preventDefault, toggle on/off). Suites: 1526 PHP-side in the block's class run green, 901 JS.

## Testing instructions:

* Insert an Event Date block in an event (or an Event Query loop), open the block's Display Settings, and enable "Link to event".
* In the editor the date renders as a link that doesn't navigate; on the frontend the datetime is wrapped in a link to the event's permalink.
* Toggle it off — the date renders as plain text again.

### Credit (for release notes)

My WordPress.org username: mauteri