### PR TITLE
Stand Block Guard down where core already restricts editing

### DIFF
--- a/.github/changelog/1817-guard-defers-to-core-restrictions
+++ b/.github/changelog/1817-guard-defers-to-core-restrictions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Block Guard now stands down inside contentOnly template locks and synced pattern instances, where core already protects structure but deliberately keeps text editable — previously the guard made that content uneditable with no way to reach the toggle.

--- a/src/supports/block-guard.js
+++ b/src/supports/block-guard.js
@@ -5,6 +5,7 @@ import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addFilter, hasFilter } from '@wordpress/hooks';
 import { useState, useEffect, useCallback } from '@wordpress/element';
@@ -506,6 +507,34 @@ function generateBlockGuardStateKey( name, clientId ) {
 }
 
 /**
+ * Whether core already restricts a block's editing context.
+ *
+ * True when any ancestor imposes a contentOnly template lock or the block
+ * lives inside a synced pattern instance (core/block). In those contexts
+ * core protects structure while deliberately keeping content editable, and
+ * it removes the selection routes to the Block Guard toggle — so the guard
+ * stands down entirely rather than stacking a second, stricter lock on top
+ * (#1817). Read imperatively from the registry because core freezes
+ * rendering of blocks it resolves to a non-default editing mode, which
+ * makes hook-based reads (getBlockEditingMode, useBlockEditingMode) report
+ * a stale `default` forever.
+ *
+ * @param {string} clientId - The block's client ID.
+ *
+ * @return {boolean} Whether core restricts this block's context.
+ */
+function isCoreRestrictedBlock( clientId ) {
+	const { getBlockParents, getBlockName, getTemplateLock } =
+		select( 'core/block-editor' );
+
+	return getBlockParents( clientId ).some(
+		( parentClientId ) =>
+			'contentOnly' === getTemplateLock( parentClientId ) ||
+			'core/block' === getBlockName( parentClientId ),
+	);
+}
+
+/**
  * Higher-Order Component to add BlockGuard functionality to supported GatherPress blocks.
  *
  * This HOC injects a toggle control into the Inspector Controls of blocks
@@ -554,13 +583,24 @@ const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
 
 			injectBlockGuardStyles();
 
+			// The restriction check runs inside each pass, not as a hook:
+			// core freezes rendering of blocks it resolves to a non-default
+			// editing mode, so no hook ever delivers the mode change — but
+			// these observer passes keep firing on DOM churn and read the
+			// live registry each time.
+			const applyPass = () =>
+				applyBlockGuard(
+					clientId,
+					name,
+					stateKey,
+					isBlockGuardEnabled && ! isCoreRestrictedBlock( clientId ),
+				);
+
 			// Apply initially.
-			applyBlockGuard( clientId, name, stateKey, isBlockGuardEnabled );
+			applyPass();
 
 			// Set up observer for DOM changes.
-			const observer = new MutationObserver( () => {
-				applyBlockGuard( clientId, name, stateKey, isBlockGuardEnabled );
-			} );
+			const observer = new MutationObserver( applyPass );
 			observer.observe( document.body, {
 				childList: true,
 				subtree: true,
@@ -581,18 +621,21 @@ const withBlockGuard = createHigherOrderComponent( ( BlockEdit ) => {
 			let dropHandler = null;
 
 			const handleListView = () => {
-				applyListViewGuardForBlock( clientId, isBlockGuardEnabled );
+				const isGuardActive =
+					isBlockGuardEnabled && ! isCoreRestrictedBlock( clientId );
+
+				applyListViewGuardForBlock( clientId, isGuardActive );
 
 				// The inspector's List View tab (WordPress 7.0 `listView`
 				// support) only renders for the selected block, so gate on
 				// selection to keep unselected instances of guarded blocks
 				// from fighting over the shared inspector DOM.
 				if ( isSelected ) {
-					applyInspectorListViewGuard( isBlockGuardEnabled );
+					applyInspectorListViewGuard( isGuardActive );
 				}
 
 				// Handle drag prevention for block guard.
-				if ( isBlockGuardEnabled ) {
+				if ( isGuardActive ) {
 					// Prevent drops into this block like WordPress lock removal.
 					if ( ! dropHandler ) {
 						dropHandler = createDropHandler( clientId );
@@ -717,6 +760,7 @@ export {
 	applyListViewGuardForBlock,
 	applyInspectorListViewGuard,
 	injectBlockGuardStyles,
+	isCoreRestrictedBlock,
 	cleanupBlockGuard,
 	applyBlockGuard,
 };

--- a/test/unit/js/src/supports/block-guard.test.js
+++ b/test/unit/js/src/supports/block-guard.test.js
@@ -14,9 +14,23 @@ import '@testing-library/jest-dom';
 /**
  * WordPress dependencies
  */
+// Registry state steering isCoreRestrictedBlock; tests reshape this to
+// simulate core-restricted contexts (contentOnly template locks, synced
+// pattern instances).
+const mockRegistry = {
+	parents: [],
+	names: {},
+	locks: {},
+};
+
 jest.mock( '@wordpress/data', () => ( {
 	dispatch: jest.fn( () => ( {
 		selectBlock: jest.fn(),
+	} ) ),
+	select: jest.fn( () => ( {
+		getBlockParents: () => mockRegistry.parents,
+		getBlockName: ( id ) => mockRegistry.names[ id ],
+		getTemplateLock: ( id ) => mockRegistry.locks[ id ],
 	} ) ),
 } ) );
 
@@ -66,6 +80,7 @@ jest.mock( '@wordpress/element', () => ( {
  * Internal dependencies
  */
 import {
+	isCoreRestrictedBlock,
 	generateBlockGuardStateKey,
 	getEditorDocument,
 	applyGuardToContainer,
@@ -1054,5 +1069,47 @@ describe( 'injectBlockGuardStyles', () => {
 		expect( styles[ 0 ].textContent ).toContain(
 			'.gatherpress-block-guard-panel',
 		);
+	} );
+} );
+
+/**
+ * Coverage for isCoreRestrictedBlock (#1817).
+ */
+describe( 'isCoreRestrictedBlock', () => {
+	afterEach( () => {
+		mockRegistry.parents = [];
+		mockRegistry.names = {};
+		mockRegistry.locks = {};
+	} );
+
+	it( 'returns false for a block with no ancestors', () => {
+		expect( isCoreRestrictedBlock( 'solo' ) ).toBe( false );
+	} );
+
+	it( 'returns false when no ancestor restricts editing', () => {
+		mockRegistry.parents = [ 'group-1' ];
+		mockRegistry.names = { 'group-1': 'core/group' };
+		mockRegistry.locks = { 'group-1': false };
+
+		expect( isCoreRestrictedBlock( 'child' ) ).toBe( false );
+	} );
+
+	it( 'returns true when an ancestor imposes a contentOnly template lock', () => {
+		mockRegistry.parents = [ 'outer', 'locked-group' ];
+		mockRegistry.names = {
+			outer: 'core/group',
+			'locked-group': 'core/group',
+		};
+		mockRegistry.locks = { outer: false, 'locked-group': 'contentOnly' };
+
+		expect( isCoreRestrictedBlock( 'child' ) ).toBe( true );
+	} );
+
+	it( 'returns true inside a synced pattern instance', () => {
+		mockRegistry.parents = [ 'pattern-instance' ];
+		mockRegistry.names = { 'pattern-instance': 'core/block' };
+		mockRegistry.locks = {};
+
+		expect( isCoreRestrictedBlock( 'child' ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #1817

## Proposed changes:

This is the actionable outcome of the #1817 review. Full audit findings:

* **The conflict (confirmed empirically):** inside a `templateLock: "contentOnly"` container, core assigns a guarded GatherPress block the `disabled` editing mode and its inner text blocks `contentOnly` — core's promise is that the text stays editable. Block Guard's `inert` overlay broke that promise, and because core removes both selection routes to a disabled block (canvas clicks select nothing; the block is hidden from List View entirely), the Block Guard toggle was unreachable. Net effect: content inside guarded blocks in locked containers was permanently uneditable with no UI escape.
* **The fix:** the guard stands down whenever core already restricts the block's context — any ancestor with a contentOnly template lock, or a synced pattern instance (`core/block`) ancestor. Core's protection is stronger and more granular there; stacking ours on top only subtracted. The guard resumes automatically in normal contexts.
* **Implementation note (the tricky part):** the restriction check runs imperatively inside each guard application pass instead of as a hook. Core freezes rendering of blocks it resolves to a non-default editing mode, so both `getBlockEditingMode` and `useBlockEditingMode` report a stale `default` forever from inside the frozen component — verified with render instrumentation. The guard's MutationObserver passes keep firing on DOM churn regardless of React, and read the live registry each time, so the guard releases as soon as the lock resolves.

Other review findings, for the record: synced pattern instances are fully `disabled` by core (guard now stands down there too — consistent, and pattern overrides are core-blocks-only anyway); our registered starter patterns detach to `default` mode on insertion, unaffected; `allowedBlocks` coverage already exists where it matters (modal in block.json, dropdown and rsvp-form in JS); and the `role: "content"` annotation gaps surfaced by this audit are #1816's worklist.

### Other information:

- [x] Have you written new tests for your changes, if applicable? — Four unit tests for `isCoreRestrictedBlock` (no ancestors, unrestricted ancestors, contentOnly lock, synced pattern); block-guard suite at 53, full JS suite at 905.

## Testing instructions:

* Create an event, add a Group block, set its template lock to contentOnly via code or `templateLock` attribute, and place an RSVP block inside plus a plain paragraph as control.
* Before this fix: the paragraph edits, but everything inside the RSVP block is dead — no clicks, absent from List View, toggle unreachable.
* After: text inside the RSVP block (button labels, status text) behaves exactly like the control paragraph — editable per contentOnly, structure protected by core.
* Outside any lock, Block Guard behaves exactly as before (default on, toggle in both inspector tabs).

### Credit (for release notes)

My WordPress.org username: mauteri