### PR TITLE
Add a Duplicate row action for events

### DIFF
--- a/.github/changelog/2057-duplicate-event
+++ b/.github/changelog/2057-duplicate-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a Duplicate row action for events. It copies the content, taxonomy terms including the venue, the featured image, and the event meta into a fresh draft, moving the datetimes forward by whole weeks so the copy keeps the original weekday, time of day, and duration without landing in the past. RSVPs, the slug, and the published status stay with the original.

--- a/includes/core/classes/event/class-duplicate.php
+++ b/includes/core/classes/event/class-duplicate.php
@@ -1,0 +1,419 @@
+<?php
+/**
+ * Duplicates an event into a fresh draft.
+ *
+ * Most groups run the same event repeatedly: same description, same venue,
+ * same RSVP limits, new date. This file defines the `Duplicate` class, which
+ * copies everything about an event except the parts that belong to the
+ * original occurrence, so an organizer sets the date and publishes rather
+ * than rebuilding the event from scratch.
+ *
+ * @package GatherPress\Core\Event
+ * @since 0.35.0
+ */
+
+namespace GatherPress\Core\Event;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use GatherPress\Core\Event;
+use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Utility;
+use WP_Error;
+use WP_Post;
+
+/**
+ * Duplicates an event into a fresh draft.
+ *
+ * Copies content, taxonomy terms (including the venue), the featured image,
+ * and every author-writable event meta key, then moves the datetimes forward
+ * so the copy is not in the past. RSVPs, comments, the slug, and the
+ * published status deliberately do not come along: those describe the
+ * occurrence that already happened.
+ *
+ * @since 0.35.0
+ */
+final class Duplicate {
+
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Query action that triggers a duplication request.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @var string
+	 */
+	const ACTION = 'gatherpress_duplicate_event';
+
+	/**
+	 * Class constructor.
+	 *
+	 * This method initializes the object and sets up necessary hooks.
+	 *
+	 * @since 0.35.0
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Set up hooks for various purposes.
+	 *
+	 * This method adds hooks for different purposes as needed.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks(): void {
+		add_filter( 'post_row_actions', array( $this, 'row_action' ), 10, 2 );
+		add_action( sprintf( 'admin_action_%s', self::ACTION ), array( $this, 'handle_request' ) );
+	}
+
+	/**
+	 * Add a Duplicate link to an event's row on the posts list table.
+	 *
+	 * Hooked on the generic `post_row_actions` rather than per post type:
+	 * the support check below covers every post type acting as an event,
+	 * including ones companion plugins register after this class loads.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param array   $actions Row action links keyed by action name.
+	 * @param WP_Post $post    The post the row represents.
+	 *
+	 * @return array Row action links, with Duplicate added for events.
+	 */
+	public function row_action( array $actions, WP_Post $post ): array {
+		if (
+			! post_type_supports( $post->post_type, 'gatherpress-event-date' )
+			|| ! current_user_can( 'edit_post', $post->ID )
+		) {
+			return $actions;
+		}
+
+		$actions['gatherpress_duplicate'] = sprintf(
+			'<a href="%s" aria-label="%s">%s</a>',
+			esc_url( self::get_url( $post->ID ) ),
+			esc_attr(
+				sprintf(
+					/* translators: %s is the event title. */
+					__( 'Duplicate &#8220;%s&#8221; as a new draft', 'gatherpress' ),
+					$post->post_title
+				)
+			),
+			esc_html__( 'Duplicate', 'gatherpress' )
+		);
+
+		return $actions;
+	}
+
+	/**
+	 * Nonced admin URL that duplicates the given event when requested.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param int $post_id The event post ID to duplicate.
+	 *
+	 * @return string The duplication request URL.
+	 */
+	public static function get_url( int $post_id ): string {
+		return wp_nonce_url(
+			add_query_arg(
+				array(
+					'action' => self::ACTION,
+					'post'   => $post_id,
+				),
+				admin_url( 'admin.php' )
+			),
+			sprintf( '%s_%d', self::ACTION, $post_id )
+		);
+	}
+
+	/**
+	 * Handle a duplication request and send the author to the new draft.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return void
+	 *
+	 * @throws Exception If reading the source event's datetimes fails.
+	 */
+	public function handle_request(): void {
+		$post_id = absint( Utility::get_http_input( INPUT_GET, 'post' ) );
+
+		check_admin_referer( sprintf( '%s_%d', self::ACTION, $post_id ) );
+
+		$duplicate = $this->duplicate( $post_id );
+
+		if ( is_wp_error( $duplicate ) ) {
+			wp_die(
+				esc_html( $duplicate->get_error_message() ),
+				esc_html__( 'Duplicate event', 'gatherpress' ),
+				array( 'response' => 403 )
+			);
+		}
+
+		// A filtered-away redirect (which is how tests observe this) returns
+		// false, so the exit stays behind the successful redirect.
+		if ( wp_safe_redirect( admin_url( sprintf( 'post.php?post=%d&action=edit', $duplicate ) ) ) ) {
+			exit;
+		}
+	}
+
+	/**
+	 * Duplicate an event into a new draft.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param int $post_id The event post ID to duplicate.
+	 *
+	 * @return int|WP_Error The new draft's post ID, or an error describing why it was refused.
+	 *
+	 * @throws Exception If reading the source event's datetimes fails.
+	 */
+	public function duplicate( int $post_id ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post instanceof WP_Post || ! post_type_supports( $post->post_type, 'gatherpress-event-date' ) ) {
+			return new WP_Error(
+				'gatherpress_duplicate_invalid_event',
+				__( 'That event could not be found.', 'gatherpress' )
+			);
+		}
+
+		$post_type_object = get_post_type_object( $post->post_type );
+
+		if (
+			! current_user_can( 'edit_post', $post->ID )
+			|| ! current_user_can( $post_type_object->cap->create_posts )
+		) {
+			return new WP_Error(
+				'gatherpress_duplicate_not_allowed',
+				__( 'You are not allowed to duplicate this event.', 'gatherpress' )
+			);
+		}
+
+		$postarr = array(
+			'post_type'      => $post->post_type,
+			'post_title'     => $post->post_title,
+			'post_content'   => $post->post_content,
+			'post_excerpt'   => $post->post_excerpt,
+			'post_status'    => 'draft',
+			'post_author'    => get_current_user_id(),
+			'comment_status' => $post->comment_status,
+			'ping_status'    => $post->ping_status,
+			'menu_order'     => $post->menu_order,
+		);
+
+		/**
+		 * Filters the post data used to create an event duplicate.
+		 *
+		 * The slug, the published status, and the RSVP comments are left out
+		 * by design: they describe the occurrence being copied from. Anything
+		 * added here is passed straight to `wp_insert_post()`.
+		 *
+		 * @since 0.35.0
+		 *
+		 * @param array   $postarr Post data for the duplicate.
+		 * @param WP_Post $post    The event being duplicated.
+		 *
+		 * @return array Post data for the duplicate.
+		 */
+		$postarr = (array) apply_filters( 'gatherpress_duplicate_event_postarr', $postarr, $post );
+
+		$duplicate_id = wp_insert_post( wp_slash( $postarr ), true );
+
+		if ( is_wp_error( $duplicate_id ) ) {
+			return $duplicate_id;
+		}
+
+		$this->copy_terms( $post, (int) $duplicate_id );
+		$this->copy_meta( $post, (int) $duplicate_id );
+		$this->copy_datetimes( $post, (int) $duplicate_id );
+
+		/**
+		 * Fires after an event has been duplicated.
+		 *
+		 * @since 0.35.0
+		 *
+		 * @param int     $duplicate_id The new draft's post ID.
+		 * @param WP_Post $post         The event that was duplicated.
+		 *
+		 * @return void
+		 */
+		do_action( 'gatherpress_event_duplicated', (int) $duplicate_id, $post );
+
+		return (int) $duplicate_id;
+	}
+
+	/**
+	 * Copy every taxonomy term from the source event to the duplicate.
+	 *
+	 * Reads the terms actually attached to the source across all registered
+	 * taxonomies rather than walking the post type's taxonomy list. The venue
+	 * association is a hidden shadow taxonomy wired onto the post type by the
+	 * venue subsystem, so on a site where that wiring has not run (or a
+	 * companion plugin attaches its own shadow taxonomy later) the post type's
+	 * list can be missing a taxonomy the post still has terms in. Grouping by
+	 * what is attached copies topics, the venue, and anything a companion
+	 * plugin added, in one query.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param WP_Post $post         The event being duplicated.
+	 * @param int     $duplicate_id The new draft's post ID.
+	 *
+	 * @return void
+	 */
+	private function copy_terms( WP_Post $post, int $duplicate_id ): void {
+		$terms = wp_get_object_terms( $post->ID, get_taxonomies() );
+
+		if ( is_wp_error( $terms ) ) {
+			return;
+		}
+
+		$term_ids_by_taxonomy = array();
+
+		foreach ( $terms as $term ) {
+			$term_ids_by_taxonomy[ $term->taxonomy ][] = $term->term_id;
+		}
+
+		foreach ( $term_ids_by_taxonomy as $taxonomy => $term_ids ) {
+			wp_set_object_terms( $duplicate_id, $term_ids, $taxonomy );
+		}
+	}
+
+	/**
+	 * Copy the featured image and the author-writable event meta.
+	 *
+	 * Works from the meta the source event actually stores rather than a
+	 * literal key list, so meta added later travels without this method being
+	 * updated. Two groups are skipped: the derived datetime keys in
+	 * `Meta::READONLY_DATETIME_KEYS`, which `Event::save_datetimes()` rewrites
+	 * from scratch, and `gatherpress_datetime` itself, which
+	 * `copy_datetimes()` sets to the shifted values.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param WP_Post $post         The event being duplicated.
+	 * @param int     $duplicate_id The new draft's post ID.
+	 *
+	 * @return void
+	 */
+	private function copy_meta( WP_Post $post, int $duplicate_id ): void {
+		$thumbnail_id = get_post_thumbnail_id( $post );
+
+		if ( ! empty( $thumbnail_id ) ) {
+			// update_post_meta rather than set_post_thumbnail: the source's
+			// choice is already valid, and set_post_thumbnail re-validates by
+			// rendering the attachment, which drops the image for any
+			// attachment that produces no markup.
+			update_post_meta( $duplicate_id, '_thumbnail_id', $thumbnail_id );
+		}
+
+		foreach ( (array) get_post_meta( $post->ID ) as $meta_key => $values ) {
+			if (
+				! str_starts_with( (string) $meta_key, 'gatherpress_' )
+				|| 'gatherpress_datetime' === $meta_key
+				|| in_array( $meta_key, Meta::READONLY_DATETIME_KEYS, true )
+			) {
+				continue;
+			}
+
+			// add_post_meta per stored row rather than a single update: a key
+			// registered as non-single would otherwise collapse to one value.
+			foreach ( (array) $values as $value ) {
+				add_post_meta( $duplicate_id, (string) $meta_key, maybe_unserialize( $value ) );
+			}
+		}
+	}
+
+	/**
+	 * Move the source event's datetimes forward onto the duplicate.
+	 *
+	 * The shift is a whole number of weeks, the smallest that puts the start
+	 * in the future, which keeps the weekday, the time of day, and the
+	 * timezone of the original: what a group repeating a meetup expects. The
+	 * duration is preserved rather than recalculated. A duplicate of a future
+	 * event still moves a week out, so two events never sit on the same slot
+	 * by accident.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param WP_Post $post         The event being duplicated.
+	 * @param int     $duplicate_id The new draft's post ID.
+	 *
+	 * @return void
+	 *
+	 * @throws Exception If the source datetimes cannot be read as dates.
+	 */
+	private function copy_datetimes( WP_Post $post, int $duplicate_id ): void {
+		$datetime = ( new Event( $post->ID ) )->get_datetime();
+
+		if ( empty( $datetime['datetime_start'] ) || empty( $datetime['datetime_end'] ) ) {
+			return;
+		}
+
+		$timezone = new DateTimeZone( Utility::normalize_timezone_string( (string) $datetime['timezone'] ) );
+		$start    = new DateTimeImmutable( (string) $datetime['datetime_start'], $timezone );
+		$end      = new DateTimeImmutable( (string) $datetime['datetime_end'], $timezone );
+		$now      = new DateTimeImmutable( 'now', $timezone );
+
+		$weeks     = max( 1, (int) ceil( ( $now->getTimestamp() - $start->getTimestamp() ) / WEEK_IN_SECONDS ) );
+		$new_start = $start->modify( sprintf( '+%d weeks', $weeks ) );
+		$new_end   = $new_start->add(
+			new DateInterval( sprintf( 'PT%dS', $end->getTimestamp() - $start->getTimestamp() ) )
+		);
+
+		$params = array(
+			'post_id'        => $duplicate_id,
+			'datetime_start' => $new_start->format( Event::DATETIME_FORMAT ),
+			'datetime_end'   => $new_end->format( Event::DATETIME_FORMAT ),
+			'timezone'       => $datetime['timezone'],
+		);
+
+		/**
+		 * Filters the datetimes a duplicated event lands on.
+		 *
+		 * Defaults to the source event's slot moved forward by whole weeks
+		 * until it is in the future, preserving weekday, time of day, and
+		 * duration. Return values in the same shape to place the duplicate
+		 * somewhere else.
+		 *
+		 * @since 0.35.0
+		 *
+		 * @param array   $params   Datetime values for the duplicate, as accepted by `Event::save_datetimes()`.
+		 * @param array   $datetime The source event's datetime values.
+		 * @param WP_Post $post     The event being duplicated.
+		 *
+		 * @return array Datetime values for the duplicate.
+		 */
+		$params = (array) apply_filters( 'gatherpress_duplicate_event_datetime', $params, $datetime, $post );
+
+		// The JSON meta is what the editor reads; save_datetimes writes the
+		// custom table and the derived meta the queries and list table use.
+		update_post_meta(
+			$duplicate_id,
+			'gatherpress_datetime',
+			wp_json_encode(
+				array(
+					'dateTimeStart' => $params['datetime_start'],
+					'dateTimeEnd'   => $params['datetime_end'],
+					'timezone'      => $params['timezone'],
+				)
+			)
+		);
+
+		( new Event( $duplicate_id ) )->save_datetimes( $params );
+	}
+}

--- a/includes/core/classes/event/class-meta.php
+++ b/includes/core/classes/event/class-meta.php
@@ -48,6 +48,26 @@ final class Meta {
 	use Singleton;
 
 	/**
+	 * Datetime meta keys derived from `gatherpress_datetime`.
+	 *
+	 * Written only by `Event::save_datetimes()`, which is why they register
+	 * with an `auth_callback` of `__return_false`. Single source of truth for
+	 * the REST strip in `filter_readonly_meta()` and for anything else that
+	 * needs to leave derived values alone, such as duplicating an event.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @var string[]
+	 */
+	const READONLY_DATETIME_KEYS = array(
+		'gatherpress_datetime_start',
+		'gatherpress_datetime_start_gmt',
+		'gatherpress_datetime_end',
+		'gatherpress_datetime_end_gmt',
+		'gatherpress_timezone',
+	);
+
+	/**
 	 * Class constructor.
 	 *
 	 * @since 0.34.0
@@ -261,18 +281,10 @@ final class Meta {
 	 * @return stdClass The prepared post object.
 	 */
 	public function filter_readonly_meta( stdClass $prepared_post, WP_REST_Request $request ): stdClass {
-		$readonly_keys = array(
-			'gatherpress_datetime_start',
-			'gatherpress_datetime_start_gmt',
-			'gatherpress_datetime_end',
-			'gatherpress_datetime_end_gmt',
-			'gatherpress_timezone',
-		);
-
 		$meta = $request->get_param( 'meta' );
 
 		if ( is_array( $meta ) ) {
-			foreach ( $readonly_keys as $key ) {
+			foreach ( self::READONLY_DATETIME_KEYS as $key ) {
 				unset( $meta[ $key ] );
 			}
 

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -78,6 +78,7 @@ final class Setup {
 	 */
 	protected function instantiate_classes(): void {
 		Admin_List::get_instance();
+		Duplicate::get_instance();
 		Meta::get_instance();
 		Query::get_instance();
 		Rest_Api::get_instance();

--- a/test/unit/php/includes/tests/core/classes/event/class-test-duplicate.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-duplicate.php
@@ -1,0 +1,513 @@
+<?php
+/**
+ * Class handles unit tests for GatherPress\Core\Event\Duplicate.
+ *
+ * @package GatherPress\Core\Event
+ * @since 0.35.0
+ */
+
+namespace GatherPress\Tests\Core\Event;
+
+use GatherPress\Core\Event;
+use GatherPress\Core\Event\Duplicate;
+use GatherPress\Core\Topic;
+use GatherPress\Core\Venue;
+use GatherPress\Tests\Base;
+use WP_Post;
+
+/**
+ * Class Test_Duplicate.
+ *
+ * @coversDefaultClass \GatherPress\Core\Event\Duplicate
+ */
+class Test_Duplicate extends Base {
+
+	/**
+	 * Build a published event with datetimes, a venue term, and a topic.
+	 *
+	 * @param string $datetime_start Local start datetime for the event.
+	 * @param string $datetime_end   Local end datetime for the event.
+	 *
+	 * @return int The event post ID.
+	 */
+	private function make_event(
+		string $datetime_start = '2020-06-15 18:00:00',
+		string $datetime_end = '2020-06-15 20:00:00'
+	): int {
+		$event_id = $this->mock->post(
+			array(
+				'post_type'    => Event::POST_TYPE,
+				'post_title'   => 'Monthly Meetup',
+				'post_name'    => 'monthly-meetup',
+				'post_content' => '<!-- wp:paragraph --><p>Same as every month.</p><!-- /wp:paragraph -->',
+				'post_excerpt' => 'Same as every month.',
+				'post_status'  => 'publish',
+			)
+		)->get()->ID;
+
+		$event = new Event( $event_id );
+		$event->save_datetimes(
+			array(
+				'datetime_start' => $datetime_start,
+				'datetime_end'   => $datetime_end,
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		update_post_meta( $event_id, 'gatherpress_max_attendance_limit', 25 );
+		update_post_meta( $event_id, 'gatherpress_online_event_link', 'https://example.org/room' );
+
+		$venue_id = $this->mock->post(
+			array(
+				'post_type'  => Venue::POST_TYPE,
+				'post_title' => 'Brooklyn Office',
+				'post_name'  => 'brooklyn-office',
+			)
+		)->get()->ID;
+
+		wp_set_post_terms( $event_id, '_brooklyn-office', Venue::TAXONOMY );
+		wp_set_post_terms( $event_id, array( 'social' ), Topic::TAXONOMY );
+
+		return $event_id;
+	}
+
+	/**
+	 * Coverage for setup_hooks.
+	 *
+	 * @covers ::setup_hooks
+	 *
+	 * @return void
+	 */
+	public function test_setup_hooks(): void {
+		$instance = Duplicate::get_instance();
+		$hooks    = array(
+			array(
+				'type'     => 'filter',
+				'name'     => 'post_row_actions',
+				'priority' => 10,
+				'callback' => array( $instance, 'row_action' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => sprintf( 'admin_action_%s', Duplicate::ACTION ),
+				'priority' => 10,
+				'callback' => array( $instance, 'handle_request' ),
+			),
+		);
+
+		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * Coverage for row_action on an event the current user can edit.
+	 *
+	 * @covers ::row_action
+	 * @covers ::get_url
+	 *
+	 * @return void
+	 */
+	public function test_row_action_adds_duplicate_link_for_events(): void {
+		$this->mock->user( 'admin' );
+
+		$event_id = $this->make_event();
+		$actions  = Duplicate::get_instance()->row_action( array(), get_post( $event_id ) );
+
+		$this->assertArrayHasKey(
+			'gatherpress_duplicate',
+			$actions,
+			'Events should offer a Duplicate row action.'
+		);
+		$this->assertStringContainsString(
+			sprintf( 'action=%s', Duplicate::ACTION ),
+			$actions['gatherpress_duplicate'],
+			'The Duplicate link should carry the duplication action.'
+		);
+		$this->assertStringContainsString(
+			'_wpnonce=',
+			$actions['gatherpress_duplicate'],
+			'The Duplicate link should be nonced.'
+		);
+	}
+
+	/**
+	 * Coverage for row_action on a post type that is not an event, and on an
+	 * event the current user cannot edit.
+	 *
+	 * @covers ::row_action
+	 *
+	 * @return void
+	 */
+	public function test_row_action_skips_non_events_and_unprivileged_users(): void {
+		$this->mock->user( 'admin' );
+
+		$post_id = $this->mock->post( array( 'post_type' => 'post' ) )->get()->ID;
+
+		$this->assertSame(
+			array(),
+			Duplicate::get_instance()->row_action( array(), get_post( $post_id ) ),
+			'A post type without event-date support should not offer duplication.'
+		);
+
+		$event_id = $this->make_event();
+
+		$this->mock->user( 'subscriber' );
+
+		$this->assertSame(
+			array(),
+			Duplicate::get_instance()->row_action( array(), get_post( $event_id ) ),
+			'A user who cannot edit the event should not be offered duplication.'
+		);
+	}
+
+	/**
+	 * Coverage for duplicate: content, terms, meta, and featured image travel
+	 * to a fresh draft while RSVPs, slug, and status do not.
+	 *
+	 * @covers ::duplicate
+	 * @covers ::copy_terms
+	 * @covers ::copy_meta
+	 * @covers ::copy_datetimes
+	 *
+	 * @return void
+	 */
+	public function test_duplicate_copies_event_into_a_draft(): void {
+		$this->mock->user( 'admin' );
+
+		$event_id     = $this->make_event();
+		$thumbnail_id = $this->mock->post( array( 'post_type' => 'attachment' ) )->get()->ID;
+
+		// update_post_meta rather than set_post_thumbnail: the latter refuses
+		// an attachment that renders no image markup, which a mocked one does not.
+		update_post_meta( $event_id, '_thumbnail_id', $thumbnail_id );
+
+		$duplicate_id = Duplicate::get_instance()->duplicate( $event_id );
+
+		$this->assertIsInt( $duplicate_id, 'Duplicating an event should return the new post ID.' );
+
+		$duplicate = get_post( $duplicate_id );
+
+		$this->assertSame( 'draft', $duplicate->post_status, 'A duplicate should land as a draft.' );
+		$this->assertSame( 'Monthly Meetup', $duplicate->post_title, 'The title should travel.' );
+		$this->assertStringContainsString(
+			'Same as every month.',
+			$duplicate->post_content,
+			'The content should travel.'
+		);
+		$this->assertSame( 'Same as every month.', $duplicate->post_excerpt, 'The excerpt should travel.' );
+		$this->assertNotSame(
+			get_post_field( 'post_name', $event_id ),
+			$duplicate->post_name,
+			'The duplicate should get its own slug.'
+		);
+		$this->assertSame(
+			$thumbnail_id,
+			get_post_thumbnail_id( $duplicate_id ),
+			'The featured image should travel.'
+		);
+		$this->assertSame(
+			'25',
+			(string) get_post_meta( $duplicate_id, 'gatherpress_max_attendance_limit', true ),
+			'Author-writable event meta should travel.'
+		);
+		$this->assertSame(
+			'https://example.org/room',
+			get_post_meta( $duplicate_id, 'gatherpress_online_event_link', true ),
+			'The online event link should travel.'
+		);
+		$this->assertSame(
+			wp_get_object_terms( $event_id, Venue::TAXONOMY, array( 'fields' => 'ids' ) ),
+			wp_get_object_terms( $duplicate_id, Venue::TAXONOMY, array( 'fields' => 'ids' ) ),
+			'The venue association should travel.'
+		);
+		$this->assertSame(
+			wp_get_object_terms( $event_id, Topic::TAXONOMY, array( 'fields' => 'ids' ) ),
+			wp_get_object_terms( $duplicate_id, Topic::TAXONOMY, array( 'fields' => 'ids' ) ),
+			'Topics should travel.'
+		);
+	}
+
+	/**
+	 * Coverage for copy_datetimes: a past event moves forward by whole weeks,
+	 * keeping weekday, time of day, timezone, and duration.
+	 *
+	 * @covers ::duplicate
+	 * @covers ::copy_datetimes
+	 *
+	 * @return void
+	 */
+	public function test_duplicate_moves_datetimes_into_the_future(): void {
+		$this->mock->user( 'admin' );
+
+		$event_id     = $this->make_event( '2020-06-15 18:00:00', '2020-06-15 20:00:00' );
+		$duplicate_id = Duplicate::get_instance()->duplicate( $event_id );
+		$datetime     = ( new Event( $duplicate_id ) )->get_datetime();
+
+		$start = strtotime( $datetime['datetime_start'] );
+		$end   = strtotime( $datetime['datetime_end'] );
+
+		$this->assertGreaterThan(
+			time(),
+			strtotime( $datetime['datetime_start_gmt'] . ' GMT' ),
+			'The duplicate should start in the future.'
+		);
+		$this->assertSame(
+			'Monday',
+			gmdate( 'l', $start ),
+			'The weekday of the source event should be preserved.'
+		);
+		$this->assertSame(
+			'18:00:00',
+			gmdate( 'H:i:s', $start ),
+			'The time of day of the source event should be preserved.'
+		);
+		$this->assertSame(
+			2 * HOUR_IN_SECONDS,
+			$end - $start,
+			'The duration of the source event should be preserved.'
+		);
+		$this->assertSame(
+			'America/New_York',
+			$datetime['timezone'],
+			'The timezone of the source event should be preserved.'
+		);
+	}
+
+	/**
+	 * Coverage for copy_datetimes when the source event is in the future: the
+	 * duplicate still moves one week out rather than colliding with it.
+	 *
+	 * @covers ::copy_datetimes
+	 *
+	 * @return void
+	 */
+	public function test_duplicate_of_future_event_moves_one_week_out(): void {
+		$this->mock->user( 'admin' );
+
+		$start        = gmdate( 'Y-m-d H:i:s', time() + ( 2 * WEEK_IN_SECONDS ) );
+		$end          = gmdate( 'Y-m-d H:i:s', time() + ( 2 * WEEK_IN_SECONDS ) + HOUR_IN_SECONDS );
+		$event_id     = $this->make_event( $start, $end );
+		$duplicate_id = Duplicate::get_instance()->duplicate( $event_id );
+
+		$this->assertSame(
+			WEEK_IN_SECONDS,
+			strtotime( ( new Event( $duplicate_id ) )->get_datetime()['datetime_start'] ) - strtotime( $start ),
+			'A future event should be duplicated one week later.'
+		);
+	}
+
+	/**
+	 * Coverage for copy_datetimes when the source event has no datetimes: the
+	 * duplicate is created and the datetime pass bails.
+	 *
+	 * @covers ::copy_datetimes
+	 *
+	 * @return void
+	 */
+	public function test_duplicate_without_datetimes_skips_the_datetime_pass(): void {
+		$this->mock->user( 'admin' );
+
+		$event_id     = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+		$duplicate_id = Duplicate::get_instance()->duplicate( $event_id );
+
+		$this->assertIsInt( $duplicate_id, 'An event without datetimes should still duplicate.' );
+		$this->assertEmpty(
+			get_post_meta( $duplicate_id, 'gatherpress_datetime', true ),
+			'No datetime meta should be written when the source has none.'
+		);
+	}
+
+	/**
+	 * Coverage for the duplicate guards: a missing post, a post type without
+	 * event-date support, and a user without the capability.
+	 *
+	 * @covers ::duplicate
+	 *
+	 * @return void
+	 */
+	public function test_duplicate_refuses_invalid_requests(): void {
+		$this->mock->user( 'admin' );
+
+		$instance = Duplicate::get_instance();
+
+		$this->assertSame(
+			'gatherpress_duplicate_invalid_event',
+			$instance->duplicate( 0 )->get_error_code(),
+			'A post that does not exist should be refused.'
+		);
+
+		$post_id = $this->mock->post( array( 'post_type' => 'post' ) )->get()->ID;
+
+		$this->assertSame(
+			'gatherpress_duplicate_invalid_event',
+			$instance->duplicate( $post_id )->get_error_code(),
+			'A post type without event-date support should be refused.'
+		);
+
+		$event_id = $this->make_event();
+
+		$this->mock->user( 'subscriber' );
+
+		$this->assertSame(
+			'gatherpress_duplicate_not_allowed',
+			$instance->duplicate( $event_id )->get_error_code(),
+			'A user without the capability should be refused.'
+		);
+	}
+
+	/**
+	 * Coverage for the postarr filter, which lets consumers reshape the copy.
+	 *
+	 * @covers ::duplicate
+	 *
+	 * @return void
+	 */
+	public function test_duplicate_event_postarr_filter_applies(): void {
+		$this->mock->user( 'admin' );
+
+		$event_id = $this->make_event();
+
+		add_filter(
+			'gatherpress_duplicate_event_postarr',
+			static function ( array $postarr, WP_Post $post ): array {
+				$postarr['post_title'] = sprintf( '%s (copy)', $post->post_title );
+
+				return $postarr;
+			},
+			10,
+			2
+		);
+
+		$duplicate_id = Duplicate::get_instance()->duplicate( $event_id );
+
+		remove_all_filters( 'gatherpress_duplicate_event_postarr' );
+
+		$this->assertSame(
+			'Monthly Meetup (copy)',
+			get_post_field( 'post_title', $duplicate_id ),
+			'The postarr filter should be able to rename the duplicate.'
+		);
+	}
+
+	/**
+	 * Coverage for the datetime filter, which lets consumers place the copy
+	 * somewhere other than the default weekly shift.
+	 *
+	 * @covers ::copy_datetimes
+	 *
+	 * @return void
+	 */
+	public function test_duplicate_event_datetime_filter_applies(): void {
+		$this->mock->user( 'admin' );
+
+		$event_id = $this->make_event();
+
+		add_filter(
+			'gatherpress_duplicate_event_datetime',
+			static function ( array $params ): array {
+				$params['datetime_start'] = '2040-01-01 09:00:00';
+				$params['datetime_end']   = '2040-01-01 10:00:00';
+
+				return $params;
+			}
+		);
+
+		$duplicate_id = Duplicate::get_instance()->duplicate( $event_id );
+
+		remove_all_filters( 'gatherpress_duplicate_event_datetime' );
+
+		$this->assertSame(
+			'2040-01-01 09:00:00',
+			( new Event( $duplicate_id ) )->get_datetime()['datetime_start'],
+			'The datetime filter should be able to place the duplicate.'
+		);
+	}
+
+	/**
+	 * Coverage for the duplicated action, which fires with the new post ID.
+	 *
+	 * @covers ::duplicate
+	 *
+	 * @return void
+	 */
+	public function test_duplicate_fires_duplicated_action(): void {
+		$this->mock->user( 'admin' );
+
+		$event_id = $this->make_event();
+		$fired    = array();
+
+		add_action(
+			'gatherpress_event_duplicated',
+			static function ( int $duplicate_id, WP_Post $post ) use ( &$fired ): void {
+				$fired = array( $duplicate_id, $post->ID );
+			},
+			10,
+			2
+		);
+
+		$duplicate_id = Duplicate::get_instance()->duplicate( $event_id );
+
+		remove_all_actions( 'gatherpress_event_duplicated' );
+
+		$this->assertSame(
+			array( $duplicate_id, $event_id ),
+			$fired,
+			'The duplicated action should report the new and source post IDs.'
+		);
+	}
+
+	/**
+	 * Coverage for handle_request: a valid nonced request duplicates the event
+	 * and redirects to the new draft.
+	 *
+	 * @covers ::handle_request
+	 *
+	 * @return void
+	 */
+	public function test_handle_request_redirects_to_the_duplicate(): void {
+		$this->mock->user( 'admin' );
+
+		$event_id = $this->make_event();
+
+		$_REQUEST['_wpnonce'] = wp_create_nonce( sprintf( '%s_%d', Duplicate::ACTION, $event_id ) );
+		$redirects            = array();
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, int $type, string $var_name ) use ( $event_id ) {
+				if ( INPUT_GET === $type && 'post' === $var_name ) {
+					return (string) $event_id;
+				}
+
+				return $pre_value;
+			},
+			10,
+			3
+		);
+		add_filter(
+			'wp_redirect',
+			static function ( string $location ) use ( &$redirects ) {
+				$redirects[] = $location;
+
+				return false;
+			}
+		);
+
+		Duplicate::get_instance()->handle_request();
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+		remove_all_filters( 'wp_redirect' );
+		unset( $_REQUEST['_wpnonce'] );
+
+		$this->assertCount( 1, $redirects, 'A valid request should redirect once.' );
+		$this->assertStringContainsString(
+			'post.php?post=',
+			$redirects[0],
+			'The redirect should target the new draft in the editor.'
+		);
+		$this->assertStringContainsString(
+			'action=edit',
+			$redirects[0],
+			'The redirect should open the new draft for editing.'
+		);
+	}
+}


### PR DESCRIPTION
Fixes #2057

## Proposed changes:

* Adds a **Duplicate** row action to the events list table, which copies an event into a fresh draft and opens it in the editor.

What travels: content, excerpt, title, taxonomy terms (topics and the venue, which is a hidden shadow term), the featured image, and every `gatherpress_`-prefixed meta key stored on the source.

What deliberately does not: RSVPs, comments, the slug, and the published status. Those describe the occurrence being copied from.

The datetimes move forward by the smallest whole number of weeks that lands in the future. That keeps the weekday, the time of day, the timezone, and the duration of the original, which is what a group repeating a meetup expects, and it means duplicating a future event still steps a week out instead of stacking two events on the same slot. `gatherpress_datetime` is written for the editor and `Event::save_datetimes()` for the custom table and the derived meta, so the copy is correct in the list table and queries before its first save.

Recurring events (#80) remains the full answer to repetition; this is the small slice that covers most of the day-to-day need without committing to a recurrence model.

Two extension points, both documented in the docblocks: `gatherpress_duplicate_event_postarr` reshapes the copy (renaming it "(copy)" is a one-liner if that is preferred as the default), and `gatherpress_duplicate_event_datetime` places it somewhere other than the weekly shift. `gatherpress_event_duplicated` fires afterwards with both post IDs.

Also in this PR: `Event\Meta::READONLY_DATETIME_KEYS`, so the derived datetime keys have a single definition shared by the REST strip in `filter_readonly_meta()` and the duplicate pass, instead of a literal array in each. Same shape as `Venue\Meta::STRUCTURED_ADDRESS_FIELDS`.

Two calls worth a maintainer opinion:

1. The title is copied verbatim rather than suffixed. A monthly meetup reuses its name, and the draft status distinguishes the copy in the list. Easy to change via the filter or by default if you would rather see "(copy)".
2. `copy_meta()` reads the meta stored on the source instead of `get_registered_meta_keys()`, so meta added later travels with no change here. It skips `gatherpress_datetime` and the read-only derived keys.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

`Test_Duplicate` adds 12 tests: hooks, the row action for events and its two refusal paths, a full copy assertion, the weekly shift for past and future events, the no-datetimes bail, all three `duplicate()` guards, both filters, and the action. `handle_request()` is covered by filtering `wp_redirect` to false so the redirect is observable without the exit.

Local runs: full PHP suite 1659 tests with the same 27 pre-existing failures my ad-hoc single-site environment produces on a clean `develop` checkout (missing `gatherpress_events` table plus `wp_`-prefix expectations), so no change in that count; PHPCS and PHPStan clean on all four changed files.

## Testing instructions:

1. Publish an event with a venue, a topic, a featured image, and an RSVP or two. Set an RSVP limit so there is meta to check.
2. Go to **Events** in the admin, hover the event's row, click **Duplicate**.
3. You land in the editor on a new draft. Confirm the content, venue, topic, featured image, and RSVP settings match the original, and that the date is the same weekday and time of day, a week or more later.
4. Confirm the RSVPs did not come along, and that the original is untouched.
5. Duplicate an event that is already in the future: the copy lands exactly one week after it.
6. As a subscriber (or any user who cannot edit the event), confirm no Duplicate link appears, and that hitting the URL directly is refused.

Verified by hand on WP 7.0.2 / PHP 8.2.29 with GatherPress 0.35.0-beta.1: duplicating a July 31 18:00 UTC event produced a draft on August 7 18:00 UTC with a matching 2 hour duration, the same content and excerpt, zero RSVPs on the copy, the `gatherpress_events` row written, and nothing in `debug.log`.

### Credit (for release notes)

My WordPress.org username: motylanogha
