### PR TITLE
Drop the 0.34.1 changelog entries from develop

### DIFF
--- a/.github/changelog/1920-distignore-wp-env-test
+++ b/.github/changelog/1920-distignore-wp-env-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Exclude .wp-env.test.json from the WordPress.org distribution package.

--- a/.github/changelog/1963-requirement-notices
+++ b/.github/changelog/1963-requirement-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Warn sites running PHP below 8.1 or WordPress below 7.0 that GatherPress 0.35.0 raises those requirements.


### PR DESCRIPTION
The changelog entries for the fixes cherry-picked into 0.34.1 belong to that release now, not to the next minor. Removing them from develop so they don't double-list.

## What's removed

| Entry | Cherry-picked to `version-0.34.1` via |
|---|---|
| `1920-distignore-wp-env-test` | #1920 (from #1980) |
| `1963-requirement-notices` | #1963 (from #1981) |

Both were born on develop and cherry-picked onto `version-0.34.1`, so they roll into the `[0.34.1]` CHANGELOG section when that tag is cut. Left queued on develop, they'd roll a **second** time into `[0.35.0]`.

`1982-gatherpress-loaded-signal` is **not** touched — it was authored directly on `version-0.34.1` and never existed on develop.

## Timing note

The 0.34.1 release rollup (`release/0.34.1` → develop) is designed to delete these same files as part of closing the loop, so this can also be left to the automation. Doing it in an explicit PR keeps develop's queue accurate in the interim and shrinks the rollup's diff — merge it whenever fits the release plan; if the rollup runs first, this becomes a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)