### PR TITLE
Rebuild the credits standing branch from develop on every run

### DIFF
--- a/.github/workflows/credits-sync.yml
+++ b/.github/workflows/credits-sync.yml
@@ -17,6 +17,11 @@ name: Credits Sync
 # - Membership is checked against the newest credits file (leads + team +
 #   contributors) plus any pending entries already on the standing branch, so
 #   double-crediting can't happen even while the standing PR is open.
+# - The standing branch is rebuilt from develop's head on every run, with the
+#   pending entries re-applied as one fresh commit. Without the rebuild the
+#   branch accumulates merge conflicts: the standing PR squash-merges (its
+#   commits never land in develop's history) and version bumps rewrite
+#   unreleased.json on develop.
 # - Leads and team stay hand-curated; this only ever appends to the
 #   contributors long tail via unreleased.json.
 # - Contributors props-bot can't resolve (no GitHub link on their wp.org
@@ -82,49 +87,64 @@ jobs:
           fi
           echo "Props usernames: $(paste -sd, /tmp/props.txt)"
 
-          # 2. Base state: if the standing branch exists, its unreleased.json
-          # (with pending, not-yet-merged additions) is the base; otherwise
-          # develop's copy is.
+          # 2. Base state: develop's copy (this checkout) is always the base.
+          # The standing branch only contributes its not-yet-merged pending
+          # entries; its history is rebuilt from develop on every run (step
+          # 5). A long-lived branch drifts into merge conflicts otherwise:
+          # the standing PR squash-merges, so its commits never enter
+          # develop's history, and the version bump rewrites unreleased.json
+          # on develop out from under the branch.
+          cp "${UNRELEASED_PATH}" /tmp/unreleased.json
+
           if gh api "repos/${REPO}/git/ref/heads/${SYNC_BRANCH}" > /dev/null 2>&1; then
             branch_exists=1
             gh api "repos/${REPO}/contents/${UNRELEASED_PATH}?ref=${SYNC_BRANCH}" \
-              --jq .content | base64 -d > /tmp/unreleased.json
+              --jq .content | base64 -d \
+              | jq -r '(.contributors // [])[]' | sort -u > /tmp/pending.txt
           else
             branch_exists=0
-            cp "${UNRELEASED_PATH}" /tmp/unreleased.json
+            : > /tmp/pending.txt
           fi
 
-          # 3. Membership: newest version file's full roster + pending entries.
+          # 3. Membership: newest version file's full roster + develop's own
+          # unreleased entries. Pending branch entries are filtered against
+          # it too, so entries already consumed by a release are never
+          # re-proposed from the stale branch copy.
           newest=$(ls .github/scripts/release/credits/*.json | grep -v unreleased | sort -V | tail -1)
           echo "Roster source: ${newest}"
           jq -r '[(.leads // [])[], (.team // [])[], (.contributors // [])[]] | .[]' "${newest}" > /tmp/roster.txt
           jq -r '(.contributors // [])[]' /tmp/unreleased.json >> /tmp/roster.txt
           sort -u /tmp/roster.txt -o /tmp/roster.txt
 
+          pending=$(comm -23 /tmp/pending.txt /tmp/roster.txt || true)
           new_contributors=$(comm -23 /tmp/props.txt /tmp/roster.txt || true)
+          additions=$(printf '%s\n%s\n' "${pending}" "${new_contributors}" | sed '/^$/d' | sort -u)
 
-          if [[ -z "${new_contributors}" ]]; then
+          if [[ -z "${additions}" ]]; then
             echo "::notice::Everyone on PR #${PR_NUMBER} is already credited for this cycle."
             exit 0
           fi
-          echo "New contributors: $(echo "${new_contributors}" | paste -sd, -)"
+          echo "Crediting: $(echo "${additions}" | paste -sd, -)"
 
           # 4. Append and write the updated staging file.
-          jq --argjson add "$(echo "${new_contributors}" | jq -R . | jq -s .)" \
+          jq --argjson add "$(echo "${additions}" | jq -R . | jq -s .)" \
             '.contributors = ((.contributors // []) + $add | unique)' \
             /tmp/unreleased.json > /tmp/unreleased.new.json
           printf '%s\n' "$(jq --indent 4 . /tmp/unreleased.new.json)" > /tmp/unreleased.final.json
 
-          # 5. Ensure the standing branch exists (created from develop's head).
+          # 5. Rebuild the standing branch from develop's head so the single
+          # commit below always sits on current develop and the standing PR
+          # can never conflict.
           develop_sha=$(gh api "repos/${REPO}/git/ref/heads/develop" --jq .object.sha)
 
           if [[ "${branch_exists}" == "0" ]]; then
             gh api "repos/${REPO}/git/refs" \
               -f ref="refs/heads/${SYNC_BRANCH}" -f sha="${develop_sha}" > /dev/null
-            head_sha="${develop_sha}"
           else
-            head_sha=$(gh api "repos/${REPO}/git/ref/heads/${SYNC_BRANCH}" --jq .object.sha)
+            gh api -X PATCH "repos/${REPO}/git/refs/heads/${SYNC_BRANCH}" \
+              -f sha="${develop_sha}" -F force=true > /dev/null
           fi
+          head_sha="${develop_sha}"
 
           # 6. Commit via GraphQL so GitHub signs it (develop requires signed
           # commits; an unsigned CLI commit would block auto-merge).


### PR DESCRIPTION
## What

Fixes the recurring merge conflicts on the standing "Credit new contributors" PR (currently #1964).

## Why it conflicts

The credits-sync workflow kept `credits/unreleased-sync` as a long-lived branch: created from develop once, then stacked with commits across cycles. But the standing PR **squash-merges** into develop, so the branch's commits never enter develop's history — after the first squash the branch's merge-base is stale, and both sides have edited the same lines of `unreleased.json`. A version bump makes it worse: the release flow consumes and rewrites `unreleased.json` on develop while the branch still carries the fat pre-release copy. Conflicts are structural, not incidental.

## The fix

Treat the branch as disposable and its *file contents* as the state:

- develop's copy of `unreleased.json` is always the base;
- the standing branch contributes only its not-yet-merged pending contributor entries, filtered against the released roster (so a version bump can't resurrect consumed credits);
- the branch ref is **force-reset to develop's head** before the single signed commit is created on top.

Every run rebuilds one commit on current develop, so the standing PR can never conflict again, and pending credits survive squashes and releases as data rather than git history.

The currently conflicted branch will be healed in place (same procedure, run once manually) so #1964 turns mergeable with its pending credits (w3lld1 from #1943, linewebdigital from #1953) intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)