### PR TITLE
Declare native return types where only docblocks had them (#1961)

### DIFF
--- a/.github/changelog/1961-native-return-types
+++ b/.github/changelog/1961-native-return-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Declare native return types on methods that only described them in a docblock, so static analysis verifies them instead of trusting the comment. No behavior change.

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -703,7 +703,7 @@ final class Rsvp_Form {
 	 *
 	 * @return mixed|false The sanitized value, or false if sanitization fails.
 	 */
-	public function sanitize_custom_field_value( $value, array $config ) {
+	public function sanitize_custom_field_value( $value, array $config ): mixed {
 		// Handle required field validation.
 		if ( ! empty( $config['required'] ) && empty( $value ) ) {
 			return false;

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -63,7 +63,7 @@ final class Calendar {
 	 *
 	 * @return string|false Endpoint URL, or false if the event post can't be resolved.
 	 */
-	public function get_ical_url() {
+	public function get_ical_url(): string|false {
 		return $this->get_endpoint_url( Setup::ICAL_SLUG );
 	}
 
@@ -78,7 +78,7 @@ final class Calendar {
 	 *
 	 * @return string|false Endpoint URL, or false if the event post can't be resolved.
 	 */
-	public function get_outlook_url() {
+	public function get_outlook_url(): string|false {
 		return $this->get_endpoint_url( 'outlook' );
 	}
 
@@ -99,7 +99,7 @@ final class Calendar {
 	 *
 	 * @return string|false Endpoint URL, or false if the event post can't be resolved.
 	 */
-	public function get_google_url() {
+	public function get_google_url(): string|false {
 		return $this->get_endpoint_url( 'google-calendar' );
 	}
 
@@ -115,7 +115,7 @@ final class Calendar {
 	 *
 	 * @return string|false Endpoint URL, or false if the event post can't be resolved.
 	 */
-	public function get_yahoo_url() {
+	public function get_yahoo_url(): string|false {
 		return $this->get_endpoint_url( 'yahoo-calendar' );
 	}
 
@@ -303,7 +303,7 @@ final class Calendar {
 	 *
 	 * @return string|false              URL of the event's endpoint, or false when the post can't be resolved.
 	 */
-	protected function get_endpoint_url( string $endpoint_slug, ?string $query_var = null ) {
+	protected function get_endpoint_url( string $endpoint_slug, ?string $query_var = null ): string|false {
 		$post = $this->event->event;
 
 		if ( ! $post ) {

--- a/includes/core/classes/class-export.php
+++ b/includes/core/classes/class-export.php
@@ -176,7 +176,7 @@ final class Export extends Migrate {
 	 * @return void
 	 * @since 0.30.0
 	 */
-	public function render( array $callbacks, string $key, WP_Post $post ) {
+	public function render( array $callbacks, string $key, WP_Post $post ): void {
 		if (
 			! isset( $callbacks['export_callback'] ) ||
 			! is_callable( $callbacks['export_callback'] ) ||

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -585,7 +585,7 @@ final class Geocoding {
 	 *
 	 * @return WP_REST_Response|WP_Error Response with coordinates or error.
 	 */
-	public function geocode_address( WP_REST_Request $request ) {
+	public function geocode_address( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$rate_limited = $this->check_rate_limit();
 		if ( null !== $rate_limited ) {
 			return $rate_limited;
@@ -649,7 +649,7 @@ final class Geocoding {
 	 *     country_code: string
 	 * }|WP_Error Result payload, or WP_Error on Photon HTTP failure.
 	 */
-	public function geocode_to_result( string $address ) {
+	public function geocode_to_result( string $address ): array|WP_Error {
 		// Cap oversize input for parity with search_addresses(); protects
 		// upstream from pathological requests.
 		$address = mb_substr( trim( $address ), 0, 200 );
@@ -776,7 +776,7 @@ final class Geocoding {
 	 *
 	 * @return WP_REST_Response|WP_Error Suggestions or error.
 	 */
-	public function search_addresses( WP_REST_Request $request ) {
+	public function search_addresses( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$rate_limited = $this->check_rate_limit();
 		if ( null !== $rate_limited ) {
 			return $rate_limited;

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -888,7 +888,7 @@ class Settings {
 	 *
 	 * @return mixed The value of the option or its default value.
 	 */
-	public function get( string $option ) {
+	public function get( string $option ): mixed {
 		// Read from the network options table when this is an inherited
 		// option on a multisite subsite, otherwise the local options table.
 		// `get_site_option` returns false on single-site, so the type check
@@ -971,7 +971,7 @@ class Settings {
 	 *
 	 * @return mixed The default value of the option or an empty string if not defined.
 	 */
-	public function get_flat_default( string $option ) {
+	public function get_flat_default( string $option ): mixed {
 		$defaults = $this->get_defaults_map();
 
 		return $defaults[ $option ] ?? '';

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -272,7 +272,7 @@ final class Setup {
 	 *
 	 * @return void
 	 */
-	public function add_privacy_policy_content() {
+	public function add_privacy_policy_content(): void {
 		$content = '<h2>' .
 			__( 'Inform your visitors about GatherPress\' use of OpenStreetMap services.', 'gatherpress' ) .
 			'</h2>'

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -645,7 +645,7 @@ final class Utility {
 	 *
 	 * @return int|false The user ID if authentication was successful, false otherwise.
 	 */
-	public static function ensure_user_authentication() {
+	public static function ensure_user_authentication(): int|false {
 		// Force WordPress to authenticate the user.
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$user_id = apply_filters( 'determine_current_user', false );
@@ -753,7 +753,7 @@ final class Utility {
 	 *
 	 * @return string|false The referer URL on success, false on failure.
 	 */
-	public static function get_wp_referer() {
+	public static function get_wp_referer(): string|false {
 		// Only allow pre-filtering during unit tests for security.
 		if ( defined( 'WP_TESTS_DOMAIN' ) || ( defined( 'PHPUNIT_RUNNING' ) && PHPUNIT_RUNNING ) ) {
 			/**

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -329,7 +329,7 @@ final class Admin_List {
 	 *
 	 * @return string[] Updated list of allowed query variables.
 	 */
-	public function query_vars( array $query_vars ) {
+	public function query_vars( array $query_vars ): array {
 		$query_vars[] = 'gatherpress_event_query';
 		return $query_vars;
 	}

--- a/includes/core/classes/rsvp/class-cache.php
+++ b/includes/core/classes/rsvp/class-cache.php
@@ -53,7 +53,7 @@ final class Cache {
 	 *
 	 * @return array|null The cached RSVP data, or null when no valid cache exists.
 	 */
-	public static function get( int $post_id ) {
+	public static function get( int $post_id ): ?array {
 		$value = get_transient( self::cache_key( $post_id ) );
 
 		if ( empty( $value ) || ! is_array( $value ) ) {
@@ -73,7 +73,7 @@ final class Cache {
 	 *
 	 * @return void
 	 */
-	public static function set( int $post_id, $value ) {
+	public static function set( int $post_id, $value ): void {
 		set_transient( self::cache_key( $post_id ), $value, self::CACHE_EXPIRATION );
 	}
 
@@ -86,7 +86,7 @@ final class Cache {
 	 *
 	 * @return void
 	 */
-	public static function delete( int $post_id ) {
+	public static function delete( int $post_id ): void {
 		delete_transient( self::cache_key( $post_id ) );
 	}
 
@@ -99,7 +99,7 @@ final class Cache {
 	 *
 	 * @return string The cache key for the given post ID.
 	 */
-	private static function cache_key( $post_id ) {
+	private static function cache_key( $post_id ): string {
 		return sprintf( self::CACHE_KEY, $post_id );
 	}
 }

--- a/includes/core/classes/rsvp/class-cleanup.php
+++ b/includes/core/classes/rsvp/class-cleanup.php
@@ -44,7 +44,7 @@ final class Cleanup {
 	 *
 	 * @return void
 	 */
-	private function setup_hooks() {
+	private function setup_hooks(): void {
 		add_action( 'init', array( $this, 'schedule_cleanup_cron' ) );
 		add_action( 'gatherpress_rsvp_cleanup', array( $this, 'rsvp_cleanup' ), 10, 0 );
 		add_action( 'update_option_gatherpress_settings', array( $this, 'reschedule_cleanup_cron' ), 10, 2 );
@@ -111,7 +111,7 @@ final class Cleanup {
 	 *
 	 * @return void
 	 */
-	public function schedule_cleanup_cron() {
+	public function schedule_cleanup_cron(): void {
 		$settings = Settings::get_instance();
 		$switch   = $settings->get( 'rsvp_cleanup_switch' );
 

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -559,7 +559,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @return string HTML markup for the checkbox input element.
 	 */
-	public function column_cb( $item ) {
+	public function column_cb( $item ): string {
 		return sprintf(
 			'<input type="checkbox" name="gatherpress_rsvp_id[]" value="%d" />',
 			intval( $item['comment_ID'] )
@@ -963,7 +963,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function display() {
+	public function display(): void {
 		wp_nonce_field( Rsvp::COMMENT_TYPE );
 		wp_nonce_field( 'gatherpress_rsvp_action', '_gatherpress_rsvp_action_nonce' );
 

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -115,7 +115,7 @@ final class Query {
 	 *
 	 * @return mixed Array of RSVP comments or integer count when count parameter is true.
 	 */
-	public function get_rsvps( array $args ) {
+	public function get_rsvps( array $args ): mixed {
 		$args['type']         = Rsvp::COMMENT_TYPE;
 		$args['type__in']     = array();
 		$args['type__not_in'] = array();
@@ -248,7 +248,7 @@ final class Query {
 	 *
 	 * @return void
 	 */
-	public function exclude_rsvp_from_comment_query( WP_Comment_Query $query ) {
+	public function exclude_rsvp_from_comment_query( WP_Comment_Query $query ): void {
 		/**
 		 * Filters whether RSVP comments should be excluded from a comment query.
 		 *

--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -202,7 +202,7 @@ final class Setup {
 	 *
 	 * @return bool|string[] Filtered allowed block types.
 	 */
-	public function filter_rsvp_block_types( $allowed_block_types ) {
+	public function filter_rsvp_block_types( $allowed_block_types ): bool|array {
 		$settings         = Settings::get_instance();
 		$remove_all_rsvp  = 'disabled' === $settings->get( 'rsvp_mode' );
 		$remove_open_form = ! $settings->get( 'enable_open_rsvp' );
@@ -246,7 +246,7 @@ final class Setup {
 	 *
 	 * @return string|int User ID if logged in, email address if via token, or 0 if neither.
 	 */
-	public function get_user_identifier() {
+	public function get_user_identifier(): string|int {
 		$user_identifier = get_current_user_id();
 		$rsvp_token      = Token::from_url_parameter();
 
@@ -526,7 +526,7 @@ final class Setup {
 	 *
 	 * @return mixed The screen option value or false to use default.
 	 */
-	public function set_rsvp_screen_options( $status, $option, $value ) {
+	public function set_rsvp_screen_options( $status, $option, $value ): mixed {
 		if ( $this->get_per_page_option() === $option ) {
 			return $value;
 		}

--- a/includes/core/classes/rsvp/response/class-data.php
+++ b/includes/core/classes/rsvp/response/class-data.php
@@ -67,7 +67,7 @@ final class Data {
 	 *
 	 * @return self A new instance with the given status applied.
 	 */
-	public function with_status( Status $status ) {
+	public function with_status( Status $status ): self {
 		return new self(
 			$this->identity,
 			$status,

--- a/includes/core/classes/settings/class-base.php
+++ b/includes/core/classes/settings/class-base.php
@@ -171,7 +171,7 @@ abstract class Base {
 	 *
 	 * @return mixed|null The value of the property or null if it doesn't exist.
 	 */
-	public function get( string $property ) {
+	public function get( string $property ): mixed {
 		return $this->$property ?? null;
 	}
 

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -300,7 +300,7 @@ final class Network {
 	 *
 	 * @return mixed
 	 */
-	public function route_read_to_site_option( $pre ) {
+	public function route_read_to_site_option( $pre ): mixed {
 		unset( $pre );
 
 		return get_site_option( Settings::OPTION_NAME, array() );

--- a/includes/core/classes/venue/map/provider/class-google.php
+++ b/includes/core/classes/venue/map/provider/class-google.php
@@ -101,7 +101,7 @@ final class Google extends Base {
 		int $height,
 		int $density = 1,
 		string $map_type = 'roadmap'
-	) {
+	): ?GdImage {
 		// PHP built without the GD extension. Can't simulate in a unit test without making the runtime itself broken.
 		if ( ! function_exists( 'imagecreatefromstring' ) ) { // @codeCoverageIgnore
 			return null; // @codeCoverageIgnore

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -111,7 +111,7 @@ final class OSM extends Base {
 		int $height,
 		int $density = 1,
 		string $map_type = 'roadmap'
-	) {
+	): ?GdImage {
 		// OSM tiles are roadmap-only; $map_type is accepted for provider parity.
 		// PHP built without the GD extension. Can't simulate in a unit test without making the runtime itself broken.
 		if ( ! function_exists( 'imagecreatetruecolor' ) ) { // @codeCoverageIgnore


### PR DESCRIPTION
Second slice of [#1961](https://github.com/GatherPress/gatherpress/issues/1961), following #1975. Ticks the *"native parameter/return types where we only have docblock types today — lets PHPStan verify instead of trust"* box.

## Scope

Much smaller than the issue's rough count of ~91. Of **105** methods with no native return type:

| | Count |
|---|---|
| Constructors (cannot have a return type) | 68 |
| JavaScript inside a settings template (false positive) | 1 |
| Already typed / no docblock to go on | 2 |
| **Real candidates — converted** | **34** |

## The conversions

Mechanical, driven by each method's existing `@return`: `void` (8), `string|false` (6), `mixed` (7), `WP_REST_Response|WP_Error` (2), `?GdImage` (2), `string` (2), plus one each of `?array`, `int|false`, `string|int`, `bool|array`, `self`, `array`, and `array|WP_Error`.

Two judgment calls:

- Docblock `mixed|false` and `mixed|null` become plain **`mixed`** — it already subsumes both.
- `string[]` and `array{...}` become **`array`**; the precise shape stays in the docblock, where PHPStan still reads it.

## PHPStan earned its keep

It caught a real bug I introduced. `Geocoding::geocode_to_result()` has a multi-line docblock:

```
@return array{ latitude: string, ... }|WP_Error
```

Reading only the first token typed it `: array` — which would have **fataled** on the method's two `return new WP_Error(...)` paths. It's now `array|WP_Error`, and PHPStan is clean.

For the same class of risk, every `void` candidate was checked for value-returning statements before conversion (one flagged, but it turned out to be the words *"can return false here"* inside a docblock, not code).

## Verification

| Gate | Result |
|---|---|
| PHPUnit single-site | 1616 tests, 6826 assertions — OK |
| PHPUnit multisite | 323 tests, 856 assertions — OK |
| PHPCS | clean |
| PHPStan | `[OK] No errors` |
| `php -l` on all 18 touched files | parse OK |

## Still open on #1961

Constructor promotion + `readonly` (68 constructors — a bigger surface than first counted), `match` for assign-only `switch` (14), and enums for the const bags (~14 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)