### PR TITLE
Add a public API for online events

### DIFF
--- a/.github/changelog/2047-online-event-api
+++ b/.github/changelog/2047-online-event-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a public API for online events: `Event::is_online()` and `Event::set_online()`, which own the online-event term and the link meta together, plus `Venue\Setup::ONLINE_EVENT_TERM_SLUG`, `is_online_event_term_slug()` and `get_online_event_term_id()`. The resolved term ID is exposed to the block editor so components stop looking it up individually.

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -13,7 +13,7 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue\Setup;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 use WP_Block;
 
 /**
@@ -116,14 +116,18 @@ final class Online_Event {
 			return false;
 		}
 
-		$taxonomy    = Setup::get_instance()->taxonomy_for_event_post_type( $event_post_type );
+		$taxonomy    = Venue_Setup::get_instance()->taxonomy_for_event_post_type( $event_post_type );
 		$venue_terms = get_the_terms( $post_id, $taxonomy );
 
 		if ( ! is_array( $venue_terms ) ) {
 			return false;
 		}
 
-		return in_array( 'online-event', wp_list_pluck( $venue_terms, 'slug' ), true );
+		return in_array(
+			Venue_Setup::ONLINE_EVENT_TERM_SLUG,
+			wp_list_pluck( $venue_terms, 'slug' ),
+			true
+		);
 	}
 
 	/**

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -361,7 +361,7 @@ final class Setup {
 		Venue\Setup::get_instance()->register_taxonomy();
 
 		$term_name = __( 'Online event', 'gatherpress' );
-		$term_slug = 'online-event';
+		$term_slug = Venue\Setup::ONLINE_EVENT_TERM_SLUG;
 
 		// Ensure the online-event term exists in each registered venue taxonomy.
 		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $venue_post_type ) {

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -828,7 +828,7 @@ class Event {
 		$taxonomy    = $venue_setup->taxonomy_for_event_post_type( $this->event->post_type );
 		$term_id     = $venue_setup->get_online_event_term_id( $this->event->post_type );
 
-		if ( empty( $taxonomy ) || null === $term_id ) {
+		if ( null === $term_id ) {
 			return false;
 		}
 

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -765,6 +765,94 @@ class Event {
 	}
 
 	/**
+	 * Whether this event is online.
+	 *
+	 * The unconditional answer, unlike {@see self::maybe_get_online_event_link()},
+	 * which asks whether the current visitor should be shown the link right now.
+	 * Online status lives in the venue taxonomy as a sentinel term, so this reads
+	 * the terms rather than any meta.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return bool True when the event carries the online-event term.
+	 */
+	public function is_online(): bool {
+		if ( ! $this->event instanceof WP_Post ) {
+			return false;
+		}
+
+		$venue_setup = Setup::get_instance();
+		$terms       = get_the_terms(
+			$this->event->ID,
+			$venue_setup->taxonomy_for_event_post_type( $this->event->post_type )
+		);
+
+		if ( ! is_array( $terms ) ) {
+			return false;
+		}
+
+		foreach ( $terms as $term ) {
+			if ( $venue_setup->is_online_event_term_slug( $term->slug ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Mark this event online or not, and set its link.
+	 *
+	 * Online status is a term and the link is post meta, and the two have to
+	 * move together: an event tagged online with no link is a dead end, and a
+	 * link left behind on an event that moved to a venue leaks a room URL that
+	 * is no longer the answer. Nothing owned that pairing before, so every
+	 * consumer outside our own editor reimplemented it.
+	 *
+	 * Setting an event online replaces any venue term, since an event is at one
+	 * or the other. Turning it off removes the term and clears the link.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param bool   $is_online Whether the event is online.
+	 * @param string $link      Optional. The online event link. Ignored when `$is_online` is false.
+	 *
+	 * @return bool True on success, false when the event or the online term cannot be resolved.
+	 */
+	public function set_online( bool $is_online, string $link = '' ): bool {
+		if ( ! $this->event instanceof WP_Post ) {
+			return false;
+		}
+
+		$venue_setup = Setup::get_instance();
+		$taxonomy    = $venue_setup->taxonomy_for_event_post_type( $this->event->post_type );
+		$term_id     = $venue_setup->get_online_event_term_id( $this->event->post_type );
+
+		if ( empty( $taxonomy ) || null === $term_id ) {
+			return false;
+		}
+
+		if ( ! $is_online ) {
+			// Only the online term goes; a venue term on the same event is
+			// somebody else's state to manage.
+			wp_remove_object_terms( $this->event->ID, $term_id, $taxonomy );
+			delete_post_meta( $this->event->ID, 'gatherpress_online_event_link' );
+
+			return true;
+		}
+
+		wp_set_object_terms( $this->event->ID, $term_id, $taxonomy );
+
+		if ( '' === $link ) {
+			delete_post_meta( $this->event->ID, 'gatherpress_online_event_link' );
+		} else {
+			update_post_meta( $this->event->ID, 'gatherpress_online_event_link', sanitize_url( $link ) );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Get the online event link if the user is attending and the event hasn't passed.
 	 *
 	 * This method retrieves the online event link for a user who is attending an event

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -29,6 +29,7 @@ use GatherPress\Core\Venue\Map\Setup as Map_Setup;
 use stdClass;
 use WP_Block_Patterns_Registry;
 use WP_Post;
+use WP_Term;
 
 /**
  * Class Setup.
@@ -48,6 +49,20 @@ final class Setup {
 	 * Enforces a single instance of this class.
 	 */
 	use Singleton;
+
+	/**
+	 * Term slug marking an event as online rather than at a venue.
+	 *
+	 * A sentinel term in the venue taxonomy, not a shadow term for a venue
+	 * post, which is why it carries no leading underscore and why
+	 * {@see self::is_venue_term_slug()} deliberately excludes it. Declared here
+	 * so the slug has one home instead of being repeated at every call site.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @var string
+	 */
+	const ONLINE_EVENT_TERM_SLUG = 'online-event';
 
 	/**
 	 * Class constructor.
@@ -164,6 +179,10 @@ final class Setup {
 		}
 
 		$settings['gatherpress']['config']['venuePostTypes'] = $this->get_venue_post_type_map();
+
+		// Resolved once here so editor components stop each running their own
+		// getEntityRecords lookup for the same sentinel term.
+		$settings['gatherpress']['config']['onlineEventTermId'] = $this->get_online_event_term_id();
 
 		return $settings;
 	}
@@ -471,7 +490,7 @@ final class Setup {
 			$venue_terms = get_the_terms( $post_id, $this->taxonomy_for_event_post_type( $post_type ) );
 			$venue_slug  = ( is_array( $venue_terms ) && ! empty( $venue_terms ) ) ? $venue_terms[0]->slug : null;
 
-			$venue_meta['isOnlineEventTerm'] = ( 'online-event' === $venue_slug );
+			$venue_meta['isOnlineEventTerm'] = self::ONLINE_EVENT_TERM_SLUG === $venue_slug;
 			$venue_meta['onlineEventLink']   = $event->maybe_get_online_event_link();
 
 			$venue_post = $this->get_venue_post_from_event_post_id( $post_id );
@@ -569,6 +588,49 @@ final class Setup {
 	 */
 	public function is_venue_term_slug( string $slug ): bool {
 		return Shadow_Source::get_instance()->is_shadow_term_slug( $slug );
+	}
+
+	/**
+	 * Returns true when `$slug` is the online-event sentinel term slug.
+	 *
+	 * The counterpart to {@see self::is_venue_term_slug()}: that one answers
+	 * "is this a venue", this one answers "is this the online marker", and the
+	 * two are deliberately mutually exclusive.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param string $slug The term slug to test.
+	 *
+	 * @return bool
+	 */
+	public function is_online_event_term_slug( string $slug ): bool {
+		return self::ONLINE_EVENT_TERM_SLUG === $slug;
+	}
+
+	/**
+	 * Term ID of the online-event sentinel in an event post type's venue taxonomy.
+	 *
+	 * Every call site that needed this was resolving the term by slug itself.
+	 * Returns null when the term does not exist yet, which is the state between
+	 * plugin activation and {@see \GatherPress\Core\Setup::add_online_event_term()}
+	 * running, rather than a failure worth an error.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param string $event_post_type Optional. Event post type whose venue taxonomy to look in.
+	 *
+	 * @return int|null The term ID, or null when the term is absent.
+	 */
+	public function get_online_event_term_id( string $event_post_type = '' ): ?int {
+		$taxonomy = $this->taxonomy_for_event_post_type( $event_post_type );
+
+		if ( empty( $taxonomy ) ) {
+			return null;
+		}
+
+		$term = get_term_by( 'slug', self::ONLINE_EVENT_TERM_SLUG, $taxonomy );
+
+		return ( $term instanceof WP_Term ) ? (int) $term->term_id : null;
 	}
 
 	/**

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -622,13 +622,10 @@ final class Setup {
 	 * @return int|null The term ID, or null when the term is absent.
 	 */
 	public function get_online_event_term_id( string $event_post_type = '' ): ?int {
+		// Always a taxonomy name: an unmapped event post type falls back to the
+		// built-in venue post type, so there is no empty case to guard.
 		$taxonomy = $this->taxonomy_for_event_post_type( $event_post_type );
-
-		if ( empty( $taxonomy ) ) {
-			return null;
-		}
-
-		$term = get_term_by( 'slug', self::ONLINE_EVENT_TERM_SLUG, $taxonomy );
+		$term     = get_term_by( 'slug', self::ONLINE_EVENT_TERM_SLUG, $taxonomy );
 
 		return ( $term instanceof WP_Term ) ? (int) $term->term_id : null;
 	}

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -14,10 +14,12 @@ use GatherPress\Core\Event\Event;
 use GatherPress\Core\Rsvp\Rsvp;
 use GatherPress\Core\Setup;
 use GatherPress\Core\Venue;
+use GatherPress\Core\Venue\Setup as Venue_Setup;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 use ReflectionClass;
 use WP_Post;
+use WP_Term;
 
 /**
  * Class Test_Event.
@@ -1247,5 +1249,61 @@ class Test_Event extends Base {
 
 		$this->assertFalse( $event->is_online(), 'is_online should bail without a post.' );
 		$this->assertFalse( $event->set_online( true ), 'set_online should bail without a post.' );
+	}
+
+	/**
+	 * An event carrying a venue term is not online: the loop has to read every
+	 * term before it can answer, rather than treating any term as the sentinel.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @covers ::is_online
+	 *
+	 * @return void
+	 */
+	public function test_is_online_is_false_with_a_venue_term(): void {
+		$post     = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+		$taxonomy = Venue_Setup::get_instance()->taxonomy_for_event_post_type( Event::POST_TYPE );
+		$term     = wp_insert_term( 'Some Venue', $taxonomy, array( 'slug' => '_some-venue' ) );
+
+		wp_set_object_terms( $post->ID, (int) $term['term_id'], $taxonomy );
+
+		$this->assertFalse(
+			( new Event( $post->ID ) )->is_online(),
+			'An event tagged with a venue should not report as online.'
+		);
+	}
+
+	/**
+	 * Before the online-event term exists there is nothing to tag the event
+	 * with, so set_online reports failure rather than storing a link that
+	 * nothing can read back.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @covers ::set_online
+	 *
+	 * @return void
+	 */
+	public function test_set_online_is_false_without_the_sentinel_term(): void {
+		$venue_setup = Venue_Setup::get_instance();
+		$taxonomy    = $venue_setup->taxonomy_for_event_post_type( Event::POST_TYPE );
+		$existing    = get_term_by( 'slug', Venue_Setup::ONLINE_EVENT_TERM_SLUG, $taxonomy );
+
+		if ( $existing instanceof WP_Term ) {
+			wp_delete_term( $existing->term_id, $taxonomy );
+		}
+
+		$post = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+
+		$this->assertFalse(
+			( new Event( $post->ID ) )->set_online( true, 'https://example.org/room' ),
+			'An event should not be markable online while the sentinel term is absent.'
+		);
+		$this->assertSame(
+			'',
+			get_post_meta( $post->ID, 'gatherpress_online_event_link', true ),
+			'No link should be stored when the term cannot be resolved.'
+		);
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -12,6 +12,7 @@ use DateTime;
 use DateTimeZone;
 use GatherPress\Core\Event\Event;
 use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Setup;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
@@ -1137,5 +1138,114 @@ class Test_Event extends Base {
 
 		$this->assertNull( $event->event, 'Failed to assert event is null for non-event post.' );
 		$this->assertNull( $event->rsvp, 'Failed to assert rsvp is null for non-event post.' );
+	}
+
+	/**
+	 * Coverage for is_online on an event with no venue terms at all.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @covers ::is_online
+	 *
+	 * @return void
+	 */
+	public function test_is_online_is_false_without_terms(): void {
+		$post  = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+		$event = new Event( $post->ID );
+
+		$this->assertFalse(
+			$event->is_online(),
+			'An event with no venue terms should not report as online.'
+		);
+	}
+
+	/**
+	 * Coverage for set_online and is_online together: the term and the link move
+	 * as one, and turning it off clears both.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @covers ::set_online
+	 * @covers ::is_online
+	 *
+	 * @return void
+	 */
+	public function test_set_online_owns_the_term_and_the_link(): void {
+		Setup::get_instance()->add_online_event_term();
+
+		$post  = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+		$event = new Event( $post->ID );
+
+		$this->assertTrue(
+			$event->set_online( true, 'https://example.org/room' ),
+			'Marking an event online should succeed.'
+		);
+		$this->assertTrue(
+			$event->is_online(),
+			'The event should report as online afterwards.'
+		);
+		$this->assertSame(
+			'https://example.org/room',
+			get_post_meta( $post->ID, 'gatherpress_online_event_link', true ),
+			'The link should be stored.'
+		);
+
+		$this->assertTrue(
+			$event->set_online( false ),
+			'Turning an event offline should succeed.'
+		);
+		$this->assertFalse(
+			$event->is_online(),
+			'The event should no longer report as online.'
+		);
+		$this->assertSame(
+			'',
+			get_post_meta( $post->ID, 'gatherpress_online_event_link', true ),
+			'The link should be cleared so a stale room URL is not left behind.'
+		);
+	}
+
+	/**
+	 * An online event without a link stores no link rather than an empty string
+	 * that later reads as a real value.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @covers ::set_online
+	 *
+	 * @return void
+	 */
+	public function test_set_online_without_a_link_stores_nothing(): void {
+		Setup::get_instance()->add_online_event_term();
+
+		$post  = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+		$event = new Event( $post->ID );
+
+		$event->set_online( true, 'https://example.org/room' );
+		$event->set_online( true );
+
+		$this->assertTrue( $event->is_online(), 'The event should still be online.' );
+		$this->assertSame(
+			'',
+			get_post_meta( $post->ID, 'gatherpress_online_event_link', true ),
+			'Re-marking online without a link should clear the previous one.'
+		);
+	}
+
+	/**
+	 * Both methods bail rather than fatal when the instance wraps no post.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @covers ::is_online
+	 * @covers ::set_online
+	 *
+	 * @return void
+	 */
+	public function test_online_methods_bail_without_a_post(): void {
+		$event = new Event( 0 );
+
+		$this->assertFalse( $event->is_online(), 'is_online should bail without a post.' );
+		$this->assertFalse( $event->set_online( true ), 'set_online should bail without a post.' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -1252,6 +1252,47 @@ class Test_Event extends Base {
 	}
 
 	/**
+	 * An event that has never been given datetimes reads every meta key as
+	 * empty and cannot compare two dates it does not have.
+	 *
+	 * The empty-datetime paths were only reached through the empty-params case
+	 * of the display-datetime provider, which depends on that test running
+	 * first and on nothing having warmed the datetime cache. This asserts them
+	 * directly instead.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @covers ::is_same_date
+	 * @covers ::get_gmt_datetime
+	 *
+	 * @return void
+	 */
+	public function test_is_same_date_is_false_without_datetimes(): void {
+		global $wpdb;
+
+		$post  = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+		$table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->delete( $table, array( 'post_id' => $post->ID ), array( '%d' ) );
+		delete_transient( sprintf( Event::DATETIME_CACHE_KEY, $post->ID ) );
+
+		foreach ( array( 'datetime_start', 'datetime_start_gmt', 'datetime_end', 'datetime_end_gmt' ) as $key ) {
+			delete_post_meta( $post->ID, sprintf( 'gatherpress_%s', $key ) );
+		}
+
+		$this->assertFalse(
+			( new Event( $post->ID ) )->is_same_date(),
+			'An event with no datetimes should not report the same date.'
+		);
+		$this->assertSame(
+			'',
+			( new Event( $post->ID ) )->get_datetime()['datetime_start'],
+			'Every empty datetime meta key should be skipped rather than stored.'
+		);
+	}
+
+	/**
 	 * An event carrying a venue term is not online: the loop has to read every
 	 * term before it can answer, rather than treating any term as the sentinel.
 	 *

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -1260,10 +1260,19 @@ class Test_Event extends Base {
 	 * first and on nothing having warmed the datetime cache. This asserts them
 	 * directly instead.
 	 *
+	 * Keep the get_datetime entry in the covers list below. PHPUnit treats
+	 * that list as a whitelist and throws away anything the test executes
+	 * outside it, so without the entry the skip-empty-key branch in
+	 * get_datetime() runs here but is credited to nobody. The only other test
+	 * that reaches that branch, test_get_datetime(), gets there by leaving a
+	 * fresh post's meta alone rather than by deleting it, which makes its
+	 * coverage depend on no earlier test having written defaults.
+	 *
 	 * @since 0.35.0
 	 *
 	 * @covers ::is_same_date
 	 * @covers ::get_gmt_datetime
+	 * @covers ::get_datetime
 	 *
 	 * @return void
 	 */
@@ -1285,11 +1294,15 @@ class Test_Event extends Base {
 			( new Event( $post->ID ) )->is_same_date(),
 			'An event with no datetimes should not report the same date.'
 		);
-		$this->assertSame(
-			'',
-			( new Event( $post->ID ) )->get_datetime()['datetime_start'],
-			'Every empty datetime meta key should be skipped rather than stored.'
-		);
+		$datetime = ( new Event( $post->ID ) )->get_datetime();
+
+		foreach ( array( 'datetime_start', 'datetime_start_gmt', 'datetime_end', 'datetime_end_gmt' ) as $key ) {
+			$this->assertSame(
+				'',
+				$datetime[ $key ],
+				sprintf( 'Empty %s meta should be skipped rather than stored.', $key )
+			);
+		}
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-setup.php
@@ -11,9 +11,11 @@ namespace GatherPress\Tests\Core\Venue;
 use GatherPress\Core\Event;
 use GatherPress\Core\Venue\Map\Setup as Map_Setup;
 use GatherPress\Core\Venue\Meta;
+use GatherPress\Core\Setup as Core_Setup;
 use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
+use WP_Term;
 use PMC\Unit_Test\Utility;
 use WP_Block_Patterns_Registry;
 
@@ -1309,6 +1311,92 @@ class Test_Setup extends Base {
 			array( 'gatherpress_event' ),
 			$passthrough,
 			'Filter callback should pass through unchanged for non-venue sources.'
+		);
+	}
+
+	/**
+	 * The online-event sentinel predicate is the counterpart to
+	 * is_venue_term_slug, and the two are mutually exclusive.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @covers ::is_online_event_term_slug
+	 *
+	 * @return void
+	 */
+	public function test_is_online_event_term_slug(): void {
+		$instance = Setup::get_instance();
+
+		$this->assertTrue(
+			$instance->is_online_event_term_slug( Setup::ONLINE_EVENT_TERM_SLUG ),
+			'The sentinel slug should be recognized.'
+		);
+		$this->assertFalse(
+			$instance->is_online_event_term_slug( '_a-venue' ),
+			'A shadow venue term slug is not the online sentinel.'
+		);
+		$this->assertFalse(
+			$instance->is_venue_term_slug( Setup::ONLINE_EVENT_TERM_SLUG ),
+			'The online sentinel is not a venue term.'
+		);
+	}
+
+	/**
+	 * The term ID helper resolves the sentinel once the term exists, and reports
+	 * null rather than failing before it does.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @covers ::get_online_event_term_id
+	 *
+	 * @return void
+	 */
+	public function test_get_online_event_term_id(): void {
+		$instance = Setup::get_instance();
+		$taxonomy = $instance->taxonomy_for_event_post_type( Event::POST_TYPE );
+
+		$existing = get_term_by( 'slug', Setup::ONLINE_EVENT_TERM_SLUG, $taxonomy );
+
+		if ( $existing instanceof WP_Term ) {
+			wp_delete_term( $existing->term_id, $taxonomy );
+		}
+
+		$this->assertNull(
+			$instance->get_online_event_term_id( Event::POST_TYPE ),
+			'The helper should report null while the sentinel term is absent.'
+		);
+
+		Core_Setup::get_instance()->add_online_event_term();
+
+		$term_id = $instance->get_online_event_term_id( Event::POST_TYPE );
+
+		$this->assertIsInt( $term_id, 'The helper should resolve the sentinel term ID.' );
+		$this->assertSame(
+			Setup::ONLINE_EVENT_TERM_SLUG,
+			get_term( $term_id, $taxonomy )->slug,
+			'The resolved term should be the online sentinel.'
+		);
+	}
+
+	/**
+	 * The resolved sentinel term ID reaches the block editor settings, so editor
+	 * components stop looking it up one by one.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @covers ::add_editor_settings
+	 *
+	 * @return void
+	 */
+	public function test_add_editor_settings_exposes_online_event_term_id(): void {
+		Core_Setup::get_instance()->add_online_event_term();
+
+		$settings = Setup::get_instance()->add_editor_settings( array() );
+
+		$this->assertSame(
+			Setup::get_instance()->get_online_event_term_id( Event::POST_TYPE ),
+			$settings['gatherpress']['config']['onlineEventTermId'],
+			'Editor settings should carry the resolved online-event term ID.'
 		);
 	}
 }


### PR DESCRIPTION
Fixes #2047 (parts 1 and 2)

## Proposed changes:

Part 1, the missing getter and setter on `Event`:

* `is_online(): bool` reads the online-event term directly. Distinct from `maybe_get_online_event_link()`, which answers "should this visitor see the link right now" rather than "is this event online".
* `set_online( bool $is_online, string $link = '' ): bool` owns the term and the link meta together. Marking an event online sets the term and stores the link; turning it off removes the term and deletes the link, so a room URL is not left behind on an event that moved to a venue. Re-marking online without a link clears the old one rather than leaving a stale value under a new setting.

Part 2, the slug:

* `Venue\Setup::ONLINE_EVENT_TERM_SLUG`, so the literal has one home.
* `is_online_event_term_slug()`, symmetric with the existing `is_venue_term_slug()`. The two are deliberately mutually exclusive, which the tests assert.
* `get_online_event_term_id( string $event_post_type = '' ): ?int`. Returns null while the sentinel term does not exist yet, which is the ordinary state between activation and `add_online_event_term()` running, not an error.
* The resolved term ID rides along in the editor settings that already carry `venuePostTypes`, as `onlineEventTermId`, so components can stop each running their own `getEntityRecords` lookup for the same term.
* The three PHP call sites that had the literal now use the constant.

Part 3 is deliberately untouched: the issue asks for the `is_online` REST representation to be settled before anyone writes it, and I agree a registered field reading through to the term beats duplicating the state in meta.

The JS literals listed in the issue are also left for a follow-up. `onlineEventTermId` is what those six call sites need, and swapping them is a separate, mechanical change that deserves its own review rather than riding along here.

This is what [WordPress/wordcamp.org#1825](https://github.com/WordPress/wordcamp.org/issues/1825) is waiting on, so the groups site can drop its own term-plus-meta coordination.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

4 tests on `Test_Event` for the getter and setter: no terms, the full online / offline round trip including link clearing, online without a link, and both methods bailing when the instance wraps no post. 3 on `Venue\Test_Setup` for the predicate, the term-ID resolver in both its states, and the editor settings exposure.

`Venue\Test_Setup` is `@group multisite`, so those three only run in the multisite suite. Local runs of both: single-site 1651 tests, multisite 326 tests, in each case with exactly the same failures a clean `develop` produces in my environment (27 and 2, all from the missing `gatherpress_events` table and `wp_`-prefix expectations). PHPCS and PHPStan clean.

## Testing instructions:

1. On an event with no venue, run `( new \GatherPress\Core\Event\Event( $id ) )->is_online()` and confirm `false`.
2. Call `set_online( true, 'https://meet.example.org/room' )`. The event now carries the `online-event` term, `gatherpress_online_event_link` holds the URL, and `is_online()` is `true`. The Online Event block renders the link as before.
3. Call `set_online( false )`. The term is gone, the link meta is deleted, and `is_online()` is `false`.
4. `Venue\Setup::get_instance()->get_online_event_term_id()` returns the term ID, and `is_online_event_term_slug( 'online-event' )` is `true` while `is_venue_term_slug( 'online-event' )` stays `false`.
5. In the editor, `wp.data.select( 'core/editor' ).getEditorSettings().gatherpress.config.onlineEventTermId` is that same ID.

Verified on WP 7.0.2 / PHP 8.2.29 with 0.35.0-beta.1:

```
term id helper: 2
is_online_event_term_slug(online-event): true   is_online_event_term_slug(_a-venue): false
before: is_online=false
after set_online(true):  is_online=true  link=https://meet.example.org/beta-room  terms: online-event
after set_online(false): is_online=false link=""                                  terms: (none)
```

No notices with `WP_DEBUG_LOG` on.

Props motylanogha
