### PR TITLE
Admin ARIA fixes: aria-current, describedby reference, count link names

### DIFF
--- a/.github/changelog/2093-from-description
+++ b/.github/changelog/2093-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Announce the active settings tab and RSVP status view to assistive technology, fix the profile date-time table's broken description reference, and give the RSVP count links accessible names.

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -546,12 +546,16 @@ final class Admin_List {
 				admin_url( 'edit.php' )
 			);
 
-			// Display approved RSVP count with rounded box.
+			// Display approved RSVP count with rounded box. The visually
+			// hidden suffix turns the bare number into an accessible link
+			// name ("3 approved RSVPs") — a link named only "3" is
+			// meaningless in a screen-reader link list.
 			echo '<span class="gatherpress-rsvp-container">';
 			printf(
-				'<a href="%s" class="gatherpress-rsvp-approved"><span class="gatherpress-rsvp-icon">%d</span></a>',
+				'<a href="%s" class="gatherpress-rsvp-approved"><span class="gatherpress-rsvp-icon">%d</span><span class="screen-reader-text"> %s</span></a>',
 				esc_url( $approved_rsvp_url ),
-				(int) $approved_rsvps
+				(int) $approved_rsvps,
+				esc_html( _n( 'approved RSVP', 'approved RSVPs', (int) $approved_rsvps, 'gatherpress' ) )
 			);
 
 			// Show unapproved RSVPs indicator if there are any unapproved.
@@ -566,11 +570,15 @@ final class Admin_List {
 					admin_url( 'edit.php' )
 				);
 
+				// Visually hidden text rather than only the title attribute:
+				// assistive technology exposes title inconsistently, and once
+				// the link has text content the name comes from the content.
 				printf(
-					'<a href="%s" class="gatherpress-rsvp-pending" title="%s">%d</a>',
+					'<a href="%s" class="gatherpress-rsvp-pending" title="%s">%d<span class="screen-reader-text"> %s</span></a>',
 					esc_url( $unapproved_rsvp_url ),
 					esc_attr( __( 'Unapproved RSVPs', 'gatherpress' ) ),
-					(int) $unapproved_rsvps
+					(int) $unapproved_rsvps,
+					esc_html( _n( 'unapproved RSVP', 'unapproved RSVPs', (int) $unapproved_rsvps, 'gatherpress' ) )
 				);
 			}
 

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -552,7 +552,8 @@ final class Admin_List {
 			// meaningless in a screen-reader link list.
 			echo '<span class="gatherpress-rsvp-container">';
 			printf(
-				'<a href="%s" class="gatherpress-rsvp-approved"><span class="gatherpress-rsvp-icon">%d</span><span class="screen-reader-text"> %s</span></a>',
+				'<a href="%s" class="gatherpress-rsvp-approved"><span class="gatherpress-rsvp-icon">%d</span>' .
+				'<span class="screen-reader-text"> %s</span></a>',
 				esc_url( $approved_rsvp_url ),
 				(int) $approved_rsvps,
 				esc_html( _n( 'approved RSVP', 'approved RSVPs', (int) $approved_rsvps, 'gatherpress' ) )
@@ -574,7 +575,8 @@ final class Admin_List {
 				// assistive technology exposes title inconsistently, and once
 				// the link has text content the name comes from the content.
 				printf(
-					'<a href="%s" class="gatherpress-rsvp-pending" title="%s">%d<span class="screen-reader-text"> %s</span></a>',
+					'<a href="%s" class="gatherpress-rsvp-pending" title="%s">%d' .
+					'<span class="screen-reader-text"> %s</span></a>',
 					esc_url( $unapproved_rsvp_url ),
 					esc_attr( __( 'Unapproved RSVPs', 'gatherpress' ) ),
 					(int) $unapproved_rsvps,

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -863,7 +863,13 @@ final class List_Table extends WP_List_Table {
 	/**
 	 * Gets the CSS class attribute for current status links.
 	 *
+	 * The active view also carries `aria-current="page"` so assistive
+	 * technology announces which status filter is selected — the visual
+	 * `current` styling alone conveys nothing programmatically. Mirrors
+	 * the Events list views (`Admin_List`).
+	 *
 	 * @since 0.34.0
+	 * @since 0.35.0 Active link also carries `aria-current="page"`.
 	 *
 	 * @param string $status_key The status key to check.
 	 * @param string $current    The currently active status.
@@ -871,7 +877,7 @@ final class List_Table extends WP_List_Table {
 	 * @return string The class attribute string or empty string.
 	 */
 	private function get_current_class_attr( string $status_key, string $current ): string {
-		return $status_key === $current ? ' class="current"' : '';
+		return $status_key === $current ? ' class="current" aria-current="page"' : '';
 	}
 
 	/**

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -861,12 +861,13 @@ final class List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Gets the CSS class attribute for current status links.
+	 * Gets the current-view attributes for status links.
 	 *
-	 * The active view also carries `aria-current="page"` so assistive
-	 * technology announces which status filter is selected — the visual
-	 * `current` styling alone conveys nothing programmatically. Mirrors
-	 * the Events list views (`Admin_List`).
+	 * The active view carries the `current` CSS class plus
+	 * `aria-current="page"` so assistive technology announces which status
+	 * filter is selected — the visual `current` styling alone conveys
+	 * nothing programmatically. Mirrors the Events list views
+	 * (`Admin_List`).
 	 *
 	 * @since 0.34.0
 	 * @since 0.35.0 Active link also carries `aria-current="page"`.
@@ -874,7 +875,7 @@ final class List_Table extends WP_List_Table {
 	 * @param string $status_key The status key to check.
 	 * @param string $current    The currently active status.
 	 *
-	 * @return string The class attribute string or empty string.
+	 * @return string The class and aria-current attributes, or empty string.
 	 */
 	private function get_current_class_attr( string $status_key, string $current ): string {
 		return $status_key === $current ? ' class="current" aria-current="page"' : '';

--- a/includes/templates/admin/settings/index.php
+++ b/includes/templates/admin/settings/index.php
@@ -39,7 +39,11 @@ $gatherpress_settings = Settings::get_instance();
 				admin_url( $gatherpress_settings::PARENT_SLUG )
 			);
 			?>
-			<a class="<?php echo esc_attr( 'nav-tab ' . $gatherpress_active_page ); ?>" href="<?php echo esc_url( $gatherpress_url ); ?>"<?php echo '' !== $gatherpress_active_page ? ' aria-current="page"' : ''; ?>>
+			<a
+				class="<?php echo esc_attr( 'nav-tab ' . $gatherpress_active_page ); ?>"
+				href="<?php echo esc_url( $gatherpress_url ); ?>"
+				<?php echo '' !== $gatherpress_active_page ? ' aria-current="page"' : ''; ?>
+			>
 				<?php echo esc_html( $gatherpress_value['name'] ); ?>
 			</a>
 			<?php

--- a/includes/templates/admin/settings/index.php
+++ b/includes/templates/admin/settings/index.php
@@ -39,7 +39,7 @@ $gatherpress_settings = Settings::get_instance();
 				admin_url( $gatherpress_settings::PARENT_SLUG )
 			);
 			?>
-			<a class="<?php echo esc_attr( 'nav-tab ' . $gatherpress_active_page ); ?>" href="<?php echo esc_url( $gatherpress_url ); ?>">
+			<a class="<?php echo esc_attr( 'nav-tab ' . $gatherpress_active_page ); ?>" href="<?php echo esc_url( $gatherpress_url ); ?>"<?php echo '' !== $gatherpress_active_page ? ' aria-current="page"' : ''; ?>>
 				<?php echo esc_html( $gatherpress_value['name'] ); ?>
 			</a>
 			<?php

--- a/includes/templates/admin/settings/network-page.php
+++ b/includes/templates/admin/settings/network-page.php
@@ -98,6 +98,7 @@ $gatherpress_is_network  = Network::NETWORK_TAB === $current_tab;
 			<a
 				class="<?php echo esc_attr( trim( 'nav-tab ' . $gatherpress_active ) ); ?>"
 				href="<?php echo esc_url( $gatherpress_href ); ?>"
+				<?php echo '' !== $gatherpress_active ? 'aria-current="page"' : ''; ?>
 			>
 				<?php echo esc_html( $gatherpress_tab['name'] ); ?>
 			</a>

--- a/includes/templates/admin/settings/network-page.php
+++ b/includes/templates/admin/settings/network-page.php
@@ -98,7 +98,7 @@ $gatherpress_is_network  = Network::NETWORK_TAB === $current_tab;
 			<a
 				class="<?php echo esc_attr( trim( 'nav-tab ' . $gatherpress_active ) ); ?>"
 				href="<?php echo esc_url( $gatherpress_href ); ?>"
-				<?php echo '' !== $gatherpress_active ? 'aria-current="page"' : ''; ?>
+				<?php echo '' !== $gatherpress_active ? ' aria-current="page"' : ''; ?>
 			>
 				<?php echo esc_html( $gatherpress_tab['name'] ); ?>
 			</a>

--- a/includes/templates/admin/user/date-time.php
+++ b/includes/templates/admin/user/date-time.php
@@ -19,9 +19,9 @@ if ( ! isset( $time_format, $timezone, $tz_choices ) ) {
 	<h2 id="gatherpress-user-time-formatting">
 		<?php esc_html_e( 'Time Display Formatting', 'gatherpress' ); ?>
 	</h2>
-	<table class="form-table" aria-describedby="gatherpress-date-time-formatting">
+	<table class="form-table" aria-describedby="gatherpress-user-time-formatting">
 		<tr>
-			<th><label for="gatherpress_time_format"><?php esc_html_e( 'Time Format', 'gatherpress' ); ?></label></th>
+			<th scope="row"><label for="gatherpress_time_format"><?php esc_html_e( 'Time Format', 'gatherpress' ); ?></label></th>
 			<td>
 				<div class="form-wrap">
 					<select name="gatherpress_time_format" id="gatherpress_time_format">
@@ -40,7 +40,7 @@ if ( ! isset( $time_format, $timezone, $tz_choices ) ) {
 			</td>
 		</tr>
 		<tr>
-			<th><label for="gatherpress_timezone"><?php esc_html_e( 'Timezone', 'gatherpress' ); ?></label></th>
+			<th scope="row"><label for="gatherpress_timezone"><?php esc_html_e( 'Timezone', 'gatherpress' ); ?></label></th>
 			<td>
 				<div class="form-wrap">
 					<select name="gatherpress_timezone" id="gatherpress_timezone">

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -1266,6 +1266,11 @@ class Test_Admin_List extends Base {
 
 		$this->assertStringContainsString( 'gatherpress-rsvp-approved', $output, 'Should show approved RSVP count.' );
 		$this->assertStringContainsString( '>1<', $output, 'Should show count of 1.' );
+		$this->assertStringContainsString(
+			'<span class="screen-reader-text"> approved RSVP</span>',
+			$output,
+			'Should append the visually hidden accessible-name suffix.'
+		);
 	}
 
 	/**
@@ -1307,6 +1312,11 @@ class Test_Admin_List extends Base {
 			'Should show unapproved RSVP indicator.'
 		);
 		$this->assertStringContainsString( 'Unapproved RSVPs', $output, 'Should contain title for unapproved.' );
+		$this->assertStringContainsString(
+			'<span class="screen-reader-text"> unapproved RSVP</span>',
+			$output,
+			'Should append the visually hidden accessible-name suffix.'
+		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
@@ -971,7 +971,7 @@ class Test_List_Table extends Base {
 			'get_current_class_attr',
 			array( 'pending', 'pending' )
 		);
-		$this->assertEquals( ' class="current"', $result );
+		$this->assertEquals( ' class="current" aria-current="page"', $result );
 
 		// Test when status does not match current.
 		$result = Utility::invoke_hidden_method(
@@ -987,7 +987,7 @@ class Test_List_Table extends Base {
 			'get_current_class_attr',
 			array( 'all', 'all' )
 		);
-		$this->assertEquals( ' class="current"', $result );
+		$this->assertEquals( ' class="current" aria-current="page"', $result );
 
 		// Test with 'mine' status.
 		$result = Utility::invoke_hidden_method(


### PR DESCRIPTION
Fixes #2092 

## Proposed changes:
* **`aria-current="page"` on active tabs and views** — Settings tabs
  (`settings/index.php`), RSVPs status views
  (`Rsvp\List_Table::get_current_class_attr()`), and network settings tabs
  (`network-page.php`). Copies the exact pattern the Events list views already use
  (`Event\Admin_List`); only the active item carries the attribute.
* **Profile date-time table** (`user/date-time.php`): `aria-describedby` now points
  at the heading's real id (`gatherpress-user-time-formatting` — it referenced a
  nonexistent `gatherpress-date-time-formatting`), and the two `<th>` cells gain
  `scope="row"`, matching the sibling notifications table.
* **RSVP count links** (`Event\Admin_List`): visually hidden `_n()`-pluralized
  suffixes give the links real accessible names — "3 approved RSVPs" instead of a
  link named "3". The unapproved link keeps its `title` tooltip for sighted hover,
  but its name now comes from content (AT exposes `title` inconsistently).

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Updated the existing `test_get_current_class_attr()` assertions to expect the
`aria-current` attribute on matching views (the non-match empty-string cases are
unchanged). The count-link rendering has no existing test coverage; happy to add
some if wanted.

## Testing instructions:
1. Check out the branch, activate the plugin (no build step — PHP only). Have at
   least one event with an RSVP (one pending/unapproved RSVP makes the second link
   type visible).
2. **Events → Settings**: the active tab now carries `aria-current="page"`
   (inspect, or NVDA announces "current page" on it). Inactive tabs are unchanged.
3. **Events → RSVPs**: the active status view (e.g. "All") carries
   `aria-current="page"`.
4. **Events list**: inspect an RSVP count link — accessible name is now
   "1 approved RSVP" / "1 unapproved RSVP" (visible layout unchanged; the suffix is
   `screen-reader-text`).
5. **Profile page**:
   `document.querySelector('table[aria-describedby="gatherpress-user-time-formatting"]')`
   finds the table, and the referenced heading exists;
   `getElementById('gatherpress-date-time-formatting')` is `null` on `develop`.
6. Multisite network settings tabs get the same `aria-current` treatment
   (code-reviewed; single-site install here).

### Credit (for release notes)

My WordPress.org username: matthewneilcowan

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Announce the active settings tab and RSVP status view to assistive technology, fix
the profile date-time table's broken description reference, and give the RSVP count
links accessible names.

</details>
