### PR TITLE
Render interactive Google maps with the Maps JavaScript API (#1936)

### DIFF
--- a/.github/changelog/1936-google-maps-js-api
+++ b/.github/changelog/1936-google-maps-js-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Interactive Google maps now use the Maps JavaScript API when an API key is configured, unlocking hybrid and terrain map types.

--- a/docs/user/venues.md
+++ b/docs/user/venues.md
@@ -68,14 +68,16 @@ Two toggles apply to any link destination except "None":
 
 ### Sitewide defaults
 
-Under `Settings > GatherPress > Venues > Maps` you choose the **mapping platform** (OpenStreetMap or Google Maps). For Google Maps you can add an optional **Google Maps API key**. It is stored and edited as a normal text field (not a masked password); restrict the key by HTTP referrer in Google Cloud. The value is used where maps run (including the block editor and the front of the site), so treat it like any other client-side API key.
+Under `Settings > GatherPress > Venues > Maps` you choose the **mapping platform** (OpenStreetMap or Google Maps). For Google Maps you can add an optional **Google Maps API key**. Enable the **Maps JavaScript API**, **Maps Embed API**, and **Maps Static API** for the key in Google Cloud — interactive maps run on the Maps JavaScript API, the Embed API backs the iframe fallback, and static images use the Static API. It is stored and edited as a normal text field (not a masked password); restrict the key by HTTP referrer in Google Cloud. The value is used where maps run (including the block editor and the front of the site), so treat it like any other client-side API key.
+
+With an API key configured, interactive Google maps support all four map types (roadmap, satellite, hybrid, and terrain). Without a key, interactive Google maps fall back to a keyless embed that only offers roadmap and satellite.
 
 The same screen sets defaults for **new** Venue Map blocks (render mode, zoom, height, width, aspect ratio, scale, map type, and related options). Highlights:
 
 - **Default Render Mode** — interactive or static image.
 - **Default Zoom Level** — 1 (world) to 20 (street).
 - **Default Height** — in pixels.
-- **Default Map Type** — roadmap, satellite, hybrid, or terrain (Google Maps only; OpenStreetMap and static images ignore this).
+- **Default Map Type** — roadmap, satellite, hybrid, or terrain (Google Maps only; OpenStreetMap ignores this). Static Google maps and — with an API key — interactive Google maps honor all four types; keyless interactive Google maps render roadmap and satellite only.
 
 Changing a default only affects blocks added afterwards — existing blocks keep the values the editor chose at insertion time, so a sitewide change never rewrites published content.
 

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -119,7 +119,7 @@ final class Venues extends Base {
 							sprintf(
 								// phpcs:disable Generic.Files.LineLength.TooLong -- One translator string for the full API key guidance sentence.
 								/* translators: %s: link to "Get an API key" documentation. */
-								__( 'Optional. Referrer-restricted Google Maps key (Embed + Static APIs). Roadmap and satellite views only. %s', 'gatherpress' ),
+								__( 'Optional. Referrer-restricted Google Maps key (Maps JavaScript + Embed + Static APIs). Unlocks all map types; without a key, interactive maps show roadmap and satellite views only. %s', 'gatherpress' ),
 								// phpcs:enable Generic.Files.LineLength.TooLong
 								'<a href="https://developers.google.com/maps/documentation/embed/get-api-key"'
 								. ' target="_blank" rel="noopener noreferrer">'

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -33,7 +33,7 @@ import { isInFSETemplate } from '../../helpers/editor';
 import { getFromSettings } from '../../helpers/editor-settings';
 import MapEmbed from '../../components/MapEmbed';
 import {
-	GOOGLE_IFRAME_UNSUPPORTED_MAP_TYPE_SLUGS,
+	GOOGLE_KEYLESS_UNSUPPORTED_MAP_TYPE_SLUGS,
 	GOOGLE_MAP_TYPE_DEFINITIONS,
 	toMapsEmbedApiMapType,
 } from '../../components/GoogleMap';
@@ -297,12 +297,11 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 		: SCALE_DEFAULT;
 	const showMapTypeControl = 'google' === mapPlatform;
 
-	// Full list of map types for Google. Maps Embed API (iframe) supports
-	// only roadmap and satellite — hybrid/terrain are filtered out for
-	// interactive mode until a Maps JavaScript API integration can use
-	// the full set without changing `GOOGLE_MAP_TYPE_DEFINITIONS` in
-	// `GoogleMap.js`. Static mode uses the Static Maps API, which supports
-	// all four types.
+	// Full list of map types for Google. With an API key, interactive mode
+	// runs on the Maps JavaScript API and supports all four types — same as
+	// static mode's Static Maps API. Only the keyless interactive path (the
+	// legacy embed iframe) is limited to roadmap and satellite, so the
+	// hybrid/terrain options drop out just for that combination.
 	const GOOGLE_MAP_TYPE_OPTIONS_ALL = GOOGLE_MAP_TYPE_DEFINITIONS.map(
 		( definition ) => ( {
 			label: definition.label,
@@ -310,20 +309,26 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 		} )
 	);
 
-	const IFRAME_UNSUPPORTED_GOOGLE_MAP_TYPES = new Set(
-		GOOGLE_IFRAME_UNSUPPORTED_MAP_TYPE_SLUGS
+	const KEYLESS_UNSUPPORTED_GOOGLE_MAP_TYPES = new Set(
+		GOOGLE_KEYLESS_UNSUPPORTED_MAP_TYPE_SLUGS
 	);
 
+	const isKeylessInteractiveGoogle =
+		'static' !== renderMode && '' === googleMapsApiKey.trim();
+
 	let googleMapTypeSelectOptions = GOOGLE_MAP_TYPE_OPTIONS_ALL;
-	if ( 'static' !== renderMode ) {
+	if ( isKeylessInteractiveGoogle ) {
 		googleMapTypeSelectOptions = GOOGLE_MAP_TYPE_OPTIONS_ALL.filter(
-			( opt ) => ! IFRAME_UNSUPPORTED_GOOGLE_MAP_TYPES.has( opt.value )
+			( opt ) => ! KEYLESS_UNSUPPORTED_GOOGLE_MAP_TYPES.has( opt.value )
 		);
 	}
 
+	// Keep the stored type inside what the keyless embed can render so the
+	// Map type control never shows a value its own option list dropped —
+	// e.g. content authored with an API key that has since been removed.
 	useEffect( () => {
 		if (
-			'interactive' === renderMode &&
+			isKeylessInteractiveGoogle &&
 			showMapTypeControl &&
 			! [ 'roadmap', 'satellite' ].includes( type )
 		) {
@@ -331,7 +336,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 				type: toMapsEmbedApiMapType( type ),
 			} );
 		}
-	}, [ renderMode, showMapTypeControl, type, setAttributes ] );
+	}, [ isKeylessInteractiveGoogle, showMapTypeControl, type, setAttributes ] );
 
 	// Link destination options track the site's mapping platform: on an
 	// OSM-powered site we only offer the OpenStreetMap preset (and vice

--- a/src/components/GoogleMap.js
+++ b/src/components/GoogleMap.js
@@ -1,14 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { select } from '@wordpress/data';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { loadGoogleMapsApi } from '../helpers/google-maps-api';
 
 /**
  * GoogleMap component for GatherPress.
  *
- * This component is used to embed a Google Map with specified location,
- * zoom level, map type, and height.
+ * Renders the interactive Google map for the venue-map block. With a Google
+ * Maps API key configured the map runs on the Maps JavaScript API — the only
+ * Google surface that honors all four map types (roadmap, satellite, hybrid,
+ * terrain). Without a key the component falls back to the keyless legacy
+ * embed iframe, which supports roadmap and satellite only.
  *
  * @since 0.27.0
  *
@@ -28,6 +37,11 @@ import { select } from '@wordpress/data';
  * Canonical Google map types for the venue-map block: localized label, block
  * attribute slug, and legacy keyless embed `t=` parameter letter.
  *
+ * The slugs double as Maps JavaScript API `mapTypeId` values, so the keyed
+ * interactive path passes them through untouched. The `legacyEmbedLetter`
+ * values back the keyless embed fallback.
+ *
+ * @see https://developers.google.com/maps/documentation/javascript/maptypes
  * @see https://developers.google.com/maps/documentation/embed/map-parameters
  */
 export const GOOGLE_MAP_TYPE_DEFINITIONS = [
@@ -54,10 +68,12 @@ export const GOOGLE_MAP_TYPE_DEFINITIONS = [
 ];
 
 /**
- * Slugs omitted from the editor map-type control while the iframe path uses
- * the Embed API (roadmap and satellite only).
+ * Slugs the keyless legacy embed iframe can't honor — it only renders the
+ * roadmap and satellite views, matching the coercion in
+ * `toMapsEmbedApiMapType()`. The keyed Maps JavaScript API path supports
+ * every slug in `GOOGLE_MAP_TYPE_DEFINITIONS`.
  */
-export const GOOGLE_IFRAME_UNSUPPORTED_MAP_TYPE_SLUGS = [
+export const GOOGLE_KEYLESS_UNSUPPORTED_MAP_TYPE_SLUGS = [
 	'hybrid',
 	'terrain',
 ];
@@ -75,19 +91,29 @@ const LEGACY_EMBED_LETTER_BY_SLUG = GOOGLE_MAP_TYPE_DEFINITIONS.reduce(
 );
 
 /**
+ * Normalize a block map-type slug to the canonical set.
+ *
+ * @param {string} type Map type slug from the block.
+ *
+ * @return {string} A slug from `GOOGLE_MAP_TYPE_DEFINITIONS`; unknown values fall back to roadmap.
+ */
+export function toGoogleMapType( type ) {
+	return type && BLOCK_MAP_TYPE_SLUGS.includes( type ) ? type : 'roadmap';
+}
+
+/**
  * Maps Embed API `view` (and related) modes only allow `roadmap` or `satellite`
- * for `maptype`. Hybrid or terrain in block data (e.g. before the editor
- * normalizes) are coerced so keyed iframe URLs stay valid.
+ * for `maptype`. Hybrid or terrain in block data (e.g. content authored while
+ * an API key was configured) are coerced so embed URLs stay valid.
  *
  * @see https://developers.google.com/maps/documentation/embed/embedding-map#view_mode
  *
  * @param {string} type Map type slug from the block.
  *
- * @return {'roadmap'|'satellite'} Coercion for interactive iframe: hybrid→satellite, terrain→roadmap.
+ * @return {'roadmap'|'satellite'} Coercion for the embed iframe: hybrid→satellite, terrain→roadmap.
  */
 export function toMapsEmbedApiMapType( type ) {
-	const normalized =
-		type && BLOCK_MAP_TYPE_SLUGS.includes( type ) ? type : 'roadmap';
+	const normalized = toGoogleMapType( type );
 	if ( 'satellite' === normalized || 'hybrid' === normalized ) {
 		return 'satellite';
 	}
@@ -99,6 +125,10 @@ const GOOGLE_LEGACY_EMBED_BASE = 'https://maps.google.com/maps';
 
 /**
  * Builds the iframe `src` for a Google map embed.
+ *
+ * With an API key this is the Maps Embed API `view` URL — only used as the
+ * fallback when the Maps JavaScript API fails to load. Without a key it is
+ * the keyless legacy embed URL, the primary no-key path.
  *
  * @param {Object} params           Parameters.
  * @param {string} params.latitude  Latitude.
@@ -117,8 +147,7 @@ export function getGoogleMapEmbedSrc( {
 	apiKey,
 } ) {
 	const z = zoom || 10;
-	const safeType =
-		type && BLOCK_MAP_TYPE_SLUGS.includes( type ) ? type : 'roadmap';
+	const safeType = toGoogleMapType( type );
 	const trimmedKey = ( apiKey || '' ).trim();
 
 	if ( trimmedKey ) {
@@ -131,17 +160,146 @@ export function getGoogleMapEmbedSrc( {
 		return `${ GOOGLE_EMBED_VIEW_BASE }?${ params.toString() }`;
 	}
 
+	// toMapsEmbedApiMapType() only ever returns roadmap or satellite, both
+	// of which are always present in the letter table.
 	const legacyType = toMapsEmbedApiMapType( safeType );
 	const params = new URLSearchParams( {
 		q: `${ latitude },${ longitude }`,
 		z: String( z ),
-		t:
-			LEGACY_EMBED_LETTER_BY_SLUG[ legacyType ] ||
-			LEGACY_EMBED_LETTER_BY_SLUG.roadmap,
+		t: LEGACY_EMBED_LETTER_BY_SLUG[ legacyType ],
 		output: 'embed',
 	} );
 	return `${ GOOGLE_LEGACY_EMBED_BASE }?${ params.toString() }`;
 }
+
+/**
+ * Interactive Google map backed by the Maps JavaScript API.
+ *
+ * Mounts a `google.maps.Map` with a marker into a plain div, re-pointing the
+ * existing instance when props change rather than tearing it down. If the
+ * API script fails to load (network error, key without the Maps JavaScript
+ * API enabled), the component falls back to the keyed Maps Embed API iframe
+ * so the block still shows a map.
+ *
+ * @since 0.35.0
+ *
+ * @param {Object}  props              - Component properties.
+ * @param {string}  props.location     - Marker tooltip text.
+ * @param {string}  props.latitude     - Latitude.
+ * @param {string}  props.longitude    - Longitude.
+ * @param {number}  props.zoom         - Zoom level.
+ * @param {string}  props.type         - Map type slug.
+ * @param {string}  props.className    - Additional CSS class names.
+ * @param {Object}  props.style        - Wrapper inline style.
+ * @param {string}  props.apiKey       - Google Maps API key (non-empty).
+ * @param {boolean} props.isPostEditor - Whether the map renders inside the post editor canvas.
+ *
+ * @return {JSX.Element} The rendered React component.
+ */
+const GoogleMapsApiMap = ( {
+	location,
+	latitude,
+	longitude,
+	zoom,
+	type,
+	className,
+	style,
+	apiKey,
+	isPostEditor,
+} ) => {
+	const containerRef = useRef( null );
+	const mapRef = useRef( null );
+	const markerRef = useRef( null );
+	const [ loadFailed, setLoadFailed ] = useState( false );
+
+	const z = zoom || 10;
+	const safeType = toGoogleMapType( type );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		// The editor canvas can live in its own iframe — the API script must
+		// load into the document that owns the map container or it bootstraps
+		// against the wrong window.
+		const doc = containerRef.current?.ownerDocument || document;
+
+		loadGoogleMapsApi( apiKey, doc )
+			.then( ( maps ) => {
+				if ( cancelled || ! containerRef.current ) {
+					return;
+				}
+
+				const center = {
+					lat: parseFloat( latitude ),
+					lng: parseFloat( longitude ),
+				};
+
+				if ( ! mapRef.current ) {
+					mapRef.current = new maps.Map( containerRef.current, {
+						center,
+						zoom: z,
+						mapTypeId: safeType,
+					} );
+					markerRef.current = new maps.Marker( {
+						position: center,
+						map: mapRef.current,
+						title: location,
+					} );
+					return;
+				}
+
+				// Re-point the live instance instead of remounting — keeps
+				// the editor preview smooth while controls change. The
+				// marker is created alongside the map, so it's always set
+				// whenever the map is.
+				mapRef.current.setCenter( center );
+				mapRef.current.setZoom( z );
+				mapRef.current.setMapTypeId( safeType );
+				markerRef.current.setPosition( center );
+				markerRef.current.setTitle( location );
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setLoadFailed( true );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ apiKey, latitude, longitude, z, safeType, location ] );
+
+	// The Maps JavaScript API didn't come up — fall back to the keyed Maps
+	// Embed API iframe (roadmap/satellite only) so the block still renders.
+	if ( loadFailed ) {
+		return (
+			<iframe
+				src={ getGoogleMapEmbedSrc( {
+					latitude,
+					longitude,
+					zoom: z,
+					type: safeType,
+					apiKey,
+				} ) }
+				style={ { ...style, border: 0 } }
+				className={ className }
+				title={ location }
+				{ ...( isPostEditor && { inert: '' } ) }
+			></iframe>
+		);
+	}
+
+	return (
+		<div
+			ref={ containerRef }
+			className={ className }
+			// Carry the block's border-radius down so the map canvas stays
+			// clipped to the same rounded corners as the wrapper.
+			style={ { ...style, borderRadius: 'inherit', overflow: 'hidden' } }
+			{ ...( isPostEditor && { inert: '' } ) }
+		></div>
+	);
+};
 
 const GoogleMap = ( props ) => {
 	const {
@@ -164,8 +322,8 @@ const GoogleMap = ( props ) => {
 	const validLng =
 		longitude && '' !== longitude && ! isNaN( parseFloat( longitude ) );
 
-	// Show placeholder when no valid coordinates — avoids keyed Embed API
-	// requests with an invalid `center` param on new events before geocode.
+	// Show placeholder when no valid coordinates — avoids keyed API
+	// requests with an invalid `center` on new events before geocode.
 	if ( ! validLat || ! validLng ) {
 		return (
 			<div
@@ -182,18 +340,36 @@ const GoogleMap = ( props ) => {
 		);
 	}
 
+	// Matches the OpenStreetMap editor fix: the `inert` attribute stops the
+	// map from capturing clicks/focus so the user can select the block
+	// itself instead of interacting with the embedded map inside the canvas.
+	const isPostEditor = Boolean( select( 'core/edit-post' ) );
+
+	const trimmedKey = ( apiKey || '' ).trim();
+
+	if ( trimmedKey ) {
+		return (
+			<GoogleMapsApiMap
+				location={ location }
+				latitude={ latitude }
+				longitude={ longitude }
+				zoom={ zoom }
+				type={ type }
+				className={ className }
+				style={ style }
+				apiKey={ trimmedKey }
+				isPostEditor={ isPostEditor }
+			/>
+		);
+	}
+
 	const srcURL = getGoogleMapEmbedSrc( {
 		latitude,
 		longitude,
 		zoom,
 		type,
-		apiKey,
+		apiKey: '',
 	} );
-
-	// Matches the OpenStreetMap editor fix: the `inert` attribute stops the
-	// iframe from capturing clicks/focus so the user can select the block
-	// itself instead of interacting with the embedded map inside the canvas.
-	const isPostEditor = Boolean( select( 'core/edit-post' ) );
 
 	return (
 		<iframe

--- a/src/helpers/google-maps-api.js
+++ b/src/helpers/google-maps-api.js
@@ -1,0 +1,146 @@
+/**
+ * Loader for the Google Maps JavaScript API.
+ *
+ * The interactive Google map runs on the Maps JavaScript API whenever a
+ * Google Maps API key is configured — that is the only Google surface that
+ * renders all four map types (roadmap, satellite, hybrid, terrain). The
+ * keyless Maps Embed API iframe stays as the no-key fallback and only
+ * renders roadmap and satellite.
+ *
+ * Loading is per document on purpose. The block editor renders the canvas
+ * inside an iframe, so the `<script>` has to land in the document that owns
+ * the map container — otherwise the API bootstraps against the wrong
+ * `window` and the map never paints.
+ *
+ * @since 0.35.0
+ */
+
+const GOOGLE_MAPS_API_URL = 'https://maps.googleapis.com/maps/api/js';
+
+/**
+ * In-flight and settled loads, keyed by document and then by API key.
+ *
+ * A WeakMap on the document keeps the editor iframe's entry from leaking
+ * once that iframe is torn down.
+ *
+ * @since 0.35.0
+ *
+ * @type {WeakMap<Document, Map<string, Promise<Object>>>}
+ */
+let loadsByDocument = new WeakMap();
+
+/**
+ * Counter feeding the unique global callback name handed to the API.
+ *
+ * @since 0.35.0
+ *
+ * @type {number}
+ */
+let callbackCounter = 0;
+
+/**
+ * Reset the loader cache.
+ *
+ * Only used by tests — each case needs a fresh document/key cache so a
+ * previously resolved (or rejected) load doesn't leak into the next one.
+ *
+ * @since 0.35.0
+ *
+ * @return {void}
+ */
+export function clearGoogleMapsApiCache() {
+	loadsByDocument = new WeakMap();
+	callbackCounter = 0;
+}
+
+/**
+ * Load the Google Maps JavaScript API into a document and resolve its
+ * `google.maps` namespace.
+ *
+ * Repeat calls for the same document and key share one `<script>` and one
+ * promise. A key that is empty (or whitespace) rejects rather than issuing
+ * a request the API would answer with an auth error.
+ *
+ * @since 0.35.0
+ *
+ * @param {string}   apiKey Google Maps API key.
+ * @param {Document} doc    Document that owns the map container.
+ *
+ * @return {Promise<Object>} Resolves with the `google.maps` namespace.
+ */
+export function loadGoogleMapsApi( apiKey, doc ) {
+	const key = ( apiKey || '' ).trim();
+	const targetDocument = doc || document;
+
+	if ( ! key ) {
+		return Promise.reject(
+			new Error( 'A Google Maps API key is required.' )
+		);
+	}
+
+	if ( ! loadsByDocument.has( targetDocument ) ) {
+		loadsByDocument.set( targetDocument, new Map() );
+	}
+
+	const loads = loadsByDocument.get( targetDocument );
+
+	if ( loads.has( key ) ) {
+		return loads.get( key );
+	}
+
+	const targetWindow = targetDocument.defaultView || window;
+
+	// Another plugin, the theme, or an earlier mount in a document we no
+	// longer hold a cache entry for already brought the API in.
+	if ( targetWindow.google?.maps ) {
+		const resolved = Promise.resolve( targetWindow.google.maps );
+		loads.set( key, resolved );
+
+		return resolved;
+	}
+
+	callbackCounter += 1;
+	const callbackName = `gatherpressGoogleMapsApiReady_${ callbackCounter }`;
+
+	const load = new Promise( ( resolve, reject ) => {
+		const script = targetDocument.createElement( 'script' );
+
+		const cleanUp = () => {
+			delete targetWindow[ callbackName ];
+		};
+
+		targetWindow[ callbackName ] = () => {
+			cleanUp();
+			resolve( targetWindow.google.maps );
+		};
+
+		script.addEventListener( 'error', () => {
+			cleanUp();
+			// Drop the cache entry so a later mount (or a re-save that
+			// fixes the key) gets a fresh attempt instead of replaying
+			// this rejection forever.
+			loads.delete( key );
+			script.remove();
+			reject(
+				new Error(
+					'The Google Maps JavaScript API could not be loaded.'
+				)
+			);
+		} );
+
+		script.src = `${ GOOGLE_MAPS_API_URL }?${ new URLSearchParams( {
+			key,
+			// `loading=async` is Google's recommended bootstrap; paired
+			// with `callback` it avoids polling for the namespace.
+			loading: 'async',
+			callback: callbackName,
+		} ).toString() }`;
+		script.async = true;
+
+		targetDocument.head.appendChild( script );
+	} );
+
+	loads.set( key, load );
+
+	return load;
+}

--- a/test/unit/js/src/blocks/venue-map/edit.test.js
+++ b/test/unit/js/src/blocks/venue-map/edit.test.js
@@ -21,6 +21,10 @@ let capturedVenueStateSelector = null;
 // drive its resize callbacks with crafted elements.
 let capturedResizableProps = null;
 
+// Capture every SelectControl render so tests can inspect the Map type
+// control's option list under different render-mode / API-key combos.
+let mockSelectControlProps = [];
+
 // A minimal select mock that puts the block into the early-bail path:
 // effectiveVenuePostId === 0 because both context.postId and
 // core/editor.getCurrentPostId() return falsy values.
@@ -103,7 +107,10 @@ jest.mock( '@wordpress/components', () => ( {
 			</div>
 		);
 	},
-	SelectControl: () => null,
+	SelectControl: ( props ) => {
+		mockSelectControlProps.push( props );
+		return null;
+	},
 	TextControl: () => null,
 	ToggleControl: () => null,
 	ToolbarButton: () => null,
@@ -134,9 +141,19 @@ jest.mock( '@src/helpers/editor-settings', () => ( {
 jest.mock( '@src/components/MapEmbed', () => () => null );
 
 jest.mock( '@src/components/GoogleMap', () => ( {
-	GOOGLE_IFRAME_UNSUPPORTED_MAP_TYPE_SLUGS: [],
-	GOOGLE_MAP_TYPE_DEFINITIONS: [],
-	toMapsEmbedApiMapType: jest.fn( ( type ) => type ),
+	GOOGLE_KEYLESS_UNSUPPORTED_MAP_TYPE_SLUGS: [ 'hybrid', 'terrain' ],
+	GOOGLE_MAP_TYPE_DEFINITIONS: [
+		{ slug: 'roadmap', label: 'Roadmap' },
+		{ slug: 'satellite', label: 'Satellite' },
+		{ slug: 'hybrid', label: 'Hybrid' },
+		{ slug: 'terrain', label: 'Terrain' },
+	],
+	toMapsEmbedApiMapType: jest.fn( ( type ) => {
+		if ( 'hybrid' === type || 'satellite' === type ) {
+			return 'satellite';
+		}
+		return 'roadmap';
+	} ),
 } ) );
 
 jest.mock( '@src/supports/block-guard', () => ( {
@@ -165,6 +182,7 @@ jest.mock( '@src/blocks/venue-map/helpers', () => ( {
  * Internal dependencies
  */
 import Edit from '@src/blocks/venue-map/edit';
+import { getFromSettings } from '@src/helpers/editor-settings';
 import { isVenuePostType } from '@src/helpers/venue';
 
 const DEFAULT_ATTRIBUTES = {
@@ -392,6 +410,212 @@ describe( 'venue-map Edit useSelect selector stability', () => {
 		expect( result1.staticMapDescriptors ).toBe(
 			result2.staticMapDescriptors
 		);
+	} );
+} );
+
+describe( 'venue-map Edit Google map type control', () => {
+	/**
+	 * Settings mock for a Google-platform site.
+	 *
+	 * @param {string} apiKey Google Maps API key setting value.
+	 *
+	 * @return {Function} getFromSettings implementation.
+	 */
+	const googleSettings =
+		( apiKey ) =>
+			( key ) => {
+				if ( 'mapPlatform' === key ) {
+					return 'google';
+				}
+				if ( 'googleMapsApiKey' === key ) {
+					return apiKey;
+				}
+				return null;
+			};
+
+	/**
+	 * Find the Map type SelectControl captured during the last render.
+	 *
+	 * @return {Object|undefined} Captured props.
+	 */
+	const getMapTypeControl = () =>
+		mockSelectControlProps.find(
+			( props ) => 'Map type' === props.label
+		);
+
+	/**
+	 * Invoke every effect registered with the mocked useEffect.
+	 *
+	 * @return {void}
+	 */
+	const runEffects = () => {
+		const { useEffect } = jest.requireMock( '@wordpress/element' );
+		act( () => {
+			useEffect.mock.calls.forEach( ( [ callback ] ) => callback() );
+		} );
+	};
+
+	beforeEach( () => {
+		mockSelectControlProps = [];
+		jest.clearAllMocks();
+		isVenuePostType.mockReturnValue( false );
+	} );
+
+	it( 'offers only roadmap and satellite for keyless interactive maps', () => {
+		getFromSettings.mockImplementation( googleSettings( null ) );
+
+		render(
+			<Edit
+				attributes={ {
+					...DEFAULT_ATTRIBUTES,
+					renderMode: 'interactive',
+				} }
+				setAttributes={ jest.fn() }
+				context={ {} }
+				clientId=""
+			/>
+		);
+
+		expect(
+			getMapTypeControl().options.map( ( opt ) => opt.value )
+		).toEqual( [ 'roadmap', 'satellite' ] );
+	} );
+
+	it( 'offers all four types for interactive maps with an API key', () => {
+		getFromSettings.mockImplementation( googleSettings( 'unit-test-key' ) );
+
+		render(
+			<Edit
+				attributes={ {
+					...DEFAULT_ATTRIBUTES,
+					renderMode: 'interactive',
+				} }
+				setAttributes={ jest.fn() }
+				context={ {} }
+				clientId=""
+			/>
+		);
+
+		expect(
+			getMapTypeControl().options.map( ( opt ) => opt.value )
+		).toEqual( [ 'roadmap', 'satellite', 'hybrid', 'terrain' ] );
+	} );
+
+	it( 'offers all four types for static maps without an API key', () => {
+		getFromSettings.mockImplementation( googleSettings( null ) );
+
+		render(
+			<Edit
+				attributes={ DEFAULT_ATTRIBUTES }
+				setAttributes={ jest.fn() }
+				context={ {} }
+				clientId=""
+			/>
+		);
+
+		expect(
+			getMapTypeControl().options.map( ( opt ) => opt.value )
+		).toEqual( [ 'roadmap', 'satellite', 'hybrid', 'terrain' ] );
+	} );
+
+	it( 'coerces a stored hybrid type when the interactive map is keyless', () => {
+		getFromSettings.mockImplementation( googleSettings( null ) );
+		const setAttributes = jest.fn();
+
+		render(
+			<Edit
+				attributes={ {
+					...DEFAULT_ATTRIBUTES,
+					renderMode: 'interactive',
+					type: 'hybrid',
+				} }
+				setAttributes={ setAttributes }
+				context={ {} }
+				clientId=""
+			/>
+		);
+
+		runEffects();
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			type: 'satellite',
+		} );
+	} );
+
+	it( 'keeps a stored hybrid type when an API key is configured', () => {
+		getFromSettings.mockImplementation( googleSettings( 'unit-test-key' ) );
+		const setAttributes = jest.fn();
+
+		render(
+			<Edit
+				attributes={ {
+					...DEFAULT_ATTRIBUTES,
+					renderMode: 'interactive',
+					type: 'hybrid',
+				} }
+				setAttributes={ setAttributes }
+				context={ {} }
+				clientId=""
+			/>
+		);
+
+		runEffects();
+
+		expect( setAttributes ).not.toHaveBeenCalledWith( {
+			type: expect.anything(),
+		} );
+	} );
+
+	it( 'keeps a roadmap type untouched on the keyless interactive path', () => {
+		getFromSettings.mockImplementation( googleSettings( null ) );
+		const setAttributes = jest.fn();
+
+		render(
+			<Edit
+				attributes={ {
+					...DEFAULT_ATTRIBUTES,
+					renderMode: 'interactive',
+					type: 'roadmap',
+				} }
+				setAttributes={ setAttributes }
+				context={ {} }
+				clientId=""
+			/>
+		);
+
+		runEffects();
+
+		expect( setAttributes ).not.toHaveBeenCalledWith( {
+			type: expect.anything(),
+		} );
+	} );
+
+	it( 'never coerces when the map type control is hidden (OSM platform)', () => {
+		getFromSettings.mockImplementation( ( key ) =>
+			'mapPlatform' === key ? 'osm' : null
+		);
+		const setAttributes = jest.fn();
+
+		render(
+			<Edit
+				attributes={ {
+					...DEFAULT_ATTRIBUTES,
+					renderMode: 'interactive',
+					type: 'hybrid',
+				} }
+				setAttributes={ setAttributes }
+				context={ {} }
+				clientId=""
+			/>
+		);
+
+		expect( getMapTypeControl() ).toBeUndefined();
+
+		runEffects();
+
+		expect( setAttributes ).not.toHaveBeenCalledWith( {
+			type: expect.anything(),
+		} );
 	} );
 } );
 

--- a/test/unit/js/src/components/GoogleMap.test.js
+++ b/test/unit/js/src/components/GoogleMap.test.js
@@ -1,15 +1,71 @@
 /**
- * External dependencies.
+ * External dependencies
  */
-import { expect, test } from '@jest/globals';
+import { render, act } from '@testing-library/react';
+import { expect, test, jest, beforeEach } from '@jest/globals';
+import '@testing-library/jest-dom';
 
 /**
- * Internal dependencies.
+ * Mock WordPress data
  */
-import {
+jest.mock( '@wordpress/data', () => ( {
+	select: jest.fn( () => null ),
+} ) );
+
+/**
+ * Mock Google Maps API loader
+ */
+jest.mock( '@src/helpers/google-maps-api', () => ( {
+	loadGoogleMapsApi: jest.fn(),
+} ) );
+
+/**
+ * Internal dependencies
+ */
+import GoogleMap, {
 	getGoogleMapEmbedSrc,
+	toGoogleMapType,
 	toMapsEmbedApiMapType,
 } from '@src/components/GoogleMap';
+import { loadGoogleMapsApi } from '@src/helpers/google-maps-api';
+import { select } from '@wordpress/data';
+
+/**
+ * Build a fake `google.maps` namespace whose constructors record their calls.
+ *
+ * @return {Object} Fake namespace plus captured instances.
+ */
+function createFakeMapsNamespace() {
+	const mapInstance = {
+		setCenter: jest.fn(),
+		setZoom: jest.fn(),
+		setMapTypeId: jest.fn(),
+	};
+	const markerInstance = {
+		setPosition: jest.fn(),
+		setTitle: jest.fn(),
+	};
+	const maps = {
+		Map: jest.fn( () => mapInstance ),
+		Marker: jest.fn( () => markerInstance ),
+	};
+
+	return { maps, mapInstance, markerInstance };
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	select.mockReturnValue( null );
+} );
+
+test( 'toGoogleMapType passes canonical slugs through and defaults unknowns to roadmap', () => {
+	expect( toGoogleMapType( 'roadmap' ) ).toBe( 'roadmap' );
+	expect( toGoogleMapType( 'satellite' ) ).toBe( 'satellite' );
+	expect( toGoogleMapType( 'hybrid' ) ).toBe( 'hybrid' );
+	expect( toGoogleMapType( 'terrain' ) ).toBe( 'terrain' );
+	expect( toGoogleMapType( '' ) ).toBe( 'roadmap' );
+	expect( toGoogleMapType( 'bogus' ) ).toBe( 'roadmap' );
+} );
 
 test( 'toMapsEmbedApiMapType coerces block slugs to Embed API allow-list', () => {
 	expect( toMapsEmbedApiMapType( 'roadmap' ) ).toBe( 'roadmap' );
@@ -39,6 +95,16 @@ test( 'getGoogleMapEmbedSrc never sends hybrid or terrain as maptype when key is
 	expect( terrainSrc ).not.toContain( 'maptype=terrain' );
 } );
 
+test( 'getGoogleMapEmbedSrc defaults zoom to 10 when unset', () => {
+	const src = getGoogleMapEmbedSrc( {
+		latitude: '40',
+		longitude: '-74',
+		type: 'roadmap',
+		apiKey: '',
+	} );
+	expect( src ).toContain( '&z=10' );
+} );
+
 test( 'getGoogleMapEmbedSrc coerces legacy hybrid and terrain t= codes without key', () => {
 	const base = {
 		latitude: '40',
@@ -52,4 +118,338 @@ test( 'getGoogleMapEmbedSrc coerces legacy hybrid and terrain t= codes without k
 	expect( getGoogleMapEmbedSrc( { ...base, type: 'terrain' } ) ).toContain(
 		'&t=m',
 	);
+} );
+
+test( 'GoogleMap renders a placeholder when coordinates are missing', () => {
+	const { container } = render(
+		<GoogleMap location="Test" apiKey="unit-test-key" />,
+	);
+
+	expect( container.children[ 0 ].tagName ).toBe( 'DIV' );
+	expect( container.children[ 0 ] ).toHaveStyle( {
+		backgroundColor: 'rgb(224, 224, 224)',
+	} );
+	expect( loadGoogleMapsApi ).not.toHaveBeenCalled();
+} );
+
+test( 'GoogleMap without a key renders the keyless legacy embed iframe', () => {
+	const { container } = render(
+		<GoogleMap
+			location="Test"
+			latitude="40.81"
+			longitude="-74.21"
+			zoom={ 12 }
+			type="roadmap"
+		/>,
+	);
+
+	const iframe = container.children[ 0 ];
+	expect( iframe.tagName ).toBe( 'IFRAME' );
+	expect( iframe.getAttribute( 'src' ) ).toContain(
+		'https://maps.google.com/maps?',
+	);
+	expect( iframe.hasAttribute( 'inert' ) ).toBe( false );
+	expect( loadGoogleMapsApi ).not.toHaveBeenCalled();
+} );
+
+test( 'GoogleMap with a key mounts a Maps JavaScript API map with a marker', async () => {
+	const { maps } = createFakeMapsNamespace();
+	loadGoogleMapsApi.mockResolvedValue( maps );
+
+	let container;
+	await act( async () => {
+		( { container } = render(
+			<GoogleMap
+				location="Test venue"
+				latitude="40.81"
+				longitude="-74.21"
+				zoom={ 15 }
+				type="hybrid"
+				className="unit-test"
+				apiKey=" unit-test-key "
+			/>,
+		) );
+	} );
+
+	const mount = container.children[ 0 ];
+	expect( mount.tagName ).toBe( 'DIV' );
+	expect( mount ).toHaveClass( 'unit-test' );
+
+	expect( loadGoogleMapsApi ).toHaveBeenCalledWith(
+		'unit-test-key',
+		document,
+	);
+	expect( maps.Map ).toHaveBeenCalledWith( mount, {
+		center: { lat: 40.81, lng: -74.21 },
+		zoom: 15,
+		mapTypeId: 'hybrid',
+	} );
+	expect( maps.Marker ).toHaveBeenCalledWith( {
+		position: { lat: 40.81, lng: -74.21 },
+		map: maps.Map.mock.results[ 0 ].value,
+		title: 'Test venue',
+	} );
+} );
+
+test( 'GoogleMap defaults zoom to 10 and unknown types to roadmap on the JS API path', async () => {
+	const { maps } = createFakeMapsNamespace();
+	loadGoogleMapsApi.mockResolvedValue( maps );
+
+	await act( async () => {
+		render(
+			<GoogleMap
+				location="Test"
+				latitude="40.81"
+				longitude="-74.21"
+				type="bogus"
+				apiKey="unit-test-key"
+			/>,
+		);
+	} );
+
+	expect( maps.Map ).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining( { zoom: 10, mapTypeId: 'roadmap' } ),
+	);
+} );
+
+test( 'GoogleMap re-points the existing map instance when props change', async () => {
+	const { maps, mapInstance, markerInstance } = createFakeMapsNamespace();
+	loadGoogleMapsApi.mockResolvedValue( maps );
+
+	let rerender;
+	await act( async () => {
+		( { rerender } = render(
+			<GoogleMap
+				location="Test"
+				latitude="40.81"
+				longitude="-74.21"
+				zoom={ 15 }
+				type="hybrid"
+				apiKey="unit-test-key"
+			/>,
+		) );
+	} );
+
+	await act( async () => {
+		rerender(
+			<GoogleMap
+				location="Renamed venue"
+				latitude="41.00"
+				longitude="-75.00"
+				zoom={ 12 }
+				type="terrain"
+				apiKey="unit-test-key"
+			/>,
+		);
+	} );
+
+	// One map — no remount on prop changes.
+	expect( maps.Map ).toHaveBeenCalledTimes( 1 );
+	expect( mapInstance.setCenter ).toHaveBeenCalledWith( {
+		lat: 41,
+		lng: -75,
+	} );
+	expect( mapInstance.setZoom ).toHaveBeenCalledWith( 12 );
+	expect( mapInstance.setMapTypeId ).toHaveBeenCalledWith( 'terrain' );
+	expect( markerInstance.setPosition ).toHaveBeenCalledWith( {
+		lat: 41,
+		lng: -75,
+	} );
+	expect( markerInstance.setTitle ).toHaveBeenCalledWith(
+		'Renamed venue',
+	);
+} );
+
+test( 'GoogleMap falls back to the keyed Embed API iframe when the JS API fails to load', async () => {
+	loadGoogleMapsApi.mockRejectedValue( new Error( 'blocked' ) );
+
+	let container;
+	await act( async () => {
+		( { container } = render(
+			<GoogleMap
+				location="Test"
+				latitude="40.81"
+				longitude="-74.21"
+				zoom={ 15 }
+				type="terrain"
+				apiKey="unit-test-key"
+			/>,
+		) );
+	} );
+
+	const iframe = container.children[ 0 ];
+	expect( iframe.tagName ).toBe( 'IFRAME' );
+	const src = iframe.getAttribute( 'src' );
+	expect( src ).toContain( 'https://www.google.com/maps/embed/v1/view?' );
+	expect( src ).toContain( 'key=unit-test-key' );
+	// Embed API only offers roadmap/satellite; terrain coerces to roadmap.
+	expect( src ).toContain( 'maptype=roadmap' );
+} );
+
+test( 'GoogleMap ignores a load settled after unmount', async () => {
+	const { maps } = createFakeMapsNamespace();
+	let resolveLoad;
+	loadGoogleMapsApi.mockReturnValue(
+		new Promise( ( resolve ) => {
+			resolveLoad = resolve;
+		} ),
+	);
+
+	const { unmount } = render(
+		<GoogleMap
+			location="Test"
+			latitude="40.81"
+			longitude="-74.21"
+			zoom={ 15 }
+			type="roadmap"
+			apiKey="unit-test-key"
+		/>,
+	);
+
+	unmount();
+
+	await act( async () => {
+		resolveLoad( maps );
+	} );
+
+	expect( maps.Map ).not.toHaveBeenCalled();
+} );
+
+test( 'GoogleMap ignores a load rejected after unmount', async () => {
+	let rejectLoad;
+	loadGoogleMapsApi.mockReturnValue(
+		new Promise( ( resolve, reject ) => {
+			rejectLoad = reject;
+		} ),
+	);
+
+	const { unmount } = render(
+		<GoogleMap
+			location="Test"
+			latitude="40.81"
+			longitude="-74.21"
+			zoom={ 15 }
+			type="roadmap"
+			apiKey="unit-test-key"
+		/>,
+	);
+
+	unmount();
+
+	await act( async () => {
+		rejectLoad( new Error( 'blocked' ) );
+	} );
+
+	// No state update on an unmounted component — nothing to assert beyond
+	// the act() above not warning; the component is gone.
+	expect( loadGoogleMapsApi ).toHaveBeenCalledTimes( 1 );
+} );
+
+test( 'GoogleMap skips map updates while the fallback iframe is showing', async () => {
+	loadGoogleMapsApi.mockRejectedValue( new Error( 'blocked' ) );
+
+	let rerender;
+	await act( async () => {
+		( { rerender } = render(
+			<GoogleMap
+				location="Test"
+				latitude="40.81"
+				longitude="-74.21"
+				zoom={ 15 }
+				type="roadmap"
+				apiKey="unit-test-key"
+			/>,
+		) );
+	} );
+
+	// The failure swapped the mount div for the fallback iframe. A prop
+	// change re-runs the effect with no container to mount into — the load
+	// result (here another rejection already surfaced) must be a no-op.
+	const { maps } = createFakeMapsNamespace();
+	loadGoogleMapsApi.mockResolvedValue( maps );
+
+	await act( async () => {
+		rerender(
+			<GoogleMap
+				location="Test"
+				latitude="40.81"
+				longitude="-74.21"
+				zoom={ 12 }
+				type="roadmap"
+				apiKey="unit-test-key"
+			/>,
+		);
+	} );
+
+	expect( maps.Map ).not.toHaveBeenCalled();
+} );
+
+test( 'GoogleMap marks the fallback iframe inert inside the post editor', async () => {
+	select.mockImplementation( ( store ) =>
+		'core/edit-post' === store ? {} : null,
+	);
+	loadGoogleMapsApi.mockRejectedValue( new Error( 'blocked' ) );
+
+	let container;
+	await act( async () => {
+		( { container } = render(
+			<GoogleMap
+				location="Test"
+				latitude="40.81"
+				longitude="-74.21"
+				zoom={ 15 }
+				type="roadmap"
+				apiKey="unit-test-key"
+			/>,
+		) );
+	} );
+
+	const iframe = container.children[ 0 ];
+	expect( iframe.tagName ).toBe( 'IFRAME' );
+	expect( iframe.hasAttribute( 'inert' ) ).toBe( true );
+} );
+
+test( 'GoogleMap marks the keyless iframe inert inside the post editor', () => {
+	select.mockImplementation( ( store ) =>
+		'core/edit-post' === store ? {} : null,
+	);
+
+	const { container } = render(
+		<GoogleMap
+			location="Test"
+			latitude="40.81"
+			longitude="-74.21"
+			zoom={ 12 }
+			type="roadmap"
+		/>,
+	);
+
+	const iframe = container.children[ 0 ];
+	expect( iframe.tagName ).toBe( 'IFRAME' );
+	expect( iframe.hasAttribute( 'inert' ) ).toBe( true );
+} );
+
+test( 'GoogleMap marks the map container inert inside the post editor', async () => {
+	select.mockImplementation( ( store ) =>
+		'core/edit-post' === store ? {} : null,
+	);
+	const { maps } = createFakeMapsNamespace();
+	loadGoogleMapsApi.mockResolvedValue( maps );
+
+	let container;
+	await act( async () => {
+		( { container } = render(
+			<GoogleMap
+				location="Test"
+				latitude="40.81"
+				longitude="-74.21"
+				zoom={ 15 }
+				type="roadmap"
+				apiKey="unit-test-key"
+			/>,
+		) );
+	} );
+
+	expect( container.children[ 0 ].hasAttribute( 'inert' ) ).toBe( true );
 } );

--- a/test/unit/js/src/components/MapEmbed.test.js
+++ b/test/unit/js/src/components/MapEmbed.test.js
@@ -13,9 +13,17 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 
 /**
+ * Mock Google Maps API loader
+ */
+jest.mock( '@src/helpers/google-maps-api', () => ( {
+	loadGoogleMapsApi: jest.fn(),
+} ) );
+
+/**
  * Internal dependencies
  */
 import MapEmbed from '@src/components/MapEmbed';
+import { loadGoogleMapsApi } from '@src/helpers/google-maps-api';
 import { select } from '@wordpress/data';
 
 beforeEach( () => {
@@ -155,7 +163,7 @@ test( 'Google MapEmbed returns address in source when location is set', () => {
 	);
 } );
 
-test( 'Google MapEmbed uses Embed API when googleMapsApiKey prop is set', () => {
+test( 'Google MapEmbed uses the Maps JavaScript API when googleMapsApiKey prop is set', async () => {
 	select.mockImplementation( ( store ) => {
 		if ( 'core' === store ) {
 			return { canUser: jest.fn( () => false ) };
@@ -172,52 +180,43 @@ test( 'Google MapEmbed uses Embed API when googleMapsApiKey prop is set', () => 
 		}
 		return null;
 	} );
-	const { container } = render(
-		<MapEmbed
-			location="Test"
-			latitude="40.8117036"
-			longitude="-74.2187738"
-			zoom={ 15 }
-			type="terrain"
-			googleMapsApiKey="unit-test-key"
-		/>,
-	);
-	const src = container.children[ 0 ].getAttribute( 'src' );
-	expect( src ).toContain( 'https://www.google.com/maps/embed/v1/view?' );
-	expect( src ).toContain( 'key=unit-test-key' );
-	// Maps Embed API only allows roadmap or satellite; terrain maps to roadmap.
-	expect( src ).toContain( 'maptype=roadmap' );
-} );
 
-test( 'Google MapEmbed maps hybrid to satellite for Embed API when key is set', () => {
-	select.mockImplementation( ( store ) => {
-		if ( 'core' === store ) {
-			return { canUser: jest.fn( () => false ) };
-		}
-		if ( 'core/edit-post' === store ) {
-			return null;
-		}
-		if ( 'core/editor' === store ) {
-			return {
-				getEditorSettings: () => ( {
-					gatherpress: { settings: { mapPlatform: 'google' } },
-				} ),
-			};
-		}
-		return null;
+	const mapInstance = {
+		setCenter: jest.fn(),
+		setZoom: jest.fn(),
+		setMapTypeId: jest.fn(),
+	};
+	const maps = {
+		Map: jest.fn( () => mapInstance ),
+		Marker: jest.fn( () => ( {} ) ),
+	};
+	loadGoogleMapsApi.mockResolvedValue( maps );
+
+	let container;
+	await act( async () => {
+		( { container } = render(
+			<MapEmbed
+				location="Test"
+				latitude="40.8117036"
+				longitude="-74.2187738"
+				zoom={ 15 }
+				type="terrain"
+				googleMapsApiKey="unit-test-key"
+			/>,
+		) );
 	} );
-	const { container } = render(
-		<MapEmbed
-			location="Test"
-			latitude="40.8117036"
-			longitude="-74.2187738"
-			zoom={ 15 }
-			type="hybrid"
-			googleMapsApiKey="unit-test-key"
-		/>,
+
+	// The keyed path mounts a JS API map into a div — no iframe.
+	expect( container.children[ 0 ].tagName ).toBe( 'DIV' );
+	expect( loadGoogleMapsApi ).toHaveBeenCalledWith(
+		'unit-test-key',
+		document,
 	);
-	const src = container.children[ 0 ].getAttribute( 'src' );
-	expect( src ).toContain( 'maptype=satellite' );
+	// The JS API honors the full map-type set — terrain stays terrain.
+	expect( maps.Map ).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.objectContaining( { mapTypeId: 'terrain', zoom: 15 } ),
+	);
 } );
 
 test( 'MapEmbed returns address in source when location, zoom, map type, and class are set', () => {

--- a/test/unit/js/src/helpers/google-maps-api.test.js
+++ b/test/unit/js/src/helpers/google-maps-api.test.js
@@ -1,0 +1,145 @@
+/**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+/**
+ * Internal dependencies
+ */
+import {
+	clearGoogleMapsApiCache,
+	loadGoogleMapsApi,
+} from '@src/helpers/google-maps-api';
+
+/**
+ * Find the Google Maps API script tags currently in a document.
+ *
+ * @param {Document} doc Document to search.
+ *
+ * @return {HTMLScriptElement[]} Matching script elements.
+ */
+function getApiScripts( doc = document ) {
+	return Array.from( doc.querySelectorAll( 'script' ) ).filter( ( s ) =>
+		s.src.startsWith( 'https://maps.googleapis.com/maps/api/js' )
+	);
+}
+
+/**
+ * Resolve a pending load by invoking the global callback the script tag
+ * registered, mimicking the API's bootstrap.
+ *
+ * @param {HTMLScriptElement} script Script whose callback should fire.
+ * @param {Object}            maps   Fake `google.maps` namespace to install.
+ *
+ * @return {void}
+ */
+function fireApiCallback( script, maps ) {
+	const callbackName = new URL( script.src ).searchParams.get( 'callback' );
+	window.google = { maps };
+	window[ callbackName ]();
+}
+
+describe( 'loadGoogleMapsApi', () => {
+	beforeEach( () => {
+		clearGoogleMapsApiCache();
+	} );
+
+	afterEach( () => {
+		getApiScripts().forEach( ( script ) => script.remove() );
+		delete window.google;
+	} );
+
+	it( 'rejects without a key', async () => {
+		await expect( loadGoogleMapsApi( '', document ) ).rejects.toThrow(
+			'API key is required'
+		);
+		await expect(
+			loadGoogleMapsApi( undefined, document )
+		).rejects.toThrow( 'API key is required' );
+		await expect( loadGoogleMapsApi( '   ', document ) ).rejects.toThrow(
+			'API key is required'
+		);
+		expect( getApiScripts() ).toHaveLength( 0 );
+	} );
+
+	it( 'appends one script per key and resolves via the global callback', async () => {
+		const promise = loadGoogleMapsApi( ' unit-test-key ', document );
+
+		const scripts = getApiScripts();
+		expect( scripts ).toHaveLength( 1 );
+
+		const params = new URL( scripts[ 0 ].src ).searchParams;
+		expect( params.get( 'key' ) ).toBe( 'unit-test-key' );
+		expect( params.get( 'loading' ) ).toBe( 'async' );
+		expect( params.get( 'callback' ) ).toMatch(
+			/^gatherpressGoogleMapsApiReady_\d+$/
+		);
+		expect( scripts[ 0 ].async ).toBe( true );
+
+		const fakeMaps = { Map: () => {} };
+		fireApiCallback( scripts[ 0 ], fakeMaps );
+
+		await expect( promise ).resolves.toBe( fakeMaps );
+		// The one-shot global callback is removed once it has fired.
+		expect(
+			window[ params.get( 'callback' ) ]
+		).toBeUndefined();
+	} );
+
+	it( 'shares one load between repeat calls for the same document and key', () => {
+		const first = loadGoogleMapsApi( 'unit-test-key', document );
+		const second = loadGoogleMapsApi( 'unit-test-key', document );
+
+		expect( second ).toBe( first );
+		expect( getApiScripts() ).toHaveLength( 1 );
+	} );
+
+	it( 'resolves without a script when the namespace is already present', async () => {
+		const fakeMaps = { Map: () => {} };
+		window.google = { maps: fakeMaps };
+
+		await expect(
+			loadGoogleMapsApi( 'unit-test-key', document )
+		).resolves.toBe( fakeMaps );
+		expect( getApiScripts() ).toHaveLength( 0 );
+	} );
+
+	it( 'defaults to the global document when none is passed', () => {
+		loadGoogleMapsApi( 'unit-test-key' );
+
+		expect( getApiScripts() ).toHaveLength( 1 );
+	} );
+
+	it( 'falls back to the global window when the document has no defaultView', async () => {
+		const detachedDoc = {
+			defaultView: null,
+			head: document.head,
+			createElement: ( tag ) => document.createElement( tag ),
+		};
+		const fakeMaps = { Map: () => {} };
+		window.google = { maps: fakeMaps };
+
+		await expect(
+			loadGoogleMapsApi( 'unit-test-key', detachedDoc )
+		).resolves.toBe( fakeMaps );
+	} );
+
+	it( 'rejects on script error, removes the tag, and retries fresh', async () => {
+		const promise = loadGoogleMapsApi( 'unit-test-key', document );
+		const [ script ] = getApiScripts();
+		const callbackName = new URL( script.src ).searchParams.get(
+			'callback'
+		);
+
+		script.dispatchEvent( new Event( 'error' ) );
+
+		await expect( promise ).rejects.toThrow( 'could not be loaded' );
+		expect( window[ callbackName ] ).toBeUndefined();
+		expect( getApiScripts() ).toHaveLength( 0 );
+
+		// The failed entry was evicted — a retry issues a fresh script.
+		const retry = loadGoogleMapsApi( 'unit-test-key', document );
+		expect( retry ).not.toBe( promise );
+		expect( getApiScripts() ).toHaveLength( 1 );
+	} );
+} );


### PR DESCRIPTION
Closes #1936

## What

Interactive Google maps now render via the **Maps JavaScript API** whenever a Google Maps API key is configured, which unlocks the full map-type set — roadmap, satellite, **hybrid**, and **terrain**. Without a key, the keyless legacy embed iframe keeps working exactly as it does today (roadmap and satellite only).

## How

- **New `src/helpers/google-maps-api.js`** — loads the Maps JavaScript API once per document (the editor canvas can be iframed, so the script has to land in the document that owns the map container), dedupes concurrent loads per key, resolves through Google's `callback` bootstrap with `loading=async`, and evicts failed loads so a corrected key can retry.
- **`GoogleMap.js`** — with a key, mounts a `google.maps.Map` + `Marker` into a div and re-points the live instance on prop changes (no remount churn in the editor preview). If the script fails to load (network error, key without the Maps JavaScript API enabled), it falls back to the keyed Maps Embed API iframe so the block still shows a map. The keyless path is unchanged. `inert` handling in the editor matches the previous iframe behavior.
- **`edit.js`** — `GOOGLE_IFRAME_UNSUPPORTED_MAP_TYPE_SLUGS` is renamed to `GOOGLE_KEYLESS_UNSUPPORTED_MAP_TYPE_SLUGS` and the map-type control now only filters hybrid/terrain on the *keyless interactive* combination. The coercing `useEffect` is reduced to that same case (e.g. content authored with a key after the key is removed), per the issue's acceptance criteria.
- **Docs** — the settings-field description and `docs/user/venues.md` now list the **Maps JavaScript API** in the key requirements alongside the Embed + Static APIs, and describe which paths honor which map types.

The static-map side needs no changes here: #1940 already wired the chosen map type through `build_static_map_url()`, and `normalize_map_type()`/`supported_map_types()` cover the server side.

## Testing

- New `test/unit/js/src/helpers/google-maps-api.test.js` — 100% statements/branches on the loader (callback resolution, per-key dedupe, preexisting-namespace short-circuit, error eviction + retry, no-`defaultView` fallback).
- `GoogleMap.test.js` — component tests for the JS API mount, marker creation, re-pointing on prop changes, Embed-iframe fallback on load failure, unmount races, and `inert` in the editor; `GoogleMap.js` is at 100% statements/branches.
- `edit.test.js` — new describe block covering the option-list filtering and type coercion across keyed/keyless × interactive/static × platform combos.
- `npm run build` and `npx wp-scripts build --experimental-modules` both compile clean; `lint:js`, `lint:php`, `lint:phpstan`, `lint:md:docs`, and the full `test:unit:js` suite (957 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
