### PR TITLE
Label the RSVP list-table row checkboxes

### DIFF
--- a/.github/changelog/2080-from-description
+++ b/.github/changelog/2080-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Label each RSVP list-table row checkbox with the attendee it selects, matching core's list-table pattern.

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -544,19 +544,56 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * Generates a checkbox input element for each RSVP record that allows users
 	 * to select multiple entries for performing bulk actions. The checkbox value
-	 * is set to the comment ID.
+	 * is set to the comment ID. A visually hidden label names the checkbox after
+	 * the attendee — mirroring core's post/comment list tables — so screen-reader
+	 * users know which entry each checkbox selects.
 	 *
 	 * @since 0.34.0
 	 *
 	 * @param array|object $item RSVP comment data containing the comment_ID.
 	 *
-	 * @return string HTML markup for the checkbox input element.
+	 * @return string HTML markup for the labeled checkbox input element.
 	 */
 	public function column_cb( $item ): string {
+		$item       = (array) $item;
+		$comment_id = intval( $item['comment_ID'] );
+
 		return sprintf(
-			'<input type="checkbox" name="gatherpress_rsvp_id[]" value="%d" />',
-			intval( $item['comment_ID'] )
+			'<label class="label-covers-full-cell" for="cb-select-%1$d"><span class="screen-reader-text">%2$s</span></label>' .
+			'<input id="cb-select-%1$d" type="checkbox" name="gatherpress_rsvp_id[]" value="%1$d" />',
+			$comment_id,
+			esc_html(
+				sprintf(
+					/* translators: %s: Attendee name. */
+					__( 'Select %s', 'gatherpress' ),
+					$this->get_attendee_name( $item )
+				)
+			)
 		);
+	}
+
+	/**
+	 * Resolves the display name for an RSVP entry.
+	 *
+	 * Registered users are shown by their display name; open (account-less)
+	 * RSVPs fall back to the submitted author name. Mirrors the resolution
+	 * used when rendering the Attendee column.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param array $item RSVP comment data.
+	 *
+	 * @return string The attendee's display name.
+	 */
+	protected function get_attendee_name( array $item ): string {
+		$username = (string) ( $item['comment_author'] ?? '' );
+
+		if ( ! empty( $item['user_id'] ) ) {
+			$user     = get_userdata( $item['user_id'] );
+			$username = $user->display_name ?? __( 'Unknown', 'gatherpress' );
+		}
+
+		return $username;
 	}
 
 	/**

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -549,6 +549,7 @@ final class List_Table extends WP_List_Table {
 	 * users know which entry each checkbox selects.
 	 *
 	 * @since 0.34.0
+	 * @since 0.35.0 Row checkboxes carry a visually hidden label naming the attendee.
 	 *
 	 * @param array|object $item RSVP comment data containing the comment_ID.
 	 *
@@ -559,7 +560,8 @@ final class List_Table extends WP_List_Table {
 		$comment_id = intval( $item['comment_ID'] );
 
 		return sprintf(
-			'<label class="label-covers-full-cell" for="cb-select-%1$d"><span class="screen-reader-text">%2$s</span></label>' .
+			'<label class="label-covers-full-cell" for="cb-select-%1$d">' .
+			'<span class="screen-reader-text">%2$s</span></label>' .
 			'<input id="cb-select-%1$d" type="checkbox" name="gatherpress_rsvp_id[]" value="%1$d" />',
 			$comment_id,
 			esc_html(
@@ -576,8 +578,10 @@ final class List_Table extends WP_List_Table {
 	 * Resolves the display name for an RSVP entry.
 	 *
 	 * Registered users are shown by their display name; open (account-less)
-	 * RSVPs fall back to the submitted author name. Mirrors the resolution
-	 * used when rendering the Attendee column.
+	 * RSVPs — and stale user IDs whose account was deleted — fall back to the
+	 * submitted author name. Mirrors the resolution used when rendering the
+	 * Attendee column, and always returns a non-empty name so the checkbox
+	 * label never renders as a bare "Select ".
 	 *
 	 * @since 0.35.0
 	 *
@@ -589,8 +593,15 @@ final class List_Table extends WP_List_Table {
 		$username = (string) ( $item['comment_author'] ?? '' );
 
 		if ( ! empty( $item['user_id'] ) ) {
-			$user     = get_userdata( $item['user_id'] );
-			$username = $user->display_name ?? __( 'Unknown', 'gatherpress' );
+			$user = get_userdata( $item['user_id'] );
+
+			if ( $user && '' !== trim( (string) $user->display_name ) ) {
+				$username = $user->display_name;
+			}
+		}
+
+		if ( '' === trim( $username ) ) {
+			$username = __( 'Unknown', 'gatherpress' );
 		}
 
 		return $username;

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
@@ -550,6 +550,27 @@ class Test_List_Table extends Base {
 	}
 
 	/**
+	 * Tests column_cb never renders an empty attendee name.
+	 *
+	 * @covers ::column_cb
+	 * @covers ::get_attendee_name
+	 * @return void
+	 */
+	public function test_column_cb_unknown_attendee(): void {
+		$rsvp                   = $this->rsvp;
+		$rsvp['comment_author'] = '';
+		$rsvp['user_id']        = 0;
+
+		$cb_col = $this->list_table->column_cb( $rsvp );
+
+		$this->assertStringContainsString(
+			'Select Unknown',
+			$cb_col,
+			'Failed to assert an empty name resolution falls back to "Unknown".'
+		);
+	}
+
+	/**
 	 * Tests column_attendee method.
 	 *
 	 * @covers ::column_attendee

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
@@ -503,6 +503,53 @@ class Test_List_Table extends Base {
 	}
 
 	/**
+	 * Tests column_cb labels registered users by their display name.
+	 *
+	 * @covers ::column_cb
+	 * @covers ::get_attendee_name
+	 * @return void
+	 */
+	public function test_column_cb_registered_user(): void {
+		$user_id = $this->factory->user->create(
+			array(
+				'display_name' => 'Registered Attendee',
+			)
+		);
+
+		$rsvp            = $this->rsvp;
+		$rsvp['user_id'] = $user_id;
+
+		$cb_col = $this->list_table->column_cb( $rsvp );
+
+		$this->assertStringContainsString(
+			'Select Registered Attendee',
+			$cb_col,
+			'Failed to assert label uses the registered user\'s display name.'
+		);
+	}
+
+	/**
+	 * Tests column_cb falls back to the submitted author name when the
+	 * stored user ID no longer resolves to an account.
+	 *
+	 * @covers ::column_cb
+	 * @covers ::get_attendee_name
+	 * @return void
+	 */
+	public function test_column_cb_stale_user_id(): void {
+		$rsvp            = $this->rsvp;
+		$rsvp['user_id'] = 999999; // No such user.
+
+		$cb_col = $this->list_table->column_cb( $rsvp );
+
+		$this->assertStringContainsString(
+			sprintf( 'Select %s', $this->rsvp['comment_author'] ),
+			$cb_col,
+			'Failed to assert a stale user ID falls back to the submitted author name.'
+		);
+	}
+
+	/**
 	 * Tests column_attendee method.
 	 *
 	 * @covers ::column_attendee

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
@@ -480,6 +480,26 @@ class Test_List_Table extends Base {
 			$cb_col,
 			'Failed to assert checkbox has comment ID as value.'
 		);
+		$this->assertStringContainsString(
+			sprintf( 'for="cb-select-%d"', $this->rsvp['comment_ID'] ),
+			$cb_col,
+			'Failed to assert label is associated with the checkbox.'
+		);
+		$this->assertStringContainsString(
+			sprintf( 'id="cb-select-%d"', $this->rsvp['comment_ID'] ),
+			$cb_col,
+			'Failed to assert checkbox carries the id the label points at.'
+		);
+		$this->assertStringContainsString(
+			'screen-reader-text',
+			$cb_col,
+			'Failed to assert label text is visually hidden.'
+		);
+		$this->assertStringContainsString(
+			sprintf( 'Select %s', $this->rsvp['comment_author'] ),
+			$cb_col,
+			'Failed to assert label names the attendee the checkbox selects.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2079

<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes:

* Give every RSVP list-table row checkbox an accessible name. `column_cb()` now
  renders core's list-table pattern — `<label class="label-covers-full-cell">` with
  a `screen-reader-text` span reading "Select {attendee}", associated to the input
  by `id`/`for` — instead of a bare `<input type="checkbox">`.
* New `get_attendee_name()` helper resolves the name the same way the Attendee
  column does: registered users by their display name, open (account-less) RSVPs by
  their submitted author name.
* The header select-all checkbox is untouched (core already labels it); no other
  columns or behavior change. The `label-covers-full-cell` class is core admin CSS,
  so the label also enlarges the checkbox's effective click target to the full
  cell — same as core tables.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Extended `test_column_cb()` with four assertions: label/checkbox `for`/`id`
association, visually hidden text, and the "Select {attendee}" naming.

## Testing instructions:

1. Check out the branch, activate the plugin (no build step — PHP only). Ensure at
   least one RSVP exists (RSVP to any event).
2. Go to **Events → RSVPs** and inspect a row checkbox: it now has
   `id="cb-select-{id}"` with an associated label whose hidden text reads
   "Select {attendee name}".
3. Console:
   `document.querySelector('.wp-list-table tbody input[type=checkbox]').labels[0].textContent.trim()`
   → `"Select {name}"` (on `develop`: `.labels.length` is `0`).
4. With NVDA, Tab through the checkbox column: each announces "Select {name},
   checkbox". Both name paths work — registered users announce their display name,
   open RSVPs their submitted name.
5. axe-core (`label` rule) on the table: zero violations — on `develop`, one
   critical violation per row.
6. Bulk selection still works: check rows, run a bulk action (see #2062 for a
   pre-existing, unrelated bulk-action bug on this screen).

### Credit (for release notes)

My WordPress.org username: matthewneilcowan

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Label each RSVP list-table row checkbox with the attendee it selects, matching
core's list-table pattern.

</details>