### PR TITLE
Fire registered_taxonomy_for_object_type for the topic/event pairing (#1639)

### DIFF
--- a/.github/changelog/1639-register-taxonomy-for-object-type
+++ b/.github/changelog/1639-register-taxonomy-for-object-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fire registered_taxonomy_for_object_type for the topic/event pairing by wiring the taxonomy explicitly, so extenders can hook the connection.

--- a/includes/core/classes/class-topic.php
+++ b/includes/core/classes/class-topic.php
@@ -130,6 +130,10 @@ final class Topic {
 				'show_in_rest'      => true,
 			)
 		);
+
+		// register_taxonomy() alone never fires `registered_taxonomy_for_object_type`;
+		// this explicit call does, giving extenders a hook for the pairing (#1639).
+		register_taxonomy_for_object_type( self::TAXONOMY, Event::POST_TYPE );
 	}
 
 	/**

--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -137,6 +137,8 @@ final class Setup {
 	 * @return void
 	 */
 	public function register_taxonomy(): void {
+		// No register_taxonomy_for_object_type() here (#1639): core requires a
+		// post type object and returns false for 'comment'.
 		register_taxonomy(
 			Status::TAXONOMY,
 			'comment',

--- a/test/unit/php/includes/tests/core/classes/class-test-topic.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-topic.php
@@ -8,6 +8,7 @@
 
 namespace GatherPress\Tests\Core;
 
+use GatherPress\Core\Event;
 use GatherPress\Core\Topic;
 use GatherPress\Tests\Base;
 
@@ -54,9 +55,29 @@ class Test_Topic extends Base {
 
 		$this->assertFalse( taxonomy_exists( Topic::TAXONOMY ), 'Failed to assert that taxonomy does not exist.' );
 
+		// Capture the pairings announced during registration (#1639).
+		$paired   = array();
+		$listener = static function ( $taxonomy, $object_type ) use ( &$paired ): void {
+			$paired[] = array( $taxonomy, $object_type );
+		};
+
+		add_action( 'registered_taxonomy_for_object_type', $listener, 10, 2 );
+
 		$instance->register_taxonomy();
 
+		remove_action( 'registered_taxonomy_for_object_type', $listener );
+
 		$this->assertTrue( taxonomy_exists( Topic::TAXONOMY ), 'Failed to assert that taxonomy exists.' );
+		$this->assertContains(
+			array( Topic::TAXONOMY, Event::POST_TYPE ),
+			$paired,
+			'Failed to assert that registered_taxonomy_for_object_type fired for the topic/event pairing.'
+		);
+		$this->assertContains(
+			Topic::TAXONOMY,
+			get_object_taxonomies( Event::POST_TYPE ),
+			'Failed to assert that the topic taxonomy is attached to the event post type.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1639.

## What actually changes

One line: `register_taxonomy_for_object_type( self::TAXONOMY, Event::POST_TYPE )` after the topic taxonomy registration.

The connection *state* was already correct — verified live that `get_taxonomy( 'gatherpress_topic' )->object_type` contains `gatherpress_event` and `get_object_taxonomies( 'gatherpress_event' )` includes the topic taxonomy. The core-docs "minetrap" warning doesn't bite modern WP here. What genuinely never happened is the **`registered_taxonomy_for_object_type` action firing** (verified live: it did not) — core only fires it from `register_post_type()` with a `taxonomies` arg, or from this explicit call. That hook is what @carstingaxion needs for #955, so the value of this change is extensibility, not safety.

## Why "all occurrences" shrank to one

The issue asks for the pattern across every `register_taxonomy()` call. The survey:

| Call site | Verdict |
|---|---|
| **Topic** | The gap — fixed here |
| **Shadow_Source** (+ Venue, which delegates to it) | Already compliant since the 0.34.0 refactor: registers with empty object types, wires explicitly via `register_taxonomy_for_object_type()` behind the `gatherpress_shadow_taxonomy_object_types` filter |
| **RSVP status + provider** (comment taxonomies) | **Impossible** — core's `register_taxonomy_for_object_type()` requires a post type object and returns `false` for `'comment'` (verified live). A comment on their registration now records the exemption so this issue can't be "finished" later with dead calls |

## Ordering

Safe: `Event\Setup` is instantiated before `Topic` in core `Setup`, so their `init` callbacks run in that order and the post type exists when the wiring call runs.

## Regression guard

`test_register_taxonomy` now listens for the action during registration and asserts it announces the `(gatherpress_topic, gatherpress_event)` pair — the exact thing #955 needs — plus that the taxonomy is attached to the event post type.

## Verification

| Gate | Result |
|---|---|
| PHPUnit single-site | 1653 tests, 6909 assertions — OK |
| PHPUnit multisite | 323 tests, 856 assertions — OK |
| Coverage | `class-topic.php` 100% (81/81), `rsvp/class-setup.php` 100% (203/203) |
| PHPCS / PHPStan | clean / `[OK] No errors` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)