### PR TITLE
Correct the gatherpress_loaded @since to 0.34.1 (#1982)

### DIFF
--- a/.github/changelog/1982-gatherpress-loaded-since
+++ b/.github/changelog/1982-gatherpress-loaded-since
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Correct the gatherpress_loaded action's @since to 0.34.1, the release it now first ships in.

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -72,7 +72,7 @@ add_action(
 		 * Fires on `plugins_loaded`, so any plugin can catch it. See the
 		 * plugin lifecycle guide (`docs/developer/plugin-lifecycle.md`).
 		 *
-		 * @since 0.35.0
+		 * @since 0.34.1
 		 */
 		do_action( 'gatherpress_loaded' );
 	}


### PR DESCRIPTION
One line. The `gatherpress_loaded` action is documented `@since 0.35.0`, but it now ships first in **0.34.1** as the fix for #1982 — the site-wide fatal when GatherPress fails its requirements check while GatherPress Alpha is active.

Per the docblock conventions in `AGENTS.md`, `@since` tracks the release a symbol first ships in, so the earlier release wins.

## Context

The action exists on develop but is absent from both `main` and the `0.34.0` tag, so it's being added to the 0.34.1 patch branch in #1983. Alpha then boots from it instead of from `defined( 'GATHERPRESS_VERSION' )` ([gatherpress-alpha#54](https://github.com/GatherPress/gatherpress-alpha/pull/54)), which is what stops the fatal.

Docs-only; the generated hook docs under `docs/developer/hooks/` are left for CI to regenerate on merge, per the AGENTS.md rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)