### PR TITLE
Skip install scripts in the version-bump lockfile step

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -72,7 +72,10 @@ jobs:
         run: npm run version:bump -- --version="${VERSION}"
 
       - name: Refresh package-lock.json
-        run: npm i --package-lock-only
+        # --ignore-scripts: this step only rewrites the lockfile, and the
+        # postinstall (patch-package) would run against an empty node_modules
+        # in CI and fail (the @wordpress/env patch-package hook; see AGENTS.md).
+        run: npm i --package-lock-only --ignore-scripts
 
       - name: Open the version PR
         env:


### PR DESCRIPTION
The Version Bump workflow fails at **Refresh package-lock.json** on its first real use (cutting 0.35.0-alpha.1).

## Root cause

The step runs `npm i --package-lock-only` with **no preceding `npm install`** (setup-node only), so `node_modules` is empty in CI. But `package.json` has `postinstall: patch-package`, and `--package-lock-only` **still runs lifecycle scripts** — so patch-package fires against an empty `node_modules`, can't find `@wordpress/env` to apply `patches/@wordpress+env+11.2.0.patch`, and fails the step.

It passes locally only because a developer's `node_modules` is already populated.

Verified: `npm i --package-lock-only --foreground-scripts` shows `patch-package` running; `npm i --package-lock-only --ignore-scripts` exits clean.

## Fix

Add `--ignore-scripts`. `--package-lock-only` only rewrites the lockfile, so the postinstall is unnecessary there anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)