### PR TITLE
Add the 0.35.0-beta.1 credits file

### DIFF
--- a/.github/scripts/release/credits/0.35.0-beta.1.json
+++ b/.github/scripts/release/credits/0.35.0-beta.1.json
@@ -1,0 +1,22 @@
+{
+    "leads": [
+        "mauteri",
+        "patricia70"
+    ],
+    "team": [
+        "hrmervin",
+        "jmarx75",
+        "stephenerdelyi",
+        "carstenbach",
+        "supernovia"
+    ],
+    "contributors": [
+        "andremenrath",
+        "bor0",
+        "linewebdigital",
+        "w3lld1",
+        "fahimmurshed",
+        "lheroorg",
+        "matthewneilcowan"
+    ]
+}


### PR DESCRIPTION
### Description of the Change

Adds `.github/scripts/release/credits/0.35.0-beta.1.json`, the first of the three release-train PRs for `0.35.0-beta.1`.

Carried forward unchanged from `0.35.0-alpha.2`. Every PR merged to `develop` since that tag was authored by a maintainer, Dependabot, or the hook-docs bot, so there are no new contributors to fold in. `credits/unreleased.json` is empty.

### How to test the Change

Nothing to exercise at runtime. The generator reads this file during the version bump and regenerates `includes/data/credits.php` from it.

### Changelog Entry

None — release tooling. `Skip Changelog` applied, matching #2022 (the alpha.2 credits file).

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.