### PR TITLE
Document that companion plugins boot on gatherpress_loaded (#1982)

### DIFF
--- a/.github/changelog/1982-gatherpress-loaded-companion-docs
+++ b/.github/changelog/1982-gatherpress-loaded-companion-docs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Document how companion plugins boot on the gatherpress_loaded lifecycle action, and align the hook's @since with its 0.34.1 release.
+Document how companion plugins boot on the gatherpress_loaded lifecycle action.

--- a/.github/changelog/1982-gatherpress-loaded-companion-docs
+++ b/.github/changelog/1982-gatherpress-loaded-companion-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Document how companion plugins boot on the gatherpress_loaded lifecycle action, and align the hook's @since with its 0.34.1 release.

--- a/docs/developer/plugin-lifecycle.md
+++ b/docs/developer/plugin-lifecycle.md
@@ -15,7 +15,7 @@ a short, fixed sequence:
 
 ## `gatherpress_loaded`
 
-*Available since GatherPress 0.34.1.*
+*Available since GatherPress 0.34.0.*
 
 ```php
 add_action( 'gatherpress_loaded', function () {

--- a/docs/developer/plugin-lifecycle.md
+++ b/docs/developer/plugin-lifecycle.md
@@ -15,6 +15,8 @@ a short, fixed sequence:
 
 ## `gatherpress_loaded`
 
+*Available since GatherPress 0.34.1.*
+
 ```php
 add_action( 'gatherpress_loaded', function () {
     // Every core GatherPress class exists — safe to integrate.
@@ -25,6 +27,12 @@ Fires once, on `plugins_loaded`, to signal that **every core GatherPress class
 has been instantiated**. Code that needs a GatherPress class to already exist —
 a registry to register into, a singleton to read — can run here instead of
 guessing at load order.
+
+Crucially, it fires **only after the requirements check has passed**. If
+GatherPress bails early — the site is below the minimum PHP or WordPress
+version, or the build is missing — the action never fires. That makes it the
+correct signal for anything that must not run when GatherPress isn't fully
+loaded (see [Companion plugins](#companion-plugins) below).
 
 The classes are actually constructed earlier, at step 4 (plugin include time).
 The action is deliberately deferred to `plugins_loaded` so that it fires *after
@@ -48,6 +56,71 @@ plugins can register custom providers once the registry is ready. See the
   from `plugins_loaded` onward (including `init`) works, since GatherPress is
   fully instantiated by then. Guarding with `class_exists()` / `function_exists()`
   is still good practice for a soft dependency.
+- **If you are a companion plugin whose classes load through GatherPress's
+  autoloader**, you must boot on `gatherpress_loaded` — see below.
+
+## Companion plugins
+
+A companion plugin (GatherPress Alpha, GatherPress Awesome, and the like)
+registers its namespace with GatherPress's autoloader through the
+`gatherpress_autoloader` filter, then instantiates its own `Setup` once
+GatherPress is ready:
+
+```php
+// Register the namespace with GatherPress's autoloader (top level, so it is
+// in place before GatherPress instantiates).
+add_filter( 'gatherpress_autoloader', function ( array $namespaces ): array {
+    $namespaces['GatherPress_Awesome'] = __DIR__;
+
+    return $namespaces;
+} );
+
+// Boot once GatherPress has fully loaded.
+add_action( 'gatherpress_loaded', function (): void {
+    GatherPress_Awesome\Setup::get_instance();
+} );
+```
+
+**Boot on `gatherpress_loaded`, never on the `GATHERPRESS_VERSION` constant and
+never on `plugins_loaded` alone.** The constant is defined *before* the
+requirements check, so `defined( 'GATHERPRESS_VERSION' )` means "GatherPress
+began loading", not "GatherPress loaded successfully". If GatherPress bails at
+its requirements gate, the constant is set but the autoloader was never
+registered — so a companion that boots on the constant calls into its own
+classes, which cannot be autoloaded, and the whole site fatals with a white
+screen instead of GatherPress's "please upgrade" notice. Gating on
+`gatherpress_loaded` avoids this: the action simply never fires, and the
+companion stays dormant.
+
+Two details matter:
+
+- **Register the listener at the top level of your main file**, not inside a
+  `plugins_loaded` callback. GatherPress dispatches `gatherpress_loaded` from
+  within its own `plugins_loaded` callback, which is registered first, so a
+  listener you add inside yours would be attached after the action had already
+  fired.
+- **Notices that explain why your plugin is dormant** ("GatherPress is not
+  installed", a version-mismatch warning) belong on `plugins_loaded`, because
+  they must run in exactly the cases where `gatherpress_loaded` never fires.
+
+### The coexistence guard
+
+The same rule applies to registering with GatherPress's coexistence guard.
+GatherPress's `Coexistence_Guard` listens for the
+`gatherpress_register_coexistence_guard` action, and that listener only exists
+once GatherPress has bootstrapped — so announce your plugin on
+`gatherpress_loaded`:
+
+```php
+add_action( 'gatherpress_loaded', function (): void {
+    do_action(
+        'gatherpress_register_coexistence_guard',
+        'gatherpress-awesome',      // Folder slug; main file must be <slug>.php.
+        'GatherPress Awesome',      // Display name.
+        __FILE__                    // Absolute path to your main plugin file.
+    );
+} );
+```
 
 ## See also
 

--- a/docs/developer/plugin-lifecycle.md
+++ b/docs/developer/plugin-lifecycle.md
@@ -15,7 +15,7 @@ a short, fixed sequence:
 
 ## `gatherpress_loaded`
 
-*Available since GatherPress 0.34.0.*
+*Available since GatherPress 0.34.1.*
 
 ```php
 add_action( 'gatherpress_loaded', function () {

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -72,7 +72,7 @@ add_action(
 		 * Fires on `plugins_loaded`, so any plugin can catch it. See the
 		 * plugin lifecycle guide (`docs/developer/plugin-lifecycle.md`).
 		 *
-		 * @since 0.35.0
+		 * @since 0.34.1
 		 */
 		do_action( 'gatherpress_loaded' );
 	}

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -72,7 +72,7 @@ add_action(
 		 * Fires on `plugins_loaded`, so any plugin can catch it. See the
 		 * plugin lifecycle guide (`docs/developer/plugin-lifecycle.md`).
 		 *
-		 * @since 0.34.0
+		 * @since 0.34.1
 		 */
 		do_action( 'gatherpress_loaded' );
 	}

--- a/gatherpress.php
+++ b/gatherpress.php
@@ -72,7 +72,7 @@ add_action(
 		 * Fires on `plugins_loaded`, so any plugin can catch it. See the
 		 * plugin lifecycle guide (`docs/developer/plugin-lifecycle.md`).
 		 *
-		 * @since 0.34.1
+		 * @since 0.34.0
 		 */
 		do_action( 'gatherpress_loaded' );
 	}


### PR DESCRIPTION
Docs-only. Develop-facing reference for the 0.35.0 line; **not part of the 0.34.1 release train** (the guide doesn't exist on `main`/`0.34.0`, and docs aren't a shipped artifact).

Follows the companion-plugin boot fixes for [GatherPress Alpha #54](https://github.com/GatherPress/gatherpress-alpha/pull/54) and [GatherPress Awesome #10](https://github.com/GatherPress/gatherpress-awesome/pull/10), which fix [#1982](https://github.com/GatherPress/gatherpress/issues/1982).

## Why

`plugin-lifecycle.md` framed `gatherpress_loaded` only as the RSVP-provider integration point, and its "Which hook should I use?" section said *any hook from `plugins_loaded` onward works* once GatherPress classes exist. For a companion plugin whose classes autoload **through** GatherPress's autoloader, that advice is actively wrong — booting on `plugins_loaded` (or on the `GATHERPRESS_VERSION` constant) is the exact site-wide fatal we just fixed in Alpha and Awesome.

The `gatherpress_register_coexistence_guard` action also had no prose docs anywhere — only a docblock that never named a hook.

## What changed

- New **Companion plugins** section: register the namespace on `gatherpress_autoloader`, boot on `gatherpress_loaded`, and do *neither* on the version constant (set before the requirements gate) *nor* inside a `plugins_loaded` callback (registered too late to catch the action). Includes the "notices stay on `plugins_loaded`" nuance.
- A **coexistence guard** subsection showing registration on `gatherpress_loaded`, with the action's three arguments documented.
- A third bullet in "Which hook should I use?" pointing companions to the new section.
- The hook's stated availability corrected to **0.34.1** (the release it first ships in — consistent with #1984), plus a note that it fires only after the requirements check passes, which is the property the whole pattern rests on.

Markdown lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)