### PR TITLE
Fix venue Save button not disabling during creation, allowing duplicate venues

### DIFF
--- a/.github/changelog/1947-venue-save-double-click
+++ b/.github/changelog/1947-venue-save-double-click
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the venue creation Save button not disabling while the request is in flight, which allowed repeated clicks to create multiple duplicate venue posts.

--- a/src/components/VenueForm.js
+++ b/src/components/VenueForm.js
@@ -10,7 +10,7 @@ import {
 	__experimentalHStack as HStack,
 	useNavigator,
 } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import { store as coreDataStore } from '@wordpress/core-data';
@@ -159,7 +159,7 @@ function CreateVenueForm( { search, ...props } ) {
 		singularLabel
 	);
 
-	const { lastError, isSaving } = useSelect(
+	const { lastError, isSaving: isSavingEntityRecord } = useSelect(
 		( select ) => ( {
 			lastError: select( coreDataStore ).getLastEntitySaveError(
 				'postType',
@@ -172,6 +172,18 @@ function CreateVenueForm( { search, ...props } ) {
 		} ),
 		[ venuePostType ]
 	);
+
+	// The venue post is created via a raw apiFetch() call rather than
+	// saveEntityRecord(), so isSavingEntityRecord never reflects the
+	// in-flight request. Track it locally so the Save button disables
+	// and repeated clicks can't create duplicate venues. A ref is used
+	// alongside the state because React batches state updates: clicks
+	// fired synchronously (e.g. a rapid double-click) all run before a
+	// re-render lands, so a state-only guard would still let every one
+	// of them start the save flow.
+	const [ isCreating, setIsCreating ] = useState( false );
+	const isSavingRef = useRef( false );
+	const isSaving = isSavingEntityRecord || isCreating;
 
 	/**
 	 * Validates the venue title.
@@ -365,15 +377,25 @@ function CreateVenueForm( { search, ...props } ) {
 	 * This function is called when the save button is clicked.
 	 */
 	const saveBogus = async () => {
-		if ( isPostTypeSupporting( 'gatherpress-venue' ) ) {
-			// This should only run for the VenueTermsCombobox.
-			await updateVenueTermOnEventPost();
-		} else {
-			// This should only run for the VenuePostsCombobox.
-			await updateVenuePostOnBlockAttributes();
+		if ( isSavingRef.current ) {
+			return;
 		}
-		// In both cases, go home.
-		navigateBack();
+		isSavingRef.current = true;
+		setIsCreating( true );
+		try {
+			if ( isPostTypeSupporting( 'gatherpress-venue' ) ) {
+				// This should only run for the VenueTermsCombobox.
+				await updateVenueTermOnEventPost();
+			} else {
+				// This should only run for the VenuePostsCombobox.
+				await updateVenuePostOnBlockAttributes();
+			}
+			// In both cases, go home.
+			navigateBack();
+		} finally {
+			isSavingRef.current = false;
+			setIsCreating( false );
+		}
 	};
 
 	const hasValidationErrors = !! titleError;

--- a/test/unit/js/src/components/VenueForm.test.js
+++ b/test/unit/js/src/components/VenueForm.test.js
@@ -1,0 +1,155 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent, act } from '@testing-library/react';
+import { expect, test, jest, beforeEach } from '@jest/globals';
+import '@testing-library/jest-dom';
+
+/**
+ * WordPress dependencies
+ */
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn( () => ( { editPost: jest.fn() } ) ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Spinner: () => <span>Spinner</span>,
+	Button: ( { children, onClick, disabled, variant } ) => (
+		<button
+			className={ `is-${ variant }` }
+			onClick={ onClick }
+			disabled={ disabled }
+		>
+			{ children }
+		</button>
+	),
+	TextControl: ( { label, value, onChange, help } ) => (
+		<div>
+			<label htmlFor="test-venue-title">{ label }</label>
+			<input
+				id="test-venue-title"
+				value={ value }
+				onChange={ ( event ) => onChange( event.target.value ) }
+			/>
+			{ help }
+		</div>
+	),
+	__experimentalHStack: ( { children } ) => <div>{ children }</div>,
+	useNavigator: jest.fn( () => ( { goTo: jest.fn() } ) ),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+/**
+ * Internal dependencies
+ */
+jest.mock( '@src/helpers/editor', () => ( {
+	usePostTypeLabel: jest.fn( () => 'Venue' ),
+} ) );
+
+jest.mock( '@src/helpers/venue', () => ( {
+	getVenuePostType: jest.fn( () => 'gatherpress_venue' ),
+	getVenueTaxonomy: jest.fn( () => '_gatherpress_venue' ),
+} ) );
+
+jest.mock( '@src/helpers/event', () => ( {
+	isPostTypeSupporting: jest.fn( () => false ),
+} ) );
+
+jest.mock( '@src/helpers/geocoding', () => ( {
+	geocodeAddress: jest.fn( () =>
+		Promise.resolve( { latitude: '1', longitude: '2' } ),
+	),
+} ) );
+
+jest.mock( '@src/components/AddressAutocompleteField', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+import apiFetch from '@wordpress/api-fetch';
+import { useSelect } from '@wordpress/data';
+import CreateVenueForm from '@src/components/VenueForm';
+
+beforeEach( () => {
+	jest.clearAllMocks();
+
+	useSelect.mockImplementation( ( selector ) =>
+		selector( ( store ) => {
+			if ( 'core' === store ) {
+				return {
+					getPostType: jest.fn( () => ( { rest_base: 'venues' } ) ),
+					getLastEntitySaveError: jest.fn( () => null ),
+					isSavingEntityRecord: jest.fn( () => false ),
+				};
+			}
+			if ( 'core/editor' === store ) {
+				return { getCurrentPostType: jest.fn( () => 'gatherpress_event' ) };
+			}
+			return null;
+		} ),
+	);
+} );
+
+/**
+ * Coverage for CreateVenueForm's duplicate-submission guard.
+ */
+test( 'Save button disables immediately and only creates one venue on repeated clicks', async () => {
+	let resolveFetch;
+	apiFetch.mockImplementation(
+		() =>
+			new Promise( ( resolve ) => {
+				resolveFetch = resolve;
+			} ),
+	);
+
+	const { container } = render(
+		<CreateVenueForm search="My Venue" context={ {} } />,
+	);
+
+	const saveButton = container.querySelector( 'button.is-primary' );
+	expect( saveButton ).not.toBeNull();
+	expect( saveButton ).not.toBeDisabled();
+
+	await act( async () => {
+		fireEvent.click( saveButton );
+		fireEvent.click( saveButton );
+		fireEvent.click( saveButton );
+	} );
+
+	expect( saveButton ).toBeDisabled();
+	expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+	await act( async () => {
+		resolveFetch( { id: 1, slug: 'my-venue' } );
+		await Promise.resolve();
+	} );
+} );
+
+test( 'Save button re-enables after the create request settles', async () => {
+	apiFetch.mockResolvedValue( { id: 1, slug: 'my-venue' } );
+
+	const { container } = render(
+		<CreateVenueForm search="My Venue" context={ {} } />,
+	);
+
+	const saveButton = container.querySelector( 'button.is-primary' );
+
+	await act( async () => {
+		fireEvent.click( saveButton );
+	} );
+
+	expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+	expect( saveButton ).not.toBeDisabled();
+
+	await act( async () => {
+		fireEvent.click( saveButton );
+	} );
+
+	expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+} );


### PR DESCRIPTION
## Summary
- The venue creation "Save" button's `disabled` state was wired to core-data's `isSavingEntityRecord` selector, but venue creation POSTs via a raw `apiFetch()` call that never touches `saveEntityRecord`, so the selector never reflected the in-flight request.
- Rapid/repeated clicks on Save could fire multiple duplicate venue-creation requests before the UI ever disabled the button.
- Adds a `useRef`-based re-entrancy guard in `CreateVenueForm` (state alone is not sufficient here since React batches state updates — clicks fired synchronously in the same tick all read the same stale `isCreating` closure) plus a `useState` flag wired into the existing `isSaving` prop, so the button now disables immediately and only one create request is ever sent per save action.

Before

https://github.com/user-attachments/assets/2ad0cdf6-3853-4394-84bc-91ccccb2842f

After

https://github.com/user-attachments/assets/1e723845-a36c-4acd-8f46-9c5602843e68

## Test plan
- [x] Added `test/unit/js/src/components/VenueForm.test.js` covering: (1) rapid repeated clicks only trigger one `apiFetch` call and the button disables, (2) the button re-enables and a subsequent click works normally after the request settles.
- [x] `npm run test:unit:js` — full suite (903 tests) passes.
- [x] `npm run lint:js` — clean on changed files.
- [x] Manually verified in the block editor: clicking Save repeatedly on the venue creation form no longer creates duplicate venue posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
