### PR TITLE
Fix bulk actions on the RSVPs screen being silently refused

### DIFF
--- a/.github/changelog/2062-rsvp-bulk-action-nonce
+++ b/.github/changelog/2062-rsvp-bulk-action-nonce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed bulk actions on the RSVPs screen doing nothing when used from a browser. The list table emitted its own nonce under the same `_wpnonce` name WordPress uses for the bulk form, so the value that reached the handler was the one it did not accept and every Approve, Unapprove, Spam or Delete was silently refused.

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -739,17 +739,41 @@ final class List_Table extends WP_List_Table {
 	 * @return void
 	 */
 	public function process_bulk_action(): void {
-		$nonce = isset( $_REQUEST['_wpnonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ) : '';
+		// Requests reach this method carrying different nonces depending on how
+		// they were made: core's `bulk-<plural>` nonce from the bulk form, the
+		// comment-type nonce from the view links and from `display()`'s own
+		// field, and the dedicated `gatherpress_rsvp_action` nonce from the
+		// row-action delete link, which is why that one only counts for
+		// `delete`. Any single valid pairing is enough; the capability check
+		// below is what authorizes the action.
+		$nonces = array();
 
-		// Accept either the standard comment-type nonce, or — only for the
-		// `delete` action — the dedicated `gatherpress_rsvp_action` nonce
-		// the row-action emits. Cap check folds in for a single guard.
-		$valid_nonce = $nonce && (
-			wp_verify_nonce( $nonce, Rsvp::COMMENT_TYPE )
-			|| ( 'delete' === $this->current_action()
-				&& wp_verify_nonce( $nonce, 'gatherpress_rsvp_action' )
-			)
+		foreach ( array( '_wpnonce', '_gatherpress_rsvp_nonce' ) as $field ) {
+			if ( isset( $_REQUEST[ $field ] ) ) {
+				$nonces[] = sanitize_text_field( wp_unslash( $_REQUEST[ $field ] ) );
+			}
+		}
+
+		$nonce_actions = array(
+			sprintf( 'bulk-%s', $this->_args['plural'] ),
+			Rsvp::COMMENT_TYPE,
 		);
+
+		if ( 'delete' === $this->current_action() ) {
+			$nonce_actions[] = 'gatherpress_rsvp_action';
+		}
+
+		$valid_nonce = false;
+
+		foreach ( $nonces as $nonce ) {
+			foreach ( $nonce_actions as $nonce_action ) {
+				if ( wp_verify_nonce( $nonce, $nonce_action ) ) {
+					$valid_nonce = true;
+
+					break 2;
+				}
+			}
+		}
 
 		if ( ! $valid_nonce || ! current_user_can( Rsvp::CAPABILITY ) ) {
 			return;
@@ -957,7 +981,11 @@ final class List_Table extends WP_List_Table {
 	 * @return void
 	 */
 	public function display(): void {
-		wp_nonce_field( Rsvp::COMMENT_TYPE );
+		// Own field name rather than the `_wpnonce` default: `parent::display()`
+		// emits core's `bulk-<plural>` nonce under `_wpnonce` too, and a browser
+		// sending both leaves PHP with the last one, which used to mean every
+		// bulk action failed verification and did nothing (#2062).
+		wp_nonce_field( Rsvp::COMMENT_TYPE, '_gatherpress_rsvp_nonce' );
 		wp_nonce_field( 'gatherpress_rsvp_action', '_gatherpress_rsvp_action_nonce' );
 
 		parent::display();

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -739,19 +739,17 @@ final class List_Table extends WP_List_Table {
 	 * @return void
 	 */
 	public function process_bulk_action(): void {
-		// Requests reach this method carrying different nonces depending on how
-		// they were made: core's `bulk-<plural>` nonce from the bulk form, the
-		// comment-type nonce from the view links and from `display()`'s own
-		// field, and the dedicated `gatherpress_rsvp_action` nonce from the
-		// row-action delete link, which is why that one only counts for
-		// `delete`. Any single valid pairing is enough; the capability check
-		// below is what authorizes the action.
+		// Requests reach this method carrying different nonces under `_wpnonce`
+		// depending on how they were made: core's `bulk-<plural>` nonce from the
+		// bulk form, the comment-type nonce from the view links, and the
+		// dedicated `gatherpress_rsvp_action` nonce from the row-action delete
+		// link, which is why that one only counts for `delete`. Any single valid
+		// pairing is enough; the capability check below is what authorizes the
+		// action.
 		$nonces = array();
 
-		foreach ( array( '_wpnonce', '_gatherpress_rsvp_nonce' ) as $field ) {
-			if ( isset( $_REQUEST[ $field ] ) ) {
-				$nonces[] = sanitize_text_field( wp_unslash( $_REQUEST[ $field ] ) );
-			}
+		if ( isset( $_REQUEST['_wpnonce'] ) ) {
+			$nonces[] = sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) );
 		}
 
 		$nonce_actions = array(
@@ -967,27 +965,5 @@ final class List_Table extends WP_List_Table {
 		);
 
 		return $status_links;
-	}
-
-	/**
-	 * Displays the RSVP list table with nonce fields.
-	 *
-	 * Outputs the HTML for the RSVP list table, including necessary nonce fields
-	 * for security. This method extends the parent display() method to add
-	 * GatherPress-specific nonce fields for RSVP actions.
-	 *
-	 * @since 0.34.0
-	 *
-	 * @return void
-	 */
-	public function display(): void {
-		// Own field name rather than the `_wpnonce` default: `parent::display()`
-		// emits core's `bulk-<plural>` nonce under `_wpnonce` too, and a browser
-		// sending both leaves PHP with the last one, which used to mean every
-		// bulk action failed verification and did nothing (#2062).
-		wp_nonce_field( Rsvp::COMMENT_TYPE, '_gatherpress_rsvp_nonce' );
-		wp_nonce_field( 'gatherpress_rsvp_action', '_gatherpress_rsvp_action_nonce' );
-
-		parent::display();
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
@@ -800,7 +800,10 @@ class Test_List_Table extends Base {
 
 		wp_set_comment_status( $rsvp_id, 'approve' );
 
-		$_REQUEST['_wpnonce']            = wp_create_nonce( 'bulk-rsvps' );
+		// Derive the bulk nonce the same way process_bulk_action() does, so the
+		// test stays honest if the list table's plural arg ever changes.
+		$plural                          = Utility::get_hidden_property( $this->list_table, '_args' )['plural'];
+		$_REQUEST['_wpnonce']            = wp_create_nonce( sprintf( 'bulk-%s', $plural ) );
 		$_REQUEST['gatherpress_rsvp_id'] = array( $rsvp_id );
 		$_REQUEST['action']              = 'unapprove';
 
@@ -813,37 +816,6 @@ class Test_List_Table extends Base {
 		);
 
 		unset( $_REQUEST['_wpnonce'], $_REQUEST['gatherpress_rsvp_id'], $_REQUEST['action'] );
-	}
-
-	/**
-	 * `display()` emits the comment-type nonce under its own field name so it
-	 * cannot shadow core's, and that field is still accepted (#2062).
-	 *
-	 * @covers ::process_bulk_action
-	 * @covers ::display
-	 *
-	 * @return void
-	 */
-	public function test_process_bulk_action_accepts_the_gatherpress_nonce_field(): void {
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
-
-		$rsvp_id = (int) $this->rsvp['comment_ID'];
-
-		wp_set_comment_status( $rsvp_id, 'approve' );
-
-		$_REQUEST['_gatherpress_rsvp_nonce'] = wp_create_nonce( Rsvp::COMMENT_TYPE );
-		$_REQUEST['gatherpress_rsvp_id']     = array( $rsvp_id );
-		$_REQUEST['action']                  = 'unapprove';
-
-		$this->list_table->process_bulk_action();
-
-		$this->assertSame(
-			'0',
-			get_comment( $rsvp_id )->comment_approved,
-			'Failed to assert the dedicated GatherPress nonce field authorizes a bulk action.'
-		);
-
-		unset( $_REQUEST['_gatherpress_rsvp_nonce'], $_REQUEST['gatherpress_rsvp_id'], $_REQUEST['action'] );
 	}
 
 	/**
@@ -1031,29 +1003,6 @@ class Test_List_Table extends Base {
 			array( 'date', true ),
 			$sortable['date'],
 			'Failed to assert date is the default sort column.'
-		);
-	}
-
-	/**
-	 * Tests display method.
-	 *
-	 * @covers ::display
-	 * @return void
-	 */
-	public function test_display(): void {
-		set_current_screen( 'gatherpress_event_page_gatherpress_rsvp' );
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
-
-		$this->list_table->prepare_items();
-
-		ob_start();
-		$this->list_table->display();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString(
-			'gatherpress_rsvp',
-			$output,
-			'Failed to assert display outputs table with RSVP nonce field.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
@@ -784,6 +784,98 @@ class Test_List_Table extends Base {
 	}
 
 	/**
+	 * The bulk form's own nonce, which is core's `bulk-<plural>` nonce, is
+	 * accepted. Before #2062 only the comment-type nonce was, and since
+	 * `WP_List_Table` emits its nonce under the same `_wpnonce` name, a browser
+	 * submit was always rejected and the screen did nothing.
+	 *
+	 * @covers ::process_bulk_action
+	 *
+	 * @return void
+	 */
+	public function test_process_bulk_action_accepts_the_core_bulk_nonce(): void {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$rsvp_id = (int) $this->rsvp['comment_ID'];
+
+		wp_set_comment_status( $rsvp_id, 'approve' );
+
+		$_REQUEST['_wpnonce']            = wp_create_nonce( 'bulk-rsvps' );
+		$_REQUEST['gatherpress_rsvp_id'] = array( $rsvp_id );
+		$_REQUEST['action']              = 'unapprove';
+
+		$this->list_table->process_bulk_action();
+
+		$this->assertSame(
+			'0',
+			get_comment( $rsvp_id )->comment_approved,
+			'Failed to assert the core bulk nonce authorizes a bulk action.'
+		);
+
+		unset( $_REQUEST['_wpnonce'], $_REQUEST['gatherpress_rsvp_id'], $_REQUEST['action'] );
+	}
+
+	/**
+	 * `display()` emits the comment-type nonce under its own field name so it
+	 * cannot shadow core's, and that field is still accepted (#2062).
+	 *
+	 * @covers ::process_bulk_action
+	 * @covers ::display
+	 *
+	 * @return void
+	 */
+	public function test_process_bulk_action_accepts_the_gatherpress_nonce_field(): void {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$rsvp_id = (int) $this->rsvp['comment_ID'];
+
+		wp_set_comment_status( $rsvp_id, 'approve' );
+
+		$_REQUEST['_gatherpress_rsvp_nonce'] = wp_create_nonce( Rsvp::COMMENT_TYPE );
+		$_REQUEST['gatherpress_rsvp_id']     = array( $rsvp_id );
+		$_REQUEST['action']                  = 'unapprove';
+
+		$this->list_table->process_bulk_action();
+
+		$this->assertSame(
+			'0',
+			get_comment( $rsvp_id )->comment_approved,
+			'Failed to assert the dedicated GatherPress nonce field authorizes a bulk action.'
+		);
+
+		unset( $_REQUEST['_gatherpress_rsvp_nonce'], $_REQUEST['gatherpress_rsvp_id'], $_REQUEST['action'] );
+	}
+
+	/**
+	 * An unrelated nonce is still refused.
+	 *
+	 * @covers ::process_bulk_action
+	 *
+	 * @return void
+	 */
+	public function test_process_bulk_action_refuses_an_unrelated_nonce(): void {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$rsvp_id = (int) $this->rsvp['comment_ID'];
+
+		wp_set_comment_status( $rsvp_id, 'approve' );
+
+		$_REQUEST['_wpnonce']            = wp_create_nonce( 'something-else' );
+		$_REQUEST['gatherpress_rsvp_id'] = array( $rsvp_id );
+		$_REQUEST['action']              = 'unapprove';
+
+		$this->list_table->process_bulk_action();
+
+		$this->assertSame(
+			'1',
+			get_comment( $rsvp_id )->comment_approved,
+			'Failed to assert an unrelated nonce is refused.'
+		);
+
+		unset( $_REQUEST['_wpnonce'], $_REQUEST['gatherpress_rsvp_id'], $_REQUEST['action'] );
+	}
+
+	/**
 	 * Tests get_views method.
 	 *
 	 * @covers ::get_views


### PR DESCRIPTION
Fixes #2062

## Proposed changes:

* `process_bulk_action()` accepts core's `bulk-<plural>` nonce, which is the nonce WordPress puts on the bulk form and therefore the one a browser actually sends.
* `display()` emits the comment-type nonce under `_gatherpress_rsvp_nonce` instead of the `_wpnonce` default, so it can no longer shadow core's field. The sibling `_gatherpress_rsvp_action_nonce` already worked this way.

Before this, `display()` wrote a `_wpnonce` for `gatherpress_rsvp` and then `parent::display()` wrote another `_wpnonce` for `bulk-rsvps`. A browser submits both in document order, PHP keeps the last, so the handler received core's nonce, matched neither of the two actions it accepted, and returned early. Approve, Unapprove, Mark as Spam, Not Spam and Delete all did nothing from the UI, and because the refusal is silent there was no notice to explain it.

The nonce reading is now a small loop over the two candidate field names against the accepted actions, so a valid pairing from any of the three entry points (bulk form, view links, row-action delete link) authorizes the action, and `gatherpress_rsvp_action` still only counts for `delete`. The capability check is untouched.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Three tests added to `Test_List_Table`: the core bulk nonce authorizes a bulk action, the dedicated GatherPress field authorizes one, and an unrelated nonce is still refused. `Test_List_Table` runs 74 tests / 113 assertions green locally, PHPCS and PHPStan clean.

## Testing instructions:

1. On an event with a couple of RSVPs, go to **Events > RSVPs**.
2. Tick both rows, choose **Unapprove**, click **Apply**.
3. On trunk: the page reloads and both rows still say Approved. With this branch: both move to Pending and the Approved / Pending counts in the view links update.
4. Repeat with **Approve**, **Mark as Spam** and **Not Spam** to confirm the rest of the set works.
5. Confirm the single-row **Delete** row action still works, since it carries its own nonce.

Verified by hand on WP 7.0.2 / PHP 8.2.29 with 0.35.0-beta.1. I also isolated the cause by replaying the screen's own POST with each of the two `_wpnonce` values against two approved RSVPs:

```
BEFORE:                        rsvp 2 approved=1   rsvp 3 approved=1
POST unapprove, first nonce:   rsvp 2 approved=0   rsvp 3 approved=0
POST approve,  first nonce:    rsvp 2 approved=1   rsvp 3 approved=1
POST unapprove, second nonce:  rsvp 2 approved=1   rsvp 3 approved=1   <- no change
```

The second value is the one a browser sends, which is what made the screen look inert.

### Credit (for release notes)

My WordPress.org username: motylanogha
