### PR TITLE
Point at wp.org's own Live Preview instead of linking Playground

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -31,9 +31,9 @@ GatherPress is built by the WordPress community for the people who organize it: 
 
 = Try it before you install =
 
-Open a working demo in your browser through WordPress Playground. No signup, no setup, and real data to click around in.
+Hit the **Live Preview** button on this page to open a working demo in your browser. No signup, no setup, and real data to click around in.
 
-[Try GatherPress in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/GatherPress/gatherpress/develop/.wordpress-org/blueprints/blueprint.json) | [Watch the intro demo](https://gatherpress.org/demovideo)
+Prefer to watch first? [There is a short intro demo](https://gatherpress.org/demovideo).
 
 = Join our community =
 


### PR DESCRIPTION
Follow-up to #2032. Those fixes were pushed to its branch a few minutes after it merged, so they never made it in and `develop` still carries the original link.

## Two problems with the shipped link

**It pointed at `develop`.** Caught by @carstingaxion in review. `readme.txt` describes the *released* plugin, so a dev branch was the wrong source.

**More to the point, it should not be there at all.** The plugin page already carries a **Live Preview** button next to Download, wp.org's built-in Playground integration driven by the blueprint the plugin ships to SVN. A hand-rolled second link competed with that and lost on every count:

| | built-in button | the link we shipped |
| --- | --- | --- |
| discoverability | next to Download | buried in the description |
| dependencies | wp.org's own integration | `playground.wordpress.net` + a `raw.githubusercontent.com` blueprint URL |
| blueprint source | deployed SVN assets | whatever sits on GitHub, free to drift |

So fixing the branch name would have polished a link that should be deleted.

## Proposed changes:

* Replaces the Playground link with a pointer to the Live Preview button already on the page.
* Keeps the intro demo video, which wp.org does not provide.

Side benefit: no `raw.githubusercontent.com` or `playground.wordpress.net` URLs left in the readme at all.

Before:

> Open a working demo in your browser through WordPress Playground. No signup, no setup, and real data to click around in.
>
> [Try GatherPress in WordPress Playground](...develop/.wordpress-org/blueprints/blueprint.json) | [Watch the intro demo](https://gatherpress.org/demovideo)

After:

> Hit the **Live Preview** button on this page to open a working demo in your browser. No signup, no setup, and real data to click around in.
>
> Prefer to watch first? [There is a short intro demo](https://gatherpress.org/demovideo).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

Copy only. Verified there are no `develop`, `playground.wordpress.net`, or `raw.githubusercontent.com` references left in the file, and that all six remaining outbound links return 200.

## Testing instructions:

1. Confirm the Live Preview button exists on <https://wordpress.org/plugins/gatherpress/> (it sits next to Download), so the readme is pointing at something real.
2. Read the section and confirm the wording reads naturally on the plugin page rather than in a code diff.