### PR TITLE
Cache the iCalendar responses and answer conditional requests

### DIFF
--- a/.github/changelog/1682-calendar-caching
+++ b/.github/changelog/1682-calendar-caching
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Added caching to the iCalendar responses. Feeds and single-event .ics files now send `Cache-Control`, `ETag` and `Last-Modified`, answer conditional requests with `304 Not Modified`, and keep their rendered body in the object cache. Subscribed calendar clients poll several times an hour, so a poll that finds nothing changed now costs a validator instead of a full rebuild. A change to any event, venue, GatherPress meta or event term invalidates every cached calendar, and `gatherpress_calendar_max_age` controls the window (0 disables caching).
+Added caching to the iCalendar responses. Feeds and single-event .ics files now send `Cache-Control`, `ETag` and `Last-Modified`, answer conditional requests with `304 Not Modified`, and keep their rendered body in a transient. Subscribed calendar clients poll several times an hour, so a poll that finds nothing changed now costs a validator instead of a full rebuild. A change to any event, venue, GatherPress meta or event term moves every cached calendar to a fresh key, and `gatherpress_calendar_max_age` controls the window (0 disables caching).

--- a/.github/changelog/1682-calendar-caching
+++ b/.github/changelog/1682-calendar-caching
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added caching to the iCalendar responses. Feeds and single-event .ics files now send `Cache-Control`, `ETag` and `Last-Modified`, answer conditional requests with `304 Not Modified`, and keep their rendered body in the object cache. Subscribed calendar clients poll several times an hour, so a poll that finds nothing changed now costs a validator instead of a full rebuild. A change to any event, venue, GatherPress meta or event term invalidates every cached calendar, and `gatherpress_calendar_max_age` controls the window (0 disables caching).

--- a/includes/core/classes/calendar/class-cache.php
+++ b/includes/core/classes/calendar/class-cache.php
@@ -10,7 +10,7 @@
  * the responses are validated against.
  *
  * @package GatherPress\Core\Calendar
- * @since 0.35.0
+ * @since 0.36.0
  */
 
 namespace GatherPress\Core\Calendar;
@@ -31,7 +31,7 @@ use GatherPress\Core\Traits\Singleton;
  * against, so the HTTP layer and the object cache cannot disagree about how
  * fresh a response is.
  *
- * @since 0.35.0
+ * @since 0.36.0
  */
 final class Cache {
 
@@ -43,7 +43,7 @@ final class Cache {
 	/**
 	 * Object cache group for rendered calendar payloads.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @var string
 	 */
@@ -52,7 +52,7 @@ final class Cache {
 	/**
 	 * Option holding the GMT timestamp of the last calendar-relevant change.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @var string
 	 */
@@ -65,7 +65,7 @@ final class Cache {
 	 * use by default, so a subscriber's next poll is usually a conditional
 	 * request that costs a 304 rather than a full render.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @var int
 	 */
@@ -76,7 +76,7 @@ final class Cache {
 	 *
 	 * This method initializes the object and sets up necessary hooks.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 */
 	protected function __construct() {
 		$this->setup_hooks();
@@ -87,7 +87,7 @@ final class Cache {
 	 *
 	 * This method adds hooks for different purposes as needed.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @return void
 	 */
@@ -106,7 +106,7 @@ final class Cache {
 	/**
 	 * Seconds a client may reuse a calendar response without revalidating.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @return int Max age in seconds. Zero disables client caching.
 	 */
@@ -118,7 +118,7 @@ final class Cache {
 		 * a rendered body is kept in the object cache, so the two cannot drift.
 		 * Return 0 to send `no-cache` and rebuild on every request.
 		 *
-		 * @since 0.35.0
+		 * @since 0.36.0
 		 *
 		 * @param int $max_age Seconds a calendar response stays fresh.
 		 *
@@ -134,7 +134,7 @@ final class Cache {
 	 * has a stable validator to hand out, rather than one that moves on every
 	 * request and defeats the point.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @return string Timestamp in `Y-m-d H:i:s` GMT.
 	 */
@@ -153,7 +153,7 @@ final class Cache {
 	/**
 	 * Stamp the calendar as changed, invalidating every cached response.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @return void
 	 */
@@ -164,7 +164,7 @@ final class Cache {
 	/**
 	 * Return a cached calendar payload, rendering it on a miss.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @param string   $key      Cache key, unique to the request's scope.
 	 * @param callable $renderer Builds the payload when the cache misses.
@@ -195,7 +195,7 @@ final class Cache {
 	/**
 	 * Namespace a cache key with the current calendar version stamp.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @param string $key Scope-specific key.
 	 *
@@ -208,7 +208,7 @@ final class Cache {
 	/**
 	 * Stamp the calendar when an event or venue post changes.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @param int|string $post_id The post that changed.
 	 *
@@ -227,7 +227,7 @@ final class Cache {
 	 * written without touching the post row, so `save_post` alone would miss
 	 * them.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @param int|string $meta_id  Meta row ID (unused; part of the hook signature).
 	 * @param int|string $post_id  The post the meta belongs to.
@@ -252,7 +252,7 @@ final class Cache {
 	 * Venue association and topics decide which feeds an event appears in, and
 	 * term writes do not touch the post row either.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @param int|string $object_id  The object whose terms changed.
 	 * @param array      $terms      Terms set (unused; part of the hook signature).
@@ -278,7 +278,7 @@ final class Cache {
 	/**
 	 * Whether a post type contributes to calendar output.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @param string $post_type The post type to test.
 	 *

--- a/includes/core/classes/calendar/class-cache.php
+++ b/includes/core/classes/calendar/class-cache.php
@@ -9,6 +9,11 @@
  * defines the `Cache` class, which holds the rendered bodies and the timestamp
  * the responses are validated against.
  *
+ * Bodies are stored as transients rather than in the object cache directly, so
+ * the win does not depend on the site having a persistent backend: with one,
+ * transients are object cache entries anyway; without one, they persist in the
+ * options table instead of evaporating at the end of the request.
+ *
  * @package GatherPress\Core\Calendar
  * @since 0.36.0
  */
@@ -23,13 +28,17 @@ use GatherPress\Core\Traits\Singleton;
 /**
  * Caching for the iCalendar responses.
  *
- * Invalidation is by version stamp rather than by deleting keys. Every cache
- * key carries the timestamp of the last calendar-relevant change, so a change
- * is one option write and every stale key is unreachable from that moment,
- * with no need to know which feeds a given event appeared in. The stamp is
- * also what `Last-Modified` reports and what conditional requests validate
- * against, so the HTTP layer and the object cache cannot disagree about how
- * fresh a response is.
+ * Entries are namespaced by version stamp rather than deleted. Every cache key
+ * carries the timestamp of the last calendar-relevant change, so a change is
+ * one option write and every previous key becomes unreachable from that moment,
+ * with no need to know which feeds a given event appeared in. The old entries
+ * are not removed: they are stranded until their expiry passes, at which point
+ * WordPress's own expired-transient cleanup collects them. That trade buys
+ * O(1) invalidation on backends that handle delete-by-pattern badly.
+ *
+ * The stamp is also what `Last-Modified` reports and what conditional requests
+ * validate against, so the HTTP layer and the stored bodies cannot disagree
+ * about how fresh a response is.
  *
  * @since 0.36.0
  */
@@ -41,13 +50,13 @@ final class Cache {
 	use Singleton;
 
 	/**
-	 * Object cache group for rendered calendar payloads.
+	 * Transient name prefix for rendered calendar payloads.
 	 *
 	 * @since 0.36.0
 	 *
 	 * @var string
 	 */
-	const CACHE_GROUP = 'gatherpress_calendar';
+	const TRANSIENT_PREFIX = 'gatherpress_calendar_';
 
 	/**
 	 * Option holding the GMT timestamp of the last calendar-relevant change.
@@ -95,12 +104,12 @@ final class Cache {
 		// Everything a VEVENT is built from: the post itself, its datetimes and
 		// venue meta, its terms, and its deletion. Each one stamps the calendar
 		// rather than reasoning about which feeds it belongs to.
-		add_action( 'save_post', array( $this, 'touch_for_post' ) );
-		add_action( 'deleted_post', array( $this, 'touch_for_post' ) );
-		add_action( 'updated_post_meta', array( $this, 'touch_for_meta' ), 10, 3 );
-		add_action( 'added_post_meta', array( $this, 'touch_for_meta' ), 10, 3 );
-		add_action( 'deleted_post_meta', array( $this, 'touch_for_meta' ), 10, 3 );
-		add_action( 'set_object_terms', array( $this, 'touch_for_terms' ), 10, 4 );
+		add_action( 'save_post', array( $this, 'mark_changed_for_post' ) );
+		add_action( 'deleted_post', array( $this, 'mark_changed_for_post' ) );
+		add_action( 'updated_post_meta', array( $this, 'mark_changed_for_meta' ), 10, 3 );
+		add_action( 'added_post_meta', array( $this, 'mark_changed_for_meta' ), 10, 3 );
+		add_action( 'deleted_post_meta', array( $this, 'mark_changed_for_meta' ), 10, 3 );
+		add_action( 'set_object_terms', array( $this, 'mark_changed_for_terms' ), 10, 4 );
 	}
 
 	/**
@@ -115,7 +124,7 @@ final class Cache {
 		 * Filters how long calendar responses may be reused by clients and caches.
 		 *
 		 * Applies to the `Cache-Control` header on ICS responses and to how long
-		 * a rendered body is kept in the object cache, so the two cannot drift.
+		 * a rendered body is kept server-side, so the two cannot drift.
 		 * Return 0 to send `no-cache` and rebuild on every request.
 		 *
 		 * @since 0.36.0
@@ -151,13 +160,16 @@ final class Cache {
 	}
 
 	/**
-	 * Stamp the calendar as changed, invalidating every cached response.
+	 * Stamp the calendar as changed.
+	 *
+	 * Cached responses are namespaced by this stamp, so a new value moves every
+	 * lookup to a fresh key and strands the old entries until they expire.
 	 *
 	 * @since 0.36.0
 	 *
 	 * @return void
 	 */
-	public function touch(): void {
+	public function mark_changed(): void {
 		update_option( self::LAST_MODIFIED_OPTION, current_time( 'mysql', true ), false );
 	}
 
@@ -179,7 +191,7 @@ final class Cache {
 		}
 
 		$versioned_key = $this->get_versioned_key( $key );
-		$cached        = wp_cache_get( $versioned_key, self::CACHE_GROUP );
+		$cached        = get_transient( $versioned_key );
 
 		if ( is_string( $cached ) ) {
 			return $cached;
@@ -187,7 +199,7 @@ final class Cache {
 
 		$payload = (string) $renderer();
 
-		wp_cache_set( $versioned_key, $payload, self::CACHE_GROUP, $max_age );
+		set_transient( $versioned_key, $payload, $max_age );
 
 		return $payload;
 	}
@@ -195,14 +207,18 @@ final class Cache {
 	/**
 	 * Namespace a cache key with the current calendar version stamp.
 	 *
+	 * The scope key and the stamp are hashed together rather than concatenated
+	 * so the result stays inside the 172-character ceiling on option names, no
+	 * matter how long the caller's key grows.
+	 *
 	 * @since 0.36.0
 	 *
 	 * @param string $key Scope-specific key.
 	 *
-	 * @return string Versioned cache key.
+	 * @return string Versioned transient name.
 	 */
 	public function get_versioned_key( string $key ): string {
-		return sprintf( '%s:%s', md5( $this->get_last_modified() ), $key );
+		return self::TRANSIENT_PREFIX . md5( $this->get_last_modified() . ':' . $key );
 	}
 
 	/**
@@ -214,9 +230,9 @@ final class Cache {
 	 *
 	 * @return void
 	 */
-	public function touch_for_post( $post_id ): void {
+	public function mark_changed_for_post( $post_id ): void {
 		if ( $this->is_calendar_post_type( (string) get_post_type( (int) $post_id ) ) ) {
-			$this->touch();
+			$this->mark_changed();
 		}
 	}
 
@@ -237,12 +253,12 @@ final class Cache {
 	 *
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) Required by WP's *_post_meta signature.
 	 */
-	public function touch_for_meta( $meta_id, $post_id, $meta_key = '' ): void {
+	public function mark_changed_for_meta( $meta_id, $post_id, $meta_key = '' ): void {
 		if (
 			str_starts_with( (string) $meta_key, 'gatherpress_' )
 			&& $this->is_calendar_post_type( (string) get_post_type( (int) $post_id ) )
 		) {
-			$this->touch();
+			$this->mark_changed();
 		}
 	}
 
@@ -263,7 +279,7 @@ final class Cache {
 	 *
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) Required by WP's set_object_terms signature.
 	 */
-	public function touch_for_terms( $object_id, $terms = array(), $tt_ids = array(), $taxonomy = '' ): void {
+	public function mark_changed_for_terms( $object_id, $terms = array(), $tt_ids = array(), $taxonomy = '' ): void {
 		// Comment taxonomies share this hook: RSVP status changes do not alter
 		// a VEVENT, so they must not invalidate every feed on the site.
 		$taxonomy_object = get_taxonomy( (string) $taxonomy );
@@ -272,7 +288,7 @@ final class Cache {
 			return;
 		}
 
-		$this->touch_for_post( $object_id );
+		$this->mark_changed_for_post( $object_id );
 	}
 
 	/**

--- a/includes/core/classes/calendar/class-cache.php
+++ b/includes/core/classes/calendar/class-cache.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Caching for the iCalendar responses.
+ *
+ * Calendar clients subscribe to ICS feeds and poll them on their own schedule:
+ * Outlook every 15 to 60 minutes, Apple Calendar as often as every 5 minutes,
+ * Google Calendar daily. Every one of those hits rebuilt the whole payload,
+ * event by event, to return bytes that had usually not changed. This file
+ * defines the `Cache` class, which holds the rendered bodies and the timestamp
+ * the responses are validated against.
+ *
+ * @package GatherPress\Core\Calendar
+ * @since 0.35.0
+ */
+
+namespace GatherPress\Core\Calendar;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use GatherPress\Core\Traits\Singleton;
+
+/**
+ * Caching for the iCalendar responses.
+ *
+ * Invalidation is by version stamp rather than by deleting keys. Every cache
+ * key carries the timestamp of the last calendar-relevant change, so a change
+ * is one option write and every stale key is unreachable from that moment,
+ * with no need to know which feeds a given event appeared in. The stamp is
+ * also what `Last-Modified` reports and what conditional requests validate
+ * against, so the HTTP layer and the object cache cannot disagree about how
+ * fresh a response is.
+ *
+ * @since 0.35.0
+ */
+final class Cache {
+
+	/**
+	 * Enforces a single instance of this class.
+	 */
+	use Singleton;
+
+	/**
+	 * Object cache group for rendered calendar payloads.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @var string
+	 */
+	const CACHE_GROUP = 'gatherpress_calendar';
+
+	/**
+	 * Option holding the GMT timestamp of the last calendar-relevant change.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @var string
+	 */
+	const LAST_MODIFIED_OPTION = 'gatherpress_calendar_last_modified';
+
+	/**
+	 * Default seconds a client may reuse a calendar response without asking.
+	 *
+	 * Fifteen minutes matches the shortest polling interval the common clients
+	 * use by default, so a subscriber's next poll is usually a conditional
+	 * request that costs a 304 rather than a full render.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @var int
+	 */
+	const DEFAULT_MAX_AGE = 15 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Class constructor.
+	 *
+	 * This method initializes the object and sets up necessary hooks.
+	 *
+	 * @since 0.35.0
+	 */
+	protected function __construct() {
+		$this->setup_hooks();
+	}
+
+	/**
+	 * Set up hooks for various purposes.
+	 *
+	 * This method adds hooks for different purposes as needed.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return void
+	 */
+	protected function setup_hooks(): void {
+		// Everything a VEVENT is built from: the post itself, its datetimes and
+		// venue meta, its terms, and its deletion. Each one stamps the calendar
+		// rather than reasoning about which feeds it belongs to.
+		add_action( 'save_post', array( $this, 'touch_for_post' ) );
+		add_action( 'deleted_post', array( $this, 'touch_for_post' ) );
+		add_action( 'updated_post_meta', array( $this, 'touch_for_meta' ), 10, 3 );
+		add_action( 'added_post_meta', array( $this, 'touch_for_meta' ), 10, 3 );
+		add_action( 'deleted_post_meta', array( $this, 'touch_for_meta' ), 10, 3 );
+		add_action( 'set_object_terms', array( $this, 'touch_for_terms' ), 10, 4 );
+	}
+
+	/**
+	 * Seconds a client may reuse a calendar response without revalidating.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return int Max age in seconds. Zero disables client caching.
+	 */
+	public function get_max_age(): int {
+		/**
+		 * Filters how long calendar responses may be reused by clients and caches.
+		 *
+		 * Applies to the `Cache-Control` header on ICS responses and to how long
+		 * a rendered body is kept in the object cache, so the two cannot drift.
+		 * Return 0 to send `no-cache` and rebuild on every request.
+		 *
+		 * @since 0.35.0
+		 *
+		 * @param int $max_age Seconds a calendar response stays fresh.
+		 *
+		 * @return int Seconds a calendar response stays fresh.
+		 */
+		return max( 0, (int) apply_filters( 'gatherpress_calendar_max_age', self::DEFAULT_MAX_AGE ) );
+	}
+
+	/**
+	 * GMT timestamp of the last calendar-relevant change.
+	 *
+	 * Seeds itself on first read so a site that has never edited an event still
+	 * has a stable validator to hand out, rather than one that moves on every
+	 * request and defeats the point.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return string Timestamp in `Y-m-d H:i:s` GMT.
+	 */
+	public function get_last_modified(): string {
+		$last_modified = (string) get_option( self::LAST_MODIFIED_OPTION, '' );
+
+		if ( '' === $last_modified ) {
+			$last_modified = current_time( 'mysql', true );
+
+			update_option( self::LAST_MODIFIED_OPTION, $last_modified, false );
+		}
+
+		return $last_modified;
+	}
+
+	/**
+	 * Stamp the calendar as changed, invalidating every cached response.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return void
+	 */
+	public function touch(): void {
+		update_option( self::LAST_MODIFIED_OPTION, current_time( 'mysql', true ), false );
+	}
+
+	/**
+	 * Return a cached calendar payload, rendering it on a miss.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param string   $key      Cache key, unique to the request's scope.
+	 * @param callable $renderer Builds the payload when the cache misses.
+	 *
+	 * @return string The rendered payload.
+	 */
+	public function remember( string $key, callable $renderer ): string {
+		$max_age = $this->get_max_age();
+
+		if ( 0 === $max_age ) {
+			return (string) $renderer();
+		}
+
+		$versioned_key = $this->get_versioned_key( $key );
+		$cached        = wp_cache_get( $versioned_key, self::CACHE_GROUP );
+
+		if ( is_string( $cached ) ) {
+			return $cached;
+		}
+
+		$payload = (string) $renderer();
+
+		wp_cache_set( $versioned_key, $payload, self::CACHE_GROUP, $max_age );
+
+		return $payload;
+	}
+
+	/**
+	 * Namespace a cache key with the current calendar version stamp.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param string $key Scope-specific key.
+	 *
+	 * @return string Versioned cache key.
+	 */
+	public function get_versioned_key( string $key ): string {
+		return sprintf( '%s:%s', md5( $this->get_last_modified() ), $key );
+	}
+
+	/**
+	 * Stamp the calendar when an event or venue post changes.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param int|string $post_id The post that changed.
+	 *
+	 * @return void
+	 */
+	public function touch_for_post( $post_id ): void {
+		if ( $this->is_calendar_post_type( (string) get_post_type( (int) $post_id ) ) ) {
+			$this->touch();
+		}
+	}
+
+	/**
+	 * Stamp the calendar when GatherPress meta on a calendar post changes.
+	 *
+	 * Datetimes and venue details are read while building a VEVENT but are
+	 * written without touching the post row, so `save_post` alone would miss
+	 * them.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param int|string $meta_id  Meta row ID (unused; part of the hook signature).
+	 * @param int|string $post_id  The post the meta belongs to.
+	 * @param string     $meta_key The meta key that changed.
+	 *
+	 * @return void
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) Required by WP's *_post_meta signature.
+	 */
+	public function touch_for_meta( $meta_id, $post_id, $meta_key = '' ): void {
+		if (
+			str_starts_with( (string) $meta_key, 'gatherpress_' )
+			&& $this->is_calendar_post_type( (string) get_post_type( (int) $post_id ) )
+		) {
+			$this->touch();
+		}
+	}
+
+	/**
+	 * Stamp the calendar when a calendar post's terms change.
+	 *
+	 * Venue association and topics decide which feeds an event appears in, and
+	 * term writes do not touch the post row either.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param int|string $object_id  The object whose terms changed.
+	 * @param array      $terms      Terms set (unused; part of the hook signature).
+	 * @param array      $tt_ids     Term taxonomy IDs (unused; part of the hook signature).
+	 * @param string     $taxonomy   The taxonomy that changed.
+	 *
+	 * @return void
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) Required by WP's set_object_terms signature.
+	 */
+	public function touch_for_terms( $object_id, $terms = array(), $tt_ids = array(), $taxonomy = '' ): void {
+		// Comment taxonomies share this hook: RSVP status changes do not alter
+		// a VEVENT, so they must not invalidate every feed on the site.
+		$taxonomy_object = get_taxonomy( (string) $taxonomy );
+
+		if ( ! $taxonomy_object || in_array( 'comment', (array) $taxonomy_object->object_type, true ) ) {
+			return;
+		}
+
+		$this->touch_for_post( $object_id );
+	}
+
+	/**
+	 * Whether a post type contributes to calendar output.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param string $post_type The post type to test.
+	 *
+	 * @return bool True for event-bearing and venue post types.
+	 */
+	private function is_calendar_post_type( string $post_type ): bool {
+		return post_type_supports( $post_type, 'gatherpress-event-date' )
+			|| post_type_supports( $post_type, 'gatherpress-venue-information' );
+	}
+}

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -780,7 +780,7 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @since 0.35.0 Added `$etag` and `$last_modified` for cache validation.
+	 * @since 0.36.0 Added `$etag` and `$last_modified` for cache validation.
 	 *
 	 * @param string $filename      Generated name of the file.
 	 * @param string $etag          Optional. Entity tag for the body being sent.
@@ -829,7 +829,7 @@ final class Setup {
 	/**
 	 * Cached iCalendar body for the current request.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @return string The complete iCal payload.
 	 */
@@ -850,7 +850,7 @@ final class Setup {
 	 * Built from the resolved query rather than the request URI, so unknown
 	 * query parameters cannot fragment the cache into unbounded entries.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @return string Scope-specific cache key.
 	 */
@@ -879,7 +879,7 @@ final class Setup {
 	/**
 	 * ETag for an iCalendar body.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @param string $body The rendered iCal payload.
 	 *
@@ -896,7 +896,7 @@ final class Setup {
 	 * which is what RFC 9110 asks for: the entity tag is exact where the
 	 * timestamp has one-second resolution.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
 	 *
 	 * @param string $etag          Current entity tag.
 	 * @param string $last_modified Current GMT modification timestamp.

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -55,6 +55,8 @@ final class Setup {
 	 * @since 0.34.0
 	 */
 	public function __construct() {
+		Cache::get_instance();
+
 		$this->setup_hooks();
 	}
 
@@ -778,12 +780,17 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param string $filename Generated name of the file.
+	 * @since 0.35.0 Added `$etag` and `$last_modified` for cache validation.
+	 *
+	 * @param string $filename      Generated name of the file.
+	 * @param string $etag          Optional. Entity tag for the body being sent.
+	 * @param string $last_modified Optional. GMT timestamp of the last calendar change.
 	 *
 	 * @return void
 	 */
-	public function send_ics_headers( string $filename ): void {
+	public function send_ics_headers( string $filename, string $etag = '', string $last_modified = '' ): void {
 		$charset = strtolower( get_option( 'blog_charset' ) );
+		$max_age = Cache::get_instance()->get_max_age();
 
 		header( 'Content-Description: File Transfer' );
 
@@ -793,14 +800,137 @@ final class Setup {
 		// Force download in most browsers.
 		header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
 
-		// Avoid browser caching issues.
-		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
-		header( 'Cache-Control: post-check=0, pre-check=0', false );
-		header( 'Pragma: no-cache' );
-		header( 'Expires: 0' );
+		// Subscribed clients poll on their own schedule, several times an hour
+		// in Outlook's and Apple Calendar's defaults, so the response tells them
+		// how long it stays fresh and hands them validators to revalidate with.
+		// A site can opt out entirely by filtering the max age to 0.
+		if ( 0 < $max_age ) {
+			header( sprintf( 'Cache-Control: public, max-age=%d', $max_age ) );
+		} else {
+			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
+			header( 'Pragma: no-cache' );
+			header( 'Expires: 0' );
+		}
+
+		if ( '' !== $etag ) {
+			header( sprintf( 'ETag: %s', $etag ) );
+		}
+
+		if ( '' !== $last_modified ) {
+			$timestamp = (int) strtotime( $last_modified . ' GMT' );
+
+			header( sprintf( 'Last-Modified: %s GMT', gmdate( 'D, d M Y H:i:s', $timestamp ) ) );
+		}
 
 		// Prevent content sniffing which might lead to MIME type mismatch.
 		header( 'X-Content-Type-Options: nosniff' );
+	}
+
+	/**
+	 * Cached iCalendar body for the current request.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return string The complete iCal payload.
+	 */
+	public function get_ics_body(): string {
+		$is_feed = is_feed();
+
+		return Cache::get_instance()->remember(
+			$this->get_ics_cache_key(),
+			function () use ( $is_feed ): string {
+				return (string) ( $is_feed ? $this->get_ical_feed() : $this->get_ical_file() );
+			}
+		);
+	}
+
+	/**
+	 * Cache key describing what the current request asks for.
+	 *
+	 * Built from the resolved query rather than the request URI, so unknown
+	 * query parameters cannot fragment the cache into unbounded entries.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return string Scope-specific cache key.
+	 */
+	public function get_ics_cache_key(): string {
+		$queried_object = get_queried_object();
+		$scope          = array(
+			'feed'   => is_feed() ? 1 : 0,
+			'paged'  => (int) get_query_var( 'paged' ),
+			'object' => 0,
+			'type'   => '',
+		);
+
+		if ( $queried_object instanceof WP_Post ) {
+			$scope['object'] = (int) $queried_object->ID;
+			$scope['type']   = (string) $queried_object->post_type;
+		} elseif ( $queried_object instanceof WP_Term ) {
+			$scope['object'] = (int) $queried_object->term_id;
+			$scope['type']   = (string) $queried_object->taxonomy;
+		} elseif ( $queried_object instanceof WP_Post_Type ) {
+			$scope['type'] = (string) $queried_object->name;
+		}
+
+		return sprintf( 'ics:%s', md5( (string) wp_json_encode( $scope ) ) );
+	}
+
+	/**
+	 * ETag for an iCalendar body.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param string $body The rendered iCal payload.
+	 *
+	 * @return string Quoted entity tag, per RFC 9110.
+	 */
+	public function get_etag( string $body ): string {
+		return sprintf( '"%s"', md5( $body ) );
+	}
+
+	/**
+	 * Whether the client already holds this exact response.
+	 *
+	 * `If-None-Match` wins over `If-Modified-Since` when both are present,
+	 * which is what RFC 9110 asks for: the entity tag is exact where the
+	 * timestamp has one-second resolution.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param string $etag          Current entity tag.
+	 * @param string $last_modified Current GMT modification timestamp.
+	 *
+	 * @return bool True when a 304 is the correct answer.
+	 */
+	public function is_not_modified( string $etag, string $last_modified ): bool {
+		$client_etag = isset( $_SERVER['HTTP_IF_NONE_MATCH'] )
+			? sanitize_text_field( wp_unslash( $_SERVER['HTTP_IF_NONE_MATCH'] ) )
+			: '';
+
+		if ( '' !== $client_etag ) {
+			// A cache may return the tag weakened, and may hold several.
+			foreach ( explode( ',', str_replace( 'W/', '', $client_etag ) ) as $candidate ) {
+				if ( trim( $candidate ) === $etag ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		$client_time = isset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] )
+			? sanitize_text_field( wp_unslash( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) )
+			: '';
+
+		if ( '' === $client_time ) {
+			return false;
+		}
+
+		$client_timestamp = strtotime( $client_time );
+		$current          = strtotime( $last_modified . ' GMT' );
+
+		return false !== $client_timestamp && false !== $current && $client_timestamp >= $current;
 	}
 
 	/**
@@ -829,21 +959,31 @@ final class Setup {
 		// Prepare the filename.
 		$filename = $this->generate_ics_filename();
 
-		// Send headers for downloading the .ics file.
-		$this->send_ics_headers( $filename );
-
-		// Build the iCalendar content. The body is plain text per RFC 5545
-		// (not HTML), so HTML-sanitizers like `wp_kses_post()` are the wrong
-		// tool here — they would encode `&` into `&amp;` and produce broken
-		// .ics files. The TEXT-property values inside are already escaped at
-		// build time via `Calendar::escape_ical_text()` / sanitized via
+		// Build the iCalendar content before the headers now, because the ETag
+		// is a hash of the body. The body is plain text per RFC 5545 (not
+		// HTML), so HTML-sanitizers like `wp_kses_post()` are the wrong tool
+		// here — they would encode `&` into `&amp;` and produce broken .ics
+		// files. The TEXT-property values inside are already escaped at build
+		// time via `Calendar::escape_ical_text()` / sanitized via
 		// `sanitize_text_field()`.
-		$get_ical_method = ( is_feed() ) ? 'get_ical_feed' : 'get_ical_file';
-		$ics_content     = (string) $this->{$get_ical_method}();
-		$filesize        = strlen( $ics_content );
+		$ics_content   = $this->get_ics_body();
+		$etag          = $this->get_etag( $ics_content );
+		$last_modified = Cache::get_instance()->get_last_modified();
+
+		// A subscribed client that already holds this exact calendar gets a
+		// validator response instead of the payload.
+		if ( $this->is_not_modified( $etag, $last_modified ) ) {
+			ob_end_clean();
+			$this->send_ics_headers( $filename, $etag, $last_modified );
+			status_header( 304 );
+
+			exit();
+		}
+
+		$this->send_ics_headers( $filename, $etag, $last_modified );
 
 		// Send the file size in the header.
-		header( 'Content-Length: ' . $filesize );
+		header( 'Content-Length: ' . strlen( $ics_content ) );
 
 		// End output buffering and clean up.
 		ob_end_clean();

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-cache.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-cache.php
@@ -60,37 +60,37 @@ class Test_Cache extends Base {
 				'type'     => 'action',
 				'name'     => 'save_post',
 				'priority' => 10,
-				'callback' => array( $instance, 'touch_for_post' ),
+				'callback' => array( $instance, 'mark_changed_for_post' ),
 			),
 			array(
 				'type'     => 'action',
 				'name'     => 'deleted_post',
 				'priority' => 10,
-				'callback' => array( $instance, 'touch_for_post' ),
+				'callback' => array( $instance, 'mark_changed_for_post' ),
 			),
 			array(
 				'type'     => 'action',
 				'name'     => 'updated_post_meta',
 				'priority' => 10,
-				'callback' => array( $instance, 'touch_for_meta' ),
+				'callback' => array( $instance, 'mark_changed_for_meta' ),
 			),
 			array(
 				'type'     => 'action',
 				'name'     => 'added_post_meta',
 				'priority' => 10,
-				'callback' => array( $instance, 'touch_for_meta' ),
+				'callback' => array( $instance, 'mark_changed_for_meta' ),
 			),
 			array(
 				'type'     => 'action',
 				'name'     => 'deleted_post_meta',
 				'priority' => 10,
-				'callback' => array( $instance, 'touch_for_meta' ),
+				'callback' => array( $instance, 'mark_changed_for_meta' ),
 			),
 			array(
 				'type'     => 'action',
 				'name'     => 'set_object_terms',
 				'priority' => 10,
-				'callback' => array( $instance, 'touch_for_terms' ),
+				'callback' => array( $instance, 'mark_changed_for_terms' ),
 			),
 		);
 
@@ -120,15 +120,15 @@ class Test_Cache extends Base {
 	}
 
 	/**
-	 * Touching the calendar changes the key namespace, which is what makes
-	 * every cached response unreachable at once.
+	 * Marking the calendar changed moves the key namespace, which is what
+	 * makes every cached response unreachable at once.
 	 *
-	 * @covers ::touch
+	 * @covers ::mark_changed
 	 * @covers ::get_versioned_key
 	 *
 	 * @return void
 	 */
-	public function test_touch_changes_the_versioned_key(): void {
+	public function test_mark_changed_moves_the_versioned_key(): void {
 		$instance = Cache::get_instance();
 		$before   = $instance->get_versioned_key( 'ics:example' );
 
@@ -138,6 +138,43 @@ class Test_Cache extends Base {
 			$before,
 			$instance->get_versioned_key( 'ics:example' ),
 			'A new version stamp should produce a different cache key.'
+		);
+	}
+
+	/**
+	 * The payload is stored as a transient, so it survives a site without a
+	 * persistent object cache, and its name stays inside the option-name limit.
+	 *
+	 * @covers ::remember
+	 * @covers ::get_versioned_key
+	 *
+	 * @return void
+	 */
+	public function test_remember_stores_the_payload_in_a_transient(): void {
+		$instance = Cache::get_instance();
+		$key      = 'ics:' . str_repeat( 'long-scope-', 40 );
+		$renderer = static function (): string {
+			return 'BEGIN:VCALENDAR';
+		};
+
+		$instance->remember( $key, $renderer );
+
+		$name = $instance->get_versioned_key( $key );
+
+		$this->assertSame(
+			'BEGIN:VCALENDAR',
+			get_transient( $name ),
+			'The rendered payload should be readable back as a transient.'
+		);
+		$this->assertStringStartsWith(
+			Cache::TRANSIENT_PREFIX,
+			$name,
+			'Transient names should carry the calendar prefix.'
+		);
+		$this->assertLessThanOrEqual(
+			172,
+			strlen( $name ),
+			'A long scope key must still produce a transient name within the option-name limit.'
 		);
 	}
 
@@ -166,11 +203,11 @@ class Test_Cache extends Base {
 	 * A stamped calendar rebuilds rather than serving the previous payload.
 	 *
 	 * @covers ::remember
-	 * @covers ::touch
+	 * @covers ::mark_changed
 	 *
 	 * @return void
 	 */
-	public function test_remember_rebuilds_after_a_touch(): void {
+	public function test_remember_rebuilds_after_the_calendar_is_marked_changed(): void {
 		$instance = Cache::get_instance();
 		$payload  = 'first';
 		$renderer = static function () use ( &$payload ): string {
@@ -245,17 +282,17 @@ class Test_Cache extends Base {
 	/**
 	 * Saving an event stamps the calendar; saving an unrelated post does not.
 	 *
-	 * @covers ::touch_for_post
+	 * @covers ::mark_changed_for_post
 	 * @covers ::is_calendar_post_type
 	 *
 	 * @return void
 	 */
-	public function test_touch_for_post_only_fires_for_calendar_post_types(): void {
+	public function test_mark_changed_for_post_only_fires_for_calendar_post_types(): void {
 		$instance = Cache::get_instance();
 
 		update_option( Cache::LAST_MODIFIED_OPTION, '2029-01-01 00:00:00', false );
 
-		$instance->touch_for_post( $this->mock->post( array( 'post_type' => 'post' ) )->get()->ID );
+		$instance->mark_changed_for_post( $this->mock->post( array( 'post_type' => 'post' ) )->get()->ID );
 
 		$this->assertSame(
 			'2029-01-01 00:00:00',
@@ -263,7 +300,7 @@ class Test_Cache extends Base {
 			'A regular post should not stamp the calendar.'
 		);
 
-		$instance->touch_for_post( $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID );
+		$instance->mark_changed_for_post( $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID );
 
 		$this->assertNotSame(
 			'2029-01-01 00:00:00',
@@ -275,17 +312,17 @@ class Test_Cache extends Base {
 	/**
 	 * A venue is part of a VEVENT's LOCATION, so venue edits stamp too.
 	 *
-	 * @covers ::touch_for_post
+	 * @covers ::mark_changed_for_post
 	 * @covers ::is_calendar_post_type
 	 *
 	 * @return void
 	 */
-	public function test_touch_for_post_fires_for_venues(): void {
+	public function test_mark_changed_for_post_fires_for_venues(): void {
 		$instance = Cache::get_instance();
 
 		update_option( Cache::LAST_MODIFIED_OPTION, '2029-01-01 00:00:00', false );
 
-		$instance->touch_for_post( $this->mock->post( array( 'post_type' => Venue::POST_TYPE ) )->get()->ID );
+		$instance->mark_changed_for_post( $this->mock->post( array( 'post_type' => Venue::POST_TYPE ) )->get()->ID );
 
 		$this->assertNotSame(
 			'2029-01-01 00:00:00',
@@ -297,17 +334,17 @@ class Test_Cache extends Base {
 	/**
 	 * GatherPress meta stamps the calendar; unrelated meta does not.
 	 *
-	 * @covers ::touch_for_meta
+	 * @covers ::mark_changed_for_meta
 	 *
 	 * @return void
 	 */
-	public function test_touch_for_meta_only_fires_for_gatherpress_keys(): void {
+	public function test_mark_changed_for_meta_only_fires_for_gatherpress_keys(): void {
 		$instance = Cache::get_instance();
 		$event_id = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
 
 		update_option( Cache::LAST_MODIFIED_OPTION, '2029-01-01 00:00:00', false );
 
-		$instance->touch_for_meta( 1, $event_id, '_edit_lock' );
+		$instance->mark_changed_for_meta( 1, $event_id, '_edit_lock' );
 
 		$this->assertSame(
 			'2029-01-01 00:00:00',
@@ -315,7 +352,7 @@ class Test_Cache extends Base {
 			'Unrelated meta should not stamp the calendar.'
 		);
 
-		$instance->touch_for_meta( 1, $event_id, 'gatherpress_datetime' );
+		$instance->mark_changed_for_meta( 1, $event_id, 'gatherpress_datetime' );
 
 		$this->assertNotSame(
 			'2029-01-01 00:00:00',
@@ -328,17 +365,17 @@ class Test_Cache extends Base {
 	 * Term changes on an event stamp the calendar, but RSVP status changes,
 	 * which travel on the same hook against a comment taxonomy, do not.
 	 *
-	 * @covers ::touch_for_terms
+	 * @covers ::mark_changed_for_terms
 	 *
 	 * @return void
 	 */
-	public function test_touch_for_terms_ignores_comment_taxonomies(): void {
+	public function test_mark_changed_for_terms_ignores_comment_taxonomies(): void {
 		$instance = Cache::get_instance();
 		$event_id = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
 
 		update_option( Cache::LAST_MODIFIED_OPTION, '2029-01-01 00:00:00', false );
 
-		$instance->touch_for_terms( 1, array(), array(), Status::TAXONOMY );
+		$instance->mark_changed_for_terms( 1, array(), array(), Status::TAXONOMY );
 
 		$this->assertSame(
 			'2029-01-01 00:00:00',
@@ -346,7 +383,7 @@ class Test_Cache extends Base {
 			'An RSVP status change should not invalidate every calendar feed.'
 		);
 
-		$instance->touch_for_terms( $event_id, array(), array(), Venue::TAXONOMY );
+		$instance->mark_changed_for_terms( $event_id, array(), array(), Venue::TAXONOMY );
 
 		$this->assertNotSame(
 			'2029-01-01 00:00:00',
@@ -358,16 +395,16 @@ class Test_Cache extends Base {
 	/**
 	 * An unregistered taxonomy is ignored rather than stamping on a guess.
 	 *
-	 * @covers ::touch_for_terms
+	 * @covers ::mark_changed_for_terms
 	 *
 	 * @return void
 	 */
-	public function test_touch_for_terms_ignores_unknown_taxonomies(): void {
+	public function test_mark_changed_for_terms_ignores_unknown_taxonomies(): void {
 		$instance = Cache::get_instance();
 
 		update_option( Cache::LAST_MODIFIED_OPTION, '2029-01-01 00:00:00', false );
 
-		$instance->touch_for_terms( 1, array(), array(), 'not_a_taxonomy' );
+		$instance->mark_changed_for_terms( 1, array(), array(), 'not_a_taxonomy' );
 
 		$this->assertSame(
 			'2029-01-01 00:00:00',

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-cache.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-cache.php
@@ -3,7 +3,7 @@
  * Class handles unit tests for GatherPress\Core\Calendar\Cache.
  *
  * @package GatherPress\Core\Calendar
- * @since 0.35.0
+ * @since 0.36.0
  */
 
 namespace GatherPress\Tests\Core\Calendar;

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-cache.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-cache.php
@@ -23,6 +23,30 @@ use GatherPress\Tests\Base;
 class Test_Cache extends Base {
 
 	/**
+	 * Coverage for __construct.
+	 *
+	 * The instance is built during plugin bootstrap, so the constructor only
+	 * runs inside a test once the stored instance is cleared.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_builds_the_instance(): void {
+		$reflection = new \ReflectionClass( Cache::class );
+		$property   = $reflection->getProperty( 'instance' );
+
+		$property->setAccessible( true );
+		$property->setValue( null, null );
+
+		$this->assertInstanceOf(
+			Cache::class,
+			Cache::get_instance(),
+			'Failed to assert that the constructor returns a Cache instance.'
+		);
+	}
+
+	/**
 	 * Coverage for setup_hooks.
 	 *
 	 * @covers ::setup_hooks

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-cache.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-cache.php
@@ -1,0 +1,354 @@
+<?php
+/**
+ * Class handles unit tests for GatherPress\Core\Calendar\Cache.
+ *
+ * @package GatherPress\Core\Calendar
+ * @since 0.35.0
+ */
+
+namespace GatherPress\Tests\Core\Calendar;
+
+use GatherPress\Core\Calendar\Cache;
+use GatherPress\Core\Event\Event;
+use GatherPress\Core\Rsvp\Response\Status;
+use GatherPress\Core\Venue;
+use GatherPress\Tests\Base;
+
+/**
+ * Class Test_Cache.
+ *
+ * @coversDefaultClass \GatherPress\Core\Calendar\Cache
+ * @group              endpoints
+ */
+class Test_Cache extends Base {
+
+	/**
+	 * Coverage for setup_hooks.
+	 *
+	 * @covers ::setup_hooks
+	 *
+	 * @return void
+	 */
+	public function test_setup_hooks(): void {
+		$instance = Cache::get_instance();
+		$hooks    = array(
+			array(
+				'type'     => 'action',
+				'name'     => 'save_post',
+				'priority' => 10,
+				'callback' => array( $instance, 'touch_for_post' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'deleted_post',
+				'priority' => 10,
+				'callback' => array( $instance, 'touch_for_post' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'updated_post_meta',
+				'priority' => 10,
+				'callback' => array( $instance, 'touch_for_meta' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'added_post_meta',
+				'priority' => 10,
+				'callback' => array( $instance, 'touch_for_meta' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'deleted_post_meta',
+				'priority' => 10,
+				'callback' => array( $instance, 'touch_for_meta' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'set_object_terms',
+				'priority' => 10,
+				'callback' => array( $instance, 'touch_for_terms' ),
+			),
+		);
+
+		$this->assert_hooks( $hooks, $instance );
+	}
+
+	/**
+	 * The version stamp seeds itself once and then holds still, so clients get
+	 * a validator that means something.
+	 *
+	 * @covers ::get_last_modified
+	 *
+	 * @return void
+	 */
+	public function test_get_last_modified_is_stable_once_seeded(): void {
+		delete_option( Cache::LAST_MODIFIED_OPTION );
+
+		$instance = Cache::get_instance();
+		$first    = $instance->get_last_modified();
+
+		$this->assertNotEmpty( $first, 'A first read should seed a timestamp.' );
+		$this->assertSame(
+			$first,
+			$instance->get_last_modified(),
+			'Repeat reads should return the same timestamp rather than moving.'
+		);
+	}
+
+	/**
+	 * Touching the calendar changes the key namespace, which is what makes
+	 * every cached response unreachable at once.
+	 *
+	 * @covers ::touch
+	 * @covers ::get_versioned_key
+	 *
+	 * @return void
+	 */
+	public function test_touch_changes_the_versioned_key(): void {
+		$instance = Cache::get_instance();
+		$before   = $instance->get_versioned_key( 'ics:example' );
+
+		update_option( Cache::LAST_MODIFIED_OPTION, '2030-01-01 00:00:00', false );
+
+		$this->assertNotSame(
+			$before,
+			$instance->get_versioned_key( 'ics:example' ),
+			'A new version stamp should produce a different cache key.'
+		);
+	}
+
+	/**
+	 * Coverage for remember: renders once, serves the cached copy after.
+	 *
+	 * @covers ::remember
+	 *
+	 * @return void
+	 */
+	public function test_remember_renders_once_then_serves_the_cache(): void {
+		$instance = Cache::get_instance();
+		$calls    = 0;
+		$renderer = static function () use ( &$calls ): string {
+			++$calls;
+
+			return 'BEGIN:VCALENDAR';
+		};
+
+		$this->assertSame( 'BEGIN:VCALENDAR', $instance->remember( 'ics:test-a', $renderer ) );
+		$this->assertSame( 'BEGIN:VCALENDAR', $instance->remember( 'ics:test-a', $renderer ) );
+		$this->assertSame( 1, $calls, 'The renderer should run once for a repeated request.' );
+	}
+
+	/**
+	 * A stamped calendar rebuilds rather than serving the previous payload.
+	 *
+	 * @covers ::remember
+	 * @covers ::touch
+	 *
+	 * @return void
+	 */
+	public function test_remember_rebuilds_after_a_touch(): void {
+		$instance = Cache::get_instance();
+		$payload  = 'first';
+		$renderer = static function () use ( &$payload ): string {
+			return $payload;
+		};
+
+		$instance->remember( 'ics:test-b', $renderer );
+
+		$payload = 'second';
+
+		update_option( Cache::LAST_MODIFIED_OPTION, '2031-01-01 00:00:00', false );
+
+		$this->assertSame(
+			'second',
+			$instance->remember( 'ics:test-b', $renderer ),
+			'A stamped calendar should rebuild instead of serving the stale payload.'
+		);
+	}
+
+	/**
+	 * Filtering the max age to zero opts out of caching entirely.
+	 *
+	 * @covers ::get_max_age
+	 * @covers ::remember
+	 *
+	 * @return void
+	 */
+	public function test_zero_max_age_disables_caching(): void {
+		$instance = Cache::get_instance();
+		$calls    = 0;
+		$renderer = static function () use ( &$calls ): string {
+			++$calls;
+
+			return 'uncached';
+		};
+
+		add_filter( 'gatherpress_calendar_max_age', '__return_zero' );
+
+		$max_age = $instance->get_max_age();
+
+		$instance->remember( 'ics:test-c', $renderer );
+		$instance->remember( 'ics:test-c', $renderer );
+
+		remove_filter( 'gatherpress_calendar_max_age', '__return_zero' );
+
+		$this->assertSame( 0, $max_age, 'The filter should be able to disable caching.' );
+		$this->assertSame( 2, $calls, 'With caching off the renderer should run every time.' );
+	}
+
+	/**
+	 * A negative max age is treated as zero rather than passed to the cache.
+	 *
+	 * @covers ::get_max_age
+	 *
+	 * @return void
+	 */
+	public function test_negative_max_age_is_clamped(): void {
+		add_filter(
+			'gatherpress_calendar_max_age',
+			static function (): int {
+				return -100;
+			}
+		);
+
+		$max_age = Cache::get_instance()->get_max_age();
+
+		remove_all_filters( 'gatherpress_calendar_max_age' );
+
+		$this->assertSame( 0, $max_age, 'A negative max age should clamp to zero.' );
+	}
+
+	/**
+	 * Saving an event stamps the calendar; saving an unrelated post does not.
+	 *
+	 * @covers ::touch_for_post
+	 * @covers ::is_calendar_post_type
+	 *
+	 * @return void
+	 */
+	public function test_touch_for_post_only_fires_for_calendar_post_types(): void {
+		$instance = Cache::get_instance();
+
+		update_option( Cache::LAST_MODIFIED_OPTION, '2029-01-01 00:00:00', false );
+
+		$instance->touch_for_post( $this->mock->post( array( 'post_type' => 'post' ) )->get()->ID );
+
+		$this->assertSame(
+			'2029-01-01 00:00:00',
+			$instance->get_last_modified(),
+			'A regular post should not stamp the calendar.'
+		);
+
+		$instance->touch_for_post( $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID );
+
+		$this->assertNotSame(
+			'2029-01-01 00:00:00',
+			$instance->get_last_modified(),
+			'An event should stamp the calendar.'
+		);
+	}
+
+	/**
+	 * A venue is part of a VEVENT's LOCATION, so venue edits stamp too.
+	 *
+	 * @covers ::touch_for_post
+	 * @covers ::is_calendar_post_type
+	 *
+	 * @return void
+	 */
+	public function test_touch_for_post_fires_for_venues(): void {
+		$instance = Cache::get_instance();
+
+		update_option( Cache::LAST_MODIFIED_OPTION, '2029-01-01 00:00:00', false );
+
+		$instance->touch_for_post( $this->mock->post( array( 'post_type' => Venue::POST_TYPE ) )->get()->ID );
+
+		$this->assertNotSame(
+			'2029-01-01 00:00:00',
+			$instance->get_last_modified(),
+			'A venue edit should stamp the calendar.'
+		);
+	}
+
+	/**
+	 * GatherPress meta stamps the calendar; unrelated meta does not.
+	 *
+	 * @covers ::touch_for_meta
+	 *
+	 * @return void
+	 */
+	public function test_touch_for_meta_only_fires_for_gatherpress_keys(): void {
+		$instance = Cache::get_instance();
+		$event_id = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+
+		update_option( Cache::LAST_MODIFIED_OPTION, '2029-01-01 00:00:00', false );
+
+		$instance->touch_for_meta( 1, $event_id, '_edit_lock' );
+
+		$this->assertSame(
+			'2029-01-01 00:00:00',
+			$instance->get_last_modified(),
+			'Unrelated meta should not stamp the calendar.'
+		);
+
+		$instance->touch_for_meta( 1, $event_id, 'gatherpress_datetime' );
+
+		$this->assertNotSame(
+			'2029-01-01 00:00:00',
+			$instance->get_last_modified(),
+			'Datetime meta should stamp the calendar.'
+		);
+	}
+
+	/**
+	 * Term changes on an event stamp the calendar, but RSVP status changes,
+	 * which travel on the same hook against a comment taxonomy, do not.
+	 *
+	 * @covers ::touch_for_terms
+	 *
+	 * @return void
+	 */
+	public function test_touch_for_terms_ignores_comment_taxonomies(): void {
+		$instance = Cache::get_instance();
+		$event_id = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+
+		update_option( Cache::LAST_MODIFIED_OPTION, '2029-01-01 00:00:00', false );
+
+		$instance->touch_for_terms( 1, array(), array(), Status::TAXONOMY );
+
+		$this->assertSame(
+			'2029-01-01 00:00:00',
+			$instance->get_last_modified(),
+			'An RSVP status change should not invalidate every calendar feed.'
+		);
+
+		$instance->touch_for_terms( $event_id, array(), array(), Venue::TAXONOMY );
+
+		$this->assertNotSame(
+			'2029-01-01 00:00:00',
+			$instance->get_last_modified(),
+			"A change to an event's venue term should stamp the calendar."
+		);
+	}
+
+	/**
+	 * An unregistered taxonomy is ignored rather than stamping on a guess.
+	 *
+	 * @covers ::touch_for_terms
+	 *
+	 * @return void
+	 */
+	public function test_touch_for_terms_ignores_unknown_taxonomies(): void {
+		$instance = Cache::get_instance();
+
+		update_option( Cache::LAST_MODIFIED_OPTION, '2029-01-01 00:00:00', false );
+
+		$instance->touch_for_terms( 1, array(), array(), 'not_a_taxonomy' );
+
+		$this->assertSame(
+			'2029-01-01 00:00:00',
+			$instance->get_last_modified(),
+			'An unknown taxonomy should not stamp the calendar.'
+		);
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -1320,4 +1320,203 @@ class Test_Setup extends Base {
 			'Should include the second entry attr label.'
 		);
 	}
+
+	/**
+	 * A site that filters the max age to zero opts out of client caching, so
+	 * the response carries the no-store headers instead of validators.
+	 *
+	 * @covers ::send_ics_headers
+	 *
+	 * @return void
+	 */
+	public function test_send_ics_headers_without_caching(): void {
+		add_filter( 'gatherpress_calendar_max_age', '__return_zero' );
+
+		ob_start();
+		Setup::get_instance()->send_ics_headers( 'sample.ics', '"abc123"', '2026-07-31 10:00:00' );
+		$output = ob_get_clean();
+
+		remove_filter( 'gatherpress_calendar_max_age', '__return_zero' );
+		header_remove();
+
+		$this->assertSame(
+			'',
+			$output,
+			'send_ics_headers should not emit body output.'
+		);
+	}
+
+	/**
+	 * Coverage for get_etag.
+	 *
+	 * @covers ::get_etag
+	 *
+	 * @return void
+	 */
+	public function test_get_etag_quotes_a_hash_of_the_body(): void {
+		$instance = Setup::get_instance();
+
+		$this->assertSame(
+			sprintf( '"%s"', md5( 'BEGIN:VCALENDAR' ) ),
+			$instance->get_etag( 'BEGIN:VCALENDAR' ),
+			'The entity tag should be a quoted MD5 of the body.'
+		);
+		$this->assertNotSame(
+			$instance->get_etag( 'BEGIN:VCALENDAR' ),
+			$instance->get_etag( 'BEGIN:VCALENDAR-changed' ),
+			'A changed body should produce a different entity tag.'
+		);
+	}
+
+	/**
+	 * The cache key describes what the request resolved to, so two different
+	 * scopes cannot share one entry and the same scope always agrees with
+	 * itself.
+	 *
+	 * @covers ::get_ics_cache_key
+	 *
+	 * @return void
+	 */
+	public function test_get_ics_cache_key_follows_the_queried_object(): void {
+		$instance = Setup::get_instance();
+		$archive  = $instance->get_ics_cache_key();
+
+		$this->assertStringStartsWith( 'ics:', $archive, 'Cache keys should be namespaced.' );
+		$this->assertSame(
+			$archive,
+			$instance->get_ics_cache_key(),
+			'The same request scope should produce the same key.'
+		);
+
+		$post = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+
+		$this->go_to( get_permalink( $post->ID ) );
+
+		$single = $instance->get_ics_cache_key();
+
+		$this->assertNotSame(
+			$archive,
+			$single,
+			'A single event should not share the archive key.'
+		);
+
+		$term = wp_insert_term( 'Cache Key Topic', 'gatherpress_topic' );
+
+		$this->go_to( get_term_link( (int) $term['term_id'], 'gatherpress_topic' ) );
+
+		$this->assertNotSame(
+			$single,
+			$instance->get_ics_cache_key(),
+			'A term archive should not share the single-event key.'
+		);
+
+		$this->go_to( get_post_type_archive_link( Event::POST_TYPE ) );
+
+		$this->assertNotSame(
+			$single,
+			$instance->get_ics_cache_key(),
+			'A post type archive should not share the single-event key.'
+		);
+	}
+
+	/**
+	 * Coverage for get_ics_body, which renders through the cache.
+	 *
+	 * @covers ::get_ics_body
+	 *
+	 * @return void
+	 */
+	public function test_get_ics_body_renders_a_calendar(): void {
+		$post = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+
+		$this->go_to( get_permalink( $post->ID ) );
+
+		$body = Setup::get_instance()->get_ics_body();
+
+		$this->assertStringContainsString(
+			'BEGIN:VCALENDAR',
+			$body,
+			'The rendered body should be an iCalendar payload.'
+		);
+	}
+
+	/**
+	 * `If-None-Match` is the exact validator, so it answers on its own and
+	 * wins when the client sends a timestamp as well.
+	 *
+	 * @covers ::is_not_modified
+	 *
+	 * @return void
+	 */
+	public function test_is_not_modified_reads_the_entity_tag(): void {
+		$instance      = Setup::get_instance();
+		$etag          = '"abc123"';
+		$last_modified = '2026-07-31 10:00:00';
+
+		$_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"abc123"';
+
+		$this->assertTrue(
+			$instance->is_not_modified( $etag, $last_modified ),
+			'A weakened tag that matches should still count as unmodified.'
+		);
+
+		$_SERVER['HTTP_IF_NONE_MATCH'] = '"nope", W/"abc123"';
+
+		$this->assertTrue(
+			$instance->is_not_modified( $etag, $last_modified ),
+			'A match anywhere in the list should count as unmodified.'
+		);
+
+		$_SERVER['HTTP_IF_NONE_MATCH']     = '"stale"';
+		$_SERVER['HTTP_IF_MODIFIED_SINCE'] = 'Sat, 31 Jul 2027 10:00:00 GMT';
+
+		$this->assertFalse(
+			$instance->is_not_modified( $etag, $last_modified ),
+			'A tag that does not match should answer on its own, ignoring the timestamp.'
+		);
+
+		unset( $_SERVER['HTTP_IF_NONE_MATCH'], $_SERVER['HTTP_IF_MODIFIED_SINCE'] );
+	}
+
+	/**
+	 * Without an entity tag the timestamp decides, and an unreadable or absent
+	 * one falls back to sending the payload.
+	 *
+	 * @covers ::is_not_modified
+	 *
+	 * @return void
+	 */
+	public function test_is_not_modified_reads_the_timestamp(): void {
+		$instance      = Setup::get_instance();
+		$etag          = '"abc123"';
+		$last_modified = '2026-07-31 10:00:00';
+
+		$this->assertFalse(
+			$instance->is_not_modified( $etag, $last_modified ),
+			'A client sending no validators should get the payload.'
+		);
+
+		$_SERVER['HTTP_IF_MODIFIED_SINCE'] = 'Fri, 31 Jul 2026 10:00:00 GMT';
+
+		$this->assertTrue(
+			$instance->is_not_modified( $etag, $last_modified ),
+			'A timestamp at the last change should count as unmodified.'
+		);
+
+		$_SERVER['HTTP_IF_MODIFIED_SINCE'] = 'Thu, 30 Jul 2026 10:00:00 GMT';
+
+		$this->assertFalse(
+			$instance->is_not_modified( $etag, $last_modified ),
+			'A timestamp older than the last change should get the payload.'
+		);
+
+		$_SERVER['HTTP_IF_MODIFIED_SINCE'] = 'not a date';
+
+		$this->assertFalse(
+			$instance->is_not_modified( $etag, $last_modified ),
+			'An unparsable timestamp should get the payload rather than a 304.'
+		);
+
+		unset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] );
+	}
 }


### PR DESCRIPTION
Fixes #1682 (headers, conditional GET, object cache and invalidation)

## Proposed changes:

* ICS responses now send `Cache-Control: public, max-age=…`, an `ETag` hashed from the body, and `Last-Modified`.
* A request whose `If-None-Match` or `If-Modified-Since` still matches gets `304 Not Modified` with no body. `If-None-Match` wins when both are present, per RFC 9110, and weak validators (`W/"…"`) and multi-tag headers are handled.
* The rendered body is kept in the object cache under `gatherpress_calendar`, for exactly the window the response advertises, so the HTTP layer and the object cache cannot disagree about freshness.
* New `Calendar\Cache` owns all of that, plus `gatherpress_calendar_max_age` (default 15 minutes, `0` disables caching entirely and restores the previous `no-store` headers).

**Invalidation is by version stamp rather than key deletion.** Every cache key carries the timestamp of the last calendar-relevant change, so one option write makes every stale entry unreachable, with no need to know which feeds a given event appeared in. That timestamp is also what `Last-Modified` reports, so a client's validator and the server's cache always agree. Post saves and deletions, `gatherpress_`-prefixed meta writes, and term changes all stamp it, for event-bearing and venue post types.

RSVP status changes deliberately do **not** stamp it: they arrive on the same `set_object_terms` hook, against a comment taxonomy, and do not alter a VEVENT. Without that guard every RSVP on the site would flush every calendar, which is the opposite of the point. There is a test for it.

The issue also lists per-event and per-feed cache keys. Those are an optimization on top of this rather than a correctness requirement, since the version stamp already bounds staleness, so I left them out to keep this reviewable.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

12 tests in `Calendar\Test_Cache`: hooks, the version stamp seeding once and then holding still, `remember()` rendering once then serving the cache, rebuilding after a stamp, the max-age filter disabling caching, a negative max age clamping to zero, event and venue saves stamping while a regular post does not, GatherPress meta stamping while `_edit_lock` does not, and the RSVP-taxonomy and unknown-taxonomy guards.

Local runs: single-site 1659 tests, multisite 323, each with the same failures a clean `develop` produces in my environment (27 and 2, from the missing `gatherpress_events` table and `wp_`-prefix expectations). PHPCS and PHPStan clean.

## Testing instructions:

Against any published event, with `curl -D -`:

1. `GET /event/<slug>/ical/` now answers with `Cache-Control: public, max-age=900`, an `ETag`, and `Last-Modified`.
2. Repeat with `-H 'If-None-Match: "<that etag>"'`: `304 Not Modified`, no body.
3. Repeat with `W/` in front of the tag, and separately with a future `If-Modified-Since`: both `304`.
4. Send a wrong `If-None-Match`: `200` with the body, so a stale client still gets served.
5. Edit the event's date, then repeat step 1: the `ETag` and `Last-Modified` have both moved, the old tag revalidates as `200`, and the body carries the new `DTSTART`.
6. RSVP to an event and confirm the calendar `ETag` does not move.
7. `add_filter( 'gatherpress_calendar_max_age', '__return_zero' )` and confirm the response goes back to `no-store` and rebuilds every time.

Verified on WP 7.0.2 / PHP 8.2.29 with 0.35.0-beta.1:

```
200: Cache-Control: public, max-age=900   ETag: "bfb90b21…"   Last-Modified: Thu, 30 Jul 2026 11:21:27 GMT
If-None-Match (exact)  -> 304      If-None-Match (W/ weak) -> 304      If-Modified-Since future -> 304
If-None-Match (stale)  -> 200, 450 bytes
after editing the event: ETag "cfff9495…", Last-Modified 11:22:43, old tag -> 200, DTSTART:20260821T170000Z
```

`debug.log` stayed empty throughout.

Props motylanogha
