### PR TITLE
Port the venue map frontend to the Interactivity API (#2009)

### DIFF
--- a/.github/changelog/2009-venue-map-interactivity
+++ b/.github/changelog/2009-venue-map-interactivity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Mount the venue map through the Interactivity API so it works with Query Loop enhanced pagination, and drop React from the frontend map path.

--- a/.github/coverage-config.json
+++ b/.github/coverage-config.json
@@ -43,6 +43,7 @@
     "src/supports/**/*",
     "src/stores/index.js",
     "src/helpers/urlrewrite.js",
+    "src/leaflet-style.js",
     "src/helpers/interactivity.js",
     "src/blocks/rsvp-response/rsvp-manager.js"
   ]

--- a/src/blocks/venue-map/block.json
+++ b/src/blocks/venue-map/block.json
@@ -52,6 +52,7 @@
 	"supports": {
 		"align": ["left", "center", "right", "wide", "full"],
 		"html": false,
+		"interactivity": true,
 		"dimensions": {
 			"height": true,
 			"__experimentalSkipSerialization": true,
@@ -84,7 +85,7 @@
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
-	"viewScript": "file:./view.js",
+	"viewScriptModule": "file:./view.js",
 	"style": "file:./style-index.css",
 	"render": "file:./render.php"
 }

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -3,11 +3,14 @@
  * Render Venue Map block.
  *
  * Emits the pre-rendered static map as the baseline (no JavaScript required).
- * When `renderMode === 'interactive'` the wrapper also carries the data
- * attributes the view.js script reads to swap the `<img>` for a live Leaflet
- * map at hydration time. When the venue has no coordinates yet — e.g. a brand
- * new venue that hasn't been geocoded — a short placeholder surfaces the
- * "map coming soon" state in place of the image.
+ * When `renderMode === 'interactive'` the wrapper also carries Interactivity
+ * API directives (`data-wp-init`) and a `data-wp-context` payload the view
+ * script module reads to swap the `<img>` for a live Leaflet or Google map —
+ * on initial load and again whenever a client-side region swap (Query Loop
+ * enhanced pagination) inserts the block (#2009). When the venue has no
+ * coordinates yet — e.g. a brand new venue that hasn't been geocoded — a
+ * short placeholder surfaces the "map coming soon" state in place of the
+ * image.
  *
  * The wrapper sizing model: width always comes from the container (and
  * the block's alignment) — never from a stored value.
@@ -157,21 +160,49 @@ if ( ! empty( $gatherpress_styles ) ) {
 }
 
 if ( 'interactive' === $gatherpress_render_mode ) {
-	$gatherpress_block_attrs = array(
-		'address'          => $gatherpress_address,
-		'latitude'         => (string) ( $gatherpress_venue_meta['latitude'] ?? '' ),
-		'longitude'        => (string) ( $gatherpress_venue_meta['longitude'] ?? '' ),
-		'mapZoomLevel'     => $attributes['zoom'] ?? Map::DEFAULT_ZOOM,
-		'mapType'          => $attributes['type'] ?? Map::DEFAULT_MAP_TYPE,
-		'mapPlatform'      => (string) Settings::get_instance()->get( 'map_platform' ),
-		'pluginUrl'        => GATHERPRESS_CORE_URL,
-		'googleMapsApiKey' => (string) Settings::get_instance()->get( 'google_maps_api_key' ),
+	$gatherpress_map_platform = (string) Settings::get_instance()->get( 'map_platform' );
+
+	// Leaflet's stylesheet and marker images cannot ride the view script
+	// module -- webpack's async CSS chunk loading does not work under ESM
+	// module output -- so the styles ship as their own build entry, enqueued
+	// here whenever an interactive Leaflet map renders.
+	if ( 'google' !== $gatherpress_map_platform ) {
+		$gatherpress_leaflet_asset = include GATHERPRESS_CORE_PATH . '/build/leaflet_style.asset.php';
+
+		wp_enqueue_style(
+			'gatherpress-leaflet-style',
+			GATHERPRESS_CORE_URL . 'build/leaflet_style.css',
+			array(),
+			$gatherpress_leaflet_asset['version'] ?? GATHERPRESS_VERSION
+		);
+	}
+
+	// Everything the view script module needs travels in the context payload:
+	// script modules cannot import @wordpress/i18n or read the block editor's
+	// config, so the tile settings and translated strings are resolved here,
+	// server-side.
+	$gatherpress_block_context = array(
+		'address'            => $gatherpress_address,
+		'latitude'           => (string) ( $gatherpress_venue_meta['latitude'] ?? '' ),
+		'longitude'          => (string) ( $gatherpress_venue_meta['longitude'] ?? '' ),
+		'mapZoomLevel'       => $attributes['zoom'] ?? Map::DEFAULT_ZOOM,
+		'mapType'            => $attributes['type'] ?? Map::DEFAULT_MAP_TYPE,
+		'mapPlatform'        => $gatherpress_map_platform,
+		'pluginUrl'          => GATHERPRESS_CORE_URL,
+		'googleMapsApiKey'   => (string) Settings::get_instance()->get( 'google_maps_api_key' ),
+		'mapTileUrl'         => Settings::get_map_tile_url(),
+		'mapTileAttribution' => Settings::get_map_tile_attribution(),
+		'i18n'               => array(
+			'gestureTouch'     => __( 'Use two fingers to move the map', 'gatherpress' ),
+			'gestureScroll'    => __( 'Use ctrl + scroll to zoom the map', 'gatherpress' ),
+			'gestureScrollMac' => __( 'Use ⌘ + scroll to zoom the map', 'gatherpress' ),
+			'tileError'        => __( 'Map could not be loaded. Please try again later.', 'gatherpress' ),
+		),
 	);
 
-	$gatherpress_wrapper_attr_args['data-gatherpress_block_name']  = 'map-embed';
-	$gatherpress_wrapper_attr_args['data-gatherpress_block_attrs'] = esc_attr(
-		(string) wp_json_encode( $gatherpress_block_attrs )
-	);
+	$gatherpress_wrapper_attr_args['data-wp-interactive'] = 'gatherpress/venue-map';
+	$gatherpress_wrapper_attr_args['data-wp-init']        = 'callbacks.init';
+	$gatherpress_wrapper_attr_args['data-wp-context']     = (string) wp_json_encode( $gatherpress_block_context );
 }
 
 printf(

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -166,6 +166,12 @@ if ( 'interactive' === $gatherpress_render_mode ) {
 	// module -- webpack's async CSS chunk loading does not work under ESM
 	// module output -- so the styles ship as their own build entry, enqueued
 	// here whenever an interactive Leaflet map renders.
+	//
+	// `!== 'google'` rather than `=== 'osm'` on purpose: this must match the
+	// view module's own branch (google mounts Google Maps, everything else
+	// mounts Leaflet), so the stylesheet ships exactly when the Leaflet path
+	// runs. Checking for 'osm' would desync the two on an unset or unexpected
+	// platform value -- Leaflet would still mount, just unstyled.
 	if ( 'google' !== $gatherpress_map_platform ) {
 		$gatherpress_leaflet_asset = include GATHERPRESS_CORE_PATH . '/build/leaflet_style.asset.php';
 

--- a/src/blocks/venue-map/view.js
+++ b/src/blocks/venue-map/view.js
@@ -1,52 +1,334 @@
 /**
  * WordPress dependencies
  */
-import domReady from '@wordpress/dom-ready';
-import { createRoot } from '@wordpress/element';
+import { store, getContext, getElement } from '@wordpress/interactivity';
 
 /**
  * Internal dependencies
  */
-import MapEmbed from '../../components/MapEmbed';
+import { loadGoogleMapsApi } from '../../helpers/google-maps-api';
+import {
+	getGoogleMapEmbedSrc,
+	parseCoordinates,
+	toGoogleMapType,
+} from '../../helpers/map-embed';
 
 /**
- * Upgrade venue-map blocks marked `data-render-mode="interactive"` into a live
- * Leaflet map.
+ * Venue-map frontend mount, Interactivity API edition.
  *
- * Static-mode wrappers are left alone — their pre-rendered `<img>` is the
- * final output. For interactive wrappers we read the JSON payload that
- * render.php emitted on the outer `<div>`, replace the wrapper's static
- * children with a React root, and mount `MapEmbed` (Google Maps or Leaflet).
+ * Interactive wrappers carry `data-wp-init="callbacks.init"`, whose callback
+ * runs whenever the element enters the DOM — on the initial page load *and*
+ * when a client-side region swap (Query Loop enhanced pagination) inserts new
+ * markup. That is the property the previous `domReady` viewScript lacked:
+ * maps on page 2+ of a client-side-navigated loop never mounted (#2009).
  *
- * @since 0.34.0
+ * Static-mode wrappers carry no directives and stay zero-JS; every wrapper
+ * keeps its server-rendered static `<img>` as the no-JS baseline.
+ *
+ * This is a script module: `@wordpress/i18n`, `@wordpress/element`, and
+ * `@wordpress/data` must not be imported here. Translated strings arrive
+ * server-rendered inside the block's `data-wp-context` payload, and the maps
+ * mount with vanilla DOM + Leaflet / Google APIs rather than React.
+ */
+
+/**
+ * Memoized Leaflet loader.
+ *
+ * The library and the gesture-handling plugin load once per page no matter
+ * how many maps mount — repeated `data-wp-init` runs (several maps in one
+ * loop, successive client-side navigations) share the same promise.
+ * `addInitHook` mutates Leaflet globally, so running the loader once also
+ * keeps the gesture handler from being registered repeatedly.
+ *
+ * Only JavaScript loads here. Webpack's async CSS chunk loading does not
+ * work under ESM module output, so the Leaflet styles and marker images
+ * ship as the `leaflet_style` build entry, enqueued server-side by
+ * render.php alongside interactive Leaflet maps.
+ *
+ * @type {Promise<Object>|null}
+ */
+let leafletPromise = null;
+
+/**
+ * Load Leaflet and the gesture-handling plugin.
+ *
+ * @return {Promise<Object>} Resolves with the Leaflet namespace.
+ */
+function loadLeaflet() {
+	if ( ! leafletPromise ) {
+		leafletPromise = ( async () => {
+			const { default: L } = await import( 'leaflet' );
+
+			// eslint-disable-next-line import/no-extraneous-dependencies
+			const gesture = await import( 'leaflet-gesture-handling' );
+
+			// Add gesture handling to Leaflet. Under ESM module output the
+			// plugin's UMD wrapper does not attach itself to the imported
+			// Leaflet instance, so read the handler from the module's own
+			// exports rather than from `L`.
+			L.Map.addInitHook(
+				'addHandler',
+				'gestureHandling',
+				gesture.GestureHandling ||
+					gesture.default ||
+					L.GestureHandling
+			);
+
+			return L;
+		} )();
+	}
+
+	return leafletPromise;
+}
+
+/**
+ * Create the fill-parent container the map (or iframe) mounts into,
+ * replacing the wrapper's static baseline.
+ *
+ * @param {HTMLElement} wrapper The venue-map block wrapper.
+ *
+ * @return {HTMLElement} The mounted container.
+ */
+function replaceBaseline( wrapper ) {
+	const container = wrapper.ownerDocument.createElement( 'div' );
+
+	// Fill the wrapper — it is the single source of size — and carry the
+	// block's border-radius down so the map stays clipped to the same
+	// rounded corners.
+	container.style.width = '100%';
+	container.style.height = '100%';
+	container.style.position = 'relative';
+	container.style.borderRadius = 'inherit';
+	container.style.overflow = 'hidden';
+
+	wrapper.replaceChildren( container );
+
+	return container;
+}
+
+/**
+ * Mount a Google map.
+ *
+ * With an API key, boots the Maps JavaScript API and falls back to the keyed
+ * Maps Embed API iframe when the script fails to load (network error, key
+ * without the Maps JavaScript API enabled). Without a key, embeds the keyless
+ * legacy iframe directly — the primary no-key path.
+ *
+ * @param {HTMLElement} wrapper The venue-map block wrapper.
+ * @param {Object}      context The block's Interactivity API context.
+ * @param {number}      lat     Parsed latitude.
+ * @param {number}      lng     Parsed longitude.
  *
  * @return {void}
  */
-domReady( () => {
-	const containers = document.querySelectorAll(
-		'[data-render-mode="interactive"][data-gatherpress_block_name="map-embed"]'
-	);
+function mountGoogleMap( wrapper, context, lat, lng ) {
+	const zoom = context.mapZoomLevel || 10;
+	const type = toGoogleMapType( context.mapType );
+	const apiKey = ( context.googleMapsApiKey || '' ).trim();
 
-	for ( const container of containers ) {
-		let attrs;
-		try {
-			attrs = JSON.parse( container.dataset.gatherpress_block_attrs );
-		} catch {
-			// Malformed JSON — leave the static baseline in place.
-			continue;
+	const embedFallback = () => {
+		const iframe = wrapper.ownerDocument.createElement( 'iframe' );
+		iframe.src = getGoogleMapEmbedSrc( {
+			latitude: lat,
+			longitude: lng,
+			zoom,
+			type,
+			apiKey,
+		} );
+		iframe.title = context.address || '';
+		iframe.style.width = '100%';
+		iframe.style.height = '100%';
+		iframe.style.border = '0';
+		wrapper.replaceChildren( iframe );
+	};
+
+	if ( ! apiKey ) {
+		embedFallback();
+		return;
+	}
+
+	loadGoogleMapsApi( apiKey, wrapper.ownerDocument )
+		.then( ( maps ) => {
+			// The wrapper may have left the DOM mid-load (client-side
+			// navigation moved on) — mounting into a detached node is
+			// wasted work.
+			if ( ! wrapper.isConnected ) {
+				return;
+			}
+
+			const container = replaceBaseline( wrapper );
+			const center = { lat, lng };
+			const map = new maps.Map( container, {
+				center,
+				zoom,
+				mapTypeId: type,
+			} );
+
+			// eslint-disable-next-line no-new -- The marker attaches itself to the map.
+			new maps.Marker( {
+				position: center,
+				map,
+				title: context.address || '',
+			} );
+		} )
+		.catch( () => {
+			if ( wrapper.isConnected ) {
+				embedFallback();
+			}
+		} );
+}
+
+/**
+ * Mount a Leaflet (OpenStreetMap) map.
+ *
+ * Ports the frontend behavior of the OpenStreetMap component: gesture
+ * handling, the configurable tile layer with a tiles-unavailable overlay,
+ * a marker centered on the coordinate, and size revalidation after layout
+ * settles and whenever the wrapper's box changes.
+ *
+ * @param {HTMLElement} wrapper The venue-map block wrapper.
+ * @param {Object}      context The block's Interactivity API context.
+ * @param {number}      lat     Parsed latitude.
+ * @param {number}      lng     Parsed longitude.
+ *
+ * @return {void}
+ */
+function mountLeafletMap( wrapper, context, lat, lng ) {
+	const zoom = context.mapZoomLevel || 10;
+	const i18n = context.i18n || {};
+
+	loadLeaflet().then( ( L ) => {
+		if ( ! wrapper.isConnected ) {
+			return;
 		}
 
-		createRoot( container ).render(
-			<MapEmbed
-				location={ attrs.address }
-				latitude={ attrs.latitude }
-				longitude={ attrs.longitude }
-				zoom={ attrs.mapZoomLevel }
-				type={ attrs.mapType }
-				mapPlatform={ attrs.mapPlatform }
-				pluginUrl={ attrs.pluginUrl }
-				googleMapsApiKey={ attrs.googleMapsApiKey }
-			/>
-		);
-	}
+		const container = replaceBaseline( wrapper );
+		const doc = wrapper.ownerDocument;
+
+		const mapEl = doc.createElement( 'div' );
+		mapEl.style.width = '100%';
+		mapEl.style.height = '100%';
+		mapEl.style.borderRadius = 'inherit';
+		container.appendChild( mapEl );
+
+		const map = L.map( mapEl, {
+			gestureHandling: true,
+			gestureHandlingOptions: {
+				duration: 1500,
+				text: {
+					touch: i18n.gestureTouch || '',
+					scroll: i18n.gestureScroll || '',
+					scrollMac: i18n.gestureScrollMac || '',
+				},
+			},
+		} ).setView( [ lat, lng ], zoom );
+
+		L.Icon.Default.imagePath =
+			( context.pluginUrl || '' ) + 'build/images/';
+
+		// Surface a clear "unavailable" state instead of a blank gray map
+		// when the tile provider fails. Only flag failure when no tile has
+		// loaded — a few stray edge-tile errors on an otherwise-working
+		// basemap shouldn't trip the message (#1731).
+		const errorEl = doc.createElement( 'output' );
+		errorEl.className = 'gatherpress-venue-map__tile-error';
+		errorEl.textContent = i18n.tileError || '';
+		errorEl.style.cssText =
+			'position:absolute;inset:0;display:none;align-items:flex-start;' +
+			'justify-content:center;padding:1rem;text-align:center;' +
+			'background-color:#e0e0e0;color:#757575;border-radius:inherit;';
+		container.appendChild( errorEl );
+
+		let tilesLoaded = 0;
+		const tileLayer = L.tileLayer( context.mapTileUrl || '', {
+			attribution: context.mapTileAttribution || '',
+		} );
+		tileLayer.on( 'tileload', () => {
+			tilesLoaded += 1;
+			errorEl.style.display = 'none';
+		} );
+		tileLayer.on( 'tileerror', () => {
+			if ( 0 === tilesLoaded ) {
+				// Pin the message to the top so it clears the centered map
+				// marker, which Leaflet paints above the overlay.
+				errorEl.style.display = 'flex';
+			}
+		} );
+		tileLayer.addTo( map );
+
+		// Center the marker icon on the coord (both axes) so the pin's
+		// visual center matches the map center — mirrors the static map's
+		// centered dot. Leaflet's default anchor is the pin tip, which
+		// leaves the body floating above center.
+		const centeredIcon = new L.Icon.Default( {
+			iconAnchor: [ 12, 20 ],
+			popupAnchor: [ 0, -20 ],
+			shadowAnchor: [ 12, 20 ],
+		} );
+		L.marker( [ lat, lng ], { icon: centeredIcon } )
+			.addTo( map )
+			.bindPopup( context.address || '' );
+
+		// Leaflet reads the container's size at init time. When the wrapper
+		// relies on CSS aspect-ratio (height derived from container width)
+		// that size can be stale by the time the map mounts, so the computed
+		// center drifts. invalidateSize() tells Leaflet to re-read the
+		// container and re-center — once after the next frame for the
+		// initial layout, and again whenever the wrapper's box changes.
+		requestAnimationFrame( () => {
+			map.invalidateSize();
+			map.setView( [ lat, lng ], zoom );
+		} );
+
+		if ( 'undefined' !== typeof ResizeObserver ) {
+			const resizeObserver = new ResizeObserver( () => {
+				if ( ! mapEl.isConnected ) {
+					resizeObserver.disconnect();
+					return;
+				}
+				map.invalidateSize();
+				map.setView( [ lat, lng ], zoom );
+			} );
+			resizeObserver.observe( mapEl );
+		}
+	} ).catch( () => {
+		// Leaflet failed to load — the server-rendered static baseline is
+		// still in place, so the block degrades to the static map image.
+	} );
+}
+
+store( 'gatherpress/venue-map', {
+	callbacks: {
+		init() {
+			const { ref } = getElement();
+
+			// A region swap can reuse a wrapper element that already booted;
+			// mounting twice would stack a second map over the first.
+			if ( ! ref || ref.dataset.gatherpressMapMounted ) {
+				return;
+			}
+
+			const context = getContext();
+
+			const { valid, lat, lng } = parseCoordinates(
+				context.latitude,
+				context.longitude
+			);
+
+			// No mappable coordinates — leave the server-rendered static
+			// baseline in place.
+			if ( ! valid ) {
+				return;
+			}
+
+			ref.dataset.gatherpressMapMounted = 'true';
+
+			if ( 'google' === context.mapPlatform ) {
+				mountGoogleMap( ref, context, lat, lng );
+				return;
+			}
+
+			mountLeafletMap( ref, context, lat, lng );
+		},
+	},
 } );

--- a/src/components/GoogleMap.js
+++ b/src/components/GoogleMap.js
@@ -9,6 +9,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { loadGoogleMapsApi } from '../helpers/google-maps-api';
+import {
+	getGoogleMapEmbedSrc,
+	toGoogleMapType,
+	toMapsEmbedApiMapType,
+} from '../helpers/map-embed';
 
 /**
  * GoogleMap component for GatherPress.
@@ -78,99 +83,10 @@ export const GOOGLE_KEYLESS_UNSUPPORTED_MAP_TYPE_SLUGS = [
 	'terrain',
 ];
 
-const BLOCK_MAP_TYPE_SLUGS = GOOGLE_MAP_TYPE_DEFINITIONS.map(
-	( definition ) => definition.slug
-);
-
-const LEGACY_EMBED_LETTER_BY_SLUG = GOOGLE_MAP_TYPE_DEFINITIONS.reduce(
-	( accumulator, definition ) => {
-		accumulator[ definition.slug ] = definition.legacyEmbedLetter;
-		return accumulator;
-	},
-	{}
-);
-
-/**
- * Normalize a block map-type slug to the canonical set.
- *
- * @param {string} type Map type slug from the block.
- *
- * @return {string} A slug from `GOOGLE_MAP_TYPE_DEFINITIONS`; unknown values fall back to roadmap.
- */
-export function toGoogleMapType( type ) {
-	return type && BLOCK_MAP_TYPE_SLUGS.includes( type ) ? type : 'roadmap';
-}
-
-/**
- * Maps Embed API `view` (and related) modes only allow `roadmap` or `satellite`
- * for `maptype`. Hybrid or terrain in block data (e.g. content authored while
- * an API key was configured) are coerced so embed URLs stay valid.
- *
- * @see https://developers.google.com/maps/documentation/embed/embedding-map#view_mode
- *
- * @param {string} type Map type slug from the block.
- *
- * @return {'roadmap'|'satellite'} Coercion for the embed iframe: hybrid→satellite, terrain→roadmap.
- */
-export function toMapsEmbedApiMapType( type ) {
-	const normalized = toGoogleMapType( type );
-	if ( 'satellite' === normalized || 'hybrid' === normalized ) {
-		return 'satellite';
-	}
-	return 'roadmap';
-}
-
-const GOOGLE_EMBED_VIEW_BASE = 'https://www.google.com/maps/embed/v1/view';
-const GOOGLE_LEGACY_EMBED_BASE = 'https://maps.google.com/maps';
-
-/**
- * Builds the iframe `src` for a Google map embed.
- *
- * With an API key this is the Maps Embed API `view` URL — only used as the
- * fallback when the Maps JavaScript API fails to load. Without a key it is
- * the keyless legacy embed URL, the primary no-key path.
- *
- * @param {Object} params           Parameters.
- * @param {string} params.latitude  Latitude.
- * @param {string} params.longitude Longitude.
- * @param {number} params.zoom      Zoom level.
- * @param {string} params.type      Map type slug from the block.
- * @param {string} params.apiKey    API key or empty string.
- *
- * @return {string} Iframe URL.
- */
-export function getGoogleMapEmbedSrc( {
-	latitude,
-	longitude,
-	zoom,
-	type,
-	apiKey,
-} ) {
-	const z = zoom || 10;
-	const safeType = toGoogleMapType( type );
-	const trimmedKey = ( apiKey || '' ).trim();
-
-	if ( trimmedKey ) {
-		const params = new URLSearchParams( {
-			key: trimmedKey,
-			center: `${ latitude },${ longitude }`,
-			zoom: String( z ),
-			maptype: toMapsEmbedApiMapType( safeType ),
-		} );
-		return `${ GOOGLE_EMBED_VIEW_BASE }?${ params.toString() }`;
-	}
-
-	// toMapsEmbedApiMapType() only ever returns roadmap or satellite, both
-	// of which are always present in the letter table.
-	const legacyType = toMapsEmbedApiMapType( safeType );
-	const params = new URLSearchParams( {
-		q: `${ latitude },${ longitude }`,
-		z: String( z ),
-		t: LEGACY_EMBED_LETTER_BY_SLUG[ legacyType ],
-		output: 'embed',
-	} );
-	return `${ GOOGLE_LEGACY_EMBED_BASE }?${ params.toString() }`;
-}
+// The type-normalization and embed-URL helpers moved to the framework-free
+// `helpers/map-embed.js` so the venue-map view module can share them; they are
+// re-exported here so existing imports keep working.
+export { getGoogleMapEmbedSrc, toGoogleMapType, toMapsEmbedApiMapType };
 
 /**
  * Interactive Google map backed by the Maps JavaScript API.

--- a/src/helpers/map-embed.js
+++ b/src/helpers/map-embed.js
@@ -1,0 +1,145 @@
+/**
+ * Framework-free map embed helpers.
+ *
+ * Shared by the editor's GoogleMap component and the venue-map view script
+ * module. This file must stay importable from a viewScriptModule: no
+ * `@wordpress/i18n`, no `@wordpress/element`, no `@wordpress/data` — script
+ * modules cannot resolve those packages (localized labels live in
+ * `src/components/GoogleMap.js`, and the frontend receives translated strings
+ * through the block's `data-wp-context` payload instead).
+ *
+ * @since 0.35.0
+ */
+
+/**
+ * Canonical Google map type slugs for the venue-map block.
+ *
+ * The slugs double as Maps JavaScript API `mapTypeId` values, so the keyed
+ * interactive path passes them through untouched.
+ *
+ * @see https://developers.google.com/maps/documentation/javascript/maptypes
+ */
+export const GOOGLE_MAP_TYPE_SLUGS = [
+	'roadmap',
+	'satellite',
+	'hybrid',
+	'terrain',
+];
+
+/**
+ * Legacy keyless embed `t=` parameter letter per map type slug.
+ *
+ * @see https://developers.google.com/maps/documentation/embed/map-parameters
+ */
+export const LEGACY_EMBED_LETTER_BY_SLUG = {
+	roadmap: 'm',
+	satellite: 'k',
+	hybrid: 'h',
+	terrain: 'p',
+};
+
+/**
+ * Normalize a block map-type slug to the canonical set.
+ *
+ * @param {string} type Map type slug from the block.
+ *
+ * @return {string} A slug from `GOOGLE_MAP_TYPE_SLUGS`; unknown values fall back to roadmap.
+ */
+export function toGoogleMapType( type ) {
+	return type && GOOGLE_MAP_TYPE_SLUGS.includes( type ) ? type : 'roadmap';
+}
+
+/**
+ * Maps Embed API `view` (and related) modes only allow `roadmap` or `satellite`
+ * for `maptype`. Hybrid or terrain in block data (e.g. content authored while
+ * an API key was configured) are coerced so embed URLs stay valid.
+ *
+ * @see https://developers.google.com/maps/documentation/embed/embedding-map#view_mode
+ *
+ * @param {string} type Map type slug from the block.
+ *
+ * @return {'roadmap'|'satellite'} Coercion for the embed iframe: hybrid→satellite, terrain→roadmap.
+ */
+export function toMapsEmbedApiMapType( type ) {
+	const normalized = toGoogleMapType( type );
+	if ( 'satellite' === normalized || 'hybrid' === normalized ) {
+		return 'satellite';
+	}
+	return 'roadmap';
+}
+
+const GOOGLE_EMBED_VIEW_BASE = 'https://www.google.com/maps/embed/v1/view';
+const GOOGLE_LEGACY_EMBED_BASE = 'https://maps.google.com/maps';
+
+/**
+ * Builds the iframe `src` for a Google map embed.
+ *
+ * With an API key this is the Maps Embed API `view` URL — only used as the
+ * fallback when the Maps JavaScript API fails to load. Without a key it is
+ * the keyless legacy embed URL, the primary no-key path.
+ *
+ * @param {Object} params           Parameters.
+ * @param {string} params.latitude  Latitude.
+ * @param {string} params.longitude Longitude.
+ * @param {number} params.zoom      Zoom level.
+ * @param {string} params.type      Map type slug from the block.
+ * @param {string} params.apiKey    API key or empty string.
+ *
+ * @return {string} Iframe URL.
+ */
+export function getGoogleMapEmbedSrc( {
+	latitude,
+	longitude,
+	zoom,
+	type,
+	apiKey,
+} ) {
+	const z = zoom || 10;
+	const safeType = toGoogleMapType( type );
+	const trimmedKey = ( apiKey || '' ).trim();
+
+	if ( trimmedKey ) {
+		const params = new URLSearchParams( {
+			key: trimmedKey,
+			center: `${ latitude },${ longitude }`,
+			zoom: String( z ),
+			maptype: toMapsEmbedApiMapType( safeType ),
+		} );
+		return `${ GOOGLE_EMBED_VIEW_BASE }?${ params.toString() }`;
+	}
+
+	// toMapsEmbedApiMapType() only ever returns roadmap or satellite, both
+	// of which are always present in the letter table.
+	const legacyType = toMapsEmbedApiMapType( safeType );
+	const params = new URLSearchParams( {
+		q: `${ latitude },${ longitude }`,
+		z: String( z ),
+		t: LEGACY_EMBED_LETTER_BY_SLUG[ legacyType ],
+		output: 'embed',
+	} );
+	return `${ GOOGLE_LEGACY_EMBED_BASE }?${ params.toString() }`;
+}
+
+/**
+ * Validate and parse a latitude/longitude pair from block data.
+ *
+ * Mirrors the validity rule the map components use: present, non-empty, and
+ * numeric. Parsing is centralized so the view module and the editor agree on
+ * what counts as mappable coordinates.
+ *
+ * @param {string|number} latitude  Latitude from block data.
+ * @param {string|number} longitude Longitude from block data.
+ *
+ * @return {{valid: boolean, lat: number, lng: number}} Parse result; lat/lng are NaN when invalid.
+ */
+export function parseCoordinates( latitude, longitude ) {
+	const lat = parseFloat( latitude );
+	const lng = parseFloat( longitude );
+
+	// A falsy input (empty string, null, undefined) is absent; anything else
+	// must parse to a number. Matches the map components' validity rule.
+	const validLat = Boolean( latitude ) && ! isNaN( lat );
+	const validLng = Boolean( longitude ) && ! isNaN( lng );
+
+	return { valid: validLat && validLng, lat, lng };
+}

--- a/src/leaflet-style.js
+++ b/src/leaflet-style.js
@@ -1,0 +1,18 @@
+/**
+ * Leaflet stylesheet + marker asset anchor for the venue-map frontend.
+ *
+ * The venue-map view script is a script module, and webpack's async CSS
+ * chunk loading does not work under ESM module output — a dynamic
+ * `import( '…/leaflet.css' )` dies in the chunk-loading runtime. So the
+ * Leaflet styles build here as a plain stylesheet that `render.php`
+ * enqueues whenever an interactive Leaflet map renders, and the marker
+ * images are imported so webpack emits them to `build/images/` for
+ * `L.Icon.Default.imagePath` to resolve at runtime (#2009).
+ */
+import 'leaflet/dist/leaflet.css';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css';
+
+import 'leaflet/dist/images/marker-icon.png';
+import 'leaflet/dist/images/marker-icon-2x.png';
+import 'leaflet/dist/images/marker-shadow.png';

--- a/test/unit/js/src/helpers/map-embed.test.js
+++ b/test/unit/js/src/helpers/map-embed.test.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from '@jest/globals';
+
+/**
  * Internal dependencies
  */
 import {

--- a/test/unit/js/src/helpers/map-embed.test.js
+++ b/test/unit/js/src/helpers/map-embed.test.js
@@ -1,0 +1,150 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getGoogleMapEmbedSrc,
+	GOOGLE_MAP_TYPE_SLUGS,
+	LEGACY_EMBED_LETTER_BY_SLUG,
+	parseCoordinates,
+	toGoogleMapType,
+	toMapsEmbedApiMapType,
+} from '../../../../../src/helpers/map-embed';
+
+describe( 'toGoogleMapType', () => {
+	it.each( GOOGLE_MAP_TYPE_SLUGS )(
+		'passes the canonical slug %s through',
+		( slug ) => {
+			expect( toGoogleMapType( slug ) ).toBe( slug );
+		}
+	);
+
+	it( 'falls back to roadmap for unknown slugs', () => {
+		expect( toGoogleMapType( 'moon' ) ).toBe( 'roadmap' );
+	} );
+
+	it( 'falls back to roadmap for empty input', () => {
+		expect( toGoogleMapType( '' ) ).toBe( 'roadmap' );
+		expect( toGoogleMapType( undefined ) ).toBe( 'roadmap' );
+	} );
+} );
+
+describe( 'toMapsEmbedApiMapType', () => {
+	it( 'keeps roadmap and satellite', () => {
+		expect( toMapsEmbedApiMapType( 'roadmap' ) ).toBe( 'roadmap' );
+		expect( toMapsEmbedApiMapType( 'satellite' ) ).toBe( 'satellite' );
+	} );
+
+	it( 'coerces hybrid to satellite', () => {
+		expect( toMapsEmbedApiMapType( 'hybrid' ) ).toBe( 'satellite' );
+	} );
+
+	it( 'coerces terrain (and unknowns) to roadmap', () => {
+		expect( toMapsEmbedApiMapType( 'terrain' ) ).toBe( 'roadmap' );
+		expect( toMapsEmbedApiMapType( 'moon' ) ).toBe( 'roadmap' );
+	} );
+} );
+
+describe( 'getGoogleMapEmbedSrc', () => {
+	const coords = { latitude: '40.7', longitude: '-74.0' };
+
+	it( 'builds the keyed Maps Embed API URL', () => {
+		const src = getGoogleMapEmbedSrc( {
+			...coords,
+			zoom: 12,
+			type: 'satellite',
+			apiKey: ' my-key ',
+		} );
+		const url = new URL( src );
+
+		expect( url.origin + url.pathname ).toBe(
+			'https://www.google.com/maps/embed/v1/view'
+		);
+		// The key is trimmed before use.
+		expect( url.searchParams.get( 'key' ) ).toBe( 'my-key' );
+		expect( url.searchParams.get( 'center' ) ).toBe( '40.7,-74.0' );
+		expect( url.searchParams.get( 'zoom' ) ).toBe( '12' );
+		expect( url.searchParams.get( 'maptype' ) ).toBe( 'satellite' );
+	} );
+
+	it( 'coerces hybrid to satellite in the keyed URL', () => {
+		const src = getGoogleMapEmbedSrc( {
+			...coords,
+			zoom: 12,
+			type: 'hybrid',
+			apiKey: 'k',
+		} );
+
+		expect( new URL( src ).searchParams.get( 'maptype' ) ).toBe(
+			'satellite'
+		);
+	} );
+
+	it( 'builds the keyless legacy embed URL', () => {
+		const src = getGoogleMapEmbedSrc( {
+			...coords,
+			zoom: 15,
+			type: 'roadmap',
+			apiKey: '',
+		} );
+		const url = new URL( src );
+
+		expect( url.origin + url.pathname ).toBe(
+			'https://maps.google.com/maps'
+		);
+		expect( url.searchParams.get( 'q' ) ).toBe( '40.7,-74.0' );
+		expect( url.searchParams.get( 'z' ) ).toBe( '15' );
+		expect( url.searchParams.get( 't' ) ).toBe(
+			LEGACY_EMBED_LETTER_BY_SLUG.roadmap
+		);
+		expect( url.searchParams.get( 'output' ) ).toBe( 'embed' );
+	} );
+
+	it( 'uses the satellite letter for keyless satellite maps', () => {
+		const src = getGoogleMapEmbedSrc( {
+			...coords,
+			zoom: 15,
+			type: 'satellite',
+			apiKey: undefined,
+		} );
+
+		expect( new URL( src ).searchParams.get( 't' ) ).toBe(
+			LEGACY_EMBED_LETTER_BY_SLUG.satellite
+		);
+	} );
+
+	it( 'defaults the zoom to 10 when falsy', () => {
+		const src = getGoogleMapEmbedSrc( {
+			...coords,
+			zoom: 0,
+			type: 'roadmap',
+			apiKey: '',
+		} );
+
+		expect( new URL( src ).searchParams.get( 'z' ) ).toBe( '10' );
+	} );
+} );
+
+describe( 'parseCoordinates', () => {
+	it( 'accepts a valid numeric-string pair', () => {
+		expect( parseCoordinates( '40.7', '-74.0' ) ).toEqual( {
+			valid: true,
+			lat: 40.7,
+			lng: -74.0,
+		} );
+	} );
+
+	it( 'rejects a missing latitude', () => {
+		expect( parseCoordinates( '', '-74.0' ).valid ).toBe( false );
+		expect( parseCoordinates( undefined, '-74.0' ).valid ).toBe( false );
+	} );
+
+	it( 'rejects a missing longitude', () => {
+		expect( parseCoordinates( '40.7', '' ).valid ).toBe( false );
+		expect( parseCoordinates( '40.7', null ).valid ).toBe( false );
+	} );
+
+	it( 'rejects non-numeric input', () => {
+		expect( parseCoordinates( 'north', '-74.0' ).valid ).toBe( false );
+		expect( parseCoordinates( '40.7', 'west' ).valid ).toBe( false );
+	} );
+} );

--- a/test/unit/js/src/leaflet-style.test.js
+++ b/test/unit/js/src/leaflet-style.test.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { describe, expect, it } from '@jest/globals';
+
+/**
  * Internal dependencies
  */
 import '../../../../src/leaflet-style';

--- a/test/unit/js/src/leaflet-style.test.js
+++ b/test/unit/js/src/leaflet-style.test.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import '../../../../src/leaflet-style';
+
+describe( 'leaflet-style', () => {
+	it( 'imports without side effects beyond asset registration', () => {
+		// The module is an asset anchor: it only imports the Leaflet
+		// stylesheets and marker images so webpack emits them for the
+		// server-enqueued leaflet_style entry. Importing it must not throw.
+		expect( true ).toBe( true );
+	} );
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,9 @@ function getVariationEntries() {
 }
 
 module.exports = [
-	...defaultConfig,
+	// The scripts (classic) config, with the project's extra entries. This
+	// replaces defaultConfig[ 0 ] rather than being appended alongside it —
+	// exporting both compiled every classic entry twice.
 	{
 		...defaultConfig[ 0 ],
 		entry: {
@@ -70,6 +72,11 @@ module.exports = [
 				'style.scss',
 			),
 			utility_style: path.resolve( process.cwd(), 'src', 'utility.scss' ),
+			leaflet_style: path.resolve(
+				process.cwd(),
+				'src',
+				'leaflet-style.js'
+			),
 			tooltip_view: path.resolve(
 				process.cwd(),
 				'src/formats/tooltip',
@@ -116,5 +123,18 @@ module.exports = [
 			} ),
 			...defaultConfig[ 0 ].plugins,
 		],
+	},
+	// The script-modules config (from --experimental-modules). Both configs
+	// emit async chunks as `[id].js` into build/ by default, and the ids can
+	// collide — the classic build then overwrites a module-format chunk with
+	// a jsonp-format one, and the module runtime dies importing it
+	// (\"Cannot read properties of undefined (reading 'length')\", #2009).
+	// A distinct chunk filename keeps the two chunk namespaces apart.
+	{
+		...defaultConfig[ 1 ],
+		output: {
+			...defaultConfig[ 1 ].output,
+			chunkFilename: '[id].module.js',
+		},
 	},
 ];


### PR DESCRIPTION
Fixes #2009. Completes what #1813 deliberately left out: the venue map was the one block genuinely incompatible with client-side navigation.

## What changed

The frontend mount moves from a `domReady` viewScript (React `createRoot` of `MapEmbed`) to a **`viewScriptModule`** on the Interactivity API:

- Interactive wrappers carry `data-wp-init="callbacks.init"` — the callback runs whenever the element enters the DOM, **including Query Loop enhanced-pagination region swaps**, which is exactly what `domReady` lacked.
- Everything the module needs travels in `data-wp-context` (coords, zoom, platform, tile config, and **server-translated strings** — script modules can't import `@wordpress/i18n`).
- Maps mount with **vanilla Leaflet / Google APIs**. `MapEmbed` remains editor-only, so **React is gone from the frontend map path** (verified absent from the page).
- `block.json` declares `supports.interactivity: true` — the last Query Loop incompatibility warning clears, and core keeps enhanced pagination enabled with maps inside (verified: `data-wp-router-region` present).

## Two real build bugs found and fixed on the way

**1. Module/classic chunk collision (the big one).** Both webpack configs emitted async chunks as `[id].js` into `build/`, and the classic build overwrote the module build's same-id Leaflet chunk with a jsonp-format file. The module runtime then imported it, found no `__webpack_esm_ids__`, and died: `Cannot read properties of undefined (reading 'length')`. Module chunks now emit as `[id].module.js`. The config also exported the untouched `defaultConfig[0]` *alongside* its customized copy, compiling every classic entry twice — fixed.

**2. Async CSS chunks don't work under ESM module output at all.** The Leaflet/gesture stylesheets can't ride the module, so they build as a new `leaflet_style` entry (`src/leaflet-style.js` asset anchor) that `render.php` enqueues for interactive Leaflet maps. Bonus: this fixes a pre-existing gap where `marker-shadow.png` was only emitted content-hashed, silently 404ing Leaflet's default shadow.

Plus one ESM interop fix: the gesture-handling plugin's UMD doesn't attach to the imported Leaflet instance under module output, so the handler registers from the plugin's own export.

## Structure

- **`src/helpers/map-embed.js`** (new, framework-free, 100% covered): Google embed URL/type helpers moved out of `GoogleMap.js` (re-exported there — all 43 existing Google/MapEmbed/edit tests pass unchanged) + shared `parseCoordinates`.
- **`src/blocks/venue-map/view.js`**: the module — memoized Leaflet loader, vanilla Leaflet mount (gesture handling, tile-error overlay, centered marker, `invalidateSize` + ResizeObserver), Google keyed JS-API mount with keyed-iframe fallback, keyless legacy iframe, re-init guard against wrapper reuse.
- **`render.php`**: directives + context payload replace the legacy `data-gatherpress_block_attrs`; enqueues `leaflet_style.css` for interactive Leaflet maps.

## Verified live (enhanced-pagination Query Loop over venues, real browser)

| Check | Result |
|---|---|
| Initial load | Leaflet mounts, tiles + marker + shadow render |
| Client-side page change (region swap) | fresh map mounts with the **correct per-venue coordinates** |
| Venue without coordinates | static baseline kept, no stale map bleed-through |
| Repeated back/forward | exactly **one** map per navigation — no double-boot |
| Gesture handling | functionally active (`scrollWheelZoom` disabled until modifier) |
| React / `wp-element` | **absent** from the page |
| No-JS baseline | static `<img>` still server-rendered for every wrapper |

## Gates

Jest 976/976 (52 suites; new `map-embed` + `leaflet-style` suites), `map-embed.js` and `GoogleMap.js` at 100%, PHPCS/PHPStan clean, PHPUnit 1653/6909. `view.js` is coverage-excluded like every other view script; DOM-heavy mount logic lives there per house convention with pure logic extracted and fully tested.

Test page used for verification: `/2009-map-loop-test/` in the dev env (left in place for review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)