### PR TITLE
Fetch the Playground blueprint override over the API, not a checkout

### DIFF
--- a/.github/workflows/playground-preview-comment.yml
+++ b/.github/workflows/playground-preview-comment.yml
@@ -61,16 +61,50 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           path: base
 
-      # PR head — ONLY to read the override file, never to execute code from it.
-      # Sparse checkout limits what we pull to just the override directory.
-      - name: Checkout PR head for blueprint override
-        uses: actions/checkout@v4
+      # PR head override file — fetched over the API rather than checked out.
+      #
+      # actions/checkout refuses to check out fork PR code from a workflow_run
+      # context, because this job holds the base repo's GITHUB_TOKEN and secrets
+      # ("pwn request"). That refusal is correct, and opting out with
+      # allow-unsafe-pr-checkout would undo the reason this workflow is split
+      # from the build in the first place.
+      #
+      # The override is data, not code: one JSON file the script below reads and
+      # sanitizes. Reading it through the contents API gets that data without a
+      # working copy of fork code, so the guard never applies. Written to the
+      # path the script already expects, so its interface is unchanged.
+      - name: Fetch PR blueprint override
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          path: pr-head
-          sparse-checkout: |
-            .github/playground
-          sparse-checkout-cone-mode: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const dir = 'pr-head/.github/playground';
+            const file = `PR-${ process.env.PR_NUMBER }-blueprint-override.json`;
+
+            fs.mkdirSync(dir, { recursive: true });
+
+            try {
+                const { data } = await github.rest.repos.getContent({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    path: `.github/playground/${ file }`,
+                    ref: context.payload.workflow_run.head_sha,
+                });
+
+                fs.writeFileSync(
+                    `${ dir }/${ file }`,
+                    Buffer.from(data.content, data.encoding)
+                );
+                console.log(`Fetched blueprint override ${ file }`);
+            } catch (error) {
+                if (404 !== error.status) {
+                    throw error;
+                }
+                console.log(`No blueprint override at ${ file }`);
+            }
 
       - name: Add Preview Links comment
         uses: actions/github-script@v7


### PR DESCRIPTION
### Description of the Change

Fork PRs stopped getting Playground preview comments. #2072 is a current example: `Playground Preview` succeeds, `Playground Preview Comment` fires and then fails.

```
Refusing to check out fork pull request code from a 'workflow_run' workflow.
This workflow runs with the base repository's GITHUB_TOKEN, secrets,
default-branch cache scope, and runner access. Fetching and executing a
fork's code in that trusted context commonly leads to "pwn request"
vulnerabilities.
```

`actions/checkout` added that guard after this workflow was written, so it broke underneath us. Every run since at least July 29 has failed.

### Why not `allow-unsafe-pr-checkout: true`

That's the opt-out the error suggests, and it would be a one-word fix. It also reintroduces exactly the risk these two workflows were split apart to avoid — `playground-preview.yml`'s own header notes CodeQL flagged the combined form as `actions/untrusted-checkout/critical`. Not worth it.

### What changed

The checkout only ever existed to read one JSON file. It was already sparse-limited to `.github/playground` and carried the comment "ONLY to read the override file, never to execute code from it."

Since it's data rather than code, `repos.getContent()` returns it without a working copy of fork code, so the guard never applies. The file is written to the same path the script already expects, so `.github/scripts/playground-preview` is untouched and its `filePath` interface is unchanged. A missing override 404s and logs, matching the previous `existsSync()` behavior.

The trusted base-repo checkout stays exactly as it was.

### How to test the Change

Can't be exercised from this PR, since `workflow_run` uses the workflow file from the default branch. Verification is the next fork PR after merge: it should get its preview comment, and a fork PR carrying a `.github/playground/PR-<n>-blueprint-override.json` should still have the override applied.

### Changelog Entry

None — CI only. `Skip Changelog` applied.

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.

### Note

Worth knowing that #1803 moves blueprint overrides into the PR description instead of a file. If that lands, this fetch step disappears along with the override file. It's currently conflicting, so this doesn't wait for it, and neither change blocks the other.