### PR TITLE
Harden the E2E ffmpeg install against CDN hangs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -98,8 +98,22 @@ jobs:
       # flaky test can never recover. This downloads only ffmpeg (a few MB),
       # not the browsers, so it doesn't reopen the 2026-05-30 hang above.
       - name: Install Playwright ffmpeg for retry videos
-        timeout-minutes: 5
-        run: npx playwright install ffmpeg
+        timeout-minutes: 6
+        run: |
+          # The ffmpeg download from Playwright's CDN sometimes hangs mid-
+          # transfer rather than failing, so cap each attempt with `timeout`
+          # and retry a few times. If it still can't be fetched, warn and
+          # continue rather than failing the whole job: ffmpeg is only needed
+          # to record a video on a test *retry*, so a run whose tests pass on
+          # the first try is unaffected — and a flaky CDN shouldn't red-x the
+          # entire E2E suite.
+          for attempt in 1 2 3; do
+            if timeout 90 npx playwright install ffmpeg; then
+              exit 0
+            fi
+            echo "ffmpeg install attempt ${attempt} timed out or failed; retrying..."
+          done
+          echo "::warning::Playwright ffmpeg unavailable after retries; retry videos disabled for this run."
 
       - name: Build plugin assets
         run: npm run build


### PR DESCRIPTION
## What

Makes the `Install Playwright ffmpeg for retry videos` step in `e2e-tests.yml` resilient to the flaky download that has been red-x'ing E2E runs (e.g. [this run on #1509](https://github.com/GatherPress/gatherpress/actions/runs/29688771267/job/88197690227)).

## Why

The step runs `npx playwright install ffmpeg` once with a 5-minute kill. The download from Playwright's CDN intermittently **hangs mid-transfer** instead of failing — so it burns the full 5 minutes and the whole E2E job fails **before a single test runs**. It's the same stall class the workflow already documents for the chromium download (2026-05-30), on the ffmpeg binary. Intermittent repo-wide, not tied to any PR.

## The change

```yaml
for attempt in 1 2 3; do
  if timeout 90 npx playwright install ffmpeg; then
    exit 0
  fi
  echo "ffmpeg install attempt ${attempt} timed out or failed; retrying..."
done
echo "::warning::Playwright ffmpeg unavailable after retries; retry videos disabled for this run."
```

- **Per-attempt `timeout 90`** — a plain retry loop wouldn't help, because the failure mode is a *hang*, not a fast error. Each attempt is killed at 90s and retried (3x, under the 6-min step cap).
- **Warn instead of fail** on persistent failure — ffmpeg only records video on the *first retry* of a flaky test, so a run whose tests pass first try never touches it. A CDN blip should not fail the suite. The only cost: in the rare case ffmpeg truly can't be fetched *and* a test flakes, that one retry loses its video.

No test or plugin code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)