### PR TITLE
docs: explain Advanced Query Loop event lists

### DIFF
--- a/docs/user/blocks/event-query.md
+++ b/docs/user/blocks/event-query.md
@@ -22,3 +22,67 @@ GatherPress includes a block-variation of the `core/query` block, called _Event 
 9. Allows to filter the queried events by Author, Keyword, Topic or Venue (and any other additionally registered taxonomies).
 10. **Filter by current venue** toggle — when placed on a venue page, the query is automatically scoped to that venue's events. The toggle is hidden on regular posts where there's no venue context to use. In templates or template parts, the toggle is shown with a note that the filter only takes effect when the template renders on a venue page.
 11. The variation is automatically loaded, when an editor chooses the „Event“ post type in a regular `core/query` block.
+
+## Curated and mixed event lists with Advanced Query Loop
+
+[Advanced Query Loop](https://wordpress.org/plugins/advanced-query-loop/) (AQL)
+adds generic query controls to the WordPress Query Loop block. GatherPress
+adds event-specific controls when an AQL query targets Events.
+
+Use AQL when you need to hand-pick events or combine events with other post
+types. Use the GatherPress Event Query variation when you only need the usual
+upcoming or past event lists.
+
+### Create a curated list of events
+
+Use this approach for a list such as featured events for a quarter.
+
+1. Install and activate Advanced Query Loop.
+2. Add an **Advanced Query Loop** block to the page or template.
+3. In AQL's query settings, set the post type to **Events**.
+4. In the **Event Query Settings** panel added by GatherPress, choose whether
+   the list contains upcoming or past events, configure inclusion of unfinished
+   events, and choose event ordering.
+5. In AQL's **Include Posts** control, search for and select the individual
+   events to display.
+6. Design the loop template as usual, for example with a title, Event Date,
+   and RSVP blocks.
+
+The **Include Posts** control belongs to AQL. It can find events by title or
+ID and can be paired with AQL's exclude control when needed.
+
+#### Why start with the AQL block
+
+GatherPress event query settings and AQL's generic controls appear together
+only on the AQL variation. Start with **Advanced Query Loop**, rather than the
+GatherPress Event Query variation, when you need to include selected events.
+
+### Mix events with posts in one list
+
+AQL can display Events together with posts or other post types.
+
+1. Add an **Advanced Query Loop** block.
+2. Set the primary post type in the AQL query settings.
+3. Use AQL's **Additional Post Types** control to add Events and any other
+   desired post types.
+4. Design a template that makes sense for every type included in the list.
+
+This creates one normal WordPress query containing the selected post types.
+It is useful for a chronological content feed where events and posts can
+appear together.
+
+#### Limits of mixed lists
+
+Mixed lists have two important limitations:
+
+- **There is one ordering rule.** Events normally order by their event date,
+  while posts normally order by publish date. A single query cannot use event
+  date for events and publish date for posts in one interleaved list. Choose
+  one ordering method for the complete list.
+- **Event Query Settings are unavailable.** Once a non-event post type is in
+  the query, GatherPress does not show the event-specific panel. Upcoming and
+  past filters do not apply to regular posts, so the mixed list is a plain
+  chronological list rather than an event-date query.
+
+If you need separate event-date ordering and post-date ordering, use separate
+Query Loop blocks instead of a mixed list.


### PR DESCRIPTION
Fix #2037 

## Summary
- document curated event lists using Advanced Query Loop
- explain where GatherPress event controls and AQL generic controls meet
- document ordering and filtering limits for mixed event and post lists

## Validation
- `npm run lint:md:docs` (run via the repository's installed wp-scripts binary; pass)
- `git diff --check`

Fixes #2037