### PR TITLE
Docs: Block Guard interaction (follow-up to #1973)

### DIFF
--- a/docs/user/blocks/README.md
+++ b/docs/user/blocks/README.md
@@ -22,9 +22,21 @@ Online Event
 
 Some GatherPress blocks use the Block Guard mechanism, which protects them from accidental edits to their inner blocks.
 
-Complex blocks like RSVP are built from many inner blocks (buttons, modals, text). With Block Guard enabled, the whole block behaves as a single unit: you can select it and move it, but you cannot click into its inner structure — the guarded block is just a wrapper. To customize or style the inner blocks, toggle Block Guard off in the block's settings sidebar first — the toggle's help text always tells you which state you are in.
+Complex blocks like RSVP are built from many inner blocks (buttons, modals, text). Without protection, a stray click inside one of them selects an inner piece, and dragging from there pulls that piece out of place. Block Guard prevents this: a guarded block behaves as a single unit until you deliberately step into it.
 
-Keep Block Guard enabled if you only need the standard layout. Toggle it off only when you intentionally want to adjust a block's inner layout, and consider re-enabling it when you are done.
+There is no setting to turn on or off. The block simply responds to how you interact with it:
+
+- **Click it once** to select the whole block. It stays protected, so dragging now moves the entire block — you cannot grab a piece out of it by accident.
+- **Double-click** to work inside it. If you double-click on text, your cursor lands right where you clicked so you can start typing. Double-clicking elsewhere — a button, an image, empty space — still opens the block, but you then click the part you want.
+- **Click outside the block** and the protection comes back on. Moving to a different spot inside an open block does not re-protect it; only leaving the block does.
+
+From the keyboard, press **Enter** or **Space** while the block is selected to open it, then use the usual block navigation to reach what you want.
+
+You can tell the two states apart: a protected block shows a pointer cursor when you hover it, and whichever block you currently have selected is tinted.
+
+The List view is never restricted. You can always expand a guarded block there and select any inner block directly, which is often the easiest way to reach something deep inside a modal. Selecting an inner block that way opens the block too.
+
+Moving a guarded block re-protects it. If you had opened a block and then dragged it somewhere else, double-click it again to carry on editing inside.
 
 Blocks using Block Guard:
 
@@ -34,6 +46,8 @@ Blocks using Block Guard:
 - RSVP Response
 - Venue
 
+While the Venue block is protected, the Venue Map inside it hides its resize handles. Open the Venue block to resize the map.
+
 ### How is this different from WordPress's block locking?
 
-They solve opposite problems. Core's block locking pins a block in place — it prevents moving or removing the block, but still lets you click inside and edit its inner blocks. Block Guard leaves the block free to move as a whole, while protecting its insides from accidental selection and editing. Use core locking when a block must stay where it is; use Block Guard to keep a complex block's inner structure intact while you work around it. The two can be combined.
+They solve opposite problems. Core's block locking pins a block in place — it prevents moving or removing the block, but still lets you click inside and edit its inner blocks. Block Guard leaves the block free to move as a whole, while protecting its insides from accidental selection and editing until you double-click in. Block Guard also never actually locks anything: the block stays fully editable, it just asks for one deliberate gesture first. Use core locking when a block must stay where it is; use Block Guard to keep a complex block's inner structure intact while you work around it. The two can be combined.

--- a/docs/user/blocks/rsvp-and-inner-blocks.md
+++ b/docs/user/blocks/rsvp-and-inner-blocks.md
@@ -2,7 +2,7 @@
 
 When you create an event, it comes with the RSVP block and its inner blocks listed below. Those blocks are the content of the Modal window that opens when clicking on the RSVP button.
 
-The RSVP block uses Block guard by default.
+The RSVP block is protected by [Block Guard](README.md#block-guard).
 
 You can see different states of the RSVP block by choosing in the dropdown:
 
@@ -12,7 +12,9 @@ You can see different states of the RSVP block by choosing in the dropdown:
 - Not attending: what they will see if they change from Attending to Not Attending, or if an admin changed it for them
 - Past event: what they will see for past events
 
-When you toggle Block guard off, you'll see in the List view the inner blocks that you can edit. This is useful if you want to modify for example the content of the Modal windows such as the buttons. Modify with care.
+Double-click the block to work inside it, or expand it in the List view and select an inner block directly. Either way you can then edit the inner blocks — for example the content of the Modal windows, such as the buttons. Modify with care.
+
+Note that moving the RSVP block re-protects it, so double-click it again if you want to keep editing inside.
 
 
 ![[../user-doc-media/20260110122237.png]]

--- a/docs/user/blocks/rsvp-response-and-inner-blocks.md
+++ b/docs/user/blocks/rsvp-response-and-inner-blocks.md
@@ -21,7 +21,7 @@ Developers can add their own patterns to the picker via the
 
 ## Editing the inner content
 
-If you want to edit the content of the RSVP Response Block, you first need to toggle off the Block Guard.
+To edit the content of the RSVP Response block, double-click it to step inside — or expand it in the List view and select an inner block directly. See [Block Guard](README.md#block-guard).
 
 You will then see the default inner content that you can modify. Be careful!
 


### PR DESCRIPTION
Follow-up to [#1973](https://github.com/GatherPress/gatherpress/pull/1973), which replaced Block Guard's on/off toggle with a two-step interaction. The user docs still described the toggle.

## What changed

`docs/user/blocks/README.md` — the Block Guard section rewritten for the shipped behavior:

- **Click once** to select the whole block; it stays protected, so dragging moves the entire block.
- **Double-click** to work inside it. On text, the cursor lands where you clicked; elsewhere the block opens and you click the part you want.
- **Click outside** to re-protect. Moving around *inside* an open block does not re-protect it.
- **Enter / Space** while selected as the keyboard equivalent.

Also documents things the old docs never covered:

- The List view is never restricted, and selecting an inner block there opens the block.
- Moving a guarded block re-protects it (double-click again to carry on).
- How to tell the states apart: pointer cursor when protected, tint on whichever block is selected.
- The Venue Map hides its resize handles while the Venue block is protected.

`rsvp-and-inner-blocks.md` and `rsvp-response-and-inner-blocks.md` — replaced "toggle Block Guard off" with the double-click / List view routes, and linked to the main section.

## Verification

Every claim was fact-checked against `src/supports/block-guard.js` by a separate reviewer pass. That caught three errors in my first draft, all fixed here:

- I had written that a *protected* block is tinted. The tint is driven by selection (`isSelf`), not by the seal — so an open-but-selected block is still tinted, and a protected unselected block is not. The always-on protected signal is the pointer cursor.
- "Your cursor lands where you clicked" was stated unconditionally; caret forwarding only happens when the double-click lands on text.
- Enter/Space was described as doing "the same thing" as double-click; it opens the block but places no cursor.

Docs-only, so `Skip Changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)