### PR TITLE
Add theme tokens for interactive Leaflet maps

### DIFF
--- a/.github/changelog/1717-venue-map-theme-tokens
+++ b/.github/changelog/1717-venue-map-theme-tokens
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Interactive OpenStreetMap venue maps now let themes customize Leaflet marker filters and attribution link colors without replacing map assets.

--- a/docs/developer/theme-customizations/README.md
+++ b/docs/developer/theme-customizations/README.md
@@ -2,6 +2,7 @@
 
 1. [Template overrides](#template-overrides)
 2. [Theme supports](#theme-supports)
+3. [CSS custom properties](#css-custom-properties)
 
 ## Template overrides
 
@@ -67,3 +68,41 @@ GatherPress does respect [theme_supports](https://developer.wordpress.org/refere
         - `example.org/feed/ical`
         - `example.org/event/feed/ical`
         - `example.org/topic/my-sample-topic/feed/ical`
+
+## CSS custom properties
+
+Some GatherPress components read CSS custom properties so a theme can restyle them without overriding selectors or replacing assets. Set them anywhere the component inherits from — `:root`, a block wrapper, or `theme.json`'s `styles.css`.
+
+They follow WordPress's own `--wp--preset--color--primary` shape: `--gatherpress--{component}--{property}`, with two dashes between segments.
+
+Each one falls back to a WordPress global style before falling back to a hard-coded default, so a theme that defines its palette through `theme.json` usually gets something reasonable without setting these at all.
+
+### Tooltip
+
+| Property | Falls back to |
+| --- | --- |
+| `--gatherpress--tooltip--text-color` | `--wp--preset--color--base`, then `--wp--preset--color--background`, then `#fff` |
+| `--gatherpress--tooltip--background-color` | `--wp--preset--color--contrast`, then `--wp--preset--color--primary`, then `#333` |
+
+### Venue map
+
+Applies to the interactive (Leaflet) map. Static maps are server-rendered images and are not affected.
+
+| Property | Falls back to |
+| --- | --- |
+| `--gatherpress--venue-map--attribution-link-color` | `--wp--preset--color--primary`, then `#0073aa` |
+| `--gatherpress--venue-map--marker-filter` | `none` |
+
+`--gatherpress--venue-map--marker-filter` is **not a color**. The map marker is one of Leaflet's raster images, so the value has to be a valid CSS [`filter`](https://developer.mozilla.org/en-US/docs/Web/CSS/filter) list. Setting a color here does nothing.
+
+To tint the default marker toward a theme color, combine `brightness(0) saturate(100%)` (which flattens the image to black) with hue and saturation adjustments:
+
+```css
+:root {
+	--gatherpress--venue-map--marker-filter: brightness(0) saturate(100%) invert(28%)
+		sepia(96%) saturate(1720%) hue-rotate(196deg);
+}
+```
+
+Themes that would rather supply their own marker artwork should replace the icon rather than filter it.
+

--- a/src/formats/tooltip/style.scss
+++ b/src/formats/tooltip/style.scss
@@ -7,8 +7,8 @@
  * Theme Integration:
  * Themes can customize tooltip colors by setting these CSS custom properties:
  *
- *   --gatherpress--gatherpress-tooltip--text-color: #fff;
- *   --gatherpress--gatherpress-tooltip--background-color: #333;
+ *   --gatherpress--tooltip--text-color: #fff;
+ *   --gatherpress--tooltip--background-color: #333;
  *
  * If not set, tooltips will use WordPress global styles (--wp--preset--color--*)
  * or fall back to colors that provide good contrast.
@@ -20,11 +20,11 @@
 // Priority: 1) Inline styles 2) GatherPress theme vars 3) WP global styles 4) Fallback
 .gatherpress-tooltip {
 	--gatherpress-tooltip-text-color: var(
-		--gatherpress--gatherpress-tooltip--text-color,
+		--gatherpress--tooltip--text-color,
 		var(--wp--preset--color--base, var(--wp--preset--color--background, #fff))
 	);
 	--gatherpress-tooltip-bg-color: var(
-		--gatherpress--gatherpress-tooltip--background-color,
+		--gatherpress--tooltip--background-color,
 		var(--wp--preset--color--contrast, var(--wp--preset--color--primary, #333))
 	);
 	--gatherpress-tooltip-padding: 8px 12px;

--- a/src/leaflet-style.js
+++ b/src/leaflet-style.js
@@ -12,6 +12,7 @@
 import 'leaflet/dist/leaflet.css';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css';
+import './leaflet-style.scss';
 
 import 'leaflet/dist/images/marker-icon.png';
 import 'leaflet/dist/images/marker-icon-2x.png';

--- a/src/leaflet-style.scss
+++ b/src/leaflet-style.scss
@@ -4,8 +4,8 @@
  * Themes can customize interactive OpenStreetMap maps with these CSS custom
  * properties:
  *
- *   --gatherpress--gatherpress-venue-map--attribution-link-color: #0073aa;
- *   --gatherpress--gatherpress-venue-map--marker-filter: brightness(0) saturate(100%);
+ *   --gatherpress--venue-map--attribution-link-color: #0073aa;
+ *   --gatherpress--venue-map--marker-filter: brightness(0) saturate(100%);
  *
  * The marker is Leaflet's raster image, so its value must be a valid CSS
  * filter list rather than a color. The default keeps Leaflet's existing
@@ -15,11 +15,11 @@
 
 .gatherpress-venue-map {
 	--gatherpress-venue-map-attribution-link-color: var(
-		--gatherpress--gatherpress-venue-map--attribution-link-color,
+		--gatherpress--venue-map--attribution-link-color,
 		var(--wp--preset--color--primary, #0073aa)
 	);
 	--gatherpress-venue-map-marker-filter: var(
-		--gatherpress--gatherpress-venue-map--marker-filter,
+		--gatherpress--venue-map--marker-filter,
 		none
 	);
 

--- a/src/leaflet-style.scss
+++ b/src/leaflet-style.scss
@@ -1,0 +1,33 @@
+/**
+ * Interactive Leaflet venue map theme styles.
+ *
+ * Themes can customize interactive OpenStreetMap maps with these CSS custom
+ * properties:
+ *
+ *   --gatherpress--gatherpress-venue-map--attribution-link-color: #0073aa;
+ *   --gatherpress--gatherpress-venue-map--marker-filter: brightness(0) saturate(100%);
+ *
+ * The marker is Leaflet's raster image, so its value must be a valid CSS
+ * filter list rather than a color. The default keeps Leaflet's existing
+ * marker appearance; themes can provide a filter that matches their palette
+ * without replacing marker assets.
+ */
+
+.gatherpress-venue-map {
+	--gatherpress-venue-map-attribution-link-color: var(
+		--gatherpress--gatherpress-venue-map--attribution-link-color,
+		var(--wp--preset--color--primary, #0073aa)
+	);
+	--gatherpress-venue-map-marker-filter: var(
+		--gatherpress--gatherpress-venue-map--marker-filter,
+		none
+	);
+
+	.leaflet-control-attribution a {
+		color: var(--gatherpress-venue-map-attribution-link-color);
+	}
+
+	.leaflet-marker-icon {
+		filter: var(--gatherpress-venue-map-marker-filter);
+	}
+}


### PR DESCRIPTION
Fixes #1717

## Proposed changes:

- Bundle component-scoped theme variables with the interactive Leaflet stylesheet.
- Let themes override the attribution link color through `--gatherpress--gatherpress-venue-map--attribution-link-color`.
- Let themes apply a CSS filter to Leaflet's existing raster marker through `--gatherpress--gatherpress-venue-map--marker-filter`, without duplicating marker assets.
- Keep the server-rendered static marker out of scope; it is tracked separately in #2082.

### Other information:

- [x] No automated unit test is applicable: this is a stylesheet-only extension point. The production asset build and complete CSS and JavaScript lint suites pass.

## Testing instructions:

1. Under **Settings > GatherPress > Venues > Maps**, select OpenStreetMap and set a Venue Map block to **Interactive**.
2. View an event or venue with coordinates and confirm that the Leaflet map, default marker, and attribution render normally.
3. Add the following CSS in a theme or a test stylesheet:

```css
.gatherpress-venue-map {
    --gatherpress--gatherpress-venue-map--attribution-link-color: #8b1e3f;
    --gatherpress--gatherpress-venue-map--marker-filter: grayscale(1);
}
```

4. Reload the page and confirm that the attribution link adopts the configured color and the existing marker image receives the filter.
5. Switch the block to **Static** and confirm that its server-rendered PNG remains unchanged.

### Credit (for release notes)

My WordPress.org username: linewebdigital

### Changelog entry

A manual changelog entry is included in `.github/changelog/1717-venue-map-theme-tokens`.

- Significance: Minor
- Type: Changed
- Message: Interactive OpenStreetMap venue maps now let themes customize Leaflet marker filters and attribution link colors without replacing map assets.
