### PR TITLE
Compose geocoded address labels through translatable format strings

### DIFF
--- a/.github/changelog/1950-locale-aware-address-formats
+++ b/.github/changelog/1950-locale-aware-address-formats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Geocoded address labels are now composed through translatable format strings, so each locale's translators control component ordering (e.g. German "Hauptstraße 42, 10115 Berlin") in the editor's address suggestions and the saved address alike. The narrow `gatherpress_geocode_street_line` filter from 0.34.0 is replaced by `gatherpress_formatted_address`, which receives the full label plus every raw address component.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -5,7 +5,7 @@
 Standalone guides for customizing specific GatherPress features through hooks:
 
 - [Event duration filters](event-duration.md): customize the editor's Duration control (`gatherpress.durationOptions`, `gatherpress.durationDefault`).
-- [Venue address format](venue-address-format.md): reorder the house number and street in geocoded address labels (`gatherpress_geocode_street_line`).
+- [Venue address format](venue-address-format.md): locale-aware ordering of geocoded address labels via translatable format strings, plus the `gatherpress_formatted_address` filter.
 
 For every hook GatherPress exposes, see the auto-generated [hook reference](hooks/) and the [hook naming convention](hooks-naming-convention.md).
 

--- a/docs/developer/venue-address-format.md
+++ b/docs/developer/venue-address-format.md
@@ -6,87 +6,133 @@ GatherPress proxies). Each suggestion is a one-line, postal-style label such as
 `42 Hauptstraße, Berlin, 10115`. Picking a suggestion writes that label into the
 venue's address.
 
-By default the street portion of that label is formatted as
-`{house number} {street}` (for example `42 Hauptstraße`). German-speaking and
-several other locales conventionally place the house number after the street
-name (`Hauptstraße 42`). The
-[`gatherpress_geocode_street_line`](#gatherpress_geocode_street_line) filter lets
-you reorder those two pieces.
+The order of the components in that label is locale-aware: GatherPress composes
+the label through two translatable format strings, so each language's
+translators decide the convention. Sites that need a different policy than
+their language's translation provides can rebuild the label with the
+[`gatherpress_formatted_address`](#gatherpress_formatted_address) filter.
 
-## `gatherpress_geocode_street_line`
+## Translatable format strings
 
-Filters the street line (house number plus street) used when GatherPress builds
-an address autocomplete suggestion label.
+The label is built from two `sprintf()` format strings, each registered with
+`_x()` so translators can reorder the placeholders per locale:
+
+| Context | Default | Placeholders |
+|---|---|---|
+| `address street line` | `%1$s %2$s` | 1: house number, 2: street name |
+| `address locality line` | `%1$s, %2$s, %3$s` | 1: city, 2: region/state, 3: postal code |
+
+The two lines are joined with `, `. With the English defaults a German address
+renders as `42 Hauptstraße, Berlin, 10115`; a German translation of `%2$s %1$s`
+and `%3$s %1$s` renders the same address as `Hauptstraße 42, 10115 Berlin` —
+house number after the street, postal code before the city, region omitted.
+
+Missing components are safe to ignore when translating: GatherPress strips the
+dangling separators an empty component leaves behind, so a suggestion without a
+house number or postal code still comes out clean. A placeholder a translation
+doesn't reference (like the region in `%3$s %1$s`) is simply dropped.
+
+Translations resolve in the locale of the request building the label — for the
+editor's autocomplete that is the locale of the user doing the editing, exactly
+like every other GatherPress string.
+
+## `gatherpress_formatted_address`
+
+Filters the finished one-line label after the format strings have composed it.
+The callback receives every raw component, so it can rebuild the label
+wholesale.
 
 | Parameter | Type | Description |
 |---|---|---|
-| `$street_line` | `string` | The default street line, `"{house number} {street}"` (for example `"42 Hauptstraße"`). |
-| `$housenumber` | `string` | The house number on its own. May be empty. |
-| `$street` | `string` | The street name on its own. May be empty. |
+| `$label` | `string` | The composed label (may be empty when the geocoder returned no usable components). |
+| `$components` | `array` | Raw components, each an empty string when absent: `house_number`, `street`, `name`, `locality`, `region`, `postcode`, `country`, `country_code`. |
 
-The filter returns the street line as a string. GatherPress trims the returned
-value; if it comes back empty, the label falls back to the feature's `name`
-property.
+The filter returns the label as a string. GatherPress trims the returned value;
+a suggestion whose label ends up empty is dropped from the autocomplete list.
 
-### Reorder unconditionally
+Notes on the components:
 
-The simplest use is to always place the house number after the street:
+- `name` is the geocoder feature's display name (a point of interest or a
+  station, for example). It becomes the street line when the feature has no
+  street data.
+- `locality` is the city, falling back to the district and then the county.
+- `region` is blanked when it duplicates the locality (city-states like
+  Berlin), before either the format strings or this filter see it.
 
-```php
-add_filter(
-	'gatherpress_geocode_street_line',
-	static function ( string $street_line, string $housenumber, string $street ): string {
-		// Leave partial results (name-only or a missing piece) untouched.
-		if ( '' === $housenumber || '' === $street ) {
-			return $street_line;
-		}
+### Key the format off the address's country
 
-		return trim( $street . ' ' . $housenumber );
-	},
-	10,
-	3
-);
-```
-
-### Reorder only for German locales
-
-To match the locale convention from
-[issue #1833](https://github.com/GatherPress/gatherpress/issues/1833), gate the
-reorder on `get_locale()` so only German-speaking sites (`de_DE`, `de_AT`,
-`de_CH`, and so on) are affected:
+Postal conventions follow the country of the address more than the language of
+the site. `country_code` (a lowercase two-letter code from the geocoder) makes
+that policy possible:
 
 ```php
 add_filter(
-	'gatherpress_geocode_street_line',
-	static function ( string $street_line, string $housenumber, string $street ): string {
-		if ( '' === $housenumber || '' === $street ) {
-			return $street_line;
+	'gatherpress_formatted_address',
+	static function ( string $label, array $components ): string {
+		if ( 'de' !== $components['country_code'] ) {
+			return $label;
 		}
 
-		if ( ! str_starts_with( get_locale(), 'de' ) ) {
-			return $street_line;
-		}
+		$street_line   = trim( $components['street'] . ' ' . $components['house_number'] );
+		$locality_line = trim( $components['postcode'] . ' ' . $components['locality'] );
 
-		return trim( $street . ' ' . $housenumber );
+		return trim( implode( ', ', array_filter( array( $street_line, $locality_line ) ) ), ', ' );
 	},
 	10,
-	3
+	2
 );
 ```
+
+### Reorder the street line only
+
+The equivalent of the removed 0.34.0 filter (see
+[Replaces `gatherpress_geocode_street_line`](#replaces-gatherpress_geocode_street_line)):
+
+```php
+add_filter(
+	'gatherpress_formatted_address',
+	static function ( string $label, array $components ): string {
+		if ( '' === $components['house_number'] || '' === $components['street'] ) {
+			return $label;
+		}
+
+		$flipped = $components['street'] . ' ' . $components['house_number'];
+
+		return str_replace(
+			$components['house_number'] . ' ' . $components['street'],
+			$flipped,
+			$label
+		);
+	},
+	10,
+	2
+);
+```
+
+For a single, always-on ordering change, prefer a translation override of the
+format strings (a `gettext_with_context` filter or a custom language pack) —
+that is what the format strings are for.
+
+## Replaces `gatherpress_geocode_street_line`
+
+The `gatherpress_geocode_street_line` filter shipped in 0.34.0 and only exposed
+the house-number/street portion of the label. It was removed in 0.35.0 in favor
+of the mechanisms above; a callback attached to it is silently ignored. Port
+street-line callbacks to `gatherpress_formatted_address` (previous section) or,
+for locale-wide conventions, to a translation of the format strings.
 
 ## Scope and limitations
 
-- The filter only changes the **suggestion label** shown in the editor's address
+- Formatting applies to the **suggestion label** shown in the editor's address
   autocomplete. That label becomes the saved `gatherpress_address` when a user
-  selects a suggestion, so the saved address follows the order you return.
+  selects a suggestion, so the saved address follows the composed order.
 - It does not change the structured address meta (`gatherpress_house_number`,
   `gatherpress_street`, and the rest). Those are stored as separate fields and
   are not reordered.
-- It only affects the street portion of the label. The locality, region, and
-  postcode are appended after it, comma-separated, and are not touched by this
-  filter.
 - An address a user types by hand (rather than choosing a suggestion) is stored
-  verbatim and never passes through this filter.
+  verbatim and never passes through the format strings or the filter.
+- Already-saved addresses are not reformatted when translations or filters
+  change — the stored address string stays the single source of truth.
 
 ## See also
 

--- a/docs/user/venues.md
+++ b/docs/user/venues.md
@@ -22,7 +22,7 @@ The Venue block allows you to add/edit:
 
 Standard content blocks allow you to add any other content.
 
-For developers: the order of the house number and street in geocoded address suggestions (for example `Hauptstraße 42` versus `42 Hauptstraße`) can be customized with a filter. See [Venue address format](../developer/venue-address-format.md).
+The order of the components in geocoded address suggestions (for example `Hauptstraße 42, 10115 Berlin` versus `42 Hauptstraße, Berlin, 10115`) follows your site language's translation, and developers can customize it further with a filter. See [Venue address format](../developer/venue-address-format.md).
 
 Note:
 

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -1007,78 +1007,159 @@ class Geocoding {
 	/**
 	 * Builds a one-line label from Photon GeocodeJson properties (country omitted).
 	 *
+	 * Component ordering is translator-controlled: the street line and the
+	 * locality tail are each composed through a translatable format string,
+	 * so polyglot teams can encode each locale's postal conventions (e.g.
+	 * German "Hauptstraße 42" and "10115 Berlin") without code changes.
+	 * The label is minted in the locale of the request doing the geocoding
+	 * and stored as plain text — it is not reformatted per viewer later.
+	 *
 	 * @since 0.34.0
+	 * @since 0.35.0 Ordering moved into translatable format strings; the
+	 *               `gatherpress_geocode_street_line` filter was replaced
+	 *               by `gatherpress_formatted_address`.
 	 *
 	 * @param array $properties Photon `properties` object.
 	 *
 	 * @return string Non-empty label or empty string.
 	 */
 	private function format_photon_feature_label( array $properties ): string {
-		$housenumber = isset( $properties['housenumber'] ) ? trim( (string) $properties['housenumber'] ) : '';
-		$street      = isset( $properties['street'] ) ? trim( (string) $properties['street'] ) : '';
-		$name        = isset( $properties['name'] ) ? trim( (string) $properties['name'] ) : '';
+		$pluck = static function ( string $key ) use ( $properties ): string {
+			// Skip non-scalar values — a malformed response with a nested
+			// object would otherwise emit "Array to string conversion"
+			// notices mid-label.
+			if ( ! isset( $properties[ $key ] ) || ! is_scalar( $properties[ $key ] ) ) {
+				return '';
+			}
+			return trim( (string) $properties[ $key ] );
+		};
 
-		$street_line = trim( $housenumber . ' ' . $street );
-
-		/**
-		 * Filters the street line (house number + street) in a geocode label.
-		 *
-		 * Defaults to "{house number} {street}" (e.g. "42 Hauptstraße").
-		 * German-speaking and other locales conventionally place the house
-		 * number after the street ("Hauptstraße 42"); both components are
-		 * passed so a developer can reorder them to match local convention,
-		 * for example by keying off `get_locale()`.
-		 *
-		 * @since 0.34.0
-		 *
-		 * @param string $street_line Default street line ("{house number} {street}").
-		 * @param string $housenumber House number component (may be empty).
-		 * @param string $street      Street name component (may be empty).
-		 */
-		$street_line = trim(
-			(string) apply_filters( 'gatherpress_geocode_street_line', $street_line, $housenumber, $street )
-		);
-
-		if ( '' === $street_line ) {
-			$street_line = $name;
-		}
+		$house_number = $pluck( 'housenumber' );
+		$street       = $pluck( 'street' );
+		$name         = $pluck( 'name' );
 
 		$locality = '';
 		foreach ( array( 'city', 'district', 'county' ) as $key ) {
-			if ( ! empty( $properties[ $key ] ) ) {
-				$locality = trim( (string) $properties[ $key ] );
+			$locality = $pluck( $key );
+			if ( '' !== $locality ) {
 				break;
 			}
 		}
 
-		$region = isset( $properties['state'] ) ? trim( (string) $properties['state'] ) : '';
+		$region   = $pluck( 'state' );
+		$postcode = $pluck( 'postcode' );
 
-		$parts = array();
-
-		if ( '' !== $street_line ) {
-			$parts[] = $street_line;
-		}
-		if ( '' !== $locality ) {
-			$parts[] = $locality;
-		}
-		if ( '' !== $region && 0 !== strcasecmp( $region, $locality ) ) {
-			$parts[] = $region;
-		}
-		if ( ! empty( $properties['postcode'] ) ) {
-			$postcode = trim( (string) $properties['postcode'] );
-			if ( '' !== $postcode ) {
-				$parts[] = $postcode;
-			}
+		// A region that duplicates the locality (city-states like Berlin)
+		// only adds noise — drop it before it reaches the format string.
+		if ( 0 === strcasecmp( $region, $locality ) ) {
+			$region = '';
 		}
 
-		$parts = array_filter(
-			array_map( 'trim', $parts ),
-			static function ( $part ): bool {
-				return '' !== $part;
-			}
+		/* translators: Address street line. 1: house number, 2: street name. Reorder freely, e.g. "%2$s %1$s". */
+		$street_format = _x( '%1$s %2$s', 'address street line', 'gatherpress' );
+		$street_line   = self::normalize_address_line(
+			sprintf( $street_format, $house_number, $street )
 		);
 
-		return implode( ', ', $parts );
+		// A feature with no street data (a POI, a station) labels by name.
+		if ( '' === $street_line ) {
+			$street_line = $name;
+		}
+
+		/* translators: Address locality line. 1: city, 2: region, 3: postal code. Reorder freely, e.g. "%3$s %1$s". */
+		$locality_format = _x( '%1$s, %2$s, %3$s', 'address locality line', 'gatherpress' );
+		$locality_line   = self::normalize_address_line(
+			sprintf( $locality_format, $locality, $region, $postcode )
+		);
+
+		$label = implode(
+			', ',
+			array_filter(
+				array( $street_line, $locality_line ),
+				static function ( string $part ): bool {
+					return '' !== $part;
+				}
+			)
+		);
+
+		/**
+		 * Filters the one-line address label minted from a geocoder result.
+		 *
+		 * Runs after the translatable street/locality format strings have
+		 * composed the default label, and receives every raw component so
+		 * a callback can rebuild the label wholesale — for example keyed
+		 * off `$components['country_code']` when postal conventions should
+		 * follow the address's country rather than the site language.
+		 *
+		 * Replaces the `gatherpress_geocode_street_line` filter from
+		 * 0.34.0, which only exposed the house-number/street portion.
+		 *
+		 * @since 0.35.0
+		 *
+		 * @param string $label      Default label (may be empty).
+		 * @param array  $components {
+		 *     Raw components from the geocoder response; empty string when absent.
+		 *
+		 *     @type string $house_number House number.
+		 *     @type string $street       Street name.
+		 *     @type string $name         Feature name (POIs, stations).
+		 *     @type string $locality     City, falling back to district, then county.
+		 *     @type string $region       State/region ('' when it duplicates the locality).
+		 *     @type string $postcode     Postal code.
+		 *     @type string $country      Country name.
+		 *     @type string $country_code Two-letter country code.
+		 * }
+		 */
+		return trim(
+			(string) apply_filters(
+				'gatherpress_formatted_address',
+				$label,
+				array(
+					'house_number' => $house_number,
+					'street'       => $street,
+					'name'         => $name,
+					'locality'     => $locality,
+					'region'       => $region,
+					'postcode'     => $postcode,
+					'country'      => $pluck( 'country' ),
+					'country_code' => $pluck( 'countrycode' ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Normalizes a sprintf-composed address line.
+	 *
+	 * The translatable format strings are filled with whatever components
+	 * the geocoder returned — missing pieces leave dangling separators
+	 * behind ("Montclair, , 07042" or " Main Road"). Splitting on commas,
+	 * trimming each segment, and dropping the empties turns every partial
+	 * fill into a clean line, so translators never have to reason about
+	 * absent components when reordering placeholders.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param string $line Raw sprintf output.
+	 *
+	 * @return string Cleaned line ('' when every component was empty).
+	 */
+	private static function normalize_address_line( string $line ): string {
+		$is_non_empty = static function ( string $piece ): bool {
+			return '' !== $piece;
+		};
+
+		// The inner space collapse handles adjacent placeholders with an
+		// empty middle component (a custom "%1$s %2$s %3$s" template with
+		// no region would otherwise yield "Montclair  07042").
+		$segments = array_map(
+			static function ( string $segment ) use ( $is_non_empty ): string {
+				return implode( ' ', array_filter( explode( ' ', $segment ), $is_non_empty ) );
+			},
+			array_map( 'trim', explode( ',', $line ) )
+		);
+
+		return implode( ', ', array_filter( $segments, $is_non_empty ) );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -1676,7 +1676,7 @@ class Test_Geocoding extends Base {
 			)
 		);
 
-		remove_filter( 'gettext_with_context', $translate, 10 );
+		remove_filter( 'gettext_with_context', $translate );
 
 		$this->assertSame(
 			'Hauptstraße 42, 10115 Berlin',
@@ -1721,7 +1721,7 @@ class Test_Geocoding extends Base {
 			)
 		);
 
-		remove_filter( 'gatherpress_formatted_address', $callback, 10 );
+		remove_filter( 'gatherpress_formatted_address', $callback );
 
 		$this->assertSame( 'Hauptstraße 42, 10115 Berlin', $rebuilt );
 		$this->assertSame(

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -1636,20 +1636,31 @@ class Test_Geocoding extends Base {
 	}
 
 	/**
-	 * Tests the gatherpress_geocode_street_line filter reorders house number and street.
+	 * Translating the two address format strings reorders components without
+	 * any code — the way a polyglot team encodes a locale's convention.
+	 * German-style translations produce "Hauptstraße 42, 10115 Berlin".
 	 *
 	 * @covers \GatherPress\Core\Geocoding::format_photon_feature_label
 	 *
 	 * @return void
 	 */
-	public function test_geocoding_street_line_filter(): void {
+	public function test_geocoding_translated_address_formats_reorder_components(): void {
 		$instance = Geocoding::get_instance();
 
-		$callback = static function ( string $street_line, string $housenumber, string $street ): string {
-			return trim( $street . ' ' . $housenumber );
+		$translate = static function ( string $translation, string $text, string $context, string $domain ): string {
+			if ( 'gatherpress' !== $domain ) {
+				return $translation;
+			}
+			if ( 'address street line' === $context ) {
+				return '%2$s %1$s';
+			}
+			if ( 'address locality line' === $context ) {
+				return '%3$s %1$s';
+			}
+			return $translation;
 		};
 
-		add_filter( 'gatherpress_geocode_street_line', $callback, 10, 3 );
+		add_filter( 'gettext_with_context', $translate, 10, 4 );
 
 		$reordered = $this->invoke_geocoding_private(
 			$instance,
@@ -1659,15 +1670,108 @@ class Test_Geocoding extends Base {
 					'housenumber' => '42',
 					'street'      => 'Hauptstraße',
 					'city'        => 'Berlin',
+					'state'       => 'Bayern',
+					'postcode'    => '10115',
 				),
 			)
 		);
 
-		remove_filter( 'gatherpress_geocode_street_line', $callback, 10 );
+		remove_filter( 'gettext_with_context', $translate, 10 );
 
-		$this->assertStringContainsString( 'Hauptstraße 42', $reordered );
-		$this->assertStringNotContainsString( '42 Hauptstraße', $reordered );
-		$this->assertStringContainsString( 'Berlin', $reordered );
+		$this->assertSame(
+			'Hauptstraße 42, 10115 Berlin',
+			$reordered,
+			'German-style templates flip the street line and drop the region from the locality line.'
+		);
+	}
+
+	/**
+	 * The gatherpress_formatted_address filter receives the composed label
+	 * plus every raw component and can rebuild the label wholesale.
+	 *
+	 * @covers \GatherPress\Core\Geocoding::format_photon_feature_label
+	 *
+	 * @return void
+	 */
+	public function test_geocoding_formatted_address_filter(): void {
+		$instance = Geocoding::get_instance();
+
+		$received = array();
+		$callback = static function ( string $label, array $components ) use ( &$received ): string {
+			$received = $components;
+			return trim( $components['street'] . ' ' . $components['house_number'] )
+				. ', ' . $components['postcode'] . ' ' . $components['locality'];
+		};
+
+		add_filter( 'gatherpress_formatted_address', $callback, 10, 2 );
+
+		$rebuilt = $this->invoke_geocoding_private(
+			$instance,
+			'format_photon_feature_label',
+			array(
+				array(
+					'housenumber' => '42',
+					'street'      => 'Hauptstraße',
+					'city'        => 'Berlin',
+					'state'       => 'Berlin',
+					'postcode'    => '10115',
+					'country'     => 'Deutschland',
+					'countrycode' => 'DE',
+				),
+			)
+		);
+
+		remove_filter( 'gatherpress_formatted_address', $callback, 10 );
+
+		$this->assertSame( 'Hauptstraße 42, 10115 Berlin', $rebuilt );
+		$this->assertSame(
+			array(
+				'house_number' => '42',
+				'street'       => 'Hauptstraße',
+				'name'         => '',
+				'locality'     => 'Berlin',
+				'region'       => '',
+				'postcode'     => '10115',
+				'country'      => 'Deutschland',
+				'country_code' => 'DE',
+			),
+			$received,
+			'Every raw component reaches the filter; the duplicate region is blanked.'
+		);
+	}
+
+	/**
+	 * Branch coverage for normalize_address_line — dangling separators from
+	 * empty components, inner space collapse, and the all-empty case.
+	 *
+	 * @covers \GatherPress\Core\Geocoding::normalize_address_line
+	 *
+	 * @return void
+	 */
+	public function test_geocoding_private_normalize_address_line(): void {
+		$instance = Geocoding::get_instance();
+
+		$cases = array(
+			'Montclair, , 07042' => 'Montclair, 07042',
+			' Main Road'         => 'Main Road',
+			'Montclair  07042'   => 'Montclair 07042',
+			', , '               => '',
+			''                   => '',
+			'0 Main Road, 0'     => '0 Main Road, 0',
+			'A, B, C'            => 'A, B, C',
+		);
+
+		foreach ( $cases as $input => $expected ) {
+			$this->assertSame(
+				$expected,
+				$this->invoke_geocoding_private(
+					$instance,
+					'normalize_address_line',
+					array( (string) $input )
+				),
+				sprintf( 'Input "%s" should normalize cleanly.', $input )
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What

Makes the ordering of address-label components locale-aware by moving it into two translatable format strings, and replaces the narrow `gatherpress_geocode_street_line` filter (shipped 0.34.0) with a general `gatherpress_formatted_address` filter.

Fixes #1950.

## How it maps to the issue

1. **Editor vs. render** — formatting happens where labels are minted: the geocode/search REST endpoint that powers the editor's address autocomplete. The suggestion labels in the dropdown and the saved `gatherpress_address` are now formatted identically, in the locale of the request.
2. **City / region / ZIP ordering** — the locality tail is now its own format string (`%1$s, %2$s, %3$s` = city, region, postal code), so a locale can reorder or drop components: German's `%3$s %1$s` yields `10115 Berlin`.
3. **Photon locale parameter** — we already send `lang` (derived from `get_locale()`) on every Photon request, but it only localizes place *names*. Photon's GeocodeJson has no locale-aware component ordering equivalent to what Nominatim's `display_name` did, so the ordering policy has to live on our side.
4. **Translation-powered defaults** — exactly what this does. Polyglot teams control both format strings per locale; no filter needed for the common case.

## For translators

| String (context) | Default | German-style translation | Result |
| --- | --- | --- | --- |
| `%1$s %2$s` (address street line) | `42 Hauptstraße` | `%2$s %1$s` | `Hauptstraße 42` |
| `%1$s, %2$s, %3$s` (address locality line) | `Berlin, Region, 10115` | `%3$s %1$s` | `10115 Berlin` |

A normalizer strips the dangling separators empty components leave behind, so translations never have to account for missing pieces (no house number, no ZIP, etc.).

## The replacement filter

`gatherpress_geocode_street_line` only exposed the house-number/street portion and shipped in 0.34.0 only — removed outright rather than deprecated. The new filter receives the whole label plus every raw component:

```php
add_filter( 'gatherpress_formatted_address', function ( string $label, array $components ): string {
	if ( 'de' === $components['country_code'] ) {
		return trim( $components['street'] . ' ' . $components['house_number'] )
			. ', ' . $components['postcode'] . ' ' . $components['locality'];
	}
	return $label;
}, 10, 2 );
```

`$components` carries `house_number`, `street`, `name`, `locality`, `region`, `postcode`, `country`, and `country_code` — the last one so a site can key policy off the **address's country** instead of the site language, which is arguably the more correct axis; the default stays locale-driven because that's what translators can act on.

## Notes

- Untranslated (English/default) output is byte-for-byte unchanged.
- Labels are still minted once and stored as plain text; already-saved addresses are not reformatted. The stored string stays the single source of truth (it's user-editable free text).
- Tests: German-style reordering via `gettext_with_context`, the new filter's contract (label + full component array), and branch-by-branch coverage of the normalizer via direct invokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)