### PR TITLE
Clarify the RSVP Cleanup Interval setting description

### DIFF
--- a/.github/changelog/rsvp-cleanup-interval-description
+++ b/.github/changelog/rsvp-cleanup-interval-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Clarified the RSVP Cleanup Interval setting description to explain that it multiplies the Cleanup Frequency.

--- a/includes/core/classes/settings/class-rsvp.php
+++ b/includes/core/classes/settings/class-rsvp.php
@@ -270,7 +270,7 @@ final class Rsvp extends Base {
 							'name' => __( 'Cleanup Interval', 'gatherpress' ),
 						),
 						'description' => __(
-							'The number of days, months, or years between each cleanup run.',
+							'Multiplies the Cleanup Frequency. Daily with an interval of 3 runs every 3 days.',
 							'gatherpress'
 						),
 						'field'       => array(


### PR DESCRIPTION
### Description of the Change

The **Cleanup Interval** setting under RSVP settings described itself as:

> The number of days, months, or years between each cleanup run.

The field is a plain number, and that sentence never says what the number counts. It also lists only three units while **Cleanup Frequency** offers five (hourly, daily, weekly, monthly, yearly), so two of them were missing.

Interval is a multiplier on Frequency. `Rsvp\Cleanup::get_interval()` resolves the frequency to a seconds multiplier and returns `$interval * $multiplier`:

```php
$multiplier = match ( $frequency ) {
	'daily'   => DAY_IN_SECONDS,
	// …
};

return $interval * $multiplier;
```

New description:

> Multiplies the Cleanup Frequency. Daily with an interval of 3 runs every 3 days.

It names the field it depends on, and the example makes the relationship concrete without listing units that could drift out of sync again.

### How to test the Change

1. Go to **Events → Settings → RSVP**.
2. Set **Toggle RSVP Cleanup** to *Enabled* so the Frequency and Interval fields appear.
3. Read the description under **Cleanup Interval**.

### Changelog Entry

> Changed - Clarified the RSVP Cleanup Interval setting description to explain that it multiplies the Cleanup Frequency.

### Credits

Props @mauteri for spotting that the description didn't explain what the number represented.

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.

Copy-only change to a translatable string, so there's nothing behavioral to test. `npm run lint:php` passes.
