### PR TITLE
Add content roles to GatherPress blocks

### DIFF
--- a/.github/changelog/1816-block-content-roles
+++ b/.github/changelog/1816-block-content-roles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+GatherPress blocks now identify user-editable content and content containers for WordPress content-only editing, including dynamic venue details that source their content from post meta.

--- a/src/blocks/add-to-calendar/block.json
+++ b/src/blocks/add-to-calendar/block.json
@@ -14,6 +14,7 @@
 		"queryId"
 	],
 	"supports": {
+		"contentRole": true,
 		"gatherpress": {
 			"blockGuard": true,
 			"postIdOverride": true

--- a/src/blocks/dropdown-item/block.json
+++ b/src/blocks/dropdown-item/block.json
@@ -9,7 +9,8 @@
 	"attributes": {
 		"text": {
 			"type": "string",
-			"default": ""
+			"default": "",
+			"role": "content"
 		}
 	},
 	"parent": ["gatherpress/dropdown"],

--- a/src/blocks/dropdown/block.json
+++ b/src/blocks/dropdown/block.json
@@ -81,7 +81,8 @@
 		},
 		"label": {
 			"type": "string",
-			"default": "Dropdown"
+			"default": "Dropdown",
+			"role": "content"
 		},
 		"labelTextColor": {
 			"type": "string",

--- a/src/blocks/event-date/block.json
+++ b/src/blocks/event-date/block.json
@@ -37,7 +37,8 @@
 		},
 		"separator": {
 			"type": "string",
-			"default": "to"
+			"default": "to",
+			"role": "content"
 		},
 		"showTimezone": {
 			"type": "string",

--- a/src/blocks/form-field/block.json
+++ b/src/blocks/form-field/block.json
@@ -23,11 +23,13 @@
 		},
 		"label": {
 			"type": "string",
-			"default": ""
+			"default": "",
+			"role": "content"
 		},
 		"placeholder": {
 			"type": "string",
-			"default": ""
+			"default": "",
+			"role": "content"
 		},
 		"required": {
 			"type": "boolean",
@@ -35,7 +37,8 @@
 		},
 		"requiredText": {
 			"type": "string",
-			"default": "(required)"
+			"default": "(required)",
+			"role": "content"
 		},
 		"minValue": {
 			"type": "number"
@@ -45,6 +48,7 @@
 		},
 		"radioOptions": {
 			"type": "array",
+			"role": "content",
 			"default": [
 				{
 					"label": "",

--- a/src/blocks/modal-content/block.json
+++ b/src/blocks/modal-content/block.json
@@ -25,6 +25,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"html": false,
 		"color": {
 			"gradients": true,

--- a/src/blocks/online-event-link/block.json
+++ b/src/blocks/online-event-link/block.json
@@ -12,7 +12,8 @@
 	"attributes": {
 		"linkText": {
 			"type": "string",
-			"default": ""
+			"default": "",
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/src/blocks/online-event/block.json
+++ b/src/blocks/online-event/block.json
@@ -21,6 +21,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"gatherpress": {
 			"blockGuard": true,
 			"postIdOverride": true

--- a/src/blocks/rsvp-count/block.json
+++ b/src/blocks/rsvp-count/block.json
@@ -16,11 +16,13 @@
 		},
 		"singularLabel": {
 			"type": "string",
-			"default": "%d attendee"
+			"default": "%d attendee",
+			"role": "content"
 		},
 		"pluralLabel": {
 			"type": "string",
-			"default": "%d attendees"
+			"default": "%d attendees",
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/src/blocks/rsvp-form/block.json
+++ b/src/blocks/rsvp-form/block.json
@@ -19,6 +19,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"gatherpress": {
 			"postIdOverride": true
 		},

--- a/src/blocks/rsvp-response-toggle/block.json
+++ b/src/blocks/rsvp-response-toggle/block.json
@@ -12,11 +12,13 @@
 	"attributes": {
 		"showAll": {
 			"type": "string",
-			"default": "Show all"
+			"default": "Show all",
+			"role": "content"
 		},
 		"showFewer": {
 			"type": "string",
-			"default": "Show fewer"
+			"default": "Show fewer",
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/src/blocks/rsvp-response/block.json
+++ b/src/blocks/rsvp-response/block.json
@@ -28,6 +28,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"gatherpress": {
 			"blockGuard": true,
 			"postIdOverride": true

--- a/src/blocks/rsvp-template/block.json
+++ b/src/blocks/rsvp-template/block.json
@@ -9,6 +9,7 @@
 	"example": {},
 	"description": "Define a reusable template for RSVP entries dynamically populated with data.",
 	"supports": {
+		"contentRole": true,
 		"html": false,
 		"listView": true
 	},

--- a/src/blocks/rsvp/block.json
+++ b/src/blocks/rsvp/block.json
@@ -28,6 +28,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"gatherpress": {
 			"blockGuard": true,
 			"postIdOverride": true

--- a/src/blocks/venue-detail/block.json
+++ b/src/blocks/venue-detail/block.json
@@ -36,6 +36,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"html": false,
 		"anchor": true,
 		"className": true,

--- a/src/blocks/venue-map/block.json
+++ b/src/blocks/venue-map/block.json
@@ -41,7 +41,8 @@
 		},
 		"href": {
 			"type": "string",
-			"default": ""
+			"default": "",
+			"role": "content"
 		},
 		"linkDestination": {
 			"type": "string",

--- a/src/blocks/venue/block.json
+++ b/src/blocks/venue/block.json
@@ -30,6 +30,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"gatherpress": {
 			"blockGuard": true,
 			"postIdOverride": true


### PR DESCRIPTION
Fixes #1816

## Summary

- mark user-editable block attributes with `role: "content"`
- mark content containers and dynamic venue details with `contentRole: true`
- add the required changelog entry

## Validation

- `npm run build`
- `npm run lint:pkg-json`
- `npm run test:unit:js -- --runInBand --no-watchman` (903 tests)
- validated all block definitions against the WordPress trunk schema
