### PR TITLE
Fix coverage comment reporting "did not run" when the check actually ran

### DIFF
--- a/.github/workflows/pr-coverage-comment.yml
+++ b/.github/workflows/pr-coverage-comment.yml
@@ -29,18 +29,20 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pr-coverage-results
-          # Drop the artifact in a sibling directory so the base-repo checkout
-          # below doesn't overwrite it.
-          path: ./artifact
+          # Drop the artifact outside the workspace. The base-repo checkout
+          # below deletes the contents of the workspace before cloning, so a
+          # path inside it (`./artifact`) is gone by the time the comment step
+          # reads the coverage output (#2087).
+          path: ${{ runner.temp }}/artifact
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read PR metadata from artifact
         id: meta
         run: |
-          echo "pr_number=$(cat ./artifact/pr-number.txt)" >> "$GITHUB_OUTPUT"
-          echo "php_status=$(cat ./artifact/php-status.txt)" >> "$GITHUB_OUTPUT"
-          echo "js_status=$(cat ./artifact/js-status.txt)" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$(cat "$RUNNER_TEMP/artifact/pr-number.txt")" >> "$GITHUB_OUTPUT"
+          echo "php_status=$(cat "$RUNNER_TEMP/artifact/php-status.txt")" >> "$GITHUB_OUTPUT"
+          echo "js_status=$(cat "$RUNNER_TEMP/artifact/js-status.txt")" >> "$GITHUB_OUTPUT"
 
       # Check out the base repo at the default branch (trusted code) so the
       # github-script step below can require .github/scripts/pr-coverage-comment
@@ -62,18 +64,23 @@ jobs:
             const fs = require('fs');
             const createCoverageComment = require('.github/scripts/pr-coverage-comment');
 
+            const artifactDir = `${process.env.RUNNER_TEMP}/artifact`;
+
+            // The fallbacks name the missing file rather than saying the check
+            // "did not run" — the check failing and its output going missing
+            // are different problems, and the old wording hid the second one.
             let phpOutput;
             try {
-              phpOutput = fs.readFileSync('./artifact/php-coverage-output.txt', 'utf8');
+              phpOutput = fs.readFileSync(`${artifactDir}/php-coverage-output.txt`, 'utf8');
             } catch {
-              phpOutput = 'PHP coverage check did not run.';
+              phpOutput = 'No PHP coverage output in the upstream artifact.';
             }
 
             let jsOutput;
             try {
-              jsOutput = fs.readFileSync('./artifact/js-coverage-output.txt', 'utf8');
+              jsOutput = fs.readFileSync(`${artifactDir}/js-coverage-output.txt`, 'utf8');
             } catch {
-              jsOutput = 'JavaScript coverage check did not run.';
+              jsOutput = 'No JavaScript coverage output in the upstream artifact.';
             }
 
             await createCoverageComment(


### PR DESCRIPTION
## Description

Every `Test Coverage Report` comment reports `PHP coverage check did not run.` regardless of what the check found. This is not intermittent and not specific to any PR.

The check runs fine. `PR Coverage Comment` downloads the upstream artifact to `./artifact`, then runs `actions/checkout` to get trusted base-repo code. Checkout deletes the contents of the workspace before cloning:

```
Deleting the contents of '/home/runner/work/gatherpress/gatherpress'
```

`./artifact` is inside the workspace, so both output files are gone by the time the `github-script` step reads them, and both `readFileSync` calls fall into their "did not run" fallback. The PR number and the pass/fail status survive only because they are read into step outputs *before* the checkout — which is why these comments show a red ❌ attached to text claiming nothing ran.

The step's own comment said the artifact was going to "a sibling directory". It wasn't. This moves it to `$RUNNER_TEMP`, which actually is one.

The fallback strings now name the missing artifact file instead of claiming the check never ran, so if this plumbing breaks again it does not look like a benign skip.

## Impact

Both currently-failing coverage PRs are affected, and in both the discarded output was immediately actionable.

**[#2041](https://github.com/GatherPress/gatherpress/pull/2041)** — run [30332113655](https://github.com/GatherPress/gatherpress/actions/runs/30332113655):

```
✅ Loaded coverage.xml
✅ Loaded coverage-multisite.xml

❌ uninstall.php - No coverage data found
```

The thread went looking for a wp-env `coverage.xml` flush problem that does not exist; both XMLs loaded in that run.

**[#2048](https://github.com/GatherPress/gatherpress/pull/2048)** — run [30370257521](https://github.com/GatherPress/gatherpress/actions/runs/30370257521):

```
❌ includes/core/classes/venue/map/class-map.php - 99.81% coverage (521/522 lines)
   Uncovered lines: 679
```

One uncovered line, named. The author had no way to see it.

## Testing

Rendered `formatCoverageComment` locally against the real captured output from both runs and confirmed each failure appears in an auto-expanded `<details open>` block, including the `Uncovered lines: 679` detail.

Verified in both upstream runs that all 5 artifact files uploaded successfully, and in the downstream comment run that checkout logs `Deleting the contents of` the workspace — so the loss is entirely on the read side.

`workflow_run` workflows always execute from the default branch, so this only takes effect once merged to `develop`. Re-running coverage on #2041 and #2048 after that is the live verification.

## Types of changes

Bug fix (CI).

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)