### PR TITLE
Delete the credits standing branch after its auto-merge

### DIFF
--- a/.github/workflows/credits-sync.yml
+++ b/.github/workflows/credits-sync.yml
@@ -183,5 +183,8 @@ jobs:
             echo "Opened standing PR #${pr_number}."
           fi
 
-          gh pr merge "${pr_number}" --auto --squash
+          # --delete-branch removes the standing branch once the auto-merge
+          # lands. It is recreated from develop's head on the next sync run
+          # (step 5), so the branch only exists while credits are pending.
+          gh pr merge "${pr_number}" --auto --squash --delete-branch
           echo "Auto-merge enabled on PR #${pr_number}."


### PR DESCRIPTION
## What

Adds `--delete-branch` to the auto-merge in `credits-sync.yml`, so the standing "Credit new contributors" PR (e.g. #1968) removes its `credits/unreleased-sync` branch once it merges.

## Why

The branch was persisting after each merge. Because the sync workflow already recreates the branch from develop's head when it doesn't exist (step 5 of the script), deleting it on merge is safe and cleaner — the branch only exists while credits are actually pending, and there's no stale ref lingering between cycles.

Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)