### PR TITLE
Give the wp.org readme a description worth reading

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -85,9 +85,14 @@ Default map tile provider when the OpenStreetMap map platform is selected. When 
 
 Override the tile URL or attribution with the `gatherpress_interactive_map_tile_url` and `gatherpress_interactive_map_tile_attribution` filters.
 
-= Google Maps (maps.google.com) =
+= Google Maps (maps.googleapis.com, www.google.com, maps.google.com) =
 
-Alternative map provider, only used when a site opts in by choosing "Google Maps" in GatherPress settings. When enabled, the visitor's browser embeds a Google Maps iframe.
+Alternative map provider, only used when a site opts in by choosing "Google Maps" in GatherPress settings. What the visitor's browser requests depends on whether a Google Maps API key is configured:
+
+- With an API key, the browser loads the Maps JavaScript API from maps.googleapis.com and renders the map in the page.
+- Without a key, or if that script fails to load, the browser embeds a Google Maps iframe from www.google.com or maps.google.com instead.
+
+Either way the request carries the venue coordinates, the visitor's IP, and standard browser headers. A configured API key travels with the request and is visible in the page source, so restrict it by HTTP referrer in Google Cloud.
 
 - Google Maps terms: https://cloud.google.com/maps-platform/terms/
 - Google privacy policy: https://policies.google.com/privacy

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === GatherPress ===
 Contributors: mauteri, patricia70, hrmervin, jmarx75, stephenerdelyi, carstenbach, supernovia
-Tags: events, event, meetup, community
+Tags: events, rsvp, meetup, community, calendar
 Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 8.1

--- a/readme.txt
+++ b/readme.txt
@@ -8,18 +8,40 @@ Stable tag: 0.35.0-alpha.2
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-GatherPress is a flexible, community-powered event management plugin for WordPress.
+Build events, together. Open source event tools for the communities that run on WordPress.
 
 == Description ==
 
-- Event scheduling (date, time, location, description)
-- Attendee registration (with optional anonymous listing)
-- Open RSVP support (non-logged-in users)
-- Attendees can bring guests
-- Email notifications for attendees and non-attendees
-- Online and in-person event support (with mapping)
-- Full block editor support
-- Multisite-ready and fully internationalized
+Running a meetup, a user group, a conference, or a class? GatherPress gives you what you need to publish events, collect RSVPs, and keep everyone in the loop, all from your own WordPress site.
+
+Your events live on your site. You own the data, you control how it looks, and you keep the relationship with the people who show up.
+
+GatherPress is built by the WordPress community for the people who organize it: meetup organizers, WordCamp teams, user groups, and anyone else who gets people together in a room. It is free, open source, and shaped by the people using it every day.
+
+= What you can do =
+
+- Publish events with the date, time, venue, and everything people need to know
+- Collect RSVPs, with anonymous listing for attendees who would rather not be named
+- Let people RSVP without an account, so nobody bounces off a signup wall
+- Let attendees bring guests
+- Email everyone who is coming, or everyone who is not, without leaving WordPress
+- Run events in person, online, or both, with maps for physical venues
+- Build and arrange it all in the block editor
+- Multisite ready and fully translatable
+
+= Try it before you install =
+
+Open a working demo in your browser through WordPress Playground. No signup, no setup, and real data to click around in.
+
+[Try GatherPress in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/GatherPress/gatherpress/develop/.wordpress-org/blueprints/blueprint.json) | [Watch the intro demo](https://gatherpress.org/demovideo)
+
+= Join our community =
+
+GatherPress is built in the open, and contributions are always welcome, whether that is code, translations, documentation, or just telling us what broke.
+
+- [Get involved](https://gatherpress.org/get-involved)
+- [Contributor guide](https://github.com/GatherPress/gatherpress/blob/main/docs/contributing.md)
+- [Open issues on GitHub](https://github.com/GatherPress/gatherpress/issues)
 
 == Installation ==
 


### PR DESCRIPTION
The [plugin page](https://wordpress.org/plugins/gatherpress/) reads as a spec sheet. This is a copy and metadata pass on `readme.txt`, taking the shape from [BuddyPress](https://wordpress.org/plugins/buddypress/) and other community plugins that present themselves well.

Three commits, reviewable separately.

## 1. A description worth reading

The problem wasn't the wording of the bullets. It's that `== Description ==` **was** the bullet list, with no prose before it. Nothing said who the plugin is for, what you can build with it, or the one thing that most sets it apart: it is built by the WordPress community for the people who organize it. For comparison, BuddyPress runs five paragraphs and three subheadings before anything resembling a feature list.

* **Short description.** Was `GatherPress is a flexible, community-powered event management plugin for WordPress`, which defines the category rather than saying anything. Now `Build events, together. Open source event tools for the communities that run on WordPress.` (90 chars, limit 150), echoing the headline already used on gatherpress.org.
* **Opening prose:** who it's for, that your events and data stay on your own site, and the community origin story.
* **Subheadings** so the section is scannable: *What you can do*, *Try it before you install*, *Join our community*.
* **Bullets rewritten** to describe outcomes. "Open RSVP support (non-logged-in users)" becomes "Let people RSVP without an account, so nobody bounces off a signup wall."
* **Playground and demo links surfaced.** These existed in the GitHub readme but never on wp.org. Points at the **stable** blueprint, not the nightly.

## 2. Corrected Google Maps external-services disclosure

Independent of the copy work, and the reason this is worth merging sooner rather than later: the section still described pre-#2003 behavior.

It claimed "the visitor's browser embeds a Google Maps iframe". Since #2003 that is only the **keyless fallback**. With an API key configured the browser loads the Maps JavaScript API from `maps.googleapis.com`, a host the disclosure did not mention at all.

Now lists all three hosts actually contacted and splits the two paths, plus notes that a configured key travels with the request and is visible in page source (matching the guidance already in `docs/user/venues.md`). This is a wp.org compliance section, so an out-of-date description of what the browser contacts is more than a nitpick.

## 3. Tags spent on terms people search

Was `events, event, meetup, community`. Now `events, rsvp, meetup, community, calendar`.

Five is the wp.org limit and one slot was going to `event`, which `events` already covers. What the biggest plugins in the category claim:

| plugin | tags |
| --- | --- |
| The Events Calendar | events, calendar, event, schedule, organizer |
| Events Manager | events, calendar, tickets, bookings, block |
| Event Tickets | tickets, event registration, RSVP, ticket sales, attendee management |

`rsvp` is the notable gap: it's the central feature and the term someone uses when they want RSVPs rather than paid ticketing. Event Tickets owns "tickets"; nothing much contests "rsvp". `calendar` is high-traffic for this category, claimed by two of the three above, and backed by real functionality here (calendar feeds, add-to-calendar block).

## Where this file lives

`AGENTS.md` listed `readme.txt` under "Generated files, never hand-edit". That was true of the old gatherpress-develop `parts/` pipeline, but #1827 moved the release tooling into `.github/scripts` and its docblock now says the opposite: README.md and readme.txt are hand-edited, and only specific lines are patched per release. **#2033 corrects AGENTS.md.**

The two lines the tooling does rewrite here (`Stable tag:` and `Contributors:`) are untouched.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

Copy and metadata only, no code. Verified: short description within the 150 character limit, five tags with no duplicates, all `== Section ==` headers intact, the two release-tooling anchor lines unmodified, and all four outbound links return 200.

## Testing instructions:

1. Read it and see whether the voice lands. This is subjective and it's your call.
2. The short description is a one-line swap if you'd rather a different angle. Two alternates considered:
   * `Your events, your site, your community. Event management built by the people who use it.`
   * `Bring your people together. Open source event management for meetups, user groups, and classes.`
3. Cross-check the Google Maps section against `src/helpers/google-maps-api.js` (JS API host) and `src/helpers/map-embed.js` (the two iframe hosts) to confirm the disclosure now matches the code.