### PR TITLE
Keep file contents off argv in the version-bump commit step

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -93,13 +93,22 @@ jobs:
           gh api "repos/${REPO}/git/refs" \
             -f ref="refs/heads/${branch}" -f sha="${head_sha}" > /dev/null
 
+          # File contents reach jq via --rawfile (and the accumulated array via
+          # --slurpfile below), never as command-line arguments: Linux caps a
+          # single argv string at 128 KiB (MAX_ARG_STRLEN), and the lockfile's
+          # base64 alone is ~10x that, killing jq with "Argument list too
+          # long" (#2002). rtrimstr drops the trailing newline base64 emits,
+          # which the old command substitution used to strip.
           additions='[]'
           while IFS= read -r file; do
+            base64 -w0 "${file}" > /tmp/bump-file.b64
             additions=$(jq \
               --arg path "${file}" \
-              --arg contents "$(base64 -w0 "${file}")" \
-              '. + [{path: $path, contents: $contents}]' <<< "${additions}")
+              --rawfile contents /tmp/bump-file.b64 \
+              '. + [{path: $path, contents: ($contents | rtrimstr("\n"))}]' <<< "${additions}")
           done < <(git status --porcelain | awk '{print $2}')
+
+          printf '%s' "${additions}" > /tmp/bump-additions.json
 
           jq -n \
             --arg query 'mutation ($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }' \
@@ -107,8 +116,8 @@ jobs:
             --arg branch "${branch}" \
             --arg oid "${head_sha}" \
             --arg headline "Start ${VERSION}" \
-            --argjson additions "${additions}" \
-            '{query: $query, variables: {input: {branch: {repositoryNameWithOwner: $repo, branchName: $branch}, expectedHeadOid: $oid, message: {headline: $headline}, fileChanges: {additions: $additions}}}}' \
+            --slurpfile additions /tmp/bump-additions.json \
+            '{query: $query, variables: {input: {branch: {repositoryNameWithOwner: $repo, branchName: $branch}, expectedHeadOid: $oid, message: {headline: $headline}, fileChanges: {additions: $additions[0]}}}}' \
             > /tmp/bump-commit.json
 
           gh api graphql --input /tmp/bump-commit.json > /dev/null


### PR DESCRIPTION
Fixes #2002 — the second first-use failure in the Version Bump workflow (the first was the lockfile step, #2000).

## Root cause — now confirmed from the log

The job log (finally retrievable after the API outage) shows the exact failure:

```
/home/runner/work/_temp/….sh: line 16: /usr/bin/jq: Argument list too long
##[error]Process completed with exit code 126.
```

Linux caps a **single argv string** at 128 KiB (`MAX_ARG_STRLEN`). The step passed each file's base64 to jq on the command line — `--arg contents "$(base64 -w0 "${file}")"` — and `package-lock.json`'s base64 is **~10× that cap**, so `execve` failed with `E2BIG` before jq even started. The final `--argjson additions "${additions}"` call had the same flaw compounded: the entire accumulated array as one argument. That's why the branch was created (step ran that far) but never got a commit.

It never failed locally because macOS doesn't enforce a per-argument cap the way Linux does.

## Fix

Route contents through files instead of argv:

- per-file loop: `base64 -w0 "${file}" > /tmp/bump-file.b64` + `--rawfile contents /tmp/bump-file.b64`
- aggregate: `printf '%s' "${additions}" > /tmp/bump-additions.json` + `--slurpfile additions /tmp/bump-additions.json` (`$additions[0]` in the program)
- `rtrimstr("\n")` drops the trailing newline base64 emits, which the old `$(...)` used to strip — payloads stay **byte-identical** to the old method for files that fit

## Verification

- Old vs new payloads compared on a normal file: **identical**.
- The step script extracted **verbatim from this YAML** and run against a fixture git repo with a 1.7 MB modified file and a stubbed `gh`: exits 0, all three `gh` calls fire in order (create-ref → graphql commit → pr create), the payload carries the full 2.3 MB contents string, and the embedded base64 **round-trips byte-identically** to the file on disk.
- `bash -n` clean.

The real end-to-end check is the **next bump dispatch** (0.35.0-alpha.2 / beta.1), per the issue's acceptance criteria — if that fails, reopen #2002.

## Noted, not changed

`release.yml`'s rollup step shares the `--arg contents "$(base64 …)"` pattern but only encodes `CHANGELOG.md` (~10 KB today, append-only). Nowhere near the cap; flagged on #2002 rather than churning the release workflow that just shipped 0.34.1 and 0.35.0-alpha.1 cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)