### PR TITLE
fix(email): make event-update subject editable per send

### DIFF
--- a/.github/changelog/827-editable-email-subject
+++ b/.github/changelog/827-editable-email-subject
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Event organizers can now set a custom subject line when sending the event-update email; the existing `📅 {title}` default stays in place when the field is left untouched, and a new `gatherpress_email_subject` filter lets developers customize the default template.

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -71,7 +71,7 @@ final class Rest_Api {
 	 */
 	protected function setup_hooks(): void {
 		add_action( 'rest_api_init', array( $this, 'register_endpoints' ) );
-		add_action( 'gatherpress_send_emails', array( $this, 'handle_email_send_action' ), 10, 3 );
+		add_action( 'gatherpress_send_emails', array( $this, 'handle_email_send_action' ), 10, 4 );
 		add_filter( sprintf( 'rest_prepare_%s', Event::POST_TYPE ), array( $this, 'prepare_event_data' ) );
 	}
 
@@ -146,6 +146,10 @@ final class Rest_Api {
 						'validate_callback' => array( Validate::class, 'event_post_id' ),
 					),
 					'message' => array(
+						'required'          => false,
+						'validate_callback' => 'sanitize_text_field',
+					),
+					'subject' => array(
 						'required'          => false,
 						'validate_callback' => 'sanitize_text_field',
 					),
@@ -386,8 +390,13 @@ final class Rest_Api {
 		$params   = $request->get_params();
 		$post_id  = intval( $params['post_id'] );
 		$message  = $params['message'] ?? '';
+		$subject  = $params['subject'] ?? '';
 		$send     = $params['send'];
-		$success  = wp_schedule_single_event( time(), 'gatherpress_send_emails', array( $post_id, $send, $message ) );
+		$success  = wp_schedule_single_event(
+			time(),
+			'gatherpress_send_emails',
+			array( $post_id, $send, $message, $subject )
+		);
 		$response = array(
 			'success' => $success,
 		);
@@ -403,15 +412,17 @@ final class Rest_Api {
 	 * as it's intended to be called by an action hook.
 	 *
 	 * @since 0.34.0
+	 * @since 0.35.0 Added `$subject` parameter for #827.
 	 *
 	 * @param int    $post_id Post ID.
 	 * @param array  $send    Members to send the email to.
 	 * @param string $message Optional message to include in the email.
+	 * @param string $subject Optional subject line. Defaults to the existing `📅 {title}` template when empty.
 	 *
 	 * @return void
 	 */
-	public function handle_email_send_action( int $post_id, array $send, string $message ): void {
-		$this->send_emails( $post_id, $send, $message );
+	public function handle_email_send_action( int $post_id, array $send, string $message, string $subject = '' ): void {
+		$this->send_emails( $post_id, $send, $message, $subject );
 	}
 
 	/**
@@ -422,14 +433,16 @@ final class Rest_Api {
 	 * the appropriate subject, body, and headers.
 	 *
 	 * @since 0.34.0
+	 * @since 0.35.0 Added `$subject` parameter for #827.
 	 *
 	 * @param int    $post_id Post ID.
 	 * @param array  $send    Members to send the email to.
 	 * @param string $message Optional message to include in the email.
+	 * @param string $subject Optional subject line. Defaults to the existing `📅 {title}` template when empty.
 	 *
 	 * @return bool True if emails were successfully sent, false otherwise.
 	 */
-	public function send_emails( int $post_id, array $send, string $message ): bool {
+	public function send_emails( int $post_id, array $send, string $message, string $subject = '' ): bool {
 		if ( Event::POST_TYPE !== get_post_type( $post_id ) ) {
 			return false;
 		}
@@ -440,7 +453,7 @@ final class Rest_Api {
 		$recipients   = $this->get_recipients( $send, $post_id );
 
 		foreach ( $recipients as $recipient ) {
-			$this->send_event_email_to_recipient( $recipient, $post_id, $message, $current_user );
+			$this->send_event_email_to_recipient( $recipient, $post_id, $message, $current_user, $subject );
 		}
 
 		return true;
@@ -456,11 +469,14 @@ final class Rest_Api {
 	 * Restores the editor's user / locale before returning.
 	 *
 	 * @since 0.34.0
+	 * @since 0.35.0 Added `$subject` parameter for #827.
 	 *
 	 * @param array   $recipient    Recipient row from `get_recipients()`.
 	 * @param int     $post_id      Event post ID.
 	 * @param string  $message      Optional editor-supplied message body.
 	 * @param WP_User $current_user Originating editor (restored after locale/user switch).
+	 * @param string  $subject      Optional subject line. Empty falls back to the default template
+	 *                              and is then filtered via `gatherpress_email_subject`.
 	 *
 	 * @return void
 	 */
@@ -468,7 +484,8 @@ final class Rest_Api {
 		array $recipient,
 		int $post_id,
 		string $message,
-		WP_User $current_user
+		WP_User $current_user,
+		string $subject = ''
 	): void {
 		// Check opt-in preference based on recipient type.
 		if ( $recipient['is_user'] ) {
@@ -500,11 +517,23 @@ final class Rest_Api {
 			wp_set_current_user( $recipient['user_id'] );
 		}
 
-		$subject = sprintf(
-			// translators: %s: event title.
-			_x( '📅 %s', 'Email notification subject with event title', 'gatherpress' ),
-			get_the_title( $post_id )
-		);
+		if ( '' === $subject ) {
+			$subject = sprintf(
+				// translators: %s: event title.
+				_x( '📅 %s', 'Email notification subject with event title', 'gatherpress' ),
+				get_the_title( $post_id )
+			);
+		}
+
+		/**
+		 * Filters the event update email subject.
+		 *
+		 * @since 0.35.0
+		 *
+		 * @param string $subject Email subject line.
+		 * @param int    $post_id Event post ID.
+		 */
+		$subject = apply_filters( 'gatherpress_email_subject', $subject, $post_id );
 		$body    = Utility::render_template(
 			sprintf( '%s/includes/templates/admin/emails/event-email.php', GATHERPRESS_CORE_PATH ),
 			array(

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -412,7 +412,7 @@ final class Rest_Api {
 	 * as it's intended to be called by an action hook.
 	 *
 	 * @since 0.34.0
-	 * @since 0.35.0 Added `$subject` parameter for #827.
+	 * @since 0.36.0 Added `$subject` parameter for #827.
 	 *
 	 * @param int    $post_id Post ID.
 	 * @param array  $send    Members to send the email to.
@@ -433,7 +433,7 @@ final class Rest_Api {
 	 * the appropriate subject, body, and headers.
 	 *
 	 * @since 0.34.0
-	 * @since 0.35.0 Added `$subject` parameter for #827.
+	 * @since 0.36.0 Added `$subject` parameter for #827.
 	 *
 	 * @param int    $post_id Post ID.
 	 * @param array  $send    Members to send the email to.
@@ -469,7 +469,7 @@ final class Rest_Api {
 	 * Restores the editor's user / locale before returning.
 	 *
 	 * @since 0.34.0
-	 * @since 0.35.0 Added `$subject` parameter for #827.
+	 * @since 0.36.0 Added `$subject` parameter for #827.
 	 *
 	 * @param array   $recipient    Recipient row from `get_recipients()`.
 	 * @param int     $post_id      Event post ID.
@@ -528,7 +528,7 @@ final class Rest_Api {
 		/**
 		 * Filters the event update email subject.
 		 *
-		 * @since 0.35.0
+		 * @since 0.36.0
 		 *
 		 * @param string $subject Email subject line.
 		 * @param int    $post_id Event post ID.

--- a/src/modals/email-communication/index.js
+++ b/src/modals/email-communication/index.js
@@ -132,6 +132,7 @@ const EventCommunicationModal = () => {
 						label={ __( 'Subject', 'gatherpress' ) }
 						value={ subject }
 						onChange={ ( value ) => setSubject( value ) }
+						style={ { marginBottom: '16px' } }
 					/>
 					<TextareaControl
 						label={ __( 'Optional message', 'gatherpress' ) }

--- a/src/modals/email-communication/index.js
+++ b/src/modals/email-communication/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 import { createRoot, useState, useEffect, useRef } from '@wordpress/element';
 import {
@@ -10,6 +10,7 @@ import {
 	Flex,
 	FlexItem,
 	Modal,
+	TextControl,
 	TextareaControl,
 } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
@@ -42,6 +43,7 @@ const EventCommunicationModal = () => {
 	const [ isWaitingListChecked, setWaitingListChecked ] = useState( false );
 	const [ isNotAttendingChecked, setNotAttendingChecked ] = useState( false );
 	const [ buttonDisabled, setButtonDisabled ] = useState( false );
+	const [ subject, setSubject ] = useState( '' );
 	const [ message, setMessage ] = useState( '' );
 	const textareaRef = useRef( null );
 	const sendMessage = () => {
@@ -54,6 +56,7 @@ const EventCommunicationModal = () => {
 				method: 'POST',
 				data: {
 					post_id: select( 'core/editor' ).getCurrentPostId(),
+					subject,
 					message,
 					send: {
 						all: isAllChecked,
@@ -65,6 +68,7 @@ const EventCommunicationModal = () => {
 			} ).then( ( res ) => {
 				if ( res.success ) {
 					closeModal();
+					setSubject( '' );
 					setMessage( '' );
 					setAllChecked( false );
 					setAttendingChecked( false );
@@ -100,6 +104,21 @@ const EventCommunicationModal = () => {
 		}
 	}, [ isOpen ] );
 
+	useEffect( () => {
+		if ( isOpen ) {
+			const title =
+				select( 'core/editor' ).getEditedPostAttribute( 'title' ) ||
+				'';
+			setSubject(
+				sprintf(
+					// translators: %s: event title.
+					_x( '📅 %s', 'Email notification subject with event title', 'gatherpress' ),
+					title,
+				),
+			);
+		}
+	}, [ isOpen ] );
+
 	return (
 		<>
 			{ isOpen && (
@@ -109,6 +128,11 @@ const EventCommunicationModal = () => {
 					shouldCloseOnClickOutside={ false }
 					style={ { maxWidth: '550px' } }
 				>
+					<TextControl
+						label={ __( 'Subject', 'gatherpress' ) }
+						value={ subject }
+						onChange={ ( value ) => setSubject( value ) }
+					/>
 					<TextareaControl
 						label={ __( 'Optional message', 'gatherpress' ) }
 						value={ message }

--- a/src/modals/email-communication/index.js
+++ b/src/modals/email-communication/index.js
@@ -132,7 +132,7 @@ const EventCommunicationModal = () => {
 						label={ __( 'Subject', 'gatherpress' ) }
 						value={ subject }
 						onChange={ ( value ) => setSubject( value ) }
-						style={ { marginBottom: '16px' } }
+						style={ { marginBottom: '1rem' } }
 					/>
 					<TextareaControl
 						label={ __( 'Optional message', 'gatherpress' ) }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -184,6 +184,7 @@ class Test_Rest_Api extends Base {
 			array(
 				'post_id' => $event_id,
 				'message' => 'Unit test',
+				'subject' => 'Custom subject',
 				'send'    => array(
 					'all'           => false,
 					'attending'     => false,
@@ -875,9 +876,10 @@ class Test_Rest_Api extends Base {
 
 		$send    = array( 'all' => true );
 		$message = 'Test message';
+		$subject = 'Test subject';
 
 		// The method should call send_emails internally.
-		$instance->handle_email_send_action( $post_id, $send, $message );
+		$instance->handle_email_send_action( $post_id, $send, $message, $subject );
 
 		// If no exception thrown, test passes.
 		$this->assertTrue( true );
@@ -1697,6 +1699,219 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
+	 * `send_emails` honors a custom subject supplied by the caller (#827).
+	 *
+	 * @covers ::send_emails
+	 *
+	 * @return void
+	 */
+	public function test_send_emails_with_custom_subject(): void {
+		$instance = Rest_Api::get_instance();
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'  => Event::POST_TYPE,
+				'post_title' => 'Custom Subject Event',
+			)
+		);
+
+		$event = new Event( $post_id );
+		$email = 'recipient@example.test';
+		$event->rsvp->save( $email, 'attending', 0, 0 );
+
+		$captured = array();
+		add_filter(
+			'pre_wp_mail',
+			static function ( $prev, $atts ) use ( &$captured ): bool {
+				$captured = $atts;
+
+				return (bool) $prev;
+			},
+			10,
+			2
+		);
+
+		$result = $instance->send_emails(
+			$post_id,
+			array( 'attending' => true ),
+			'Test message',
+			'Reminder: doors at 7'
+		);
+
+		$this->assertTrue( $result, 'send_emails should return true.' );
+		$this->assertSame(
+			'Reminder: doors at 7',
+			$captured['subject'],
+			'Subject should match the supplied custom value.'
+		);
+		$this->assertStringNotContainsString(
+			'Custom Subject Event',
+			$captured['subject'],
+			'Custom subject should bypass the default title template.'
+		);
+	}
+
+	/**
+	 * `send_emails` falls back to the default `📅 {title}` template when no subject is supplied (#827).
+	 *
+	 * @covers ::send_emails
+	 *
+	 * @return void
+	 */
+	public function test_send_emails_with_default_subject(): void {
+		$instance = Rest_Api::get_instance();
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'  => Event::POST_TYPE,
+				'post_title' => 'Default Subject Event',
+			)
+		);
+
+		$event = new Event( $post_id );
+		$email = 'recipient@example.test';
+		$event->rsvp->save( $email, 'attending', 0, 0 );
+
+		$captured = array();
+		add_filter(
+			'pre_wp_mail',
+			static function ( $prev, $atts ) use ( &$captured ): bool {
+				$captured = $atts;
+
+				return (bool) $prev;
+			},
+			10,
+			2
+		);
+
+		$instance->send_emails(
+			$post_id,
+			array( 'attending' => true ),
+			'Test message'
+		);
+
+		$this->assertStringContainsString(
+			'Default Subject Event',
+			$captured['subject'],
+			'Default subject should interpolate the event title.'
+		);
+		$this->assertStringContainsString(
+			'📅',
+			$captured['subject'],
+			'Default subject should keep the calendar emoji prefix.'
+		);
+	}
+
+	/**
+	 * `gatherpress_email_subject` filter lets developers customize the default subject (#827).
+	 *
+	 * @covers ::send_emails
+	 *
+	 * @return void
+	 */
+	public function test_send_emails_subject_filter(): void {
+		$instance = Rest_Api::get_instance();
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'  => Event::POST_TYPE,
+				'post_title' => 'Filter Event',
+			)
+		);
+
+		$event = new Event( $post_id );
+		$event->rsvp->save( 'recipient@example.test', 'attending', 0, 0 );
+
+		add_filter(
+			'gatherpress_email_subject',
+			static function ( string $subject ): string {
+				return '[Community] ' . $subject;
+			}
+		);
+
+		$captured = array();
+		add_filter(
+			'pre_wp_mail',
+			static function ( $prev, $atts ) use ( &$captured ): bool {
+				$captured = $atts;
+
+				return (bool) $prev;
+			},
+			10,
+			2
+		);
+
+		$instance->send_emails(
+			$post_id,
+			array( 'attending' => true ),
+			'Test message'
+		);
+
+		$this->assertStringStartsWith(
+			'[Community] ',
+			$captured['subject'],
+			'Filter should prepend the community prefix to the default subject.'
+		);
+		$this->assertStringContainsString(
+			'Filter Event',
+			$captured['subject'],
+			'Filter should preserve the upstream subject value.'
+		);
+	}
+
+	/**
+	 * `gatherpress_email_subject` filter applies to a custom subject too (#827).
+	 *
+	 * @covers ::send_emails
+	 *
+	 * @return void
+	 */
+	public function test_send_emails_subject_filter_with_custom_subject(): void {
+		$instance = Rest_Api::get_instance();
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+
+		$event = new Event( $post_id );
+		$event->rsvp->save( 'recipient@example.test', 'attending', 0, 0 );
+
+		add_filter(
+			'gatherpress_email_subject',
+			static function ( string $subject ): string {
+				return $subject . ' [verified]';
+			}
+		);
+
+		$captured = array();
+		add_filter(
+			'pre_wp_mail',
+			static function ( $prev, $atts ) use ( &$captured ): bool {
+				$captured = $atts;
+
+				return (bool) $prev;
+			},
+			10,
+			2
+		);
+
+		$instance->send_emails(
+			$post_id,
+			array( 'attending' => true ),
+			'Test message',
+			'Custom subject'
+		);
+
+		$this->assertSame(
+			'Custom subject [verified]',
+			$captured['subject'],
+			'Filter should apply to the supplied subject as well.'
+		);
+	}
+
+	/**
 	 * Tests send_emails with locale switching for user.
 	 *
 	 * Covers: restore_previous_locale when switched_locale is true.
@@ -2189,6 +2404,7 @@ class Test_Rest_Api extends Base {
 				$event_id,
 				'Test message',
 				wp_get_current_user(),
+				'Test subject',
 			)
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #827

## Proposed changes:

* Add an editable Subject field to the "Send event update via email" modal, pre-populated with the existing `📅 {event title}` default so behavior is unchanged when organizers leave it alone.
* Thread an optional `subject` argument through the email send chain: new `subject` arg on the `POST /email` REST route, passed as a fourth cron argument via `wp_schedule_single_event()`, then through `handle_email_send_action()` → `send_emails()` → `send_event_email_to_recipient()` → `wp_mail()`. All new parameters are optional with a `''` default, so events scheduled before this change still execute, and the cron action accepted-args count is bumped from 3 to 4.
* Add a `gatherpress_email_subject` filter so developers can customize the subject template. It applies to both the default and a supplied subject.
* The RSVP confirmation email is untouched since it is not composed by a human at send time.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Edit an upcoming event, save/publish it, and open the "Compose Message" modal from the success notice.
* The modal now shows a Subject input above the message textarea, pre-populated with `📅 {event title}`.
* Change the subject (e.g. `Reminder: doors at 7`), check a recipient box, confirm the prompt, and send. The received email carries the custom subject.
* Clear the Subject field and send again. The email falls back to the default `📅 {event title}` subject.
* Developer check: add `add_filter( 'gatherpress_email_subject', function ( $subject ) { return '[My Community] ' . $subject; } );` and the prefix appears on both default and custom subjects.
* PHPUnit: four new tests capture the outgoing subject via the `pre_wp_mail` filter (custom subject passthrough, default fallback, filter on default, filter on custom subject); existing email tests updated for the new parameter.

### Credit (for release notes)

My WordPress.org username:

### Changelog entry

A changelog entry is already committed in this branch at `.github/changelog/827-editable-email-subject`, so the automated creation below is left unchecked.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Event organizers can now set a custom subject line when sending the event-update email; the existing `📅 {title}` default stays in place when the field is left untouched, and a new `gatherpress_email_subject` filter lets developers customize the default template.

</details>

## Screen recording

https://github.com/user-attachments/assets/54fcc140-15b2-4a0c-8c6e-a7d005664fd4