### PR TITLE
Let venue block contents expand with wide and full alignments

### DIFF
--- a/.github/changelog/venue-wide-full-layout
+++ b/.github/changelog/venue-wide-full-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Venue blocks set to wide or full width now let their inner content expand with them: the block's inner layout no longer defaults to content-width constraint, and the frontend wrapper keeps the layout and block-supports classes WordPress generates instead of rebuilding a bare div.

--- a/includes/core/classes/blocks/class-venue.php
+++ b/includes/core/classes/blocks/class-venue.php
@@ -93,7 +93,7 @@ class Venue {
 		}
 
 		// Has source post — render with source context.
-		return $this->render_with_source_context( $source_post, $instance );
+		return $this->render_with_source_context( $source_post, $instance, $block_content );
 	}
 
 	/**
@@ -170,16 +170,25 @@ class Venue {
 	 *
 	 * Sets up the global post and block context to the resolved shadow-source
 	 * post (venue, tour, production, etc.), renders the inner blocks, then
-	 * restores the original context.
+	 * restores the original context. The first-pass wrapper is kept and only
+	 * its inner markup is swapped: by the time this block-specific filter
+	 * runs, the generic `render_block` filters have already decorated the
+	 * wrapper with block-supports output (core's layout classes among them),
+	 * and rebuilding the tag from scratch would silently drop all of it.
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param WP_Post  $source_post The source post to use as context.
-	 * @param WP_Block $instance    The block instance.
+	 * @param WP_Post  $source_post      The source post to use as context.
+	 * @param WP_Block $instance         The block instance.
+	 * @param string   $original_content The first-pass block markup, wrapper included.
 	 *
 	 * @return string The rendered block content.
 	 */
-	private function render_with_source_context( WP_Post $source_post, WP_Block $instance ): string {
+	private function render_with_source_context(
+		WP_Post $source_post,
+		WP_Block $instance,
+		string $original_content
+	): string {
 		global $post;
 		$original_post = $post;
 
@@ -210,7 +219,16 @@ class Venue {
 
 		$post = $original_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		// Build wrapper classes from block instance attributes.
+		// Reuse the first-pass wrapper tag verbatim — it carries
+		// get_block_wrapper_attributes() plus everything the generic
+		// `render_block` filters added (alignment, className, layout classes).
+		if ( preg_match( '#\A\s*<div\b[^>]*>#', $original_content, $matches ) ) {
+			return $matches[0] . $block_content . '</div>';
+		}
+
+		// Fallback when the original markup doesn't open with the expected
+		// wrapper tag (e.g. another filter rewrote it entirely): rebuild a
+		// minimal wrapper from the block instance attributes.
 		$classes = array( 'wp-block-gatherpress-venue' );
 
 		if ( ! empty( $instance->attributes['align'] ) ) {

--- a/src/blocks/venue/block.json
+++ b/src/blocks/venue/block.json
@@ -42,11 +42,7 @@
 		"interactivity": {
 			"clientNavigation": true
 		},
-		"layout": {
-			"default": {
-				"type": "constrained"
-			}
-		},
+		"layout": true,
 		"listView": true
 	},
 	"textdomain": "gatherpress",

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-venue.php
@@ -193,7 +193,7 @@ class Test_Venue extends Base {
 	 * @since 0.34.0
 	 * @covers ::render_block
 	 * @covers ::get_venue_post
-	 * @covers ::render_with_venue_context
+	 * @covers ::render_with_source_context
 	 *
 	 * @return void
 	 */
@@ -504,7 +504,7 @@ class Test_Venue extends Base {
 	 * Tests render_with_venue_context restores original post.
 	 *
 	 * @since 0.34.0
-	 * @covers ::render_with_venue_context
+	 * @covers ::render_with_source_context
 	 *
 	 * @return void
 	 */
@@ -564,7 +564,7 @@ class Test_Venue extends Base {
 	 * becomes the context for inner blocks by checking filter behavior.
 	 *
 	 * @since 0.34.0
-	 * @covers ::render_with_venue_context
+	 * @covers ::render_with_source_context
 	 *
 	 * @return void
 	 */
@@ -672,7 +672,7 @@ class Test_Venue extends Base {
 	 * @since 0.34.0
 	 * @covers ::render_block
 	 * @covers ::get_venue_post
-	 * @covers ::render_with_venue_context
+	 * @covers ::render_with_source_context
 	 *
 	 * @return void
 	 */
@@ -795,10 +795,11 @@ class Test_Venue extends Base {
 	}
 
 	/**
-	 * Tests render_with_venue_context applies align class.
+	 * Tests render_with_source_context preserves the align class the
+	 * first-pass wrapper carries.
 	 *
 	 * @since 0.34.0
-	 * @covers ::render_with_venue_context
+	 * @covers ::render_with_source_context
 	 *
 	 * @return void
 	 */
@@ -836,20 +837,25 @@ class Test_Venue extends Base {
 
 		$block = array( 'attrs' => array( 'selectedPostId' => $venue_id ) );
 
-		$result = $instance->render_block( '<div>Test</div>', $block, $block_instance );
+		$result = $instance->render_block(
+			'<div class="wp-block-gatherpress-venue alignwide">Test</div>',
+			$block,
+			$block_instance
+		);
 
 		$this->assertStringContainsString(
 			'alignwide',
 			$result,
-			'Should apply align class to wrapper.'
+			'The align class from the first-pass wrapper should be preserved.'
 		);
 	}
 
 	/**
-	 * Tests render_with_venue_context applies className attribute.
+	 * Tests render_with_source_context preserves custom classes the
+	 * first-pass wrapper carries.
 	 *
 	 * @since 0.34.0
-	 * @covers ::render_with_venue_context
+	 * @covers ::render_with_source_context
 	 *
 	 * @return void
 	 */
@@ -887,20 +893,27 @@ class Test_Venue extends Base {
 
 		$block = array( 'attrs' => array( 'selectedPostId' => $venue_id ) );
 
-		$result = $instance->render_block( '<div>Test</div>', $block, $block_instance );
+		$result = $instance->render_block(
+			'<div class="wp-block-gatherpress-venue custom-class another-class">Test</div>',
+			$block,
+			$block_instance
+		);
 
 		$this->assertStringContainsString(
 			'custom-class another-class',
 			$result,
-			'Should apply className attribute to wrapper.'
+			'Custom classes from the first-pass wrapper should be preserved.'
 		);
 	}
 
 	/**
-	 * Tests render_with_venue_context applies both align and className.
+	 * Tests render_with_source_context keeps the full first-pass wrapper —
+	 * base class, alignment, custom classes, and the layout classes core's
+	 * block-supports pipeline injected — while swapping the inner markup
+	 * for the context-corrected re-render.
 	 *
 	 * @since 0.34.0
-	 * @covers ::render_with_venue_context
+	 * @covers ::render_with_source_context
 	 *
 	 * @return void
 	 */
@@ -939,7 +952,10 @@ class Test_Venue extends Base {
 
 		$block = array( 'attrs' => array( 'selectedPostId' => $venue_id ) );
 
-		$result = $instance->render_block( '<div>Test</div>', $block, $block_instance );
+		$first_pass_markup  = '<div class="wp-block-gatherpress-venue alignfull my-custom-class';
+		$first_pass_markup .= ' is-layout-flow wp-block-gatherpress-venue-is-layout-flow">Original inner</div>';
+
+		$result = $instance->render_block( $first_pass_markup, $block, $block_instance );
 
 		$this->assertStringContainsString(
 			'wp-block-gatherpress-venue',
@@ -949,12 +965,91 @@ class Test_Venue extends Base {
 		$this->assertStringContainsString(
 			'alignfull',
 			$result,
-			'Should apply align class.'
+			'Should preserve the align class.'
 		);
 		$this->assertStringContainsString(
 			'my-custom-class',
 			$result,
-			'Should apply className.'
+			'Should preserve the custom className.'
+		);
+		$this->assertStringContainsString(
+			'is-layout-flow wp-block-gatherpress-venue-is-layout-flow',
+			$result,
+			'Layout classes injected by core block supports must survive the re-render.'
+		);
+		$this->assertStringContainsString(
+			'Inner content',
+			$result,
+			'The inner markup should be the context-corrected re-render.'
+		);
+		$this->assertStringNotContainsString(
+			'Original inner',
+			$result,
+			'The first-pass inner markup should be replaced.'
+		);
+	}
+
+	/**
+	 * Tests render_with_source_context falls back to a rebuilt wrapper when
+	 * the first-pass markup does not open with the expected wrapper tag.
+	 *
+	 * @since 0.34.0
+	 * @covers ::render_with_source_context
+	 *
+	 * @return void
+	 */
+	public function test_render_with_venue_context_rebuilds_wrapper_when_original_has_none(): void {
+		$instance = Venue_Block::get_instance();
+
+		$venue_id = $this->factory->post->create(
+			array(
+				'post_type'  => 'gatherpress_venue',
+				'post_title' => 'Fallback Wrapper Venue',
+			)
+		);
+
+		$block_instance = new WP_Block(
+			array(
+				'blockName'    => 'gatherpress/venue',
+				'attrs'        => array(
+					'selectedPostId' => $venue_id,
+					'align'          => 'wide',
+					'className'      => 'fallback-class',
+				),
+				'innerBlocks'  => array(
+					array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>Inner content</p>',
+						'innerContent' => array( '<p>Inner content</p>' ),
+					),
+				),
+				'innerHTML'    => '',
+				'innerContent' => array( null ),
+			)
+		);
+
+		$block = array( 'attrs' => array( 'selectedPostId' => $venue_id ) );
+
+		// A filter upstream replaced the markup with something that has no
+		// wrapper div — the fallback rebuilds one from block attributes.
+		$result = $instance->render_block( 'plain text, no wrapper', $block, $block_instance );
+
+		$this->assertStringContainsString(
+			'wp-block-gatherpress-venue',
+			$result,
+			'The fallback should rebuild the base wrapper class.'
+		);
+		$this->assertStringContainsString(
+			'alignwide',
+			$result,
+			'The fallback should rebuild the align class from block attributes.'
+		);
+		$this->assertStringContainsString(
+			'fallback-class',
+			$result,
+			'The fallback should rebuild the className from block attributes.'
 		);
 	}
 
@@ -966,7 +1061,7 @@ class Test_Venue extends Base {
 	 *
 	 * @since 0.34.0
 	 * @covers ::get_venue_post
-	 * @covers ::render_with_venue_context
+	 * @covers ::render_with_source_context
 	 *
 	 * @return void
 	 */
@@ -1048,7 +1143,7 @@ class Test_Venue extends Base {
 	 * @since 0.34.0
 	 * @covers ::render_block
 	 * @covers ::get_venue_post
-	 * @covers ::render_with_venue_context
+	 * @covers ::render_with_source_context
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
Fixes the venue block behaving oddly with wide/full alignment: the block could be set wide or full, but the contents inside never expanded with it.

## Root cause (two stacked bugs)

1. **The venue block declared a constrained inner layout** (`supports.layout.default.type = "constrained"`, since 42e8f1a6 / 0.34.0 dev). Constrained layout caps children at the theme's content width — so in the **editor**, a wide/full venue expanded while every child (detail groups, map) stayed clamped at `contentSize` and centered.
2. **The frontend never applied that layout at all.** `Blocks\Venue::render_with_source_context()` re-renders the inner blocks with the venue's post context and then rebuilt the wrapper `<div>` by hand with only the base class + align + className. Since the block-specific `render_block_gatherpress/venue` filter runs *after* the generic `render_block` filters, everything core's block-supports pipeline had injected into the real wrapper (`is-layout-*`, `wp-container-*`, `has-global-padding`) was silently thrown away. Editor and frontend disagreed with each other.

## Fix

- **Layout default switches from `constrained` to flow** (`"layout": true`). Contents now track the venue's own width in every alignment — which is exactly what the frontend has always rendered, so existing sites see no frontend change. Unaligned venues are visually identical (the constraint only ever manifested when the venue was wider than `contentSize`). The layout panel's "Inner blocks use content width" toggle remains available for anyone who wants constrained behavior back — and with the second fix it now actually works on the frontend.
- **`render_with_source_context()` reuses the first-pass wrapper tag verbatim** and swaps only the inner markup, so alignment, custom classes, and core's layout/block-supports output survive the context-corrected re-render. A minimal rebuilt wrapper remains as a fallback when the original markup doesn't open with a wrapper tag.

## Testing

- Updated the wrapper-shape tests to model the real first-pass markup (align, className, and layout classes preserved; first-pass inner markup replaced by the context-corrected render), added a fallback-branch test, and fixed stale `@covers ::render_with_venue_context` annotations pointing at the renamed method.
- Suites green: 1538 PHP + 315 multisite, 901 JS, lint/PHPStan clean.
- Verified live in wp-env: frontend venue wrapper now carries `is-layout-flow wp-block-gatherpress-venue-is-layout-flow` (previously bare `wp-block-gatherpress-venue alignfull`), editor children show `max-width: none` instead of the 645px clamp, and an unaligned venue renders pixel-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)