### PR TITLE
Give the interactive venue map an accessible name

### DIFF
--- a/.github/changelog/2090-from-description
+++ b/.github/changelog/2090-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Give the interactive venue map an accessible name and region role, matching the static map variant's labeling.

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -204,6 +204,10 @@ if ( 'interactive' === $gatherpress_render_mode ) {
 			'gestureScroll'    => __( 'Use ctrl + scroll to zoom the map', 'gatherpress' ),
 			'gestureScrollMac' => __( 'Use ⌘ + scroll to zoom the map', 'gatherpress' ),
 			'tileError'        => __( 'Map could not be loaded. Please try again later.', 'gatherpress' ),
+			'mapLabel'         => '' !== $gatherpress_address
+				/* translators: %s: full address of the venue. */
+				? sprintf( __( 'Map of %s', 'gatherpress' ), $gatherpress_address )
+				: __( 'Map', 'gatherpress' ),
 		),
 	);
 

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -204,10 +204,8 @@ if ( 'interactive' === $gatherpress_render_mode ) {
 			'gestureScroll'    => __( 'Use ctrl + scroll to zoom the map', 'gatherpress' ),
 			'gestureScrollMac' => __( 'Use ⌘ + scroll to zoom the map', 'gatherpress' ),
 			'tileError'        => __( 'Map could not be loaded. Please try again later.', 'gatherpress' ),
-			'mapLabel'         => '' !== $gatherpress_address
-				/* translators: %s: full address of the venue. */
-				? sprintf( __( 'Map of %s', 'gatherpress' ), $gatherpress_address )
-				: __( 'Map', 'gatherpress' ),
+			/* translators: %s: full address of the venue. */
+			'mapLabel'         => sprintf( __( 'Map of %s', 'gatherpress' ), $gatherpress_address ),
 		),
 	);
 

--- a/src/blocks/venue-map/view.js
+++ b/src/blocks/venue-map/view.js
@@ -212,6 +212,17 @@ function mountLeafletMap( wrapper, context, lat, lng ) {
 		mapEl.style.width = '100%';
 		mapEl.style.height = '100%';
 		mapEl.style.borderRadius = 'inherit';
+
+		// Leaflet makes the container focusable (tabindex="0") but gives it
+		// no role or accessible name, so keyboard/screen-reader users land on
+		// an unnamed region (WCAG 4.1.2). Name it like the static variant's
+		// alt text; the translated string travels via the server-built
+		// context because script modules cannot import @wordpress/i18n.
+		if ( i18n.mapLabel ) {
+			mapEl.setAttribute( 'role', 'region' );
+			mapEl.setAttribute( 'aria-label', i18n.mapLabel );
+		}
+
 		container.appendChild( mapEl );
 
 		const map = L.map( mapEl, {


### PR DESCRIPTION
Fixes #2089 

## Proposed changes:
* Name the Leaflet map container: `mountLeafletMap()` now sets `role="region"` and
  `aria-label` ("Map of {address}", matching the static variant's alt-text string)
  on the map element it creates. Applied only when the label is available, so a
  region is never announced nameless.
* Provide the translated label server-side via the block context's existing i18n payload in render.php (script modules cannot import @wordpress/i18n — same mechanism the block already uses for its gesture-hint and tile-error strings). The address is guaranteed non-empty at that point — the template early-returns without one — and view.js still guards on the label's presence before setting the attributes, so a nameless region can never ship.
* `role="region"` deliberately, not `role="application"`: application mode pulls
  screen readers out of browse mode, which is unwarranted here — the map's inner
  controls (zoom, marker, attribution) are ordinary focusable elements.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No new tests — `view.js` has no existing test harness (only the editor and helpers
are covered), and the change is two attributes verified live. Happy to scaffold a
mount test with a mocked Leaflet if the team wants one.

## Testing instructions:
1. `npm install && npm run build`, activate the plugin, create a venue with an
   address (OpenStreetMap platform) and an event at that venue.
2. On the event or venue page, Tab to the map, or inspect `.leaflet-container`:
   it now carries `role="region"` and `aria-label="Map of {address}"`.
   On `develop`, both are absent (`tabindex="0"` only).
3. Console check:
   `document.querySelector('.leaflet-container').getAttribute('aria-label')` →
   `"Map of {address}"`.
4. With NVDA, Tab to the map: announced as "Map of {address}, region" instead of an
   unnamed stop.
5. Regression: map still pans/zooms, gesture hints still show, the static-image and
   Google-embed variants are untouched.

[Video tabbing into the venue map before the fix](https://www.dropbox.com/scl/fi/9cshjnni17fwjc6vmobjz/nvda-before.mp4?rlkey=8wu2d5807ve7rzskdpk423uhi&dl=0): NVDA announces nothing when the map takes focus; 
[Video with the fix](https://www.dropbox.com/scl/fi/kc8ucr8sts5hl6avay3zv/nvda-after.mp4?rlkey=9xx8oqbxx5u74gxurhpbkyngj&dl=0), it announces "Map of 7th Avenue, New York, 10001, region" followed by the map's controls.
### Credit (for release notes)

My WordPress.org username: matthewneilcowan

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Give the interactive venue map an accessible name and region role, matching the
static map variant's labeling.

</details>