### PR TITLE
Make the upcoming-requirement notices persistently dismissible (#1963)

### DIFF
--- a/includes/core/classes/admin/notices/class-upcoming-requirement.php
+++ b/includes/core/classes/admin/notices/class-upcoming-requirement.php
@@ -79,18 +79,19 @@ abstract class Upcoming_Requirement extends Base {
 	/**
 	 * Whether dismissing the notice is remembered across page loads.
 	 *
-	 * Deliberately false. These notices can be closed for the current page
-	 * view, but they come back on the next load and keep coming back until the
-	 * site is actually updated. A requirement warning that can be silenced
-	 * forever defeats its own purpose, and would be silenced by exactly the
-	 * person who most needs to see it.
+	 * True: the point is to let the site owner know about the upcoming
+	 * requirement, once. Some sites genuinely can't move off an old PHP or
+	 * WordPress -- a managed host that hasn't upgraded, a dependency that pins
+	 * them -- and nagging someone who is already stuck helps no one. So once
+	 * they have seen it and dismissed it, it stays gone even if they never
+	 * update.
 	 *
 	 * @since 0.34.1
 	 *
-	 * @return bool Always false.
+	 * @return bool Always true.
 	 */
 	public function is_persistent(): bool {
-		return false;
+		return true;
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/admin/notices/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/admin/notices/class-test-setup.php
@@ -250,12 +250,36 @@ class Test_Setup extends Test_Base {
 	 */
 	public function test_handle_dismissal_ignores_non_persistent_notices(): void {
 		$instance = Setup::get_instance();
+
+		// A notice that is dismissible for the page view but not persistent --
+		// Base's default. handle_dismissal must not record it.
+		$notice = new class() extends Base {
+
+			/**
+			 * Unique slug identifying this notice.
+			 *
+			 * @return string The slug.
+			 */
+			public function get_slug(): string {
+				return 'gatherpress_transient_notice';
+			}
+
+			/**
+			 * The notice's message.
+			 *
+			 * @return string The message.
+			 */
+			public function get_message(): string {
+				return 'Transient.';
+			}
+		};
+
 		$original = $this->swap_notices(
 			$instance,
-			array( 'gatherpress_upcoming_php_requirement' => new Upcoming_Php_Requirement() )
+			array( $notice->get_slug() => $notice )
 		);
 
-		$slug = 'gatherpress_upcoming_php_requirement';
+		$slug = $notice->get_slug();
 
 		$_GET[ Setup::DISMISS_QUERY_ARG ] = $slug;
 		$_GET['_wpnonce']                 = wp_create_nonce( 'gatherpress_dismiss_notice_' . $slug );

--- a/test/unit/php/includes/tests/core/classes/admin/notices/class-test-upcoming-php-requirement.php
+++ b/test/unit/php/includes/tests/core/classes/admin/notices/class-test-upcoming-php-requirement.php
@@ -60,9 +60,9 @@ class Test_Upcoming_Php_Requirement extends Test_Base {
 			$notice->get_capability(),
 			'Failed to assert that the notice is gated to those who can act on it.'
 		);
-		$this->assertFalse(
+		$this->assertTrue(
 			$notice->is_persistent(),
-			'Failed to assert that a requirement warning cannot be silenced permanently.'
+			'Failed to assert that the notice can be dismissed for good.'
 		);
 	}
 


### PR DESCRIPTION
Mirrors the same change on `version-0.34.1` so develop (0.35.0) and the 0.34.1 patch branch stay in sync — the three files are byte-identical across both branches.

## What

The PHP-8.1 / WP-7.0 upcoming-requirement notices were dismissible but **not** persistent — closed for the page view, back on the next load, until the site actually met the floor. The original intent was the opposite: notify the owner once, then let them dismiss it for good.

Some sites genuinely can't move off an old PHP or WordPress (a managed host that hasn't upgraded, a dependency that pins them). Nagging someone who's already stuck helps no one. `Upcoming_Requirement::is_persistent()` now returns `true`, so dismissing writes the slug to the `gatherpress_admin_notifications` option and it stays gone.

The persistence machinery already existed on `Base` (`dismiss()`, `is_dismissed()`, the nonced link, the option) — this just opts these two notices in.

## Skip Changelog

The requirement-notices feature is credited in **0.34.1**'s changelog (`1963-requirement-notices`), not 0.35.0. This is a refinement to that same feature, so it doesn't warrant a separate 0.35.0 entry.

## Verified

Validated on `version-0.34.1` (identical code): 37 notices tests pass, PHPCS clean, 100% coverage on the changed class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)