### PR TITLE
Honor per-pattern postTypes in the starter pattern filters

### DIFF
--- a/.github/changelog/1825-per-pattern-post-types
+++ b/.github/changelog/1825-per-pattern-post-types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Starter pattern definitions passed through the `gatherpress_event_starter_patterns` and `gatherpress_venue_starter_patterns` filters may now include a `postTypes` key to register a single pattern against specific post types instead of every post type sharing the support.

--- a/docs/developer/blocks/hookable-patterns/README.md
+++ b/docs/developer/blocks/hookable-patterns/README.md
@@ -38,30 +38,37 @@ The bundled default ships with the plugin:
   in-block pattern pickers stay suppressed.
 
 Third parties can append their own without forking by hooking the
-`gatherpress_event_starter_patterns` filter. The second argument is the
-array of post types declaring `gatherpress-event-date` support that the
-patterns will be registered against — branch on it to scope an entry to
-your own event-acting post type only:
+`gatherpress_event_starter_patterns` filter. A definition without a
+`postTypes` key registers against every post type declaring
+`gatherpress-event-date` support — no slugs to enumerate, and a
+companion post type declaring the support later is included
+automatically. To scope an entry to one post type among several sharing
+the support, give the definition its own `postTypes` key (core's
+per-pattern granularity):
 
 ```php
 add_filter(
     'gatherpress_event_starter_patterns',
-    function ( array $patterns, array $post_types ): array {
-        if ( ! in_array( 'production', $post_types, true ) ) {
-            return $patterns;
-        }
+    function ( array $patterns ): array {
         $patterns[] = array(
             'name'        => 'my-plugin/minimal-event',
             'title'       => __( 'Minimal Event', 'my-plugin' ),
             'description' => __( 'Date + RSVP only.', 'my-plugin' ),
             'content'     => '<!-- wp:gatherpress/event-date /--><!-- wp:gatherpress/rsvp {"patternPicked":true} --><div class="wp-block-gatherpress-rsvp"></div><!-- /wp:gatherpress/rsvp -->',
+            // Only the `production` post type sees this pattern; omit
+            // `postTypes` to register against every supported post type.
+            'postTypes'   => array( 'production' ),
         );
         return $patterns;
-    },
-    10,
-    2
+    }
 );
 ```
+
+The filter's second argument is the array of post types declaring the
+support — useful when the returned patterns themselves should vary by
+which event-acting post types are in scope. The bundled defaults arrive
+in the same array, so they can also be reordered, modified, or removed
+here rather than only appended to.
 
 Per-user dismissal is handled by the modal's own *"Always show starter
 patterns for new pages"* toggle — that's a WordPress-core user
@@ -88,7 +95,7 @@ The bundled default:
 
 Third parties can append their own via the
 `gatherpress_venue_starter_patterns` filter — same shape as the event
-filter above.
+filter above, including the optional per-pattern `postTypes` key.
 
 Per-user dismissal is handled by the modal's own *"Always show starter
 patterns for new pages"* toggle — that's a WordPress-core user

--- a/includes/core/classes/class-starter-pattern-loader.php
+++ b/includes/core/classes/class-starter-pattern-loader.php
@@ -1,12 +1,15 @@
 <?php
 /**
- * Loads starter pattern definitions from a templates directory.
+ * Loads and registers starter pattern definitions.
  *
  * Centralizes the file-per-pattern convention used by the new-event and
  * new-venue starter pattern modals so adding a new pattern is just
  * dropping a `*.php` file into `includes/core/templates/<subsystem>/`.
  * Each file returns an associative array with `name`, `title`,
- * `description`, and `content` keys.
+ * `description`, and `content` keys. Registration against core's block
+ * patterns registry is also shared here so both subsystems honor the
+ * same definition shape — including the optional per-pattern `postTypes`
+ * key.
  *
  * @package GatherPress\Core
  * @since 0.34.0
@@ -60,5 +63,60 @@ class Starter_Pattern_Loader {
 		}
 
 		return $patterns;
+	}
+
+	/**
+	 * Register pattern definitions with core's block patterns registry.
+	 *
+	 * Every definition registers scoped to `core/post-content` (so the
+	 * block editor's starter pattern modal surfaces it on new posts) plus
+	 * the given default post types. A definition may carry its own
+	 * `postTypes` key — mirroring `register_block_pattern()`'s property —
+	 * to narrow that one pattern to specific slugs. That is the opt-out
+	 * from support-level scoping for a pattern that should target one
+	 * post type among several sharing a support.
+	 *
+	 * Entries that are not arrays or lack a `name` are skipped — `name`
+	 * is what `register_block_pattern()` keys on.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param array $patterns   Pattern definitions (`name`, `title`,
+	 *                          `description`, `content`, optional `postTypes`).
+	 * @param array $post_types Default post type slugs for definitions
+	 *                          without their own `postTypes` key.
+	 * @return void
+	 */
+	public static function register( array $patterns, array $post_types ): void {
+		foreach ( $patterns as $pattern ) {
+			if ( ! is_array( $pattern ) || empty( $pattern['name'] ) ) {
+				continue;
+			}
+
+			$pattern_post_types = $post_types;
+
+			// Non-string entries are dropped rather than cast so a malformed
+			// definition can't register a pattern against a bogus slug; an
+			// empty or fully-malformed list falls back to the defaults.
+			if ( ! empty( $pattern['postTypes'] ) && is_array( $pattern['postTypes'] ) ) {
+				$scoped = array_values( array_filter( $pattern['postTypes'], 'is_string' ) );
+
+				if ( ! empty( $scoped ) ) {
+					$pattern_post_types = $scoped;
+				}
+			}
+
+			register_block_pattern(
+				$pattern['name'],
+				array(
+					'title'       => $pattern['title'] ?? '',
+					'description' => $pattern['description'] ?? '',
+					'content'     => $pattern['content'] ?? '',
+					'blockTypes'  => array( 'core/post-content' ),
+					'postTypes'   => $pattern_post_types,
+					'source'      => 'plugin',
+				)
+			);
+		}
 	}
 }

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -252,9 +252,10 @@ class Setup {
 	 * the list through the `gatherpress_event_starter_patterns` filter so
 	 * third parties can append their own, and registers each entry scoped
 	 * to `core/post-content` plus every post type declaring
-	 * `gatherpress-event-date` support. The block editor's starter pattern
-	 * modal — the same UX Twenty Twenty-Five uses on new pages — then
-	 * surfaces them when authors create a new event.
+	 * `gatherpress-event-date` support (or the entry's own `postTypes`
+	 * list when provided). The block editor's starter pattern modal — the
+	 * same UX Twenty Twenty-Five uses on new pages — then surfaces them
+	 * when authors create a new event.
 	 *
 	 * Per-user dismissal is handled by the modal's own "Always show
 	 * starter patterns for new pages" toggle, so no site-wide setting
@@ -279,11 +280,21 @@ class Setup {
 		 * Filters the array of event starter pattern definitions.
 		 *
 		 * Each entry is an associative array with `name`, `title`,
-		 * `description`, and `content` keys. Returned patterns are
-		 * registered with `core/post-content` `blockTypes` scoping plus
-		 * every post type declaring `gatherpress-event-date` support, so
-		 * they appear in the new-event chooser modal for any post type
-		 * acting as an event source.
+		 * `description`, and `content` keys, plus an optional `postTypes`
+		 * key (an array of post type slugs) narrowing that one pattern to
+		 * specific post types. Entries without `postTypes` register
+		 * against every post type declaring `gatherpress-event-date`
+		 * support, so they appear in the new-event chooser modal for any
+		 * post type acting as an event source.
+		 *
+		 * Prefer this filter over calling `register_block_pattern()`
+		 * directly: definitions inherit the support-resolved post type
+		 * list (a companion post type declaring the support is included
+		 * automatically — no slugs to enumerate), the `core/post-content`
+		 * scoping that surfaces patterns in the chooser modal is applied
+		 * for you, and the bundled defaults arrive in the same array so
+		 * they can be reordered, modified, or removed — not just
+		 * appended to.
 		 *
 		 * The `$post_types` array lets consumers tailor the returned
 		 * patterns to the post types about to receive them — useful for
@@ -292,31 +303,18 @@ class Setup {
 		 * is in scope.
 		 *
 		 * @since 0.29.0
+		 * @since 0.35.0 Definitions may include a `postTypes` key to
+		 *               narrow a single pattern's registration.
 		 *
 		 * @param array $patterns   Pattern definitions loaded from the
 		 *                          `includes/core/templates/event/` directory.
 		 * @param array $post_types Post type slugs declaring `gatherpress-event-date`
-		 *                          support that the patterns will be registered against.
+		 *                          support that patterns without their own
+		 *                          `postTypes` key will be registered against.
 		 */
 		$patterns = apply_filters( 'gatherpress_event_starter_patterns', $patterns, $post_types );
 
-		foreach ( (array) $patterns as $pattern ) {
-			if ( ! is_array( $pattern ) || empty( $pattern['name'] ) ) {
-				continue;
-			}
-
-			register_block_pattern(
-				$pattern['name'],
-				array(
-					'title'       => $pattern['title'] ?? '',
-					'description' => $pattern['description'] ?? '',
-					'content'     => $pattern['content'] ?? '',
-					'blockTypes'  => array( 'core/post-content' ),
-					'postTypes'   => $post_types,
-					'source'      => 'plugin',
-				)
-			);
-		}
+		Starter_Pattern_Loader::register( (array) $patterns, $post_types );
 	}
 
 	/**

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -312,9 +312,10 @@ class Setup {
 	 * the list through the `gatherpress_venue_starter_patterns` filter so
 	 * third parties can append their own, and registers each entry scoped
 	 * to `core/post-content` plus every post type declaring
-	 * `gatherpress-venue-information` support. The block editor's starter
-	 * pattern modal — the same UX Twenty Twenty-Five uses on new pages —
-	 * then surfaces them when authors create a new venue.
+	 * `gatherpress-venue-information` support (or the entry's own
+	 * `postTypes` list when provided). The block editor's starter pattern
+	 * modal — the same UX Twenty Twenty-Five uses on new pages — then
+	 * surfaces them when authors create a new venue.
 	 *
 	 * Per-user dismissal is handled by the modal's own "Always show
 	 * starter patterns for new pages" toggle, so no site-wide setting
@@ -339,11 +340,21 @@ class Setup {
 		 * Filters the array of venue starter pattern definitions.
 		 *
 		 * Each entry is an associative array with `name`, `title`,
-		 * `description`, and `content` keys. Returned patterns are
-		 * registered with `core/post-content` `blockTypes` scoping plus
-		 * every post type declaring `gatherpress-venue-information`
+		 * `description`, and `content` keys, plus an optional `postTypes`
+		 * key (an array of post type slugs) narrowing that one pattern to
+		 * specific post types. Entries without `postTypes` register
+		 * against every post type declaring `gatherpress-venue-information`
 		 * support, so they appear in the new-venue chooser modal for any
 		 * post type acting as a venue source.
+		 *
+		 * Prefer this filter over calling `register_block_pattern()`
+		 * directly: definitions inherit the support-resolved post type
+		 * list (a companion post type declaring the support is included
+		 * automatically — no slugs to enumerate), the `core/post-content`
+		 * scoping that surfaces patterns in the chooser modal is applied
+		 * for you, and the bundled defaults arrive in the same array so
+		 * they can be reordered, modified, or removed — not just
+		 * appended to.
 		 *
 		 * The `$post_types` array lets consumers tailor the returned
 		 * patterns to the post types about to receive them — useful for
@@ -352,31 +363,18 @@ class Setup {
 		 * is in scope.
 		 *
 		 * @since 0.27.0
+		 * @since 0.35.0 Definitions may include a `postTypes` key to
+		 *               narrow a single pattern's registration.
 		 *
 		 * @param array $patterns   Pattern definitions loaded from the
 		 *                          `includes/core/templates/venue/` directory.
 		 * @param array $post_types Post type slugs declaring `gatherpress-venue-information`
-		 *                          support that the patterns will be registered against.
+		 *                          support that patterns without their own
+		 *                          `postTypes` key will be registered against.
 		 */
 		$patterns = apply_filters( 'gatherpress_venue_starter_patterns', $patterns, $post_types );
 
-		foreach ( (array) $patterns as $pattern ) {
-			if ( ! is_array( $pattern ) || empty( $pattern['name'] ) ) {
-				continue;
-			}
-
-			register_block_pattern(
-				$pattern['name'],
-				array(
-					'title'       => $pattern['title'] ?? '',
-					'description' => $pattern['description'] ?? '',
-					'content'     => $pattern['content'] ?? '',
-					'blockTypes'  => array( 'core/post-content' ),
-					'postTypes'   => $post_types,
-					'source'      => 'plugin',
-				)
-			);
-		}
+		Starter_Pattern_Loader::register( (array) $patterns, $post_types );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-starter-pattern-loader.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-starter-pattern-loader.php
@@ -10,6 +10,7 @@ namespace GatherPress\Tests\Core;
 
 use GatherPress\Core\Starter_Pattern_Loader;
 use GatherPress\Tests\Base;
+use WP_Block_Patterns_Registry;
 
 /**
  * Class Test_Starter_Pattern_Loader.
@@ -56,5 +57,199 @@ class Test_Starter_Pattern_Loader extends Base {
 		$patterns = Starter_Pattern_Loader::load( $dir );
 
 		$this->assertSame( array(), $patterns );
+	}
+
+	/**
+	 * Unregister a pattern if a previous test left it behind.
+	 *
+	 * @param string $name Pattern name.
+	 *
+	 * @return void
+	 */
+	protected function forget_pattern( string $name ): void {
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( $name ) ) {
+			$registry->unregister( $name );
+		}
+	}
+
+	/**
+	 * A definition without its own `postTypes` key registers against the
+	 * default post types, scoped to `core/post-content`, with the
+	 * definition fields mapped through.
+	 *
+	 * @covers ::register
+	 *
+	 * @return void
+	 */
+	public function test_register_uses_default_post_types(): void {
+		$registry = WP_Block_Patterns_Registry::get_instance();
+		$this->forget_pattern( 'unit-test/support-scoped' );
+
+		Starter_Pattern_Loader::register(
+			array(
+				array(
+					'name'        => 'unit-test/support-scoped',
+					'title'       => 'Support Scoped',
+					'description' => 'Registered against the defaults.',
+					'content'     => '<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->',
+				),
+			),
+			array( 'gatherpress_event', 'my_custom_event' )
+		);
+
+		$pattern = $registry->get_registered( 'unit-test/support-scoped' );
+
+		$this->assertSame(
+			array( 'gatherpress_event', 'my_custom_event' ),
+			$pattern['postTypes'],
+			'Without a per-pattern postTypes key, the default list applies.'
+		);
+		$this->assertSame( array( 'core/post-content' ), $pattern['blockTypes'] );
+		$this->assertSame( 'Support Scoped', $pattern['title'] );
+		$this->assertSame( 'Registered against the defaults.', $pattern['description'] );
+
+		$registry->unregister( 'unit-test/support-scoped' );
+	}
+
+	/**
+	 * A definition carrying its own `postTypes` key registers against
+	 * exactly those slugs — core's per-pattern granularity — instead of
+	 * the default list.
+	 *
+	 * @covers ::register
+	 *
+	 * @return void
+	 */
+	public function test_register_honors_per_pattern_post_types(): void {
+		$registry = WP_Block_Patterns_Registry::get_instance();
+		$this->forget_pattern( 'unit-test/slug-scoped' );
+
+		Starter_Pattern_Loader::register(
+			array(
+				array(
+					'name'      => 'unit-test/slug-scoped',
+					'title'     => 'Slug Scoped',
+					'content'   => '<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->',
+					'postTypes' => array( 'my_custom_event' ),
+				),
+			),
+			array( 'gatherpress_event', 'my_custom_event' )
+		);
+
+		$pattern = $registry->get_registered( 'unit-test/slug-scoped' );
+
+		$this->assertSame(
+			array( 'my_custom_event' ),
+			$pattern['postTypes'],
+			'A per-pattern postTypes key narrows registration to those slugs only.'
+		);
+
+		$registry->unregister( 'unit-test/slug-scoped' );
+	}
+
+	/**
+	 * Malformed `postTypes` values — a non-array, an array with no string
+	 * entries, or an empty array — fall back to the default post types
+	 * instead of registering against garbage.
+	 *
+	 * @covers ::register
+	 *
+	 * @return void
+	 */
+	public function test_register_falls_back_when_post_types_malformed(): void {
+		$registry = WP_Block_Patterns_Registry::get_instance();
+		$defaults = array( 'gatherpress_event' );
+
+		$cases = array(
+			'unit-test/non-array-post-types' => 'my_custom_event',
+			'unit-test/no-string-post-types' => array( 123, true, array( 'nested' ) ),
+			'unit-test/empty-post-types'     => array(),
+		);
+
+		foreach ( $cases as $name => $post_types_value ) {
+			$this->forget_pattern( $name );
+
+			Starter_Pattern_Loader::register(
+				array(
+					array(
+						'name'      => $name,
+						'title'     => 'Malformed',
+						'content'   => '<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->',
+						'postTypes' => $post_types_value,
+					),
+				),
+				$defaults
+			);
+
+			$pattern = $registry->get_registered( $name );
+
+			$this->assertSame(
+				$defaults,
+				$pattern['postTypes'],
+				sprintf( '%s should fall back to the default post types.', $name )
+			);
+
+			$registry->unregister( $name );
+		}
+
+		// String entries survive a partially malformed list; the junk is dropped.
+		$this->forget_pattern( 'unit-test/mixed-post-types' );
+
+		Starter_Pattern_Loader::register(
+			array(
+				array(
+					'name'      => 'unit-test/mixed-post-types',
+					'title'     => 'Mixed',
+					'content'   => '<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->',
+					'postTypes' => array( 'my_custom_event', 42, false ),
+				),
+			),
+			$defaults
+		);
+
+		$this->assertSame(
+			array( 'my_custom_event' ),
+			$registry->get_registered( 'unit-test/mixed-post-types' )['postTypes'],
+			'Non-string entries are dropped; the remaining slugs still narrow the pattern.'
+		);
+
+		$registry->unregister( 'unit-test/mixed-post-types' );
+	}
+
+	/**
+	 * Entries that are not arrays or lack a `name` are skipped, and
+	 * missing title/description/content default to empty strings.
+	 *
+	 * @covers ::register
+	 *
+	 * @return void
+	 */
+	public function test_register_skips_invalid_entries(): void {
+		$registry = WP_Block_Patterns_Registry::get_instance();
+		$this->forget_pattern( 'unit-test/bare-minimum' );
+
+		Starter_Pattern_Loader::register(
+			array(
+				'not-an-array',
+				array( 'title' => 'Nameless' ),
+				array( 'name' => 'unit-test/bare-minimum' ),
+			),
+			array( 'gatherpress_event' )
+		);
+
+		$this->assertFalse(
+			$registry->is_registered( 'Nameless' ),
+			'A definition without a name is never registered.'
+		);
+
+		$pattern = $registry->get_registered( 'unit-test/bare-minimum' );
+
+		$this->assertSame( '', $pattern['title'], 'Missing title defaults to an empty string.' );
+		$this->assertSame( '', $pattern['description'], 'Missing description defaults to an empty string.' );
+		$this->assertSame( '', $pattern['content'], 'Missing content defaults to an empty string.' );
+
+		$registry->unregister( 'unit-test/bare-minimum' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -247,6 +247,53 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * A filter-supplied definition carrying its own `postTypes` key
+	 * registers against exactly those slugs, while definitions without
+	 * one keep the full `gatherpress-event-date` support list.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_honors_per_pattern_post_types(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'unit-test/scoped-event-pattern' ) ) {
+			$registry->unregister( 'unit-test/scoped-event-pattern' );
+		}
+
+		$append_pattern = static function ( array $patterns ): array {
+			$patterns[] = array(
+				'name'      => 'unit-test/scoped-event-pattern',
+				'title'     => 'Scoped Event Pattern',
+				'content'   => '<!-- wp:paragraph --><p>Scoped</p><!-- /wp:paragraph -->',
+				'postTypes' => array( 'my_custom_event' ),
+			);
+			return $patterns;
+		};
+
+		add_filter( 'gatherpress_event_starter_patterns', $append_pattern );
+
+		$instance->register_starter_pattern();
+
+		remove_filter( 'gatherpress_event_starter_patterns', $append_pattern );
+
+		$this->assertSame(
+			array( 'my_custom_event' ),
+			$registry->get_registered( 'unit-test/scoped-event-pattern' )['postTypes'],
+			'The per-pattern postTypes key must narrow registration to those slugs only.'
+		);
+		$this->assertContains(
+			Event::POST_TYPE,
+			$registry->get_registered( 'gatherpress/event-with-rsvp' )['postTypes'],
+			'Definitions without postTypes keep the support-resolved list.'
+		);
+
+		$registry->unregister( 'unit-test/scoped-event-pattern' );
+	}
+
+	/**
 	 * The `gatherpress_event_starter_patterns` filter passes the array of
 	 * post types about to receive the registered patterns as its second
 	 * argument, so consumers can vary the returned patterns based on which

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -370,6 +370,53 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * A filter-supplied definition carrying its own `postTypes` key
+	 * registers against exactly those slugs, while definitions without
+	 * one keep the full `gatherpress-venue-information` support list.
+	 *
+	 * @covers ::register_starter_pattern
+	 *
+	 * @return void
+	 */
+	public function test_register_starter_pattern_honors_per_pattern_post_types(): void {
+		$instance = Setup::get_instance();
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		if ( $registry->is_registered( 'unit-test/scoped-venue-pattern' ) ) {
+			$registry->unregister( 'unit-test/scoped-venue-pattern' );
+		}
+
+		$append_pattern = static function ( array $patterns ): array {
+			$patterns[] = array(
+				'name'      => 'unit-test/scoped-venue-pattern',
+				'title'     => 'Scoped Venue Pattern',
+				'content'   => '<!-- wp:paragraph --><p>Scoped</p><!-- /wp:paragraph -->',
+				'postTypes' => array( 'my_custom_venue' ),
+			);
+			return $patterns;
+		};
+
+		add_filter( 'gatherpress_venue_starter_patterns', $append_pattern );
+
+		$instance->register_starter_pattern();
+
+		remove_filter( 'gatherpress_venue_starter_patterns', $append_pattern );
+
+		$this->assertSame(
+			array( 'my_custom_venue' ),
+			$registry->get_registered( 'unit-test/scoped-venue-pattern' )['postTypes'],
+			'The per-pattern postTypes key must narrow registration to those slugs only.'
+		);
+		$this->assertContains(
+			Venue::POST_TYPE,
+			$registry->get_registered( 'gatherpress/venue-with-map' )['postTypes'],
+			'Definitions without postTypes keep the support-resolved list.'
+		);
+
+		$registry->unregister( 'unit-test/scoped-venue-pattern' );
+	}
+
+	/**
 	 * The `gatherpress_venue_starter_patterns` filter passes the array of
 	 * post types about to receive the registered patterns as its second
 	 * argument, so consumers can vary the returned patterns based on which


### PR DESCRIPTION
## What

A starter pattern definition passed through `gatherpress_event_starter_patterns` / `gatherpress_venue_starter_patterns` may now include a `postTypes` key (an array of post type slugs) to register that one pattern against specific post types. Definitions without the key keep the current behavior: registration against every post type declaring the relevant support.

Fixes #1825.

## How

- The registration loop was duplicated verbatim in `Event\Setup::register_starter_pattern()` and `Venue\Setup::register_starter_pattern()`. It moves into the shared `Starter_Pattern_Loader::register( $patterns, $default_post_types )`, which owns the new `postTypes` handling in one place — the Setup methods now just resolve the support list, apply their filter, and hand off.
- Validation is deliberately minimal and core-like: a non-empty array narrows the pattern, non-string entries are dropped rather than cast (so a malformed value can't register a slug like `"Array"`), and a list left empty by that filtering falls back to the defaults. Slugs are honored verbatim, with no intersection against the support list — this is the opt-out back to core's per-slug granularity, as the issue framed it.
- Per @carstingaxion's comment, both filter docblocks (which CI turns into the hook reference pages) now explain why these filters beat calling `register_block_pattern()` directly: the support-resolved default list (no slugs to enumerate, companion post types included automatically), the `core/post-content` chooser-modal scoping applied for you, and the bundled defaults arriving in the same array so they can be reordered, modified, or removed — not just appended to.

## Example

```php
add_filter(
	'gatherpress_event_starter_patterns',
	function ( array $patterns ): array {
		$patterns[] = array(
			'name'      => 'my-plugin/minimal-event',
			'title'     => __( 'Minimal Event', 'my-plugin' ),
			'content'   => '<!-- wp:gatherpress/event-date /-->',
			// Only the `production` post type sees this pattern.
			'postTypes' => array( 'production' ),
		);
		return $patterns;
	}
);
```

## Tests

- `Starter_Pattern_Loader::register()` gets direct tests for every branch: default scoping, per-pattern narrowing, the malformed-value fallbacks (non-array, no-string-entries, empty array, mixed list), and invalid-entry skipping.
- Each Setup class gets an end-to-end test proving a filter-supplied scoped definition registers against exactly its slugs while the bundled default keeps the full support list.
- The hookable-patterns developer doc's example now shows the `postTypes` key instead of branching on the filter's `$post_types` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)