### PR TITLE
Exclude .wp-env.test.json from the distribution package (#1920)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -54,6 +54,7 @@ yarn.lock
 .github
 .wordpress-version-checker.json
 .wp-env.json
+.wp-env.test.json
 .DS_Store
 Thumbs.db
 .circleci/config.yml

--- a/.github/changelog/1920-distignore-wp-env-test
+++ b/.github/changelog/1920-distignore-wp-env-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Exclude .wp-env.test.json from the WordPress.org distribution package.


### PR DESCRIPTION
Fixes #1920. Milestoned 0.34.1; bound for the patch branch by `git cherry-pick -x`.

## Problem

`.wp-env.test.json`, the CI test-environment config added during the 0.34.0 cycle, ships to WordPress.org because `.distignore` never gained an entry for it. Its sibling `.wp-env.json` has been excluded since line 56 — the test variant was simply missed when it was introduced.

The GitHub release zip was never affected: `wp-scripts plugin-zip` builds from the `files` allowlist in `package.json`, which doesn't include it. Only the wp.org rsync, which is driven by `.distignore`, picked it up.

## Fix

One line, directly beneath the existing `.wp-env.json` entry.

The file is inert local dev config with no secrets, so 0.34.0 shipped as-is rather than being recut — the same fix-forward handling `patches/` and `jsconfig.json` got in #1905.

## Release path

Per [the patch release flow](docs/contributor/release-process.md), fixes are born on develop and cherry-picked onto `version-0.34.1` cut from `main`, which keeps the commit content-identical so the next minor's develop→main release merge auto-resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)