### PR TITLE
Mark write-once properties readonly (#1961)

### DIFF
--- a/.github/changelog/1961-readonly-promotion
+++ b/.github/changelog/1961-readonly-promotion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Mark write-once properties readonly so immutability is enforced by the type system. No behavior change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,6 +377,12 @@ Apply to PHP PHPDoc blocks and JS JSDoc blocks alike.
         - ❌ Bad: `Event::get_instance()` (doesn't exist for these classes)
     - In tests, always check the class structure before deciding instantiation method
     - Look for `use Singleton;` trait to determine if `::get_instance()` should be used
+- **`readonly` where a property is genuinely write-once** (#1961), which lets the type system enforce immutability instead of convention. The surface is far smaller than it looks — four conditions each disqualify a property, and three of them are invisible in the class itself:
+    1. **It cannot have a default value.** `protected ?WP_Post $event = null;` is out; `readonly` forbids defaults, and dropping the default only works if the constructor always assigns.
+    2. **It must be assigned unconditionally.** `Calendar\Endpoint` assigns inside `if ( $this->is_valid_registration() )`, so on the failing branch the property stays uninitialized forever — PHPStan flags this as `property.uninitializedReadonly`.
+    3. **Nothing may write it from outside the declaring class** — including tests writing to a mock, e.g. `$template->slug = '…';`. That is a fatal `Cannot initialize readonly property … from scope`.
+    4. **The PMC test helpers must not touch it.** `Utility::set_and_get_hidden_property()` writes through reflection, which PHP 8.1 forbids on an initialized readonly property, and `assert_hooks()` re-invokes the constructor on an existing instance — which throws on the *second* assignment. This is what keeps `Settings\Base::$priority` and `Rsvp::$max_attendance_limit` mutable.
+    - Before adding the keyword, grep for external writes with POSIX classes, not `\s` — **BSD grep on macOS silently matches nothing for `\s`**, which will tell you a property is safe when it is not: `grep -rnE -- "->[[:space:]]*prop[[:space:]]*=[^=>]" includes test`.
 - **Classes are `final` by default** (#1961). Extensibility flows through hooks, `post_type_supports`, and the abstract provider bases — not through subclassing concrete classes. A new class gets `final` unless it is deliberately an extension point.
     - ✅ Good: `final class Token {` — a leaf class nothing extends.
     - ✅ Good: `abstract class Base {` — the documented extension point for settings pages / RSVP response providers / venue map providers.

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -43,7 +43,7 @@ final class Calendar {
 	 *
 	 * @var Event
 	 */
-	public Event $event;
+	public readonly Event $event;
 
 	/**
 	 * Class constructor.

--- a/includes/core/classes/calendar/class-template.php
+++ b/includes/core/classes/calendar/class-template.php
@@ -39,7 +39,7 @@ class Template extends Endpoint_Type {
 	 *
 	 * @var string
 	 */
-	protected string $plugin_template_dir;
+	protected readonly string $plugin_template_dir;
 
 	/**
 	 * Class constructor.

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -61,7 +61,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @var string
 	 */
-	protected string $post_type;
+	protected readonly string $post_type;
 
 	/**
 	 * Initializes the RSVP list table.

--- a/includes/core/classes/rsvp/class-storage.php
+++ b/includes/core/classes/rsvp/class-storage.php
@@ -66,7 +66,7 @@ final class Storage {
 	 *
 	 * @var Query
 	 */
-	protected Query $rsvp_query;
+	protected readonly Query $rsvp_query;
 
 	/**
 	 * RSVP Storage constructor.

--- a/includes/core/classes/rsvp/response/class-collection.php
+++ b/includes/core/classes/rsvp/response/class-collection.php
@@ -19,23 +19,13 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 final class Collection {
 
 	/**
-	 * States.
-	 *
-	 * @since 0.35.0
-	 *
-	 * @var State[]
-	 */
-	private array $states = array();
-
-	/**
 	 * Constructor.
 	 *
 	 * @since 0.35.0
 	 *
-	 * @param State[] $states States.
+	 * @param State[] $states States held by this collection.
 	 */
-	public function __construct( array $states = array() ) {
-		$this->states = $states;
+	public function __construct( private readonly array $states = array() ) {
 	}
 
 	/**


### PR DESCRIPTION
Fourth slice of [#1961](https://github.com/GatherPress/gatherpress/issues/1961), covering the *constructor property promotion + `readonly`* bullet. After #1975, #1977 and #1978.

## Constructor promotion: 1, not 68

| | Count |
|---|---|
| Constructors total | 69 |
| Take no parameters (nothing to promote) | 48 |
| Already promoted (from #1509) | 6 |
| Take arguments but **transform** them | 14 |
| **Genuinely promotable** | **1** |

Almost every constructor with arguments derives something rather than storing it — `new Event( $post_id )`, `process_attributes( $attributes )`, conditional guards, `parent::__construct()` plus a computed regex. Promoting those would change meaning, not shorten them. Only `Response\Collection` stores its argument verbatim; it's now `private readonly array $states` promoted into the signature.

## readonly: 4 of 18

Applied to `Calendar::$event`, `Template::$plugin_template_dir`, `List_Table::$post_type`, `Storage::$rsvp_query`.

**The other 14 were disqualified, and three of the four reasons are invisible in the class itself** — which is the useful output of this slice:

1. **Default values** — `Venue::$venue`, `Event::$event`, `Token::$comment` are `= null` and only conditionally assigned. `readonly` forbids defaults.
2. **Conditional assignment** — `Calendar\Endpoint` assigns `$types` / `$reg_ex` / `$object_type` inside `if ( $this->is_valid_registration() )`. On the failing branch they'd be uninitialized *forever*. **PHPStan caught this** (`property.uninitializedReadonly`).
3. **External writes in tests** — `class-test-endpoint.php` does `$template->slug = '…'` on a mock. Fatal: *Cannot initialize readonly property … from scope*.
4. **The PMC test helpers** — `assert_hooks()` re-invokes the constructor on a live instance, so `Settings\Base::$priority` threw on the *second* assignment; and `set_and_get_hidden_property()` writes through reflection, which PHP 8.1 forbids on an initialized readonly property (`Rsvp::$max_attendance_limit`).

Reasons 3 and 4 only surfaced by running the suite — the first full run failed with 5 errors, the second with 2.

### A tooling trap worth flagging

My initial "no external writes" check used `\s` in `grep -E`, which **BSD grep on macOS silently fails to match** — it reported zero writes when two existed. `AGENTS.md` now records the POSIX-class form to use:

```
grep -rnE -- "->[[:space:]]*prop[[:space:]]*=[^=>]" includes test
```

## Verification

| Gate | Result |
|---|---|
| PHPUnit single-site | 1616 tests, 6826 assertions — OK |
| PHPUnit multisite | 323 tests, 856 assertions — OK |
| PHPCS | clean |
| PHPStan | `[OK] No errors` |

## Remaining on #1961

Only **enums for the const bags** (~14 files) — the most behavior-adjacent item, worth doing carefully and probably per-subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)