### PR TITLE
Fix/settings field labels

### DIFF
--- a/.github/changelog/2072-from-description
+++ b/.github/changelog/2072-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Give the permalink-base and RSVP settings fields their accessible labels, which previously rendered empty.

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -296,12 +296,12 @@ final class Events extends Base {
 						'field'  => array(
 							'type'    => 'text',
 							'rewrite' => true,
+							'label'   => sprintf(
+								/* translators: %s: Plural post type label, e.g. "Events". */
+								__( 'Permalink base of %s.', 'gatherpress' ),
+								Utility::post_type_label( 'name', Event::POST_TYPE )
+							),
 							'options' => array(
-								'label'   => sprintf(
-									/* translators: %s: Plural post type label, e.g. "Events". */
-									__( 'Permalink base of %s.', 'gatherpress' ),
-									Utility::post_type_label( 'name', Event::POST_TYPE )
-								),
 								'default' => Setup::get_localized_post_type_slug(),
 							),
 							'preview' => array(
@@ -321,12 +321,12 @@ final class Events extends Base {
 						'field'  => array(
 							'type'    => 'text',
 							'rewrite' => true,
+							'label'   => sprintf(
+								/* translators: %s: Plural taxonomy label, e.g. "Topics". */
+								__( 'Permalink base of %s.', 'gatherpress' ),
+								Utility::taxonomy_label( 'name', Topic::TAXONOMY )
+							),
 							'options' => array(
-								'label'   => sprintf(
-									/* translators: %s: Plural taxonomy label, e.g. "Topics". */
-									__( 'Permalink base of %s.', 'gatherpress' ),
-									Utility::taxonomy_label( 'name', Topic::TAXONOMY )
-								),
 								'default' => Topic::get_localized_taxonomy_slug(),
 							),
 							'preview' => array(

--- a/includes/core/classes/settings/class-rsvp.php
+++ b/includes/core/classes/settings/class-rsvp.php
@@ -97,6 +97,7 @@ final class Rsvp extends Base {
 						),
 						'field'       => array(
 							'type'    => 'select',
+							'label'   => __( 'RSVP mode:', 'gatherpress' ),
 							'options' => array(
 								'default' => 'enabled',
 								'items'   => array(
@@ -231,6 +232,7 @@ final class Rsvp extends Base {
 						),
 						'field'       => array(
 							'type'    => 'select',
+							'label'   => __( 'RSVP cleanup:', 'gatherpress' ),
 							'options' => array(
 								'default' => 'disabled',
 								'items'   => array(

--- a/includes/core/classes/settings/class-rsvp.php
+++ b/includes/core/classes/settings/class-rsvp.php
@@ -252,6 +252,7 @@ final class Rsvp extends Base {
 						),
 						'field'       => array(
 							'type'    => 'select',
+							'label'   => __( 'Cleanup frequency:', 'gatherpress' ),
 							'options' => array(
 								'default' => 'daily',
 								'items'   => array(
@@ -278,6 +279,7 @@ final class Rsvp extends Base {
 						'field'       => array(
 							'type'    => 'number',
 							'size'    => 'small',
+							'label'   => __( 'Cleanup interval:', 'gatherpress' ),
 							'options' => array(
 								'min'     => 1,
 								'default' => 1,

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -284,12 +284,12 @@ final class Venues extends Base {
 						'field'  => array(
 							'type'    => 'text',
 							'rewrite' => true,
+							'label'   => sprintf(
+								/* translators: %s: Plural post type label, e.g. "Venues". */
+								__( 'Permalink base of %s.', 'gatherpress' ),
+								Utility::post_type_label( 'name', Venue::POST_TYPE )
+							),
 							'options' => array(
-								'label'   => sprintf(
-									/* translators: %s: Plural post type label, e.g. "Venues". */
-									__( 'Permalink base of %s.', 'gatherpress' ),
-									Utility::post_type_label( 'name', Venue::POST_TYPE )
-								),
 								'default' => Setup::get_instance()->get_localized_post_type_slug(),
 							),
 							'preview' => array(


### PR DESCRIPTION
Fixes #2071

## Proposed changes:

* Populate the seven empty settings-field `<label>` elements so every control has an
  accessible name. Root cause was a key-path mismatch: `Settings::render_field()`
  reads `field.label`, but the three permalink-base fields (`events_url`,
  `topics_url`, `venues_url`) defined their labels under `field.options.label` —
  translated strings that never rendered anywhere — and the four RSVP fields
  (`rsvp_mode`, `rsvp_cleanup_switch`, `rsvp_cleanup_frequency`,
  `rsvp_cleanup_interval`) had no label defined at all. The last two are hidden
  behind the cleanup `show_if` toggle, which is why default-state scans miss them.
* Move the three trapped labels up to `field.label` (reviving the existing
  translated strings) and add `field.label` to the four RSVP fields (`RSVP mode:`,
  `RSVP cleanup:`, `Cleanup frequency:`, `Cleanup interval:`), matching the
  convention every working settings field already uses (Date Format, Default
  archive view, Google Maps API key, …).
* Definitions-only change in the three settings classes — no renderer, template, or
  markup changes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No new tests — the change is data-only (field definition arrays); the rendering path
it feeds is unchanged and already covered. Happy to add assertions on the definition
arrays if needed.

## Testing instructions:

1. Check out the branch, activate the plugin (no build step needed — PHP only).
2. Go to **Events → Settings**:
   - **Events tab:** the two Permalinks fields now show "Permalink base of Events." /
     "Permalink base of Topics." above their inputs (previously nothing — the
     `<label>` was empty).
   - **Venues tab:** same for "Permalink base of Venues."
   - **RSVP tab:** the RSVP Mode and RSVP Cleanup selects now show "RSVP mode:" /
     "RSVP cleanup:" labels. Then set RSVP Cleanup to **Enabled** — the revealed
     Cleanup Frequency and Cleanup Interval fields show "Cleanup frequency:" /
     "Cleanup interval:" (both previously empty; WAVE flags them on develop).
3. Console check on any tab, e.g.:
   `document.querySelector('label[for="gatherpress_rsvp_mode"]').textContent` →
   `"RSVP mode:"` (was `""` on `develop`).
4. axe-core (rules `label`, `select-name`): zero violations on all three tabs — on
   `develop` these report 5 critical violations.
5. Visual consistency: the new labels render exactly like existing fields' labels
   (e.g. Date Format's "Format of date for scheduled Events.").

### Credit (for release notes)

My WordPress.org username: matthewneilcowan

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Give the permalink-base and RSVP settings fields their accessible labels, which
previously rendered empty.

</details>