### PR TITLE
Declare Interactivity API support on every block (#1813)

### DIFF
--- a/.github/changelog/1813-client-navigation-support
+++ b/.github/changelog/1813-client-navigation-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Declare Interactivity API support on every block so Query Loops with enhanced pagination no longer flag GatherPress blocks as incompatible (the Leaflet-based venue map remains genuinely incompatible).

--- a/src/blocks/add-to-calendar/block.json
+++ b/src/blocks/add-to-calendar/block.json
@@ -20,6 +20,9 @@
 			"postIdOverride": true
 		},
 		"html": false,
+		"interactivity": {
+			"clientNavigation": true
+		},
 		"listView": true
 	},
 	"textdomain": "gatherpress",

--- a/src/blocks/dropdown-item/block.json
+++ b/src/blocks/dropdown-item/block.json
@@ -20,6 +20,7 @@
 			"text": true
 		},
 		"html": false,
+		"interactivity": true,
 		"spacing": {
 			"padding": true,
 			"margin": true

--- a/src/blocks/form-field/block.json
+++ b/src/blocks/form-field/block.json
@@ -129,7 +129,10 @@
 		}
 	},
 	"supports": {
-		"html": false
+		"html": false,
+		"interactivity": {
+			"clientNavigation": true
+		}
 	},
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js",

--- a/src/blocks/modal-content/block.json
+++ b/src/blocks/modal-content/block.json
@@ -27,6 +27,9 @@
 	"supports": {
 		"contentRole": true,
 		"html": false,
+		"interactivity": {
+			"clientNavigation": true
+		},
 		"color": {
 			"gradients": true,
 			"__experimentalDefaultControls": {

--- a/src/blocks/modal/block.json
+++ b/src/blocks/modal/block.json
@@ -17,6 +17,9 @@
 	},
 	"supports": {
 		"html": false,
+		"interactivity": {
+			"clientNavigation": true
+		},
 		"color": {
 			"gradients": true,
 			"__experimentalDefaultControls": {

--- a/src/blocks/online-event/block.json
+++ b/src/blocks/online-event/block.json
@@ -27,6 +27,9 @@
 			"postIdOverride": true
 		},
 		"html": false,
+		"interactivity": {
+			"clientNavigation": true
+		},
 		"listView": true
 	},
 	"textdomain": "gatherpress",

--- a/src/blocks/rsvp-template/block.json
+++ b/src/blocks/rsvp-template/block.json
@@ -11,6 +11,7 @@
 	"supports": {
 		"contentRole": true,
 		"html": false,
+		"interactivity": true,
 		"listView": true
 	},
 	"usesContext": [


### PR DESCRIPTION
Fixes #1813.

## Scope: the issue's 3 blocks became 7

The issue predates a lot of block churn, so I re-censused all 20 `block.json` files and grepped every block directory *and* server render class for `data-wp-*` directives. Two categories fell out:

### `{ "clientNavigation": true }` — static, no directives, no view JS

| Block | Note |
|---|---|
| `add-to-calendar` | issue's list ✓ |
| `online-event` | issue's list ✓ |
| `modal`, `modal-content` | static wrappers — `modal-manager` owns the module and directives |
| `form-field` | has `render.php` but emits zero directives |

### `"interactivity": true` — actually *use* the API, never declared it

| Block | Evidence |
|---|---|
| `rsvp-template` | `view.js` imports `@wordpress/interactivity` and calls `store()`; server class emits directives. **This answers the issue's open question** ("wondering why this block does not declare interactivity") — it should, and now does. |
| `dropdown-item` | server class injects `data-wp-interactive` + `data-wp-on--click`, dispatching to dropdown's store |

The distinction matters for accuracy — core reads `true` as "uses the API" and `clientNavigation` as "doesn't, but is safe" — though both satisfy the Query Loop check.

## The deliberate exclusion: `venue-map`

Its vanilla `viewScript` boots Leaflet on page load and never re-runs when a client-side region swap replaces the markup — it is **genuinely incompatible**, and the warning it triggers is correct. Left undeclared on purpose; porting its init to the Interactivity API is the eventual fix and a separate issue if wanted.

Net effect: a Query Loop with enhanced pagination containing any mix of GatherPress blocks no longer warns — except when a venue map is inside, which is honest.

## Verification

- **Live registration check** (wp-env/Lando): all seven blocks register with the intended `supports.interactivity` values; `venue-map` remains undeclared.
- Jest 957/957, PHPUnit 1653/6909 single-site — both green.
- Every edited `block.json` re-parsed as valid JSON; edits were textual insertions preserving tab formatting (no JSON reserialization churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)