### PR TITLE
Install Subversion before the beta trunk deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,6 +371,17 @@ jobs:
           npm ci
           npm run build
 
+      # The GitHub-hosted Ubuntu images no longer ship Subversion, so the
+      # deploy step below dies with `svn: command not found` (exit 127)
+      # without this. The stable path never hit it because
+      # 10up/action-wordpress-plugin-deploy brings its own svn; this
+      # trunk-only job talks to SVN directly.
+      - name: Install Subversion
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends subversion
+          svn --version --quiet
+
       - name: Deploy to SVN trunk
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
### Description of the Change

The `0.35.0-beta.1` release ran the beta wp.org path for the first time and it failed on its first command:

```
line 3: svn: command not found
Process completed with exit code 127
```

GitHub's Ubuntu runner images no longer ship Subversion. The `deploy-wporg-trunk` job talks to SVN directly, because `10up/action-wordpress-plugin-deploy` has no trunk-only mode ([10up/action-wordpress-plugin-deploy#103](https://github.com/10up/action-wordpress-plugin-deploy/issues/103)) — and that action bundles its own svn, which is why the stable deploy path never hit this.

Adds an install step before the deploy, with `svn --version --quiet` as a cheap assertion that the binary is actually on `PATH` afterwards.

### Nothing needs unpicking

The job died before any network call to SVN, so wp.org was never touched:

- Trunk still reads `Stable tag: 0.34.1` (verified against live SVN).
- No `tags/0.35.0-beta.1` was created.

Everything else in the release succeeded — the GitHub pre-release exists with `gatherpress.0.35.0-beta.1.zip` attached, and the alpha lockstep handoff ran.

### How to test the Change

The path can't be exercised from a PR, since it only runs on a `-beta.` tag push. Verification comes on the next beta tag.

**Strongly recommended for that run:** set the dry-run variable first, since this path still hasn't completed once.

```bash
gh variable set TRUNK_DEPLOY_DRY_RUN --repo GatherPress/gatherpress --body 1
```

The job then performs the SVN checkout, the `Stable tag:` safety checks, the rsync, and the re-pin assertion, prints `svn status` and the final `trunk/readme.txt` header, and exits before the commit and tag copy. Clear it with `gh variable unset` and re-run the job to go live.

### Re-running for `0.35.0-beta.1` specifically

The tag points at a commit without this fix, so a plain job re-run fails the same way. Either move the tag or cut `beta.2`. The job is idempotent either way — it skips the commit when trunk already matches, and skips the tag copy when `tags/<version>` already exists.

### Changelog Entry

None — CI only. `Skip Changelog` applied.

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.