### PR TITLE
Add the 0.35.0-alpha.2 credits file

### DIFF
--- a/.github/scripts/release/credits/0.35.0-alpha.2.json
+++ b/.github/scripts/release/credits/0.35.0-alpha.2.json
@@ -1,0 +1,19 @@
+{
+    "leads": [
+        "mauteri",
+        "patricia70"
+    ],
+    "team": [
+        "hrmervin",
+        "jmarx75",
+        "stephenerdelyi",
+        "carstenbach",
+        "supernovia"
+    ],
+    "contributors": [
+        "andremenrath",
+        "bor0",
+        "linewebdigital",
+        "w3lld1"
+    ]
+}


### PR DESCRIPTION
Pre-flight step 1 of the 0.35.0-alpha.2 pre-release train, per [the release runbook](docs/contributor/release-process.md).

## Proposed changes:

* Adds `.github/scripts/release/credits/0.35.0-alpha.2.json`, the roster copied forward from `0.35.0-alpha.1.json` unchanged.

`generate-version.php` bails with *"No credits file for 0.35.0-alpha.2 — add .github/scripts/release/credits/0.35.0-alpha.2.json first."* when this file is missing, so it has to merge before the Version Bump workflow is dispatched.

The three contributors currently staged in `credits/unreleased.json` (fahimmurshed, lheroorg, matthewneilcowan) are intentionally not listed here. `fold_unreleased_credits()` moves them into this file during the bump and empties the staging file, and both writes land in the version-bump commit.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No tests. Data file only.

## Testing instructions:

1. Confirm the file is valid JSON and matches `0.35.0-alpha.1.json`.
2. After this merges, the Version Bump workflow for `0.35.0-alpha.2` should run past the credits check and report folding the three unreleased contributors in.