### PR TITLE
Stop marking a new event dirty before the author edits anything

### DIFF
--- a/.github/changelog/2054-new-event-dirty-state
+++ b/.github/changelog/2054-new-event-dirty-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a brand new event being marked as having unsaved changes before the author edits anything, which made the browser warn about leaving the page and enabled Save draft immediately.

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -14,6 +14,7 @@ namespace GatherPress\Core\Event;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use DateTimeImmutable;
 use Exception;
 use GatherPress\Core\Event;
 use GatherPress\Core\Feed;
@@ -745,10 +746,26 @@ final class Setup {
 		$data = get_post_meta( $post_id, 'gatherpress_datetime', true );
 
 		if ( empty( $data ) ) {
-			return;
-		}
+			// No meta means the editor never wrote one, which is the normal
+			// path for an event saved without touching the date controls
+			// (#2054), and for any programmatic insert that omits it. Without
+			// a fallback such an event gets no row in the events table and is
+			// invisible to every upcoming / past query while still looking
+			// correct in the editor.
+			//
+			// Seed the default only when nothing is stored yet. Recomputing it
+			// on every save would walk the event's date forward a day at a
+			// time, and the meta itself is deliberately left alone so a caller
+			// that inserts the post first and sets `gatherpress_datetime`
+			// afterwards is not overwritten.
+			if ( '' !== (string) get_post_meta( $post_id, 'gatherpress_datetime_start', true ) ) {
+				return;
+			}
 
-		$data = json_decode( (string) $data, true ) ?? array();
+			$data = $this->get_default_datetime();
+		} else {
+			$data = json_decode( (string) $data, true ) ?? array();
+		}
 
 		$event  = new Event( $post_id );
 		$params = array(
@@ -759,5 +776,33 @@ final class Setup {
 		);
 
 		$event->save_datetimes( $params );
+	}
+
+	/**
+	 * Default date and time payload for an event that has none stored.
+	 *
+	 * Mirrors the editor's defaults in `src/helpers/datetime.js`: tomorrow at
+	 * 18:00 in the site timezone, running for two hours.
+	 *
+	 * The editor's duration is filterable in JavaScript through
+	 * `gatherpress.durationDefault`, which cannot be read from here. A site
+	 * that filters it only sees a difference for an event saved without the
+	 * date controls ever being touched, since any real edit writes the meta
+	 * from the editor instead.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return array{dateTimeStart: string, dateTimeEnd: string, timezone: string} Default datetime payload.
+	 */
+	protected function get_default_datetime(): array {
+		$timezone = wp_timezone();
+		$start    = new DateTimeImmutable( 'tomorrow 18:00', $timezone );
+		$end      = $start->modify( '+2 hours' );
+
+		return array(
+			'dateTimeStart' => $start->format( Event::DATETIME_FORMAT ),
+			'dateTimeEnd'   => $end->format( Event::DATETIME_FORMAT ),
+			'timezone'      => wp_timezone_string(),
+		);
 	}
 }

--- a/src/components/DateTimeRange.js
+++ b/src/components/DateTimeRange.js
@@ -50,11 +50,12 @@ const DateTimeRange = () => {
 		dateTimeMetaData = {};
 	}
 
-	const { dateTimeStart, dateTimeEnd, timezone } = useSelect(
+	const { dateTimeStart, dateTimeEnd, timezone, isCleanNewPost } = useSelect(
 		( select ) => ( {
 			dateTimeStart: select( 'gatherpress/datetime' ).getDateTimeStart(),
 			dateTimeEnd: select( 'gatherpress/datetime' ).getDateTimeEnd(),
 			timezone: select( 'gatherpress/datetime' ).getTimezone(),
+			isCleanNewPost: select( 'core/editor' ).isCleanNewPost(),
 		} ),
 		[],
 	);
@@ -64,6 +65,18 @@ const DateTimeRange = () => {
 	const matchedDuration = useMatchedDuration();
 
 	useEffect( () => {
+		// Don't write meta into an untouched new post. The store already holds
+		// the defaults while the stored meta is empty, so this effect's first
+		// run would be a real edit and the editor would report unsaved changes
+		// before the author typed anything (#2054).
+		//
+		// Nothing is lost by waiting: `Event\Setup::set_datetimes()` fills the
+		// same defaults server side when the meta is absent at save time. Any
+		// real edit clears `isCleanNewPost`, and this effect runs from then on.
+		if ( isCleanNewPost ) {
+			return;
+		}
+
 		const payload = JSON.stringify( {
 			...dateTimeMetaData,
 			dateTimeStart: createMomentWithTimezone( dateTimeStart, timezone )
@@ -81,6 +94,7 @@ const DateTimeRange = () => {
 		timezone,
 		dateTimeMetaData,
 		editPost,
+		isCleanNewPost,
 	] );
 
 	return (

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -767,13 +767,15 @@ class Test_Admin_List extends Base {
 	 *
 	 * @return void
 	 */
-	public function test_get_event_counts_with_no_date(): void {
+	public function test_get_event_counts_for_an_event_created_without_dates(): void {
 		$instance = Admin_List::get_instance();
 
 		// Reset cached counts.
 		Utility::set_and_get_hidden_property( $instance, 'event_counts', array() );
 
-		// Create an event without setting any dates.
+		// An event created without dates is seeded with the editor's default,
+		// which is tomorrow, so it counts as upcoming rather than falling out
+		// of both buckets the way a datetime-less event used to (#2054).
 		$this->mock->post(
 			array(
 				'post_type'   => Event::POST_TYPE,
@@ -783,8 +785,8 @@ class Test_Admin_List extends Base {
 
 		$counts = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
 
-		$this->assertSame( 0, $counts['upcoming'], 'Event without date should not count as upcoming.' );
-		$this->assertSame( 0, $counts['past'], 'Event without date should not count as past.' );
+		$this->assertSame( 1, $counts['upcoming'], 'Event created without dates should count as upcoming.' );
+		$this->assertSame( 0, $counts['past'], 'Event created without dates should not count as past.' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -105,10 +105,6 @@ class Test_Event extends Base {
 				'expects' => 'Monday, May 11, 2020 3:00 PM to Tuesday, May 12, 2020 5:00 PM EDT',
 			),
 			array(
-				'params'  => array(),
-				'expects' => '—',
-			),
-			array(
 				'params'  => array(
 					'datetime_start' => '2020-05-11 15:00:00',
 					'datetime_end'   => '2020-05-11 17:00:00',
@@ -310,15 +306,18 @@ class Test_Event extends Base {
 		)->get();
 		$event = new Event( $post->ID );
 
+		// A new event is seeded with the editor's default rather than left
+		// datetime-less, so it always lands in the events table (#2054).
+		$seeded = $event->get_datetime();
+
+		$this->assertNotEmpty(
+			$seeded['datetime_start'],
+			'Failed to assert that a new event is seeded with a start datetime.'
+		);
 		$this->assertSame(
-			array(
-				'datetime_start'     => '',
-				'datetime_start_gmt' => '',
-				'datetime_end'       => '',
-				'datetime_end_gmt'   => '',
-				'timezone'           => '+00:00',
-			),
-			$event->get_datetime()
+			2 * HOUR_IN_SECONDS,
+			strtotime( $seeded['datetime_end'] ) - strtotime( $seeded['datetime_start'] ),
+			'Failed to assert that the seeded default runs for two hours.'
 		);
 
 		$params = array(

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -517,10 +517,13 @@ class Test_Setup extends Base {
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
 
+		// An event with no stored datetime gets the default filled in rather
+		// than no row at all, which would leave it invisible to every
+		// upcoming / past query (#2054).
 		$instance->set_datetimes( $post_id );
-		$this->assertEmpty(
+		$this->assertNotEmpty(
 			get_post_meta( $post_id, 'gatherpress_datetime_start', true ),
-			'Failed to assert that datetime start meta is empty.'
+			'Failed to assert that a missing datetime falls back to the default.'
 		);
 
 		$post_id = $this->mock->post(
@@ -1078,6 +1081,74 @@ class Test_Setup extends Base {
 			'Label should contain GatherPress.'
 		);
 	}
+
+	/**
+	 * An event created without a stored datetime gets the editor's default
+	 * seeded server side, so it lands in the events table rather than being
+	 * invisible to every upcoming / past query (#2054).
+	 *
+	 * @covers ::set_datetimes
+	 * @covers ::get_default_datetime
+	 *
+	 * @return void
+	 */
+	public function test_set_datetimes_seeds_the_default_when_meta_is_absent(): void {
+		$post_id = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		$this->assertEmpty(
+			get_post_meta( $post_id, 'gatherpress_datetime', true ),
+			'Failed to assert the seed leaves the editor-owned meta alone.'
+		);
+
+		$start = (string) get_post_meta( $post_id, 'gatherpress_datetime_start', true );
+		$end   = (string) get_post_meta( $post_id, 'gatherpress_datetime_end', true );
+
+		$this->assertNotEmpty(
+			$start,
+			'Failed to assert the events table was populated from the default.'
+		);
+		$this->assertSame(
+			'18:00:00',
+			gmdate( 'H:i:s', (int) strtotime( $start ) ),
+			'Failed to assert the default starts at 18:00, matching the editor.'
+		);
+		$this->assertSame(
+			2 * HOUR_IN_SECONDS,
+			strtotime( $end ) - strtotime( $start ),
+			'Failed to assert the default runs for two hours, matching the editor.'
+		);
+	}
+
+	/**
+	 * The seeded default is stable across saves.
+	 *
+	 * Recomputing it each time would walk the event's date forward a day on
+	 * every save, which is why the seed only applies when nothing is stored.
+	 *
+	 * @covers ::set_datetimes
+	 *
+	 * @return void
+	 */
+	public function test_set_datetimes_default_does_not_drift_across_saves(): void {
+		$instance = Setup::get_instance();
+		$post_id  = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		$first = get_post_meta( $post_id, 'gatherpress_datetime_start', true );
+
+		$instance->set_datetimes( $post_id );
+		$second = get_post_meta( $post_id, 'gatherpress_datetime_start', true );
+
+		$this->assertSame(
+			$first,
+			$second,
+			'Failed to assert that re-saving leaves the seeded default unchanged.'
+		);
+	}
+
 
 	/**
 	 * Coverage for set_datetimes method with non-event post.


### PR DESCRIPTION
Fixes #2054

### Description of the Change

Opening `post-new.php?post_type=gatherpress_event` and navigating away triggers the browser's "Leave site?" prompt, and Save draft is active immediately. A new post or page doesn't do this, and neither does an existing event.

`DateTimeRange` writes `gatherpress_datetime` from a mount effect. On an existing event that payload equals the stored meta, so the edit is a no-op. On a new event the store already holds the defaults while the stored meta is empty, so the first run is a real edit and the post is dirty before anyone touches it.

The write can't simply be dropped. `Event\Setup::set_datetimes()` bails when the meta is empty, so an event saved without it gets **no row in the events table** and is invisible to every upcoming and past query while looking correct in the editor.

So both halves move, which is @wppoland's option 1 from the issue:

- **Client** — the effect skips while `isCleanNewPost()` is true. Any real edit clears that, and the effect runs from then on.
- **Server** — `set_datetimes()` seeds the editor's default (tomorrow 18:00 in the site timezone, running two hours) when nothing is stored.

### Two details in the seed that matter

**It doesn't write `gatherpress_datetime`.** An earlier version did, and it broke an existing test by clobbering meta set by callers who insert the post first and add meta second. The seed now only writes the derived row and leaves the editor-owned meta alone.

**It only applies when nothing is stored.** Guarded on `gatherpress_datetime_start`. Without that, every save with absent meta would recompute "tomorrow" and walk the event's date forward a day at a time.

### This makes datetime-less events unreachable

That's the intended outcome rather than a side effect, and it's a deliberate call by @mauteri: such an event was invisible to every event query, which is worse than the cosmetic bug being fixed here.

Three existing tests encoded the old contract, and all three now encode the new one:

- The empty-params case leaves `data_get_display_datetime`, since an event with no datetime can't occur.
- `test_get_datetime`'s new-event block asserts the seeded default rather than empties. The `new Event( 0 )` case is unchanged and still correct: no post means no hook.
- `test_get_event_counts_with_no_date` is reframed as `..._for_an_event_created_without_dates` and asserts it counts as upcoming. Reframed rather than deleted so it still catches a seeding regression.

The `—` fallback in `get_display_datetime()` is now unreachable through normal flows. Left in place as cover for a row deleted out from under us rather than expanding this PR.

### How to test the Change

1. Open `post-new.php?post_type=gatherpress_event`, let the editor settle, and navigate away. No "Leave site?" prompt, and Save draft is inactive.
2. Change the date, then navigate away. The prompt appears, as it should.
3. Create an event, set only a title, publish. It appears under Upcoming with tomorrow's date rather than vanishing from both views.
4. Confirm an existing event still saves its dates normally.

### Changelog Entry

> Fixed - Fixed a brand new event being marked as having unsaved changes before the author edits anything, which made the browser warn about leaving the page and enabled Save draft immediately.

### Credits

Props @wppoland for the report and the diagnosis, including the reason the client write can't just be deferred.

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.

`npm run lint:php`, `npm run lint:phpstan`, and `npx eslint` are clean. Full PHP suite: **OK (1648 tests, 6895 assertions)**.
