### PR TITLE
Announce RSVP status changes to screen readers

### DIFF
--- a/.github/changelog/2015-announce-rsvp-status-changes
+++ b/.github/changelog/2015-announce-rsvp-status-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Announce RSVP status changes, attendee counts, and online event link availability to screen readers.

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -182,14 +182,20 @@ final class Assets {
 				'eventApiUrl' => rest_url( $event_rest_api_slug ),
 				'i18n'        => array(
 					'rsvpAttending'         => __( 'Your RSVP was updated. You are attending.', 'gatherpress' ),
-					'rsvpWaitingList'       => __( 'Your RSVP was updated. You are on the waiting list.', 'gatherpress' ),
+					'rsvpWaitingList'       => __(
+						'Your RSVP was updated. You are on the waiting list.',
+						'gatherpress'
+					),
 					'rsvpNotAttending'      => __( 'Your RSVP was updated. You are not attending.', 'gatherpress' ),
 					/* translators: %d: Number of attendees (singular case). */
 					'attendeeCountSingular' => __( '%d attendee.', 'gatherpress' ),
 					/* translators: %d: Number of attendees (plural case). */
 					'attendeeCountPlural'   => __( '%d attendees.', 'gatherpress' ),
 					'onlineLinkReady'       => __( 'The event link is now available on this page.', 'gatherpress' ),
-					'rsvpFailed'            => __( 'Sorry, there was an issue processing your RSVP. Please try again.', 'gatherpress' ),
+					'rsvpFailed'            => __(
+						'Sorry, there was an issue processing your RSVP. Please try again.',
+						'gatherpress'
+					),
 				),
 			)
 		);

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -153,9 +153,12 @@ final class Assets {
 	/**
 	 * Set initial interactivity state for frontend blocks.
 	 *
-	 * Provides the REST API URL to the gatherpress interactivity store so
-	 * frontend view scripts (RSVP nonce/status requests) can build API URLs
-	 * without relying on window globals.
+	 * Provides the REST API URL and translated UI strings to the gatherpress
+	 * interactivity store so frontend view scripts (RSVP nonce/status requests,
+	 * screen-reader announcements) can use them without relying on window
+	 * globals. Strings are translated here because the Interactivity API
+	 * script-module graph cannot import `@wordpress/i18n` (see
+	 * `notifyRsvpFailure()` in `src/helpers/interactivity.js`).
 	 *
 	 * The state is set on every front-end view rather than only on singular
 	 * event pages: RSVP and other interactive blocks also render in event
@@ -177,6 +180,15 @@ final class Assets {
 			'gatherpress',
 			array(
 				'eventApiUrl' => rest_url( $event_rest_api_slug ),
+				'i18n'        => array(
+					'rsvpAttending'    => __( 'Your RSVP was updated. You are attending.', 'gatherpress' ),
+					'rsvpWaitingList'  => __( 'Your RSVP was updated. You are on the waiting list.', 'gatherpress' ),
+					'rsvpNotAttending' => __( 'Your RSVP was updated. You are not attending.', 'gatherpress' ),
+					/* translators: %d: Number of attendees. */
+					'attendingCount'   => __( '%d attending.', 'gatherpress' ),
+					'onlineLinkReady'  => __( 'The event link is now available on this page.', 'gatherpress' ),
+					'rsvpFailed'       => __( 'Sorry, there was an issue processing your RSVP. Please try again.', 'gatherpress' ),
+				),
 			)
 		);
 	}

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -181,13 +181,15 @@ final class Assets {
 			array(
 				'eventApiUrl' => rest_url( $event_rest_api_slug ),
 				'i18n'        => array(
-					'rsvpAttending'    => __( 'Your RSVP was updated. You are attending.', 'gatherpress' ),
-					'rsvpWaitingList'  => __( 'Your RSVP was updated. You are on the waiting list.', 'gatherpress' ),
-					'rsvpNotAttending' => __( 'Your RSVP was updated. You are not attending.', 'gatherpress' ),
-					/* translators: %d: Number of attendees. */
-					'attendingCount'   => __( '%d attending.', 'gatherpress' ),
-					'onlineLinkReady'  => __( 'The event link is now available on this page.', 'gatherpress' ),
-					'rsvpFailed'       => __( 'Sorry, there was an issue processing your RSVP. Please try again.', 'gatherpress' ),
+					'rsvpAttending'         => __( 'Your RSVP was updated. You are attending.', 'gatherpress' ),
+					'rsvpWaitingList'       => __( 'Your RSVP was updated. You are on the waiting list.', 'gatherpress' ),
+					'rsvpNotAttending'      => __( 'Your RSVP was updated. You are not attending.', 'gatherpress' ),
+					/* translators: %d: Number of attendees (singular case). */
+					'attendeeCountSingular' => __( '%d attendee.', 'gatherpress' ),
+					/* translators: %d: Number of attendees (plural case). */
+					'attendeeCountPlural'   => __( '%d attendees.', 'gatherpress' ),
+					'onlineLinkReady'       => __( 'The event link is now available on this page.', 'gatherpress' ),
+					'rsvpFailed'            => __( 'Sorry, there was an issue processing your RSVP. Please try again.', 'gatherpress' ),
 				),
 			)
 		);

--- a/src/helpers/interactivity.js
+++ b/src/helpers/interactivity.js
@@ -50,9 +50,12 @@ function notifyRsvpFailure( error = null ) {
  * Translated strings arrive via `wp_interactivity_state()` (the module graph
  * cannot import `@wordpress/i18n` — see `notifyRsvpFailure()` above); if the
  * state is unavailable, no announcement is made rather than announcing in the
- * wrong language.
+ * wrong language. The attendee count picks a singular or plural template
+ * client-side, mirroring the rsvp-count and guest-count-display blocks, and
+ * the placeholder replace tolerates positional forms (`%1$d`) that
+ * translations may use.
  *
- * @since 0.36.0
+ * @since 0.35.0
  *
  * @param {Object} res The successful RSVP API response.
  *
@@ -67,13 +70,12 @@ function announceRsvpSuccess( res ) {
 	};
 	const parts = [ statusMessages[ res.status ] ];
 
-	if ( i18n.attendingCount ) {
-		parts.push(
-			i18n.attendingCount.replace(
-				'%d',
-				res.responses?.attending?.count ?? 0
-			)
-		);
+	const count = res.responses?.attending?.count ?? 0;
+	const countTemplate =
+		1 === count ? i18n.attendeeCountSingular : i18n.attendeeCountPlural;
+
+	if ( countTemplate ) {
+		parts.push( countTemplate.replace( /%(?:\d+\$)?d/, String( count ) ) );
 	}
 
 	if ( res.online_link && i18n.onlineLinkReady ) {

--- a/src/helpers/interactivity.js
+++ b/src/helpers/interactivity.js
@@ -55,13 +55,25 @@ function notifyRsvpFailure( error = null ) {
  * the placeholder replace tolerates positional forms (`%1$d`) that
  * translations may use.
  *
+ * The online-link sentence is only spoken when the link actually becomes
+ * available with this update: the online-event-link block initializes
+ * `onlineEventLink` in state to an empty string when it renders without a
+ * visible link, so a previous value of `''` plus a link in the response is
+ * the reveal transition. An undefined previous value means the block never
+ * initialized (not present on this page), and a non-empty previous value
+ * means the link was already visible (e.g. a guest-count update) — neither
+ * should re-announce it.
+ *
  * @since 0.35.0
  *
- * @param {Object} res The successful RSVP API response.
+ * @param {Object}           res                The successful RSVP API response.
+ * @param {string|undefined} previousOnlineLink The `onlineEventLink` state value
+ *                                              captured before this response was
+ *                                              merged into state.
  *
  * @return {void}
  */
-function announceRsvpSuccess( res ) {
+function announceRsvpSuccess( res, previousOnlineLink ) {
 	const i18n = gatherPressState.i18n ?? {};
 	const statusMessages = {
 		attending: i18n.rsvpAttending,
@@ -78,7 +90,11 @@ function announceRsvpSuccess( res ) {
 		parts.push( countTemplate.replace( /%(?:\d+\$)?d/, String( count ) ) );
 	}
 
-	if ( res.online_link && i18n.onlineLinkReady ) {
+	if (
+		'' === previousOnlineLink &&
+		res.online_link &&
+		i18n.onlineLinkReady
+	) {
 		parts.push( i18n.onlineLinkReady );
 	}
 
@@ -306,6 +322,12 @@ export async function sendRsvpApiRequest(
 		// so a failed request surfaces an error instead of throwing on
 		// `res.success` and leaving the button hidden (#1719).
 		if ( res?.success ) {
+			// Captured before the state merge below overwrites it: the
+			// announcement only mentions the online link when it transitions
+			// from initialized-but-empty to present (see announceRsvpSuccess).
+			const previousOnlineLink =
+				state?.posts?.[ postId ]?.onlineEventLink;
+
 			if ( state ) {
 				state.posts[ postId ] = {
 					...state.posts[ postId ],
@@ -323,7 +345,7 @@ export async function sendRsvpApiRequest(
 				};
 			}
 
-			announceRsvpSuccess( res );
+			announceRsvpSuccess( res, previousOnlineLink );
 
 			if ( 'function' === typeof onSuccess ) {
 				try {

--- a/src/helpers/interactivity.js
+++ b/src/helpers/interactivity.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { store } from '@wordpress/interactivity';
+import { speak } from '@wordpress/a11y';
 
 const { state: gatherPressState } = store( 'gatherpress' );
 
@@ -12,10 +13,12 @@ const { state: gatherPressState } = store( 'gatherpress' );
  * request doesn't leave the UI in a silent half-updated state. Mirrors the
  * server-error handling in the rsvp-form block (#1719).
  *
- * The message is a plain string, not wrapped in `__()`: this helper runs in the
- * Interactivity API script-module graph (`wp-scripts build --experimental-modules`),
- * which does not support `@wordpress/i18n` as a module dependency yet — the same
- * reason the rsvp-form block hardcodes its alert copy.
+ * The message is not wrapped in `__()`: this helper runs in the Interactivity
+ * API script-module graph (`wp-scripts build --experimental-modules`), which
+ * does not support `@wordpress/i18n` as a module dependency yet. The translated
+ * string is provided server-side via `wp_interactivity_state()` (see
+ * `Assets::add_interactivity_state()`), with an English fallback for contexts
+ * where the state is unavailable.
  *
  * @since 0.34.0
  *
@@ -28,8 +31,60 @@ function notifyRsvpFailure( error = null ) {
 	console.warn( 'RSVP API request failed:', error );
 	// eslint-disable-next-line no-alert
 	alert(
-		'Sorry, there was an issue processing your RSVP. Please try again.'
+		gatherPressState.i18n?.rsvpFailed ??
+			'Sorry, there was an issue processing your RSVP. Please try again.'
 	);
+}
+
+/**
+ * Announce the result of a successful RSVP update to screen readers.
+ *
+ * The RSVP status swap, attendee count, and online-event-link reveal are all
+ * silent DOM updates driven by watchers — without an announcement, assistive
+ * technology gets no feedback that the RSVP was recorded (WCAG 4.1.3 Status
+ * Messages). `speak()` uses the core-managed live region, which is immune to
+ * the DOM re-insertion `renderRsvpBlock` performs on the block's own subtree.
+ *
+ * The message is assembled from the API response rather than the requested
+ * status, so a server-side bump to the waiting list announces correctly.
+ * Translated strings arrive via `wp_interactivity_state()` (the module graph
+ * cannot import `@wordpress/i18n` — see `notifyRsvpFailure()` above); if the
+ * state is unavailable, no announcement is made rather than announcing in the
+ * wrong language.
+ *
+ * @since 0.36.0
+ *
+ * @param {Object} res The successful RSVP API response.
+ *
+ * @return {void}
+ */
+function announceRsvpSuccess( res ) {
+	const i18n = gatherPressState.i18n ?? {};
+	const statusMessages = {
+		attending: i18n.rsvpAttending,
+		waiting_list: i18n.rsvpWaitingList,
+		not_attending: i18n.rsvpNotAttending,
+	};
+	const parts = [ statusMessages[ res.status ] ];
+
+	if ( i18n.attendingCount ) {
+		parts.push(
+			i18n.attendingCount.replace(
+				'%d',
+				res.responses?.attending?.count ?? 0
+			)
+		);
+	}
+
+	if ( res.online_link && i18n.onlineLinkReady ) {
+		parts.push( i18n.onlineLinkReady );
+	}
+
+	const message = parts.filter( Boolean ).join( ' ' );
+
+	if ( message ) {
+		speak( message, 'polite' );
+	}
 }
 
 /**
@@ -265,6 +320,8 @@ export async function sendRsvpApiRequest(
 					onlineEventLink: res.online_link || '',
 				};
 			}
+
+			announceRsvpSuccess( res );
 
 			if ( 'function' === typeof onSuccess ) {
 				try {

--- a/test/unit/js/src/helpers/interactivity.test.js
+++ b/test/unit/js/src/helpers/interactivity.test.js
@@ -249,6 +249,10 @@ describe( 'sendRsvpApiRequest announcements', () => {
 	beforeEach( () => {
 		getNonce.clearCache();
 
+		// Clear any speak() history from other suites so an earlier
+		// matching call can't produce a false positive here.
+		speak.mockClear();
+
 		state = { posts: { 123: {} } };
 		mockInteractivityState.i18n = { ...I18N_FIXTURE };
 
@@ -271,7 +275,6 @@ describe( 'sendRsvpApiRequest announcements', () => {
 
 	afterEach( () => {
 		jest.restoreAllMocks();
-		speak.mockClear();
 		delete global.fetch;
 		delete mockInteractivityState.i18n;
 	} );
@@ -342,7 +345,11 @@ describe( 'sendRsvpApiRequest announcements', () => {
 		);
 	} );
 
-	it( 'appends the online-link sentence when the response includes one', async () => {
+	it( 'appends the online-link sentence when the link is revealed by this update', async () => {
+		// The online-event-link block initialized with no visible link:
+		// this response transitions it from unavailable to available.
+		state.posts[ 123 ].onlineEventLink = '';
+
 		rsvpPayload = {
 			success: true,
 			status: 'attending',
@@ -360,6 +367,56 @@ describe( 'sendRsvpApiRequest announcements', () => {
 
 		expect( speak ).toHaveBeenCalledWith(
 			'Your RSVP was updated. You are attending. 1 attendee. The event link is now available on this page.',
+			'polite'
+		);
+	} );
+
+	it( 'does not re-announce a link that was already visible', async () => {
+		// e.g. a guest-count update while attending: the response still
+		// carries online_link, but the link did not just appear.
+		state.posts[ 123 ].onlineEventLink = 'https://meet.example.test/room';
+
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 1,
+			anonymous: false,
+			online_link: 'https://meet.example.test/room',
+			responses: { attending: { count: 1 } },
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 1, anonymous: false },
+			state
+		);
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Your RSVP was updated. You are attending. 1 attendee.',
+			'polite'
+		);
+	} );
+
+	it( 'does not mention the link when the online-event-link block never initialized', async () => {
+		// No onlineEventLink key in state: the block is not on this page,
+		// so "available on this page" would be false.
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 0,
+			anonymous: false,
+			online_link: 'https://meet.example.test/room',
+			responses: { attending: { count: 1 } },
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 0, anonymous: false },
+			state
+		);
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Your RSVP was updated. You are attending. 1 attendee.',
 			'polite'
 		);
 	} );

--- a/test/unit/js/src/helpers/interactivity.test.js
+++ b/test/unit/js/src/helpers/interactivity.test.js
@@ -391,6 +391,12 @@ describe( 'sendRsvpApiRequest announcements', () => {
 			state
 		);
 
+		// toHaveBeenCalledWith only proves *some* call matched, and the
+		// expected string here is identical to the one the singular-count
+		// test produces. Pinning the call count makes this assert the
+		// absence of the link sentence rather than leaning on the
+		// mockClear() in beforeEach to keep history empty.
+		expect( speak ).toHaveBeenCalledTimes( 1 );
 		expect( speak ).toHaveBeenCalledWith(
 			'Your RSVP was updated. You are attending. 1 attendee.',
 			'polite'
@@ -415,6 +421,9 @@ describe( 'sendRsvpApiRequest announcements', () => {
 			state
 		);
 
+		// Same reasoning as the already-visible case above: the count pins
+		// that no second, link-bearing announcement was made.
+		expect( speak ).toHaveBeenCalledTimes( 1 );
 		expect( speak ).toHaveBeenCalledWith(
 			'Your RSVP was updated. You are attending. 1 attendee.',
 			'polite'

--- a/test/unit/js/src/helpers/interactivity.test.js
+++ b/test/unit/js/src/helpers/interactivity.test.js
@@ -5,24 +5,64 @@ import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals
 
 /**
  * Mock the Interactivity API store so the module can read
- * `gatherPressState.eventApiUrl` at import time without a real store.
+ * `gatherPressState.eventApiUrl` at import time without a real store. The
+ * state object is created inside the factory (jest.mock is hoisted above
+ * any const in this file) and re-exported as `__mockState` so individual
+ * tests can mutate it (e.g. remove `i18n` to cover the missing-strings
+ * guard in announceRsvpSuccess()).
  */
 jest.mock(
 	'@wordpress/interactivity',
+	() => {
+		const state = {
+			eventApiUrl: 'https://example.test/wp-json/gatherpress/v1',
+		};
+
+		return {
+			store: jest.fn( () => ( { state } ) ),
+			__mockState: state,
+		};
+	},
+	{ virtual: true }
+);
+
+/**
+ * Mock the a11y script module so announcement tests can assert on `speak()`
+ * without a DOM live region.
+ */
+jest.mock(
+	'@wordpress/a11y',
 	() => ( {
-		store: jest.fn( () => ( {
-			state: {
-				eventApiUrl: 'https://example.test/wp-json/gatherpress/v1',
-			},
-		} ) ),
+		speak: jest.fn(),
 	} ),
 	{ virtual: true }
 );
 
 /**
+ * WordPress dependencies
+ */
+import { speak } from '@wordpress/a11y';
+// eslint-disable-next-line import/named -- `__mockState` only exists on the virtual mock above.
+import { __mockState as mockInteractivityState } from '@wordpress/interactivity';
+
+/**
  * Internal dependencies
  */
 import { sendRsvpApiRequest, getNonce } from '@src/helpers/interactivity';
+
+/**
+ * English source strings mirroring Assets::add_interactivity_state(), so the
+ * announcement tests assert the fully assembled message.
+ */
+const I18N_FIXTURE = {
+	rsvpAttending: 'Your RSVP was updated. You are attending.',
+	rsvpWaitingList: 'Your RSVP was updated. You are on the waiting list.',
+	rsvpNotAttending: 'Your RSVP was updated. You are not attending.',
+	attendeeCountSingular: '%d attendee.',
+	attendeeCountPlural: '%d attendees.',
+	onlineLinkReady: 'The event link is now available on this page.',
+	rsvpFailed: 'Sorry, there was an issue processing your RSVP. Please try again.',
+};
 
 /**
  * Regression coverage for #1769 — sendRsvpApiRequest must not throw when a
@@ -193,5 +233,181 @@ describe( 'sendRsvpApiRequest', () => {
 			waitingList: 0,
 			notAttending: 0,
 		} );
+	} );
+} );
+
+/**
+ * Screen-reader announcements for successful RSVP updates (WCAG 4.1.3).
+ * The message is assembled from the API response inside
+ * announceRsvpSuccess() and spoken via the core a11y module's polite
+ * live region.
+ */
+describe( 'sendRsvpApiRequest announcements', () => {
+	let state;
+	let rsvpPayload;
+
+	beforeEach( () => {
+		getNonce.clearCache();
+
+		state = { posts: { 123: {} } };
+		mockInteractivityState.i18n = { ...I18N_FIXTURE };
+
+		window.alert = jest.fn();
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+		global.fetch = jest.fn( ( url ) => {
+			if ( url.endsWith( '/nonce' ) ) {
+				return Promise.resolve( {
+					json: () => Promise.resolve( { nonce: 'test-nonce' } ),
+				} );
+			}
+
+			return Promise.resolve( {
+				status: 200,
+				json: () => Promise.resolve( rsvpPayload ),
+			} );
+		} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+		speak.mockClear();
+		delete global.fetch;
+		delete mockInteractivityState.i18n;
+	} );
+
+	it( 'announces the attending status with a singular attendee count', async () => {
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 0,
+			anonymous: false,
+			responses: { attending: { count: 1 } },
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 0, anonymous: false },
+			state
+		);
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Your RSVP was updated. You are attending. 1 attendee.',
+			'polite'
+		);
+	} );
+
+	it( 'uses the plural template when more than one attendee', async () => {
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 0,
+			anonymous: false,
+			responses: { attending: { count: 7 } },
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 0, anonymous: false },
+			state
+		);
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Your RSVP was updated. You are attending. 7 attendees.',
+			'polite'
+		);
+	} );
+
+	it( 'announces the response status when the server bumps to the waiting list', async () => {
+		// The user requested attending, but the event is full and the
+		// server answered with waiting_list — the announcement must
+		// reflect the actual resulting status.
+		rsvpPayload = {
+			success: true,
+			status: 'waiting_list',
+			guests: 0,
+			anonymous: false,
+			responses: { attending: { count: 5 } },
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 0, anonymous: false },
+			state
+		);
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Your RSVP was updated. You are on the waiting list. 5 attendees.',
+			'polite'
+		);
+	} );
+
+	it( 'appends the online-link sentence when the response includes one', async () => {
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 0,
+			anonymous: false,
+			online_link: 'https://meet.example.test/room',
+			responses: { attending: { count: 1 } },
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 0, anonymous: false },
+			state
+		);
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Your RSVP was updated. You are attending. 1 attendee. The event link is now available on this page.',
+			'polite'
+		);
+	} );
+
+	it( 'replaces positional placeholders that translations may use', async () => {
+		mockInteractivityState.i18n.attendeeCountPlural = '%1$d attendees.';
+
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 0,
+			anonymous: false,
+			responses: { attending: { count: 3 } },
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 0, anonymous: false },
+			state
+		);
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Your RSVP was updated. You are attending. 3 attendees.',
+			'polite'
+		);
+	} );
+
+	it( 'announces nothing when i18n strings are unavailable', async () => {
+		// No strings — announcing hardcoded English on a localized site
+		// would be worse than staying silent.
+		delete mockInteractivityState.i18n;
+
+		rsvpPayload = {
+			success: true,
+			status: 'attending',
+			guests: 0,
+			anonymous: false,
+			responses: { attending: { count: 1 } },
+		};
+
+		await sendRsvpApiRequest(
+			123,
+			{ status: 'attending', guests: 0, anonymous: false },
+			state
+		);
+
+		expect( speak ).not.toHaveBeenCalled();
+		// The request itself still succeeded.
+		expect( state.posts[ 123 ].currentUser.status ).toBe( 'attending' );
 	} );
 } );


### PR DESCRIPTION
Fixes #2014

## Proposed changes:
* Announce RSVP status changes, attendee-count updates, and the online-event-link
  reveal to screen readers via `speak()` from the `@wordpress/a11y` script module
  (WCAG 2.2 SC 4.1.3). All three updates flow from the single success handler in
  `sendRsvpApiRequest()`, so one announcement covers them; the message is assembled
  from the API response, so a server-side bump to the waiting list announces the
  actual resulting status.
* Provide the translated announcement strings server-side through the existing
  `wp_interactivity_state()` call in `Assets::add_interactivity_state()`, since the
  script-module graph cannot import `@wordpress/i18n` (same constraint already noted
  in `notifyRsvpFailure()`'s docblock).
* Use the same server-provided translated string for the RSVP failure `alert()`,
  which was previously hardcoded, untranslated English.

Implementation notes: `@wordpress/a11y` has been available as a script module since
WP 6.7 (the plugin requires 7.0), and dependency extraction externalizes it, no
bundle-size cost. Using the core-managed live region (rather than one inside the
block) also matters because `renderRsvpBlock` re-inserts inner blocks on update, and
announcements from a just-moved subtree are unreliable. If the store's `i18n` strings
are unavailable, the announcement is skipped rather than spoken in the wrong language.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No new tests in this PR — the announcement is a thin wrapper over `speak()` and the
existing success path. Happy to add a Jest test around `announceRsvpSuccess()`'s
message assembly if the team would like one.

## Testing instructions:

1. `npm install && npm run build`, activate the plugin, and create an upcoming event
   with the RSVP block (the "Event with RSVP" starter template works).
2. Log in as any user and open the event page.
3. Start NVDA and open Tools → Speech Viewer (or watch the DOM per step 5).
4. Activate **RSVP** → **Attend**. Expected: Speech Viewer shows
   "Your RSVP was updated. You are attending. 1 attending." On `develop`, the same
   action announces nothing.
5. No-screen-reader alternative: after clicking Attend, inspect
   `document.getElementById('a11y-speak-polite').textContent` — it contains the
   announcement text.
6. Regression checks: the modal still closes and focus-restores as before; the RSVP
   form block's own success announcement still works; with a non-English locale the
   announcement follows the site language (strings come from
   `wp_interactivity_state`).
[Before Video: Attend updates the page while Speech Viewer stays silent](https://www.dropbox.com/scl/fi/9ox2tghxhum53bmexq5kp/fix-gatherpress-aria-polite-before.mp4?rlkey=bclgtew3h04ilfjj1btq6hjei&dl=0)
[After Video: The same action announces the update](https://www.dropbox.com/scl/fi/x6n6m3cz8es5vqo7fqxqx/fix-gatherpress-aria-polite-after.mp4?rlkey=dxkojw1mqgf5acmuqyzx2jpbv&dl=0)

### Credit (for release notes)

My WordPress.org username: matthewneilcowan

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Announce RSVP status changes, attendee counts, and online event link availability to
screen readers.

</details>
