### PR TITLE
Use match for the switches that only pick a value (#1961)

### DIFF
--- a/.github/changelog/1961-match-expressions
+++ b/.github/changelog/1961-match-expressions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use match expressions for the three switch statements that existed only to pick a value. No behavior change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,12 @@ Apply to PHP PHPDoc blocks and JS JSDoc blocks alike.
 - **Prefer `str_contains` / `str_starts_with` / `str_ends_with` over `strpos`**: native in PHP 8 (the plugin's floor is 8.1). They read better than the `false ===` / `0 ===` dance and SonarCloud flags the legacy form.
     - ✅ Good: `if ( str_contains( $haystack, $needle ) )` / `if ( str_starts_with( $key, 'gatherpress_' ) )` / `if ( ! str_contains( $content, $token ) )`
     - ❌ Bad: `if ( false !== strpos( $haystack, $needle ) )` / `if ( 0 === strpos( $key, 'gatherpress_' ) )` / `if ( false === strpos( $content, $token ) )`
-- **Every `switch` needs a `default` case**: SonarCloud (`php:S131`) flags any switch missing a `default` branch, even when the listed cases cover the expected values. Add `default: break;` with a one-line comment explaining what falls through (e.g. "Field types without extra params render with the base $params.") — that way the reader sees the intent rather than wondering whether a case was forgotten.
+- **Prefer `match` when a `switch` exists only to produce one value.** `match` is an expression, so the assignment appears once instead of in every arm, and it is exhaustive — which retires the `default:`-arm boilerplate `php:S131` otherwise demands. Two things to check before converting, because they are behavior changes rather than style:
+    1. **`match` compares with `===`, `switch` with `==`.** Equivalent when dispatching on strings or enum cases (what we do everywhere today); not equivalent if the subject can be an int compared against string cases.
+    2. **`match` throws `UnhandledMatchError` when nothing matches**, where `switch` silently falls through. Keep a `default =>` arm unless an unmatched value genuinely is a bug worth surfacing.
+    - ✅ Good: `$multiplier = match ( $frequency ) { 'daily' => DAY_IN_SECONDS, ..., default => HOUR_IN_SECONDS };`
+    - ❌ Not a candidate: arms with side effects (`add_filter`), arms assigning *different* targets, arms with intermediate variables, or a `default` that deliberately does nothing. Leave those as `switch` — most of ours are this shape.
+- **Every remaining `switch` needs a `default` case**: SonarCloud (`php:S131`) flags any switch missing a `default` branch, even when the listed cases cover the expected values. Add `default: break;` with a one-line comment explaining what falls through (e.g. "Field types without extra params render with the base $params.") — that way the reader sees the intent rather than wondering whether a case was forgotten.
     - ✅ Good:
 
         ```php

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -655,29 +655,18 @@ class Settings {
 			foreach ( $input as $key => $value ) {
 				$type = $field_type_map[ $key ] ?? 'text';
 
-				switch ( $type ) {
-					case 'checkbox':
-						$sanitized[ $key ] = (bool) $value;
-						break;
-					case 'number':
-						// Preserve empty submissions as '' instead of
-						// coercing to 0 via intval — so a field that
-						// accepts empty (e.g. Width/Height "Auto") can
-						// round-trip blank without silently saving 0.
-						$sanitized[ $key ] = ( '' === $value || null === $value )
-							? ''
-							: intval( $value );
-						break;
-					case 'autocomplete':
-						$sanitized[ $key ] = $this->sanitize_autocomplete( $value );
-						break;
-					case 'password':
-					case 'text':
-					case 'select':
-					default:
-						$sanitized[ $key ] = sanitize_text_field( (string) $value );
-						break;
-				}
+				$sanitized[ $key ] = match ( $type ) {
+					'checkbox' => (bool) $value,
+					// Preserve empty submissions as '' instead of coercing to
+					// 0 via intval — so a field that accepts empty (e.g.
+					// Width/Height "Auto") can round-trip blank without
+					// silently saving 0.
+					'number'       => ( '' === $value || null === $value ) ? '' : intval( $value ),
+					'autocomplete' => $this->sanitize_autocomplete( $value ),
+					// password, text, select and any unrecognized type are
+					// sanitized as plain text.
+					default        => sanitize_text_field( (string) $value ),
+				};
 			}
 
 			// Merge with existing values to preserve settings from other tabs.

--- a/includes/core/classes/rsvp/class-cleanup.php
+++ b/includes/core/classes/rsvp/class-cleanup.php
@@ -141,24 +141,14 @@ final class Cleanup {
 	private function convert_to_seconds( string $frequency, int $interval ): int {
 		// Assign per-arm and return once so the dispatch isn't a five-arm
 		// return chain.
-		switch ( $frequency ) {
-			case 'daily':
-				$multiplier = DAY_IN_SECONDS;
-				break;
-			case 'weekly':
-				$multiplier = WEEK_IN_SECONDS;
-				break;
-			case 'monthly':
-				$multiplier = MONTH_IN_SECONDS;
-				break;
-			case 'yearly':
-				$multiplier = YEAR_IN_SECONDS;
-				break;
-			case 'hourly':
-			default:
-				$multiplier = HOUR_IN_SECONDS;
-				break;
-		}
+		$multiplier = match ( $frequency ) {
+			'daily'   => DAY_IN_SECONDS,
+			'weekly'  => WEEK_IN_SECONDS,
+			'monthly' => MONTH_IN_SECONDS,
+			'yearly'  => YEAR_IN_SECONDS,
+			// 'hourly' and any unrecognized frequency fall back to hourly.
+			default   => HOUR_IN_SECONDS,
+		};
 
 		return $interval * $multiplier;
 	}

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -463,19 +463,12 @@ final class List_Table extends WP_List_Table {
 					return '-';
 				}
 
-				switch ( $terms[0]->slug ) {
-					case 'attending':
-						$output = __( 'Attending', 'gatherpress' );
-						break;
-					case 'not_attending':
-						$output = __( 'Not Attending', 'gatherpress' );
-						break;
-					case 'waiting_list':
-						$output = __( 'Waiting List', 'gatherpress' );
-						break;
-					default:
-						$output = '-';
-				}
+				$output = match ( $terms[0]->slug ) {
+					'attending'     => __( 'Attending', 'gatherpress' ),
+					'not_attending' => __( 'Not Attending', 'gatherpress' ),
+					'waiting_list'  => __( 'Waiting List', 'gatherpress' ),
+					default         => '-',
+				};
 
 				break;
 			case 'event':


### PR DESCRIPTION
Third slice of [#1961](https://github.com/GatherPress/gatherpress/issues/1961), after #1975 and #1977.

## 3 of 14, not 14

The issue lists "14" as the `match` candidate count — but that's the total number of `switch` statements in `includes/`. Reviewing each, only **3** exist solely to produce one value:

| Converted | Assigns |
|---|---|
| `Cleanup::get_interval_seconds()` | `$multiplier` |
| `List_Table::column_default()` | `$output` (response column) |
| Settings sanitize callback | `$sanitized[ $key ]` |

## Why the other 11 stay as `switch`

Converting them would change meaning rather than tidy them:

- **Side effects in arms** — `Event\Query::adjust_event_sql()` calls `add_filter`/`remove_filter`.
- **Different targets per arm** — `Rsvp\Storage` (×2) sets `author_email` / `author_url` / `user_id` / nested `comment_meta`; `Settings::get_field_params()` sets several `$params` keys per case.
- **Intermediate variables** — `Rsvp_Form::sanitize_custom_field_value()` computes `$sanitized` then derives `$result`.
- **`return` mixed with assignment** — `Calendar\Endpoint` returns `true` from one case.
- **Validation that throws** — `Response\Identity` raises `InvalidArgumentException` per case.
- **A `default` that must do nothing** — `Event\Query`'s orderby: falling through deliberately leaves a third-party `posts_orderby` clause untouched. A `match` would have to invent a value.

## Safety of the three conversions

Both of `match`'s behavior differences were checked rather than assumed:

1. **`match` uses `===`, `switch` uses `==`.** All three dispatch on strings (`$frequency`, a term slug, a field-type string), so the two are equivalent here.
2. **`match` throws `UnhandledMatchError` where `switch` falls through.** Each conversion keeps a `default` arm, so no input can now throw where it previously fell through — including the `case 'hourly': default:` fall-through in `Cleanup`, which collapses to `default`.

`AGENTS.md` now records when to reach for `match` and both differences to check, so the remaining 11 don't get converted mechanically by someone counting `switch` statements later.

## Verification

| Gate | Result |
|---|---|
| PHPUnit single-site | 1616 tests, 6826 assertions — OK |
| PHPUnit multisite | 323 tests, 856 assertions — OK |
| PHPCS | clean |
| PHPStan | `[OK] No errors` |

## Remaining on #1961

Constructor promotion + `readonly` (**68** constructors — worth splitting by subsystem) and enums for the const bags (~14 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)