### PR TITLE
Register the venue command directly instead of via the admin menu

### DIFF
--- a/.github/changelog/735-command-palette
+++ b/.github/changelog/735-command-palette
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Added an "Add New Venue" item to the Events admin menu, which also gives venues a command palette entry alongside the existing one for events.
+Added an "Add New Venue" entry to the editor command palette, matching the "Add New Event" one core provides.

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -95,9 +95,6 @@ final class Setup {
 			3
 		);
 		add_action( 'init', array( $this, 'register_post_type' ) );
-		// Priority 11 so core's `_add_post_type_submenus()` (default priority)
-		// has already placed the venue listing under its parent menu.
-		add_action( 'admin_menu', array( $this, 'register_add_new_submenu' ), 11 );
 		// Priority 9 so the implicit `gatherpress-shadow-source` support is
 		// declared before Shadow_Source's own priority-10 `registered_post_type`
 		// callback wires its per-post-type lifecycle hooks for that post type.
@@ -116,55 +113,6 @@ final class Setup {
 			10,
 			2
 		);
-	}
-
-	/**
-	 * Add an "Add New Venue" item to whichever menu the venue post type sits under.
-	 *
-	 * A post type whose `show_in_menu` is a string is nested inside another
-	 * menu, and core gives those exactly one entry: `_add_post_type_submenus()`
-	 * registers the listing screen and nothing else. Only post types with
-	 * `show_in_menu === true` get the `all_items` plus `add_new_item` pair that
-	 * `wp-admin/menu.php` builds.
-	 *
-	 * Venues are nested under Events, so that asymmetry is why the admin menu
-	 * offers "Add New Event" but no venue equivalent. It also reaches the
-	 * command palette, whose "Go to:" entries core generates by walking the
-	 * `$menu` and `$submenu` globals: an admin menu with no "Add New Venue"
-	 * item produces no command for creating one either.
-	 *
-	 * Registering the missing item closes both gaps at once, and the label
-	 * comes from the post type so a venue post type renamed to "Location"
-	 * reads "Add New Location" without extra wiring.
-	 *
-	 * @since 0.35.0
-	 *
-	 * @return void
-	 */
-	public function register_add_new_submenu(): void {
-		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $post_type ) {
-			$post_type_object = get_post_type_object( $post_type );
-
-			if ( ! $post_type_object || ! $post_type_object->show_ui ) {
-				continue;
-			}
-
-			$parent_slug = $post_type_object->show_in_menu;
-
-			// A top-level post type already gets its own "Add New" entry from
-			// core; only the nested (string `show_in_menu`) case is missing one.
-			if ( ! is_string( $parent_slug ) || '' === $parent_slug ) {
-				continue;
-			}
-
-			add_submenu_page(
-				$parent_slug,
-				$post_type_object->labels->add_new_item,
-				$post_type_object->labels->add_new_item,
-				$post_type_object->cap->create_posts,
-				sprintf( 'post-new.php?post_type=%s', $post_type )
-			);
-		}
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@wordpress/api-fetch": "^7.41.0",
 				"@wordpress/block-editor": "^15.14.0",
 				"@wordpress/blocks": "^15.14.0",
+				"@wordpress/commands": "^1.41.0",
 				"@wordpress/components": "^32.3.0",
 				"@wordpress/compose": "^7.41.0",
 				"@wordpress/core-data": "^7.41.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/api-fetch": "^7.41.0",
 		"@wordpress/block-editor": "^15.14.0",
 		"@wordpress/blocks": "^15.14.0",
+		"@wordpress/commands": "^1.41.0",
 		"@wordpress/components": "^32.3.0",
 		"@wordpress/compose": "^7.41.0",
 		"@wordpress/core-data": "^7.41.0",

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { store as commandsStore } from '@wordpress/commands';
+import { dispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Build the "Go to: Events > Add New Venue" command config.
+ *
+ * The venue post type is nested under the Events admin menu, so WordPress
+ * core never gives it an "Add New" submenu entry, and the command palette —
+ * which core generates by walking the admin menu — has no venue creation
+ * command to match the "Go to: Events > Add New Event" one it derives from
+ * the event submenu.
+ *
+ * This registers that missing command directly. It is deliberately a `view`
+ * command so the palette renders it identically to core's menu-derived
+ * entries: the palette's own `CATEGORY_ICONS.view` supplies the arrow icon
+ * (any `icon` set here would be ignored for that category) and the "View"
+ * badge, and the label mirrors core's `Go to: {parent} > {child}` shape.
+ *
+ * @since 0.35.0
+ *
+ * @return {Object} A command config accepted by the commands store.
+ */
+export function getAddVenueCommand() {
+	const target = sprintf(
+		/* translators: 1: parent admin menu label (Events), 2: submenu label (Add New Venue). */
+		__( '%1$s > %2$s', 'gatherpress' ),
+		__( 'Events', 'gatherpress' ),
+		__( 'Add New Venue', 'gatherpress' )
+	);
+	/* translators: %s: admin navigation target, e.g. "Events > Add New Venue". */
+	const label = sprintf( __( 'Go to: %s', 'gatherpress' ), target );
+
+	return {
+		name: 'gatherpress/add-new-venue',
+		label,
+		searchLabel: label,
+		category: 'view',
+		callback: ( { close } ) => {
+			close();
+			document.location.href = 'post-new.php?post_type=gatherpress_venue';
+		},
+	};
+}
+
+dispatch( commandsStore ).registerCommand( getAddVenueCommand() );

--- a/src/editor.js
+++ b/src/editor.js
@@ -9,6 +9,7 @@ import { dispatch, select } from '@wordpress/data';
  */
 import { hasEventPastNotice } from './helpers/event';
 import EmailNotificationManager from './components/EmailNotificationManager';
+import './commands';
 import './stores';
 import './supports/post-id-override';
 import './supports/post-date-override';

--- a/test/unit/js/src/commands/index.test.js
+++ b/test/unit/js/src/commands/index.test.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+
+/**
+ * Mock the commands store so the registered command config can be captured
+ * without a live store.
+ */
+jest.mock(
+	'@wordpress/commands',
+	() => ( {
+		store: 'core/commands',
+	} ),
+	{ virtual: true }
+);
+
+/**
+ * Mock the data-store dispatch so registerCommand calls land on a spy. The spy
+ * is created inside the factory (jest.mock is hoisted above any const) and
+ * re-exported as `__registerCommand` so the tests can assert on it.
+ */
+jest.mock(
+	'@wordpress/data',
+	() => {
+		const registerCommand = jest.fn();
+		return {
+			dispatch: jest.fn( () => ( { registerCommand } ) ),
+			__registerCommand: registerCommand,
+		};
+	},
+	{ virtual: true }
+);
+
+/**
+ * WordPress dependencies
+ */
+// eslint-disable-next-line import/named -- `__registerCommand` only exists on the virtual mock above.
+import { __registerCommand as registerCommand } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { getAddVenueCommand } from '@src/commands';
+
+describe( 'add new venue command', () => {
+	it( 'registers a single command on import', () => {
+		// The module self-registers once at import time; getAddVenueCommand()
+		// in the other tests only builds config and never dispatches, so this
+		// count stays at 1 for the whole suite without any reset.
+		expect( registerCommand ).toHaveBeenCalledTimes( 1 );
+		expect( registerCommand ).toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'gatherpress/add-new-venue' } )
+		);
+	} );
+
+	it( 'is a view command so the palette styles it like core "Go to" entries', () => {
+		const command = getAddVenueCommand();
+
+		// `view` is what gives the palette-supplied arrow icon and "View"
+		// badge, matching the core-generated "Go to: Events > Add New Event".
+		expect( command.category ).toBe( 'view' );
+		expect( command.name ).toBe( 'gatherpress/add-new-venue' );
+	} );
+
+	it( 'labels itself "Go to: Events > Add New Venue"', () => {
+		const command = getAddVenueCommand();
+
+		expect( command.label ).toBe( 'Go to: Events > Add New Venue' );
+		// searchLabel matches the label so it is found by the same text.
+		expect( command.searchLabel ).toBe( command.label );
+	} );
+
+	it( 'closes the palette and navigates to the new venue screen', () => {
+		const command = getAddVenueCommand();
+		const close = jest.fn();
+
+		command.callback( { close } );
+
+		expect( close ).toHaveBeenCalled();
+
+		// jsdom implements no navigation and document.location is
+		// non-configurable, so the href assignment logs "Not implemented:
+		// navigation" rather than navigating. Declaring the error covers the
+		// callback body without suppressing it — the error is itself the
+		// evidence the navigation was attempted.
+		expect( console ).toHaveErrored();
+	} );
+} );

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -79,12 +79,6 @@ class Test_Setup extends Base {
 			),
 			array(
 				'type'     => 'action',
-				'name'     => 'admin_menu',
-				'priority' => 11,
-				'callback' => array( $instance, 'register_add_new_submenu' ),
-			),
-			array(
-				'type'     => 'action',
 				'name'     => 'registered_post_type',
 				'priority' => 9,
 				'callback' => array( $instance, 'maybe_link_shadow_source_support' ),
@@ -116,110 +110,6 @@ class Test_Setup extends Base {
 		);
 
 		$this->assert_hooks( $hooks, $instance );
-	}
-
-	/**
-	 * Coverage for register_add_new_submenu — the nested venue post type gets
-	 * the "Add New" entry core omits for post types whose `show_in_menu` is a
-	 * parent slug rather than `true`.
-	 *
-	 * @covers ::register_add_new_submenu
-	 *
-	 * @return void
-	 */
-	public function test_register_add_new_submenu_adds_entry_for_nested_venue(): void {
-		$instance = Setup::get_instance();
-
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-		$instance->register_add_new_submenu();
-
-		$parent  = get_post_type_object( Venue::POST_TYPE )->show_in_menu;
-		$entries = $GLOBALS['submenu'][ $parent ] ?? array();
-		$slugs   = wp_list_pluck( $entries, 2 );
-
-		$this->assertContains(
-			sprintf( 'post-new.php?post_type=%s', Venue::POST_TYPE ),
-			$slugs,
-			'Failed to assert the venue "Add New" item was added under its parent menu.'
-		);
-	}
-
-	/**
-	 * Coverage for register_add_new_submenu — post types that already own a
-	 * top-level menu are skipped, since core builds their "Add New" entry.
-	 *
-	 * @covers ::register_add_new_submenu
-	 *
-	 * @return void
-	 */
-	public function test_register_add_new_submenu_skips_top_level_post_type(): void {
-		$instance  = Setup::get_instance();
-		$post_type = 'gp_top_venue';
-
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-		register_post_type(
-			$post_type,
-			array(
-				'public'       => true,
-				'show_ui'      => true,
-				'show_in_menu' => true,
-				'supports'     => array( 'title', 'gatherpress-venue-information' ),
-			)
-		);
-
-		$instance->register_add_new_submenu();
-
-		$entries = $GLOBALS['submenu'][ sprintf( 'edit.php?post_type=%s', $post_type ) ] ?? array();
-
-		$this->assertNotContains(
-			sprintf( 'post-new.php?post_type=%s', $post_type ),
-			wp_list_pluck( $entries, 2 ),
-			'Failed to assert a top-level venue post type is left to core.'
-		);
-
-		unregister_post_type( $post_type );
-	}
-
-	/**
-	 * Coverage for register_add_new_submenu — a venue post type with no admin
-	 * UI never reaches the submenu registration.
-	 *
-	 * @covers ::register_add_new_submenu
-	 *
-	 * @return void
-	 */
-	public function test_register_add_new_submenu_skips_post_type_without_ui(): void {
-		$instance  = Setup::get_instance();
-		$post_type = 'gp_hidden_venue';
-
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-		register_post_type(
-			$post_type,
-			array(
-				'public'       => false,
-				'show_ui'      => false,
-				'show_in_menu' => 'edit.php?post_type=gatherpress_event',
-				'supports'     => array( 'title', 'gatherpress-venue-information' ),
-			)
-		);
-
-		$instance->register_add_new_submenu();
-
-		$entries = $GLOBALS['submenu']['edit.php?post_type=gatherpress_event'] ?? array();
-
-		$this->assertNotContains(
-			sprintf( 'post-new.php?post_type=%s', $post_type ),
-			wp_list_pluck( $entries, 2 ),
-			'Failed to assert a venue post type without admin UI is skipped.'
-		);
-
-		unregister_post_type( $post_type );
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #1357. Moves the "Add New Venue" command palette entry off the admin menu so it stays in ⌘K without adding a sidebar item.

## Background

#1357 gave venues a palette entry by registering an "Add New Venue" **admin submenu** and letting core derive the palette command from it (core builds `Go to:` commands by walking the admin menu). That worked, but it also put an item in the Events sidebar — which then landed at the wrong position (#2025).

The ask: keep the palette entry, drop the sidebar item.

## Proposed changes:

* Register the command directly via `@wordpress/commands` and remove `Venue\Setup::register_add_new_submenu()` (and its `admin_menu` hook + three multisite tests).
* The command is a **`view`** command, which is what makes the palette render it identically to core's `Go to: Events > Add New Event`:
  * The palette's own `CATEGORY_ICONS.view` supplies the arrow icon and the "View" badge. Any `icon` set on the command is ignored for that category, so none is set.
  * The label mirrors core's `Go to: {parent} > {child}` shape → **`Go to: Events > Add New Venue`**.
* Re-adds `@wordpress/commands` at `^1.41.0` (its deps line up with develop's `@wordpress/components ^32.3.0` / `@wordpress/data ^10.41.0`; latest 1.51 wants components ^37 and would duplicate the tree).

Result in the palette, searching "add new":

```
Go to: Events > Add New Event    View   ← core
Go to: Events > Add New Venue     View   ← this PR, visually identical
```

No sidebar item, no `@wordpress/commands` UI, just the one command.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

`src/commands/index.js` is covered at 100% (registration, the `view` category, the label, and the navigation callback).

**This makes #2025 moot** — there is no longer a venue submenu to position — so that issue should close with this.

## Testing instructions:

1. `npm install && npm run build`, load the block editor.
2. Press ⌘K (Ctrl+K) and type "add new".
3. Expected: `Go to: Events > Add New Venue` appears with the arrow icon and "View" badge, identical to `Go to: Events > Add New Event`. Selecting it closes the palette and opens the new-venue screen.
4. Confirm the Events **sidebar** no longer shows an "Add New Venue" item.
5. `npm run test:unit:js` (990 pass) and the multisite PHP suite (`Venue\Test_Setup` is `@group multisite`) both green.