### PR TITLE
Roll up 0.34.1 changelog into develop

### DIFF
--- a/.github/changelog/1920-distignore-wp-env-test
+++ b/.github/changelog/1920-distignore-wp-env-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Exclude .wp-env.test.json from the WordPress.org distribution package.

--- a/.github/changelog/1963-requirement-notices
+++ b/.github/changelog/1963-requirement-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Warn sites running PHP below 8.1 or WordPress below 7.0 that GatherPress 0.35.0 raises those requirements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Pending entries for the next release live as individual files under
 [`.github/changelog/`](.github/changelog/) and get rolled up into a new
 version section by `composer changelog:write` at release time.
 
+## [0.34.1] - 2026-07-22
+### Added
+- Warn sites running PHP below 8.1 or WordPress below 7.0 that GatherPress 0.35.0 raises those requirements. [#1983]
+
+### Fixed
+- Add the gatherpress_loaded action so companion plugins boot only after the requirements check passes, fixing a site-wide fatal when GatherPress Alpha is active and requirements fail. [#1983]
+- Exclude .wp-env.test.json from the WordPress.org distribution package. [#1983]
+
 ## [0.34.0] - 2026-07-10
 ### Security
 - Enforce per-post edit capability on venue / event meta and post-specific REST routes so unauthenticated or under-privileged callers cannot modify another user's events or venues. [#1520] [#1917]
@@ -433,6 +441,7 @@ Initial public release. Represents 18+ months of pre-1.0 development and ships t
 - Initial unit test suite with code coverage via SonarCloud.
 - Multilingual screenshots and i18n scaffolding.
 
+[0.34.1]: https://github.com/GatherPress/gatherpress/compare/0.34.0...0.34.1
 [0.34.0]: https://github.com/GatherPress/gatherpress/compare/0.33.3...0.34.0
 [0.33.3]: https://github.com/GatherPress/gatherpress/compare/0.33.2...0.33.3
 [0.33.2]: https://github.com/GatherPress/gatherpress/compare/0.33.1...0.33.2


### PR DESCRIPTION
Brings the 0.34.1 changelog rollup to develop — the clean way.

The release workflow opened [#1996](https://github.com/GatherPress/gatherpress/pull/1996) (`release/0.34.1 → develop`), but that PR is unmergeable: `release/0.34.1` is off the tag (main's state) and develop is 53 commits ahead for 0.35.0, so the PR diff is the entire main↔develop divergence (100 files, conflicting). Merging it would revert 0.35.0 work.

This instead cherry-picks just the rollup **commit** (`5885a84d`) onto develop:
- Adds the `[0.34.1]` section to `CHANGELOG.md`.
- Removes the consumed `1920-distignore-wp-env-test` and `1963-requirement-notices` entries (the `1982-gatherpress-loaded-signal` entry was authored on the release branch and never existed on develop, so its deletion is a no-op here).

Supersedes #1994 (which only did the entry removals) — close that.

Once merged, #1996 should be closed unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)