### PR TITLE
Resolve SonarCloud findings in the venue map block

### DIFF
--- a/.github/changelog/2026-public-get-asset-data
+++ b/.github/changelog/2026-public-get-asset-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+`Assets::get_asset_data()` is now public, so block templates and companion plugins can resolve a build asset's version and dependencies through the same memoized reader core uses.

--- a/.github/changelog/2026-sonarcloud-cleanup
+++ b/.github/changelog/2026-sonarcloud-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Resolved SonarCloud findings in the venue map block and closed two branch-coverage gaps in its helpers.

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -540,7 +540,7 @@ final class Assets {
 		$path = $path ?? $this->path . sprintf( '%s.asset.php', $asset );
 		if ( empty( $this->asset_data[ $asset ] ) ) {
 			// Loading a WordPress asset metadata file that returns an array, not importing a class.
-			$this->asset_data[ $asset ] = file_exists( $path ) ? require $path : array();
+			$this->asset_data[ $asset ] = file_exists( $path ) ? require $path : array(); // NOSONAR.
 		}
 
 		return (array) $this->asset_data[ $asset ];
@@ -624,7 +624,7 @@ final class Assets {
 		// Plain include, not include_once: a repeat include_once would return
 		// `true` instead of the asset array if the file was already loaded
 		// (existence is already guaranteed by the file_exists guard above).
-		$asset = include $asset_path;
+		$asset = include $asset_path; // NOSONAR — see comment above.
 
 		// Add AQL as a dependency so our script loads after theirs.
 		$dependencies   = $asset['dependencies'] ?? array();

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -525,6 +525,10 @@ final class Assets {
 	 * if the same file was already loaded elsewhere in the request, and `(array) true` would corrupt the
 	 * `dependencies` / `version` lookups. A missing file yields an empty array rather than a fatal.
 	 *
+	 * Public so block templates can resolve a build asset's version without
+	 * repeating the `include` (and its memoization) inline — see the
+	 * venue-map block's Leaflet stylesheet enqueue.
+	 *
 	 * @since 0.27.0
 	 *
 	 * @param string  $asset The file name of the asset.
@@ -532,7 +536,7 @@ final class Assets {
 	 *                       or null to use the path based on the default naming scheme.
 	 * @return array An array containing asset-related data.
 	 */
-	protected function get_asset_data( string $asset, ?string $path = null ): array {
+	public function get_asset_data( string $asset, ?string $path = null ): array {
 		$path = $path ?? $this->path . sprintf( '%s.asset.php', $asset );
 		if ( empty( $this->asset_data[ $asset ] ) ) {
 			// Loading a WordPress asset metadata file that returns an array, not importing a class.

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -524,12 +524,11 @@ final class Assets {
 	 * Plain `require` is used rather than `require_once`: `require_once` returns `true` (not the array)
 	 * if the same file was already loaded elsewhere in the request, and `(array) true` would corrupt the
 	 * `dependencies` / `version` lookups. A missing file yields an empty array rather than a fatal.
-	 *
-	 * Public so block templates can resolve a build asset's version without
-	 * repeating the `include` (and its memoization) inline — see the
-	 * venue-map block's Leaflet stylesheet enqueue.
+	 * That was a real regression (#1768), so the `require` carries a `NOSONAR` marker — converting it
+	 * to `require_once` to satisfy `php:S2003` would reintroduce the bug.
 	 *
 	 * @since 0.27.0
+	 * @since 0.35.0 Made public for use from block templates.
 	 *
 	 * @param string  $asset The file name of the asset.
 	 * @param ?string $path  (Optional) The absolute path to the asset file
@@ -540,7 +539,7 @@ final class Assets {
 		$path = $path ?? $this->path . sprintf( '%s.asset.php', $asset );
 		if ( empty( $this->asset_data[ $asset ] ) ) {
 			// Loading a WordPress asset metadata file that returns an array, not importing a class.
-			$this->asset_data[ $asset ] = file_exists( $path ) ? require $path : array(); // NOSONAR.
+			$this->asset_data[ $asset ] = file_exists( $path ) ? require $path : array(); // NOSONAR — see #1768.
 		}
 
 		return (array) $this->asset_data[ $asset ];

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -34,6 +34,7 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Assets;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Dimensions;
@@ -173,7 +174,11 @@ if ( 'interactive' === $gatherpress_render_mode ) {
 	// runs. Checking for 'osm' would desync the two on an unset or unexpected
 	// platform value -- Leaflet would still mount, just unstyled.
 	if ( 'google' !== $gatherpress_map_platform ) {
-		$gatherpress_leaflet_asset = include GATHERPRESS_CORE_PATH . '/build/leaflet_style.asset.php';
+		// Read through Assets so the file is memoized for the request: a page
+		// with several venue-map blocks resolves the version once. A bare
+		// `include_once` here would return `true` rather than the array on the
+		// second block and silently drop the version.
+		$gatherpress_leaflet_asset = Assets::get_instance()->get_asset_data( 'leaflet_style' );
 
 		wp_enqueue_style(
 			'gatherpress-leaflet-style',

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -174,10 +174,6 @@ if ( 'interactive' === $gatherpress_render_mode ) {
 	// runs. Checking for 'osm' would desync the two on an unset or unexpected
 	// platform value -- Leaflet would still mount, just unstyled.
 	if ( 'google' !== $gatherpress_map_platform ) {
-		// Read through Assets so the file is memoized for the request: a page
-		// with several venue-map blocks resolves the version once. A bare
-		// `include_once` here would return `true` rather than the array on the
-		// second block and silently drop the version.
 		$gatherpress_leaflet_asset = Assets::get_instance()->get_asset_data( 'leaflet_style' );
 
 		wp_enqueue_style(

--- a/src/blocks/venue-map/view.js
+++ b/src/blocks/venue-map/view.js
@@ -164,12 +164,15 @@ function mountGoogleMap( wrapper, context, lat, lng ) {
 				mapTypeId: type,
 			} );
 
-			// eslint-disable-next-line no-new -- The marker attaches itself to the map.
-			new maps.Marker( {
+			const marker = new maps.Marker( {
 				position: center,
-				map,
 				title: context.address || '',
 			} );
+
+			// setMap() rather than passing `map` in the options above: both
+			// attach the marker, but this one consumes the instance instead
+			// of constructing it purely for its side effect.
+			marker.setMap( map );
 		} )
 		.catch( () => {
 			if ( wrapper.isConnected ) {

--- a/test/unit/js/src/blocks/venue-map/helpers.test.js
+++ b/test/unit/js/src/blocks/venue-map/helpers.test.js
@@ -540,6 +540,13 @@ describe( 'buildComboKey', () => {
 			'16x600x300xroadmap'
 		);
 	} );
+
+	it( 'defaults to roadmap when map type is omitted entirely', () => {
+		// Exercises the default parameter rather than the `|| 'roadmap'`
+		// fallback above — callers that predate the map-type argument still
+		// resolve to the same key.
+		expect( buildComboKey( 16, 600, 300 ) ).toBe( '16x600x300xroadmap' );
+	} );
 } );
 
 describe( 'parsePxDimension', () => {
@@ -689,6 +696,46 @@ describe( 'usePlaceholderPolling', () => {
 					} ),
 				} )
 			);
+		} );
+	} );
+
+	it( 'leaves the in-flight key alone when the effect is cleaned up mid-request', async () => {
+		// The ensure POST is held open so the component can unmount while it
+		// is still pending. The effect's cleanup sets `cancelled`, so the
+		// settle handler must not clear the in-flight key — doing so would
+		// let a remount re-POST the same combo it already requested.
+		let settleEnsure;
+		mockApiFetch.mockReturnValue(
+			new Promise( ( resolve ) => {
+				settleEnsure = resolve;
+			} )
+		);
+
+		const combo = {
+			key: '16x600x300xhybrid',
+			zoom: 16,
+			width: 600,
+			height: 300,
+			aspectRatio: '2/1',
+			mapType: 'hybrid',
+		};
+
+		const { unmount } = render(
+			<Harness { ...activeProps } combo={ combo } />
+		);
+
+		await waitFor( () => {
+			expect( mockApiFetch ).toHaveBeenCalled();
+		} );
+
+		unmount();
+
+		settleEnsure( { descriptors: {}, reason: '' } );
+
+		// Let the settle handler run. It should take the guarded branch and
+		// leave the ref untouched rather than throwing.
+		await waitFor( () => {
+			expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -436,7 +436,7 @@ class Test_Assets extends Base {
 
 		Utility::set_and_get_hidden_property( $instance, 'asset_data', array() );
 
-		$asset = Utility::invoke_hidden_method( $instance, 'get_asset_data', array( 'editor' ) );
+		$asset = $instance->get_asset_data( 'editor' );
 
 		$this->assertIsArray( $asset['dependencies'], 'Failed to assert that dependencies is an array.' );
 		$this->assertIsString( $asset['version'], 'Failed to assert that version is a string.' );
@@ -466,11 +466,7 @@ class Test_Assets extends Base {
 		require_once $path;
 
 		Utility::set_and_get_hidden_property( $instance, 'asset_data', array() );
-		$asset = Utility::invoke_hidden_method(
-			$instance,
-			'get_asset_data',
-			array( 'editor_already_loaded', $path )
-		);
+		$asset = $instance->get_asset_data( 'editor_already_loaded', $path );
 
 		$this->assertArrayHasKey(
 			'version',
@@ -495,10 +491,9 @@ class Test_Assets extends Base {
 		$instance = Assets::get_instance();
 
 		Utility::set_and_get_hidden_property( $instance, 'asset_data', array() );
-		$asset = Utility::invoke_hidden_method(
-			$instance,
-			'get_asset_data',
-			array( 'does_not_exist', GATHERPRESS_CORE_PATH . '/build/missing.asset.php' )
+		$asset = $instance->get_asset_data(
+			'does_not_exist',
+			GATHERPRESS_CORE_PATH . '/build/missing.asset.php'
 		);
 
 		$this->assertSame(


### PR DESCRIPTION
First pass on #2026. Three SonarCloud findings, two related suppressions, and a small API change that falls out of the first fix.

**No finding here turned out to be a false positive** — but one of them cannot be fixed the way the rule asks.

## `php:S2003` — "Replace `include` with `include_once`"

Following the rule literally would reintroduce a **bug that already shipped**: [#1768](https://github.com/GatherPress/gatherpress/issues/1768), *"`Assets::get_asset_data()` uses `require_once`, which can return `true` instead of the asset array"*. `test_get_asset_data_returns_array_when_file_already_loaded` is its regression test.

The mechanism, confirmed rather than assumed:

```
1st: array ( 'version' => 'abc123' )
2nd: true
2nd['version']: NULL
```

`include_once` / `require_once` return `true`, not the array, once the file has been loaded. Anything reading `['version']` or `['dependencies']` off that silently gets nothing, plus a PHP 8 "array offset on value of type bool" warning.

Two different resolutions, depending on the site:

**`src/blocks/venue-map/render.php` — removed the `include` entirely.** `Assets::get_asset_data()` already reads asset files through a per-request memo, so the template now calls that instead of rolling its own `include`. Net effect: nothing for the rule to flag, and one file read per request instead of one per venue-map block on the page.

**`class-assets.php` (two sites) — marked `// NOSONAR`.** These consume the return value and cannot take the `_once` form. Both already had comments explaining why; they were just missing the marker. `NOSONAR` is the convention already used for this exact rule and reason in `Utility` (two sites) and `Starter_Pattern_Loader`, so this brings the last two in line — every non-`_once` include in the codebase is now marked, and the marker cites #1768 so the history is one click away.

Line-scoped rather than a `sonar.issue.ignore.multicriteria` entry on purpose: a genuinely wrong `include` added to either file later should still be flagged.

## `javascript:S1848` — "useless object instantiation of `maps.Marker`"

The marker was constructed purely for its side effect (passing `map` in the options attaches it), with an `eslint-disable-next-line no-new` to quiet the linter. Constructing it without the `map` option and attaching via `marker.setMap( map )` consumes the instance — behaviorally identical, and both the Sonar finding and the eslint suppression go away.

## Coverage gaps in `helpers.js` — both real

Local coverage showed 100% statements/lines but **98.14% branches**, and the instrumentation named them precisely:

| line | branch type | counts |
| --- | --- | --- |
| 271 | `default-arg` | `[0]` |
| 497 | `if` | `[1, 0]` |

* **271** — `buildComboKey`'s `mapType = 'roadmap'` default parameter was never exercised; every existing test passed a fourth argument (including `''`, which hits the separate `|| 'roadmap'` fallback, not the default).
* **497** — the `! cancelled && inFlightKeyRef.current === combo.key` guard had its **false** path uncovered. That is the cleaned-up-mid-request race the guard exists for, so the new test holds the ensure POST open, unmounts, then settles it.

A test each. `helpers.js` is now **100% on all four metrics**, with no Sonar exclusions.

## API change: `Assets::get_asset_data()` is now public

Required by the `render.php` fix above, and arguably it should have been public from the start — it is a read accessor on a singleton. Worth calling out explicitly since it widens the public surface and companion plugins can now rely on it. Carries a `@since 0.35.0` note and its own changelog entry (`minor` / `changed`).

The three existing tests called it through `Utility::invoke_hidden_method` because it was protected; they now call it directly.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Two tests added for the coverage gaps. `view.js` has no unit tests — `src/blocks/*/view.js` is in the coverage exclude list — so the marker change is covered by build plus manual verification rather than a unit test.

## Testing instructions:

1. `npm run test:unit:js` — 992 pass. For the coverage claim specifically:
   `npx jest test/unit/js/src/blocks/venue-map/helpers.test.js --coverage --collectCoverageFrom='src/blocks/venue-map/helpers.js'` → 100/100/100/100.
2. `npm run lint:js`, `npm run lint:php`, `npm run lint:phpstan` — all clean.
3. PHP suites: standard (1655) and multisite (323) both pass, including the three `get_asset_data` tests.
4. **The asset refactor, verified on a rendered page** — load a venue with an address on an OSM site and confirm the stylesheet still carries the build hash: `leaflet_style.css?ver=803a787dcfd7671765d5`, matching `build/leaflet_style.asset.php`.
5. Google Maps marker: on a site with a Google Maps API key, confirm the marker still appears at the venue coordinates with the address as its tooltip. This is the one path without automated coverage.