### PR TITLE
Adopt final-by-default for classes and retire PHP 7.4 types (#1961)

### DIFF
--- a/.github/changelog/1961-class-finality
+++ b/.github/changelog/1961-class-finality
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Mark classes that are not extension points as final, and drop return types that only existed for PHP 7.4. No behavior change; extending GatherPress continues to work through hooks, post type supports, and the abstract provider base classes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,17 @@ Apply to PHP PHPDoc blocks and JS JSDoc blocks alike.
         - ❌ Bad: `Event::get_instance()` (doesn't exist for these classes)
     - In tests, always check the class structure before deciding instantiation method
     - Look for `use Singleton;` trait to determine if `::get_instance()` should be used
+- **Classes are `final` by default** (#1961). Extensibility flows through hooks, `post_type_supports`, and the abstract provider bases — not through subclassing concrete classes. A new class gets `final` unless it is deliberately an extension point.
+    - ✅ Good: `final class Token {` — a leaf class nothing extends.
+    - ✅ Good: `abstract class Base {` — the documented extension point for settings pages / RSVP response providers / venue map providers.
+    - ❌ Bad: a plain `class Foo {` that nothing extends and that isn't meant to be extended.
+    - **Four things must stay non-final**, and the reasons are worth knowing before you add the keyword:
+        1. Abstract bases (`Settings\Base`, `Calendar\Endpoint_Type`, `Rsvp\Response\Provider\Base`, `Venue\Map\Provider\Base`).
+        2. Anything actually extended in `includes/` — currently `Calendar\Endpoint` and `Migrate`.
+        3. **Anything mocked in tests.** PHPUnit cannot mock a `final` class, so `createMock( Foo::class )` / `getMockBuilder( Foo::class )` and `final` are mutually exclusive. This is what keeps `Event`, `Settings`, `Template`, and `Endpoint` non-final. Check `grep -rn "createMock\|getMockBuilder" test/unit/php` before finalizing.
+        4. Anything a test subclasses, including anonymous `new class() extends Foo` doubles.
+    - `final` makes PHPStan's inference precise: it can prove a return type is never returned, where before a hypothetical subclass kept the union alive. Expect the analyzer to surface dead types when you add the keyword — fix them rather than widening the signature back.
+    - In a `final` class, use `self::` rather than `static::` — late static binding has no meaning once nothing can subclass, and PHPCS enforces it (`Universal.CodeAnalysis.StaticInFinalClass`).
 
 ### PHP Linting Requirements
 

--- a/includes/core/classes/blocks/class-add-to-calendar.php
+++ b/includes/core/classes/blocks/class-add-to-calendar.php
@@ -26,7 +26,7 @@ use WP_HTML_Tag_Processor;
  *
  * @since 0.33.0
  */
-class Add_To_Calendar {
+final class Add_To_Calendar {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-dropdown-item.php
+++ b/includes/core/classes/blocks/class-dropdown-item.php
@@ -24,7 +24,7 @@ use WP_HTML_Tag_Processor;
  *
  * @since 0.33.0
  */
-class Dropdown_Item {
+final class Dropdown_Item {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-dropdown.php
+++ b/includes/core/classes/blocks/class-dropdown.php
@@ -24,7 +24,7 @@ use WP_HTML_Tag_Processor;
  *
  * @since 0.33.0
  */
-class Dropdown {
+final class Dropdown {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-event-date.php
+++ b/includes/core/classes/blocks/class-event-date.php
@@ -24,7 +24,7 @@ use GatherPress\Core\Traits\Singleton;
  *
  * @since 0.33.0
  */
-class Event_Date {
+final class Event_Date {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -24,7 +24,7 @@ use WP_REST_Request;
  *
  * @since 0.33.0
  */
-class Event_Query {
+final class Event_Query {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-form-field.php
+++ b/includes/core/classes/blocks/class-form-field.php
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.33.0
  */
-class Form_Field {
+final class Form_Field {
 
 	/**
 	 * Processed form field attributes with defaults applied.

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -29,7 +29,7 @@ use WP_HTML_Tag_Processor;
  *
  * @since 0.33.0
  */
-class General_Block {
+final class General_Block {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-modal-manager.php
+++ b/includes/core/classes/blocks/class-modal-manager.php
@@ -25,7 +25,7 @@ use WP_HTML_Tag_Processor;
  *
  * @since 0.33.0
  */
-class Modal_Manager {
+final class Modal_Manager {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-modal.php
+++ b/includes/core/classes/blocks/class-modal.php
@@ -26,7 +26,7 @@ use WP_HTML_Tag_Processor;
  *
  * @since 0.33.0
  */
-class Modal {
+final class Modal {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -22,7 +22,7 @@ use WP_Block;
  *
  * @since 0.34.0
  */
-class Online_Event {
+final class Online_Event {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -30,7 +30,7 @@ use WP_HTML_Tag_Processor;
  *
  * @since 0.33.0
  */
-class Rsvp_Form {
+final class Rsvp_Form {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -28,7 +28,7 @@ use WP_User;
  *
  * @since 0.33.0
  */
-class Rsvp_Response {
+final class Rsvp_Response {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -30,7 +30,7 @@ use WP_HTML_Tag_Processor;
  *
  * @since 0.33.0
  */
-class Rsvp_Template {
+final class Rsvp_Template {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -27,7 +27,7 @@ use WP_HTML_Tag_Processor;
  *
  * @since 0.33.0
  */
-class Rsvp {
+final class Rsvp {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-setup.php
+++ b/includes/core/classes/blocks/class-setup.php
@@ -25,7 +25,7 @@ use WP_Post;
  *
  * @since 0.34.0
  */
-class Setup {
+final class Setup {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/blocks/class-venue.php
+++ b/includes/core/classes/blocks/class-venue.php
@@ -26,7 +26,7 @@ use WP_Post;
  *
  * @since 0.34.0
  */
-class Venue {
+final class Venue {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -34,7 +34,7 @@ use GatherPress\Core\Event;
  *
  * @since 0.34.0
  */
-class Calendar {
+final class Calendar {
 
 	/**
 	 * Event this Calendar instance wraps.

--- a/includes/core/classes/calendar/class-post-type-feed.php
+++ b/includes/core/classes/calendar/class-post-type-feed.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.34.0
  */
-class Post_Type_Feed extends Endpoint {
+final class Post_Type_Feed extends Endpoint {
 
 	/**
 	 * Class constructor.

--- a/includes/core/classes/calendar/class-post-type-single-feed.php
+++ b/includes/core/classes/calendar/class-post-type-single-feed.php
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.34.0
  */
-class Post_Type_Single_Feed extends Endpoint {
+final class Post_Type_Single_Feed extends Endpoint {
 
 	/**
 	 * Class constructor.

--- a/includes/core/classes/calendar/class-post-type-single.php
+++ b/includes/core/classes/calendar/class-post-type-single.php
@@ -26,7 +26,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.34.0
  */
-class Post_Type_Single extends Endpoint {
+final class Post_Type_Single extends Endpoint {
 
 	/**
 	 * Class constructor.

--- a/includes/core/classes/calendar/class-redirect.php
+++ b/includes/core/classes/calendar/class-redirect.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.34.0
  */
-class Redirect extends Endpoint_Type {
+final class Redirect extends Endpoint_Type {
 
 	/**
 	 * The target URL for the redirection.

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -39,7 +39,7 @@ use WP_Term;
  *
  * @since 0.34.0
  */
-class Setup {
+final class Setup {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/calendar/class-sitewide-feed.php
+++ b/includes/core/classes/calendar/class-sitewide-feed.php
@@ -28,7 +28,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.34.0
  */
-class Sitewide_Feed extends Endpoint {
+final class Sitewide_Feed extends Endpoint {
 
 	/**
 	 * Class constructor.

--- a/includes/core/classes/calendar/class-taxonomy-feed.php
+++ b/includes/core/classes/calendar/class-taxonomy-feed.php
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.34.0
  */
-class Taxonomy_Feed extends Endpoint {
+final class Taxonomy_Feed extends Endpoint {
 
 	/**
 	 * Class constructor.

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -22,7 +22,7 @@ use GatherPress\Core\Traits\Singleton;
  *
  * @since 0.27.0
  */
-class Assets {
+final class Assets {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-autoloader.php
+++ b/includes/core/classes/class-autoloader.php
@@ -22,7 +22,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.27.0
  */
-class Autoloader {
+final class Autoloader {
 
 	/**
 	 * Register method for autoloader.

--- a/includes/core/classes/class-cli.php
+++ b/includes/core/classes/class-cli.php
@@ -27,7 +27,7 @@ use WP_CLI;
  *
  * @since 0.27.0
  */
-class Cli {
+final class Cli {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-coexistence-guard.php
+++ b/includes/core/classes/class-coexistence-guard.php
@@ -28,7 +28,7 @@ use GatherPress\Core\Traits\Singleton;
  *
  * @since 0.34.0
  */
-class Coexistence_Guard {
+final class Coexistence_Guard {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-export.php
+++ b/includes/core/classes/class-export.php
@@ -23,7 +23,7 @@ use WP_Post;
  *
  * @since 0.30.0
  */
-class Export extends Migrate {
+final class Export extends Migrate {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -28,7 +28,7 @@ use WP_Query;
  *
  * @since 0.33.0
  */
-class Feed {
+final class Feed {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -31,7 +31,7 @@ use WP_REST_Server;
  *
  * @since 0.34.0
  */
-class Geocoding {
+final class Geocoding {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-import.php
+++ b/includes/core/classes/class-import.php
@@ -24,7 +24,7 @@ use GatherPress\Core\Traits\Singleton;
  *
  * @since 0.30.0
  */
-class Import extends Migrate {
+final class Import extends Migrate {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -25,7 +25,7 @@ use WP_Site;
  *
  * @since 0.27.0
  */
-class Setup {
+final class Setup {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-shadow-source.php
+++ b/includes/core/classes/class-shadow-source.php
@@ -41,7 +41,7 @@ use WP_Term;
  *
  * @since 0.34.0
  */
-class Shadow_Source {
+final class Shadow_Source {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-site-health.php
+++ b/includes/core/classes/class-site-health.php
@@ -23,7 +23,7 @@ use GatherPress\Core\Traits\Singleton;
  *
  * @since 0.34.0
  */
-class Site_Health {
+final class Site_Health {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-starter-pattern-loader.php
+++ b/includes/core/classes/class-starter-pattern-loader.php
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.34.0
  */
-class Starter_Pattern_Loader {
+final class Starter_Pattern_Loader {
 
 	/**
 	 * Load every starter pattern definition found in a directory.

--- a/includes/core/classes/class-topic.php
+++ b/includes/core/classes/class-topic.php
@@ -23,7 +23,7 @@ use stdClass;
  *
  * @since 0.29.0
  */
-class Topic {
+final class Topic {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/class-user.php
+++ b/includes/core/classes/class-user.php
@@ -28,7 +28,7 @@ use WP_User;
  *
  * @since 0.28.0
  */
-class User {
+final class User {
 
 	/**
 	 * Enforces a single instance of this class.
@@ -96,13 +96,13 @@ class User {
 		if ( $user_id ) {
 			$user_time_format = get_user_meta( $user_id, 'gatherpress_time_format', true );
 
-			if ( static::HOUR_12 === $user_time_format ) {
+			if ( self::HOUR_12 === $user_time_format ) {
 				$time_format = str_replace( 'G', 'g', $time_format );
 
 				if ( ! str_contains( $time_format, 'a' ) ) {
 					$time_format = str_replace( 'i', 'ia', $time_format );
 				}
-			} elseif ( static::HOUR_24 === $user_time_format ) {
+			} elseif ( self::HOUR_24 === $user_time_format ) {
 				$time_format = str_replace(
 					array(
 						'g',

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -24,7 +24,7 @@ use WP_HTML_Tag_Processor;
  *
  * @since 0.27.0
  */
-class Utility {
+final class Utility {
 
 	/**
 	 * Renders a template file.

--- a/includes/core/classes/class-validate.php
+++ b/includes/core/classes/class-validate.php
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.31.0
  */
-class Validate {
+final class Validate {
 
 	/**
 	 * Validate RSVP status.
@@ -63,7 +63,7 @@ class Validate {
 	 */
 	public static function event_post_id( $param ): bool {
 		return (
-			static::positive_number( $param ) &&
+			self::positive_number( $param ) &&
 			post_type_supports( (string) get_post_type( $param ), 'gatherpress-event-date' )
 		);
 	}

--- a/includes/core/classes/commands/class-event-cli.php
+++ b/includes/core/classes/commands/class-event-cli.php
@@ -26,7 +26,7 @@ use WP_CLI;
  * @package GatherPress\Core
  * @since 0.29.0
  */
-class Event_Cli extends WP_CLI {
+final class Event_Cli extends WP_CLI {
 
 	/**
 	 * Update RSVP status for an event.
@@ -74,7 +74,7 @@ class Event_Cli extends WP_CLI {
 		$event     = new Event( $event_id );
 		$response  = $event->rsvp->save( $user_id, $status, $anonymous, $guests );
 
-		static::success(
+		self::success(
 			sprintf(
 				/* translators: %1$d: event ID, %2$s: attendance status, %3$d: user ID. */
 				__(

--- a/includes/core/classes/commands/class-settings-cli.php
+++ b/includes/core/classes/commands/class-settings-cli.php
@@ -23,7 +23,7 @@ use WP_CLI;
  * @package GatherPress\Core
  * @since 0.34.0
  */
-class Settings_Cli extends WP_CLI {
+final class Settings_Cli extends WP_CLI {
 
 	/**
 	 * Export GatherPress settings to JSON.
@@ -60,7 +60,7 @@ class Settings_Cli extends WP_CLI {
 
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 			if ( false === file_put_contents( $file, $json ) ) {
-				static::error(
+				self::error(
 					sprintf(
 						/* translators: %s: File path. */
 						__( 'Failed to write to file: %s', 'gatherpress' ),
@@ -71,7 +71,7 @@ class Settings_Cli extends WP_CLI {
 				return; // @phpstan-ignore deadCode.unreachable
 			}
 
-			static::success(
+			self::success(
 				sprintf(
 					/* translators: %s: File path. */
 					__( 'Settings exported to %s', 'gatherpress' ),
@@ -128,7 +128,7 @@ class Settings_Cli extends WP_CLI {
 		$file = $args[0];
 
 		if ( ! file_exists( $file ) ) {
-			static::error(
+			self::error(
 				sprintf(
 					/* translators: %s: File path. */
 					__( 'File not found: %s', 'gatherpress' ),
@@ -144,7 +144,7 @@ class Settings_Cli extends WP_CLI {
 		$data = json_decode( $json, true );
 
 		if ( ! is_array( $data ) ) {
-			static::error( __( 'Invalid JSON file.', 'gatherpress' ) );
+			self::error( __( 'Invalid JSON file.', 'gatherpress' ) );
 
 			return; // @phpstan-ignore deadCode.unreachable
 		}
@@ -153,18 +153,18 @@ class Settings_Cli extends WP_CLI {
 		$apply    = isset( $assoc_args['apply'] );
 
 		if ( ! $apply ) {
-			static::log( __( 'Dry run — no changes will be applied. Use --apply to import.', 'gatherpress' ) );
+			self::log( __( 'Dry run — no changes will be applied. Use --apply to import.', 'gatherpress' ) );
 
 			$validation = $settings->validate_import( $data );
 
 			if ( ! empty( $validation['warnings'] ) ) {
 				foreach ( $validation['warnings'] as $warning ) {
-					static::warning( $warning );
+					self::warning( $warning );
 				}
 			}
 
 			if ( ! empty( $validation['changes'] ) ) {
-				static::log(
+				self::log(
 					sprintf(
 						/* translators: %s: Comma-separated list of setting keys. */
 						__( 'Would change: %s', 'gatherpress' ),
@@ -172,11 +172,11 @@ class Settings_Cli extends WP_CLI {
 					)
 				);
 			} else {
-				static::log( __( 'No changes would be made.', 'gatherpress' ) );
+				self::log( __( 'No changes would be made.', 'gatherpress' ) );
 			}
 
 			if ( ! empty( $validation['unknown'] ) ) {
-				static::warning(
+				self::warning(
 					sprintf(
 						/* translators: %s: Comma-separated list of unknown keys. */
 						__( 'Unknown keys (would be skipped): %s', 'gatherpress' ),
@@ -192,7 +192,7 @@ class Settings_Cli extends WP_CLI {
 		$result = $settings->import_settings( $data, $mode );
 
 		if ( ! $result['success'] ) {
-			static::error(
+			self::error(
 				! empty( $result['warnings'] )
 					? implode( ' ', $result['warnings'] )
 					: __( 'Import failed.', 'gatherpress' )
@@ -203,12 +203,12 @@ class Settings_Cli extends WP_CLI {
 
 		if ( ! empty( $result['warnings'] ) ) {
 			foreach ( $result['warnings'] as $warning ) {
-				static::warning( $warning );
+				self::warning( $warning );
 			}
 		}
 
 		if ( ! empty( $result['skipped'] ) ) {
-			static::warning(
+			self::warning(
 				sprintf(
 					/* translators: %s: Comma-separated list of skipped keys. */
 					__( 'Skipped unknown keys: %s', 'gatherpress' ),
@@ -217,7 +217,7 @@ class Settings_Cli extends WP_CLI {
 			);
 		}
 
-		static::success(
+		self::success(
 			sprintf(
 				/* translators: %d: Number of imported settings. */
 				__( '%d setting(s) imported successfully.', 'gatherpress' ),

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -33,7 +33,7 @@ use WP_Query;
  * @package GatherPress\Core\Event
  * @since 0.34.0
  */
-class Admin_List {
+final class Admin_List {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/event/class-meta.php
+++ b/includes/core/classes/event/class-meta.php
@@ -40,7 +40,7 @@ use WP_REST_Request;
  *
  * @since 0.34.0
  */
-class Meta {
+final class Meta {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -32,7 +32,7 @@ use WP_Query;
  *
  * @since 0.34.0
  */
-class Query {
+final class Query {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -42,7 +42,7 @@ use WP_User;
  *
  * @since 0.34.0
  */
-class Rest_Api {
+final class Rest_Api {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -34,7 +34,7 @@ use WP_Query;
  *
  * @since 0.34.0
  */
-class Setup {
+final class Setup {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/rsvp/class-cache.php
+++ b/includes/core/classes/rsvp/class-cache.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.35.0
  */
-class Cache {
+final class Cache {
 
 	/**
 	 * Cache key format for RSVPs.

--- a/includes/core/classes/rsvp/class-cleanup.php
+++ b/includes/core/classes/rsvp/class-cleanup.php
@@ -22,7 +22,7 @@ use GatherPress\Core\Traits\Singleton;
  *
  * This class manages rsvp cleanup events.
  */
-class Cleanup {
+final class Cleanup {
 
 	use Singleton;
 

--- a/includes/core/classes/rsvp/class-form.php
+++ b/includes/core/classes/rsvp/class-form.php
@@ -31,7 +31,7 @@ use WP_User;
  * @package GatherPress\Core\Rsvp
  * @since 0.34.0
  */
-class Form {
+final class Form {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -35,7 +35,7 @@ use WP_List_Table;
  * @package GatherPress\Core\Rsvp
  * @since 0.34.0
  */
-class List_Table extends WP_List_Table {
+final class List_Table extends WP_List_Table {
 
 	/**
 	 * Default number of RSVPs to display per page in the admin list table.

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -27,7 +27,7 @@ use WP_Tax_Query;
  * @package GatherPress\Core\Rsvp
  * @since 0.34.0
  */
-class Query {
+final class Query {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -37,7 +37,7 @@ use WP_Post;
  *
  * @since 0.34.0
  */
-class Rsvp {
+final class Rsvp {
 
 	/**
 	 * Capability required to manage RSVPs.
@@ -239,7 +239,7 @@ class Rsvp {
 		string $status,
 		int $anonymous = 0,
 		int $guests = 0,
-	): ?array {
+	): array {
 		$identity = $this->resolve_identity( $identifier );
 
 		if ( null === $identity ) {

--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -36,7 +36,7 @@ use WP_Comment;
  * @package GatherPress\Core\Rsvp
  * @since 0.34.0
  */
-class Setup {
+final class Setup {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/rsvp/class-token.php
+++ b/includes/core/classes/rsvp/class-token.php
@@ -28,7 +28,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  * @package GatherPress\Core\Rsvp
  * @since 0.34.0
  */
-class Token {
+final class Token {
 
 	/**
 	 * The parameter name used for RSVP tokens in URLs.
@@ -201,7 +201,7 @@ class Token {
 	 * @return string The formatted meta key.
 	 */
 	private function get_meta_key(): string {
-		return sprintf( '%s%s', self::META_KEY_PREFIX, static::NAME );
+		return sprintf( '%s%s', self::META_KEY_PREFIX, self::NAME );
 	}
 
 	/**
@@ -410,7 +410,7 @@ class Token {
 
 		$token_value = $this->format_token_value( (int) $comment->comment_ID, $token );
 
-		return add_query_arg( static::NAME, $token_value, $event_url );
+		return add_query_arg( self::NAME, $token_value, $event_url );
 	}
 
 	/**

--- a/includes/core/classes/settings/class-credits.php
+++ b/includes/core/classes/settings/class-credits.php
@@ -24,7 +24,7 @@ use GatherPress\Core\Utility;
  *
  * @since 0.27.0
  */
-class Credits extends Base {
+final class Credits extends Base {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -27,7 +27,7 @@ use GatherPress\Core\Utility;
  *
  * @since 0.34.0
  */
-class Events extends Base {
+final class Events extends Base {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -28,7 +28,7 @@ use GatherPress\Core\Utility;
  *
  * @since 0.34.0
  */
-class Network {
+final class Network {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/settings/class-roles.php
+++ b/includes/core/classes/settings/class-roles.php
@@ -24,7 +24,7 @@ use GatherPress\Core\Traits\Singleton;
  *
  * @since 0.34.0
  */
-class Roles extends Base {
+final class Roles extends Base {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/settings/class-rsvp.php
+++ b/includes/core/classes/settings/class-rsvp.php
@@ -25,7 +25,7 @@ use GatherPress\Core\Utility;
  *
  * @since 0.34.0
  */
-class Rsvp extends Base {
+final class Rsvp extends Base {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/settings/class-tools.php
+++ b/includes/core/classes/settings/class-tools.php
@@ -25,7 +25,7 @@ use GatherPress\Core\Utility;
  *
  * @since 0.34.0
  */
-class Tools extends Base {
+final class Tools extends Base {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -28,7 +28,7 @@ use GatherPress\Core\Venue\Setup;
  *
  * @since 0.34.0
  */
-class Venues extends Base {
+final class Venues extends Base {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/venue/class-meta.php
+++ b/includes/core/classes/venue/class-meta.php
@@ -37,7 +37,7 @@ use WP_REST_Request;
  *
  * @since 0.34.0
  */
-class Meta {
+final class Meta {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -42,7 +42,7 @@ use WP_Post;
  *
  * @since 0.34.0
  */
-class Setup {
+final class Setup {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/venue/class-venue.php
+++ b/includes/core/classes/venue/class-venue.php
@@ -30,7 +30,7 @@ use WP_Term;
  *
  * @since 0.34.0
  */
-class Venue {
+final class Venue {
 
 	/**
 	 * Default venue post type slug.

--- a/includes/core/classes/venue/map/class-dimensions.php
+++ b/includes/core/classes/venue/map/class-dimensions.php
@@ -26,7 +26,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
  *
  * @since 0.35.0
  */
-class Dimensions {
+final class Dimensions {
 
 	/**
 	 * Read a dimension for the venue map from its block attributes.

--- a/includes/core/classes/venue/map/class-manager.php
+++ b/includes/core/classes/venue/map/class-manager.php
@@ -38,7 +38,7 @@ use GatherPress\Core\Venue\Map\Provider\OSM;
  *
  * @since 0.34.0
  */
-class Manager {
+final class Manager {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -50,7 +50,7 @@ use WP_Post;
  * @phpstan-type DescriptorMap array<string, Descriptor>
  * @phpstan-type ProviderDescriptorMap array<string, DescriptorMap>
  */
-class Map {
+final class Map {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/venue/map/class-prewarm.php
+++ b/includes/core/classes/venue/map/class-prewarm.php
@@ -40,7 +40,7 @@ use WP_Post;
  *
  * @since 0.34.0
  */
-class Prewarm {
+final class Prewarm {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/venue/map/class-rest-api.php
+++ b/includes/core/classes/venue/map/class-rest-api.php
@@ -32,7 +32,7 @@ use WP_REST_Server;
  *
  * @since 0.35.0
  */
-class Rest_Api {
+final class Rest_Api {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/venue/map/class-setup.php
+++ b/includes/core/classes/venue/map/class-setup.php
@@ -27,7 +27,7 @@ use GatherPress\Core\Traits\Singleton;
  *
  * @since 0.34.0
  */
-class Setup {
+final class Setup {
 
 	/**
 	 * Enforces a single instance of this class.

--- a/includes/core/classes/venue/map/provider/class-google.php
+++ b/includes/core/classes/venue/map/provider/class-google.php
@@ -30,7 +30,7 @@ use Throwable;
  *
  * @since 0.35.0
  */
-class Google extends Base {
+final class Google extends Base {
 
 	/**
 	 * Google Static Maps API endpoint.
@@ -81,10 +81,6 @@ class Google extends Base {
 	 * Returns null when GD is unavailable, the API key is missing, the
 	 * HTTP request fails, or the response body is not a valid PNG.
 	 *
-	 * Return type is intentionally untyped at the PHP signature level for
-	 * PHP 7.4 compatibility (GD returns a `resource` there, not a
-	 * `GdImage`).
-	 *
 	 * @since 0.35.0
 	 *
 	 * @param float  $latitude  Venue latitude in decimal degrees.
@@ -95,7 +91,7 @@ class Google extends Base {
 	 * @param int    $density   Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @param string $map_type  Map type slug passed from the orchestrator.
 	 *
-	 * @return GdImage|resource|null Finished image, or null on failure.
+	 * @return GdImage|null Finished image, or null on failure.
 	 */
 	public function render(
 		float $latitude,
@@ -245,9 +241,9 @@ class Google extends Base {
 	 *
 	 * @param string $bytes Raw PNG bytes from `fetch_static_map()`.
 	 *
-	 * @return GdImage|resource|false Decoded image, or false when the bytes don't decode.
+	 * @return GdImage|false Decoded image, or false when the bytes don't decode.
 	 */
-	protected function decode_png( string $bytes ) {
+	protected function decode_png( string $bytes ): GdImage|false {
 		try {
 			return imagecreatefromstring( $bytes );
 		} catch ( Throwable $e ) {

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -32,7 +32,7 @@ use Throwable;
  *
  * @since 0.34.0
  */
-class OSM extends Base {
+final class OSM extends Base {
 
 	/**
 	 * Default XYZ tile URL template. CartoDB's "light_all" basemap —
@@ -91,10 +91,6 @@ class OSM extends Base {
 	 * unavailable, when the requested density is unsupported, or when the
 	 * retina variant would require a tile zoom past `Map::ZOOM_MAX`.
 	 *
-	 * Return type is intentionally untyped at the PHP signature level for
-	 * PHP 7.4 compatibility (GD returns a `resource` there, not a
-	 * `GdImage`).
-	 *
 	 * @since 0.34.0
 	 *
 	 * @param float  $latitude  Venue latitude in decimal degrees.
@@ -105,7 +101,7 @@ class OSM extends Base {
 	 * @param int    $density   Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @param string $map_type  Map type slug (OSM only renders roadmap tiles).
 	 *
-	 * @return GdImage|resource|null Finished image, or null on failure.
+	 * @return GdImage|null Finished image, or null on failure.
 	 */
 	public function render(
 		float $latitude,
@@ -206,13 +202,13 @@ class OSM extends Base {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param GdImage|resource $canvas     Canvas being composited into.
-	 * @param int              $tx         X tile coordinate.
-	 * @param int              $ty         Y tile coordinate.
-	 * @param int              $tile_zoom  OSM zoom level for this tile.
-	 * @param int              $left_pixel World-pixel x-offset of the canvas top-left.
-	 * @param int              $top_pixel  World-pixel y-offset of the canvas top-left.
-	 * @param string           $tiles      URL template (`{z}/{x}/{y}` placeholders).
+	 * @param GdImage $canvas     Canvas being composited into.
+	 * @param int     $tx         X tile coordinate.
+	 * @param int     $ty         Y tile coordinate.
+	 * @param int     $tile_zoom  OSM zoom level for this tile.
+	 * @param int     $left_pixel World-pixel x-offset of the canvas top-left.
+	 * @param int     $top_pixel  World-pixel y-offset of the canvas top-left.
+	 * @param string  $tiles      URL template (`{z}/{x}/{y}` placeholders).
 	 *
 	 * @return void
 	 */
@@ -284,9 +280,9 @@ class OSM extends Base {
 	 *
 	 * @param string $bytes Raw PNG bytes from `fetch_tile()`.
 	 *
-	 * @return GdImage|resource|false Decoded image, or false when the bytes don't decode.
+	 * @return GdImage|false Decoded image, or false when the bytes don't decode.
 	 */
-	protected function decode_tile( string $bytes ) {
+	protected function decode_tile( string $bytes ): GdImage|false {
 		try {
 			return imagecreatefromstring( $bytes );
 		} catch ( Throwable $e ) {
@@ -345,10 +341,10 @@ class OSM extends Base {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param GdImage|resource $canvas Destination canvas.
-	 * @param int              $x      Pixel X position (marker center).
-	 * @param int              $y      Pixel Y position (marker center).
-	 * @param float            $scale  Multiplier applied to the marker radii.
+	 * @param GdImage $canvas Destination canvas.
+	 * @param int     $x      Pixel X position (marker center).
+	 * @param int     $y      Pixel Y position (marker center).
+	 * @param float   $scale  Multiplier applied to the marker radii.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
First slice of [#1961](https://github.com/GatherPress/gatherpress/issues/1961). Settles part 1 (the finality policy) and takes the PHP 7.4 leftovers that fell out of it.

## Part 1 — finality policy

#1509 declared its RSVP classes `final`; the other 82 classes had no such convention, so we had two side by side. This adopts **Option A — final by default**, and records it in `AGENTS.md`.

**73 classes gain the keyword** — everything that is not abstract, not extended in `includes/`, and not mocked or subclassed by a test.

Deliberately left open:

| Class | Why |
|---|---|
| `Settings\Base`, `Calendar\Endpoint_Type`, `Rsvp\Response\Provider\Base`, `Venue\Map\Provider\Base` | abstract — the documented extension points |
| `Calendar\Endpoint`, `Migrate` | actually extended in `includes/` |
| `Event`, `Settings`, `Template`, `Endpoint` | **mocked in tests — PHPUnit cannot mock a `final` class** |

That third row is the trap worth knowing about, so it's written into the policy along with the `grep` to run before finalizing anything.

Two checks informed the risk: nothing in `includes/` extends these, and **none of the five companion plugins** (`-productions`, `-seasons`, `-awesome`, `-alpha`, `-productions-carsten`) extend a GatherPress class — they integrate purely through hooks and `post_type_supports`, which is the extension story we document.

## Part 2 — PHP 7.4 leftovers, surfaced by the keyword

Both of these were consequences of adding `final`, not things I went looking for:

- **PHPCS** flagged 19 `static::` references (`Universal.CodeAnalysis.StaticInFinalClass`) — late static binding is meaningless once nothing can subclass. Now `self::`.
- **PHPStan** could suddenly prove 4 return types are never returned, where a hypothetical subclass had kept the union alive. Three were `GdImage|resource` unions whose own docblocks said *"PHP 7.4 compatibility (GD returns a `resource` there, not a `GdImage`)"* — dead at the 8.1 floor. The `resource` arm is gone, and `decode_tile()` / `decode_png()` now have native `GdImage|false` return types. The fourth was `?array` on `Rsvp::save()`, which never returns null.

This is the "lets PHPStan verify instead of trust" benefit from the issue, arriving earlier than expected.

## Verification

| Gate | Result |
|---|---|
| PHPUnit single-site | 1616 tests, 6826 assertions — OK |
| PHPUnit multisite | 323 tests, 856 assertions — OK |
| PHPCS | clean |
| PHPStan | `[OK] No errors` (baseline on develop was also clean) |
| `php -l` on all 73 touched files | parse OK |

## Still open on #1961

The remaining modernization items are better as their own PRs, per the issue's own guidance: native return types (~91 methods), constructor promotion + `readonly` (33 constructors), `match` for assign-only `switch` (14), and enums for the const bags (~14 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)