### PR TITLE
Fix event REST API URL to use rest_url() instead of a hardcoded wp-json path

### DIFF
--- a/.github/changelog/1938-fix-nonce-plain-permalinks
+++ b/.github/changelog/1938-fix-nonce-plain-permalinks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the RSVP and nonce REST endpoints returning a 404 when pretty permalinks are disabled, by building the event REST API URL with rest_url() instead of a hardcoded /wp-json/ path.

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -176,7 +176,7 @@ class Assets {
 		wp_interactivity_state(
 			'gatherpress',
 			array(
-				'eventApiUrl' => home_url( 'wp-json/' . $event_rest_api_slug ),
+				'eventApiUrl' => rest_url( $event_rest_api_slug ),
 			)
 		);
 	}

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -201,7 +201,7 @@ class Test_Assets extends Base {
 	 * Coverage for add_interactivity_state method without pretty permalinks.
 	 *
 	 * Regression: eventApiUrl was previously built via
-	 * `rest_url( $slug )`, a hardcoded path that only resolves
+	 * `home_url( 'wp-json/' . $slug )`, a hardcoded path that only resolves
 	 * when pretty permalinks are enabled. With the plain permalink structure,
 	 * WordPress serves the REST API via `?rest_route=` instead, so the
 	 * hardcoded `/wp-json/` path 404s. Using `rest_url()` adapts to either
@@ -214,7 +214,7 @@ class Test_Assets extends Base {
 	public function test_add_interactivity_state_without_pretty_permalinks(): void {
 		global $wp_rewrite;
 
-		$instance          = Assets::get_instance();
+		$instance            = Assets::get_instance();
 		$permalink_structure = $wp_rewrite->permalink_structure;
 		$wp_rewrite->set_permalink_structure( '' );
 
@@ -222,12 +222,13 @@ class Test_Assets extends Base {
 		$this->go_to( get_post_type_archive_link( Event::POST_TYPE ) );
 
 		$instance->add_interactivity_state();
-		$state = wp_interactivity_state( 'gatherpress' );
+		$state    = wp_interactivity_state( 'gatherpress' );
+		$expected = rest_url( sprintf( '%s/event', GATHERPRESS_REST_NAMESPACE ) );
 
 		$wp_rewrite->set_permalink_structure( $permalink_structure );
 
 		$this->assertSame(
-			rest_url( sprintf( '%s/event', GATHERPRESS_REST_NAMESPACE ) ),
+			$expected,
 			$state['eventApiUrl'],
 			'Failed to assert eventApiUrl matches rest_url() when pretty permalinks are disabled.'
 		);

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -190,10 +190,51 @@ class Test_Assets extends Base {
 			$state,
 			'Failed to assert eventApiUrl is set in interactivity state on the event archive.'
 		);
-		$this->assertStringContainsString(
-			'wp-json/gatherpress/v1/event',
+		$this->assertSame(
+			rest_url( sprintf( '%s/event', GATHERPRESS_REST_NAMESPACE ) ),
 			$state['eventApiUrl'],
-			'Failed to assert eventApiUrl contains the correct REST API path.'
+			'Failed to assert eventApiUrl matches rest_url() so it adapts to the permalink structure.'
+		);
+	}
+
+	/**
+	 * Coverage for add_interactivity_state method without pretty permalinks.
+	 *
+	 * Regression: eventApiUrl was previously built via
+	 * `rest_url( $slug )`, a hardcoded path that only resolves
+	 * when pretty permalinks are enabled. With the plain permalink structure,
+	 * WordPress serves the REST API via `?rest_route=` instead, so the
+	 * hardcoded `/wp-json/` path 404s. Using `rest_url()` adapts to either
+	 * structure.
+	 *
+	 * @covers ::add_interactivity_state
+	 *
+	 * @return void
+	 */
+	public function test_add_interactivity_state_without_pretty_permalinks(): void {
+		global $wp_rewrite;
+
+		$instance          = Assets::get_instance();
+		$permalink_structure = $wp_rewrite->permalink_structure;
+		$wp_rewrite->set_permalink_structure( '' );
+
+		$this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+		$this->go_to( get_post_type_archive_link( Event::POST_TYPE ) );
+
+		$instance->add_interactivity_state();
+		$state = wp_interactivity_state( 'gatherpress' );
+
+		$wp_rewrite->set_permalink_structure( $permalink_structure );
+
+		$this->assertSame(
+			rest_url( sprintf( '%s/event', GATHERPRESS_REST_NAMESPACE ) ),
+			$state['eventApiUrl'],
+			'Failed to assert eventApiUrl matches rest_url() when pretty permalinks are disabled.'
+		);
+		$this->assertStringContainsString(
+			'rest_route=',
+			$state['eventApiUrl'],
+			'Failed to assert eventApiUrl uses the ?rest_route= form without pretty permalinks.'
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Without pretty permalinks, WordPress serves the REST API via `?rest_route=` instead of `/wp-json/`. `Assets::add_interactivity_state()` built `eventApiUrl` with `home_url( 'wp-json/' . $slug )`, a hardcoded path that only resolves with pretty permalinks, so requests like `/wp-json/gatherpress/v1/event/nonce` 404 without them.
- Switched to `rest_url( $slug )`, WP core's function for building REST URLs, which adapts to either permalink structure automatically.
- This state value is also consumed for the RSVP, RSVP form, and RSVP status endpoints (all built via string concatenation on `eventApiUrl` in the interactivity view scripts), so the fix covers those too.
- Updated the existing PHPUnit coverage to assert against `rest_url()` output rather than a hardcoded `wp-json/...` string, and added a new test that disables pretty permalinks and confirms the URL still resolves via the `?rest_route=` form.

| Before | After |
| ------ | ----- |
| <img width="602" height="769" alt="Screenshot 2026-07-14 at 17 25 53" src="https://github.com/user-attachments/assets/ffca524a-7b49-4d38-968d-bdeab6b0c865" /> | <img width="509" height="543" alt="Screenshot 2026-07-14 at 17 27 37" src="https://github.com/user-attachments/assets/6460eef4-f6e6-46e1-8988-3bfee0119a7c" /> |

## Test plan
- [ ] `npm run test:unit:php -- --filter Test_Assets`
- [ ] Manually confirm on a site with plain permalinks (`Settings > Permalinks > Plain`) that the RSVP block's nonce fetch (`/wp-json/gatherpress/v1/event/nonce` equivalent) no longer 404s and RSVP submission works.
- [ ] Confirm no regression on a site with pretty permalinks enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)