### PR TITLE
Stop generating rewrite rules for the private RSVP taxonomies (#825)

### DIFF
--- a/.github/changelog/825-rsvp-taxonomy-rewrite
+++ b/.github/changelog/825-rsvp-taxonomy-rewrite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop generating rewrite rules for the private RSVP status and provider comment taxonomies; their terms are never reachable through a URL.

--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -148,6 +148,7 @@ final class Setup {
 				'show_admin_column'  => false,
 				'query_var'          => true,
 				'publicly_queryable' => false,
+				'rewrite'            => false,
 				'show_in_rest'       => true,
 			)
 		);
@@ -163,6 +164,7 @@ final class Setup {
 				'show_admin_column'  => false,
 				'query_var'          => true,
 				'publicly_queryable' => false,
+				'rewrite'            => false,
 				'show_in_rest'       => true,
 			)
 		);

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-setup.php
@@ -15,6 +15,7 @@ use GatherPress\Core\Rsvp\List_Table;
 use GatherPress\Core\Rsvp\Query;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp\Setup;
+use GatherPress\Core\Rsvp\Response\Provider\Base as Provider;
 use GatherPress\Core\Rsvp\Response\Status;
 use GatherPress\Core\Rsvp\Token;
 use GatherPress\Core\Settings;
@@ -189,6 +190,18 @@ class Test_Setup extends Base {
 		$instance->register_taxonomy();
 
 		$this->assertTrue( taxonomy_exists( Status::TAXONOMY ) );
+		$this->assertTrue( taxonomy_exists( Provider::TAXONOMY ) );
+
+		// Private comment taxonomies: nothing is reachable through a term URL,
+		// so no rewrite rules may be generated for them (#825).
+		$this->assertFalse(
+			get_taxonomy( Status::TAXONOMY )->rewrite,
+			'Failed to assert that the RSVP status taxonomy registers no rewrite rules.'
+		);
+		$this->assertFalse(
+			get_taxonomy( Provider::TAXONOMY )->rewrite,
+			'Failed to assert that the RSVP provider taxonomy registers no rewrite rules.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #825.

## What

`_gatherpress_rsvp_status` is a private comment taxonomy — `publicly_queryable => false`, no admin UI, terms never reachable through a URL. But its registration never set `rewrite`, and WordPress defaults `rewrite` to the value of `public` (`true` here), so rewrite rules were generated into the `rewrite_rules` option that nothing could ever match.

One scope addition since the issue was filed: the generic RSVP work (#1509) added a second private comment taxonomy, **`_gatherpress_rsvp_provider`**, with the same copied args and therefore the same defect. Both registrations now set `'rewrite' => false` — matching the precedent `Shadow_Source` already sets for its hidden taxonomies (the other registrations, Topic and Venue, are public with intentional rewrite slugs and are untouched).

## Verified per the issue's steps

| Check | Before | After |
|---|---|---|
| `get_taxonomy( … )->rewrite` | full rewrite array, slug `_gatherpress_rsvp_status` | `false` (both taxonomies) |
| Rules mentioning `gatherpress_rsvp` after `wp rewrite flush` | **10** (term, feed ×2, embed, pagination — ×2 taxonomies) | **0** |
| Status terms readable (queries/REST, not URLs) | — | ✅ 2 terms |
| PHPUnit | — | 1653/6907 single-site, 323/856 multisite, PHPCS + PHPStan clean |

## Existing sites need no migration

`Setup::check_plugin_version()` schedules a rewrite flush (deletes the `rewrite_rules` option) on every version change, so sites shed the stale rules automatically on their first admin visit after updating.

## Regression guard

`test_register_taxonomy` now asserts both taxonomies exist **and** both register with `rewrite === false`, so the WordPress default can't silently creep back if the args are ever touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)