### PR TITLE
Activate dropdown triggers with the Space key

### DIFF
--- a/.github/changelog/2070-from-description
+++ b/.github/changelog/2070-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activate dropdown and RSVP-response-toggle triggers with the Space key, honoring their announced button role.

--- a/includes/core/classes/blocks/class-dropdown.php
+++ b/includes/core/classes/blocks/class-dropdown.php
@@ -286,6 +286,10 @@ final class Dropdown {
 				$tag->set_attribute( 'aria-expanded', 'false' );
 				$tag->set_attribute( 'tabindex', '0' );
 				$tag->set_attribute( 'data-wp-on--click', 'actions.toggleDropdown' );
+				// The trigger is an anchor announced as a button; anchors only
+				// activate on Enter, so Space must be wired up explicitly to
+				// honor the ARIA button pattern.
+				$tag->set_attribute( 'data-wp-on--keydown', 'actions.activateOnSpace' );
 			}
 
 			if ( 'hover' === $open_on ) {

--- a/src/blocks/dropdown/view.js
+++ b/src/blocks/dropdown/view.js
@@ -7,6 +7,7 @@ import { store, getElement } from '@wordpress/interactivity';
  * Internal dependencies
  */
 import {
+	activateOnSpace as activateOnSpaceHelper,
 	manageFocusTrap,
 	setupCloseHandlers,
 } from '../../helpers/interactivity';
@@ -17,6 +18,9 @@ const { actions } = store( 'gatherpress', {
 			if ( event ) {
 				event.preventDefault();
 			}
+		},
+		activateOnSpace( event ) {
+			activateOnSpaceHelper( event, getElement().ref );
 		},
 		linkHandler( event ) {
 			actions.preventDefault( event );

--- a/src/blocks/rsvp-response-toggle/render.php
+++ b/src/blocks/rsvp-response-toggle/render.php
@@ -34,6 +34,7 @@ printf(
 			data-show-fewer="%3$s"
 			data-wp-interactivity="gatherpress"
 			data-wp-on--click="actions.toggleRsvpVisibility"
+			data-wp-on--keydown="actions.activateOnSpace"
 		>%4$s</a>
 	</div>',
 	wp_kses_data( get_block_wrapper_attributes() ),

--- a/src/blocks/rsvp-response/view.js
+++ b/src/blocks/rsvp-response/view.js
@@ -6,7 +6,10 @@ import { store, getElement, getContext } from '@wordpress/interactivity';
 /**
  * Internal dependencies
  */
-import { initPostContext } from '../../helpers/interactivity';
+import {
+	activateOnSpace as activateOnSpaceHelper,
+	initPostContext,
+} from '../../helpers/interactivity';
 import { toCamelCase } from '../../helpers/globals';
 
 const { state, actions } = store( 'gatherpress', {
@@ -14,6 +17,9 @@ const { state, actions } = store( 'gatherpress', {
 		posts: {},
 	},
 	actions: {
+		activateOnSpace( event ) {
+			activateOnSpaceHelper( event, getElement().ref );
+		},
 		processRsvpSelection( event ) {
 			// Call the linkHandler action to handle the default link behavior.
 			actions.linkHandler( event );

--- a/src/helpers/interactivity.js
+++ b/src/helpers/interactivity.js
@@ -383,7 +383,9 @@ export async function sendRsvpApiRequest(
  * without it Space performs the anchor default — scrolling the page. This
  * helper mirrors native button semantics by turning Space into a click on the
  * same element, so each trigger's existing click action runs unchanged.
- * `event.repeat` is ignored so holding Space doesn't rapid-toggle.
+ * Space always suppresses the scroll default — including key-repeat events
+ * while the key is held — but only the initial (non-repeat) press clicks, so
+ * holding Space neither scrolls nor rapid-toggles.
  *
  * Registered as `actions.activateOnSpace` by the view modules whose triggers
  * carry `data-wp-on--keydown="actions.activateOnSpace"` (attached server-side
@@ -398,9 +400,12 @@ export async function sendRsvpApiRequest(
  * @return {void}
  */
 export function activateOnSpace( event, ref ) {
-	if ( ' ' === event.key && ! event.repeat ) {
+	if ( ' ' === event.key ) {
 		event.preventDefault();
-		ref.click();
+
+		if ( ! event.repeat ) {
+			ref.click();
+		}
 	}
 }
 

--- a/src/helpers/interactivity.js
+++ b/src/helpers/interactivity.js
@@ -375,6 +375,36 @@ export async function sendRsvpApiRequest(
 }
 
 /**
+ * Give a `role="button"` element the Space half of the button keyboard contract.
+ *
+ * The dropdown and RSVP-response-toggle triggers are anchors that announce
+ * themselves as buttons (`role="button"` is set at render time). Anchors only
+ * activate on Enter; the ARIA button pattern requires Space as well, and
+ * without it Space performs the anchor default — scrolling the page. This
+ * helper mirrors native button semantics by turning Space into a click on the
+ * same element, so each trigger's existing click action runs unchanged.
+ * `event.repeat` is ignored so holding Space doesn't rapid-toggle.
+ *
+ * Registered as `actions.activateOnSpace` by the view modules whose triggers
+ * carry `data-wp-on--keydown="actions.activateOnSpace"` (attached server-side
+ * in `Blocks\Dropdown::apply_dropdown_attributes()` and the
+ * rsvp-response-toggle render template).
+ *
+ * @since 0.35.0
+ *
+ * @param {KeyboardEvent} event The keydown event.
+ * @param {HTMLElement}   ref   The element carrying the directive.
+ *
+ * @return {void}
+ */
+export function activateOnSpace( event, ref ) {
+	if ( ' ' === event.key && ! event.repeat ) {
+		event.preventDefault();
+		ref.click();
+	}
+}
+
+/**
  * Manages focus trapping within a specified set of elements.
  *
  * This function ensures that keyboard navigation (using the `Tab` key) is

--- a/test/unit/js/src/helpers/interactivity.test.js
+++ b/test/unit/js/src/helpers/interactivity.test.js
@@ -505,13 +505,15 @@ describe( 'activateOnSpace', () => {
 		expect( ref.click ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'ignores key repeat so holding Space does not rapid-toggle', () => {
+	it( 'still prevents scrolling on key repeat but only clicks once', () => {
+		// Holding Space fires repeat keydowns; a native button suppresses
+		// the scroll default for the whole hold while activating only once.
 		const ref = { click: jest.fn() };
 		const event = makeEvent( ' ', true );
 
 		activateOnSpace( event, ref );
 
-		expect( event.preventDefault ).not.toHaveBeenCalled();
+		expect( event.preventDefault ).toHaveBeenCalled();
 		expect( ref.click ).not.toHaveBeenCalled();
 	} );
 

--- a/test/unit/js/src/helpers/interactivity.test.js
+++ b/test/unit/js/src/helpers/interactivity.test.js
@@ -48,7 +48,11 @@ import { __mockState as mockInteractivityState } from '@wordpress/interactivity'
 /**
  * Internal dependencies
  */
-import { sendRsvpApiRequest, getNonce } from '@src/helpers/interactivity';
+import {
+	activateOnSpace,
+	sendRsvpApiRequest,
+	getNonce,
+} from '@src/helpers/interactivity';
 
 /**
  * English source strings mirroring Assets::add_interactivity_state(), so the
@@ -475,5 +479,59 @@ describe( 'sendRsvpApiRequest announcements', () => {
 		expect( speak ).not.toHaveBeenCalled();
 		// The request itself still succeeded.
 		expect( state.posts[ 123 ].currentUser.status ).toBe( 'attending' );
+	} );
+} );
+
+/**
+ * The Space half of the button keyboard contract for role="button" anchors
+ * (dropdown and RSVP-response-toggle triggers). Space must become a click —
+ * and must not scroll the page; every other key must pass through untouched
+ * so anchors keep their native Enter behavior.
+ */
+describe( 'activateOnSpace', () => {
+	const makeEvent = ( key, repeat = false ) => ( {
+		key,
+		repeat,
+		preventDefault: jest.fn(),
+	} );
+
+	it( 'turns Space into a click and prevents the scroll default', () => {
+		const ref = { click: jest.fn() };
+		const event = makeEvent( ' ' );
+
+		activateOnSpace( event, ref );
+
+		expect( event.preventDefault ).toHaveBeenCalled();
+		expect( ref.click ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'ignores key repeat so holding Space does not rapid-toggle', () => {
+		const ref = { click: jest.fn() };
+		const event = makeEvent( ' ', true );
+
+		activateOnSpace( event, ref );
+
+		expect( event.preventDefault ).not.toHaveBeenCalled();
+		expect( ref.click ).not.toHaveBeenCalled();
+	} );
+
+	it( 'leaves Enter alone (anchors handle it natively)', () => {
+		const ref = { click: jest.fn() };
+		const event = makeEvent( 'Enter' );
+
+		activateOnSpace( event, ref );
+
+		expect( event.preventDefault ).not.toHaveBeenCalled();
+		expect( ref.click ).not.toHaveBeenCalled();
+	} );
+
+	it( 'leaves Tab alone so focus can move away from the trigger', () => {
+		const ref = { click: jest.fn() };
+		const event = makeEvent( 'Tab' );
+
+		activateOnSpace( event, ref );
+
+		expect( event.preventDefault ).not.toHaveBeenCalled();
+		expect( ref.click ).not.toHaveBeenCalled();
 	} );
 } );

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-dropdown.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-dropdown.php
@@ -429,6 +429,11 @@ class Test_Dropdown extends Base {
 			'Click trigger should have toggle action'
 		);
 		$this->assertStringContainsString(
+			'data-wp-on--keydown="actions.activateOnSpace"',
+			$result,
+			'Click trigger should activate on Space to honor its role="button" keyboard contract'
+		);
+		$this->assertStringContainsString(
 			'aria-expanded="false"',
 			$result,
 			'Click trigger should have initial expanded state'
@@ -463,6 +468,11 @@ class Test_Dropdown extends Base {
 			'data-wp-on--click="actions.toggleDropdown"',
 			$result,
 			'Hover trigger should not have toggle action'
+		);
+		$this->assertStringNotContainsString(
+			'data-wp-on--keydown',
+			$result,
+			'Hover trigger should not have the Space handler (it has no click toggle to mirror)'
 		);
 	}
 


### PR DESCRIPTION
Fixes #2069

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Give the dropdown and RSVP-response-toggle triggers the Space half of the button
  keyboard contract. Both are anchors that announce themselves as buttons
  (`role="button"` is set at render time), and anchors only activate on Enter — so
  Space performed the native anchor default, scrolling the page with the menu staying
  closed. Per the ARIA button pattern (and MDN's explicit warning about links marked
  up with `role="button"`), Space must activate too.
* New `activateOnSpace` helper in `src/helpers/interactivity.js` mirrors native
  button semantics: Space (ignoring key repeat) becomes a click on the same element,
  so each trigger's existing click action runs unchanged. Registered as
  `actions.activateOnSpace` in the dropdown and rsvp-response view stores.
* Attached server-side — `Dropdown::apply_dropdown_attributes()` adds
  `data-wp-on--keydown` to click-mode triggers, and the rsvp-response-toggle render
  template adds the same — so saved block markup is untouched and no block
  deprecation is needed. Hover-mode triggers are untouched (they have no click
  toggle to mirror).
* Deliberately **not** adding `aria-haspopup` or arrow-key navigation: the popup is
  a list of links, matching the APG *disclosure* pattern (Tab/Shift+Tab through the
  revealed links — which already works). `aria-haspopup` would announce a "menu
  button" and promise arrow-key semantics this pattern doesn't have; arrows are an
  optional disclosure enhancement per APG and out of scope here.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
Four new Jest cases for `activateOnSpace` (Space clicks + prevents the scroll
default; key repeat ignored; Enter and Tab pass through untouched) and two new
PHPUnit assertions in the dropdown block test (click-mode trigger carries the keydown
directive; hover-mode does not).

## Testing instructions:
1. `npm install && npm run build`, activate the plugin, create an event using the
   "Event with RSVP" starter template (gives you the Add-to-calendar dropdown).
2. On the event page, <kbd>Tab</kbd> to the **Add to calendar** trigger.
3. Press <kbd>Space</kbd>. Expected: the menu opens and the page does **not**
   scroll. (On `develop`, the page scrolls and the menu stays closed.)
4. <kbd>Escape</kbd> closes it with focus returned to the trigger;
   <kbd>Enter</kbd> still opens it; <kbd>Tab</kbd> moves through the revealed
   links as before.
5. RSVP-response toggle: on an event whose RSVP list exceeds the display limit, Tab
   to **Show All** and press <kbd>Space</kbd> — it toggles instead of scrolling.
   *(Testing note: this path shares the same helper and directive wiring and is
   covered by the unit tests; my local test content doesn't exceed the response
   limit, so I verified it in code and Jest rather than live.)*
[Video: keyboard-only session with the fix applied. Space opens the menu with no page scroll; Escape closes it; Enter still works.](https://www.dropbox.com/scl/fi/aygk6l5e3ek0djq0yectb/space-key-gatherpress-fix.mp4?rlkey=g5uc1204zmw6u6r6bbp711tjt&dl=0)

### Credit (for release notes)

My WordPress.org username: matthewneilcowan

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Activate dropdown and RSVP-response-toggle triggers with the Space key, honoring
their announced button role.

</details>