### PR TITLE
Let venue details wrap at narrow widths

### DIFF
--- a/src/blocks/venue/block.json
+++ b/src/blocks/venue/block.json
@@ -48,5 +48,6 @@
 	},
 	"textdomain": "gatherpress",
 	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
 	"render": "file:./render.php"
 }

--- a/src/blocks/venue/index.js
+++ b/src/blocks/venue/index.js
@@ -10,6 +10,7 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 // Address autocomplete in VenueNavigator shares venue-detail address + popover styles.
 import '../venue-detail/editor.scss';
+import './style.scss';
 import VenueBlockPluginFill from './slotfill';
 import Edit from './edit';
 import metadata from './block.json';

--- a/src/blocks/venue/style.scss
+++ b/src/blocks/venue/style.scss
@@ -14,8 +14,16 @@
  * per-container layout CSS. The media query also covers content saved
  * from older starter templates, which stored the nowrap layout in the
  * block markup itself.
+ *
+ * max-width rather than the range syntax stylelint prefers: the build
+ * ships media queries untransformed, and range notation requires
+ * Safari 16.4+ — older browsers would ignore the rule entirely and
+ * silently keep the reflow bug. An accessibility fix should reach the
+ * widest possible set of browsers.
  */
-@media (width <= 480px) {
+
+/* stylelint-disable-next-line media-feature-range-notation */
+@media (max-width: 480px) {
 	.wp-block-gatherpress-venue .wp-block-group.is-nowrap {
 		flex-wrap: wrap;
 	}

--- a/src/blocks/venue/style.scss
+++ b/src/blocks/venue/style.scss
@@ -1,0 +1,22 @@
+/**
+ * Frontend styles for the Venue block.
+ */
+
+/*
+ * The starter templates lay the venue details out in nowrap flex rows
+ * (icon + text pairs, and the phone + website groups side by side). At
+ * narrow viewports — small phones, or desktop at 400% zoom — the nowrap
+ * rows force two-dimensional scrolling (WCAG 1.4.10 Reflow). Allow the
+ * rows to wrap below 480px: flex-wrap only takes effect when a row
+ * actually runs out of room, so wider layouts are untouched. Scoped to
+ * the venue block wrapper so core's is-nowrap behavior is unchanged
+ * elsewhere, and specific enough to out-rank core's generated
+ * per-container layout CSS. The media query also covers content saved
+ * from older starter templates, which stored the nowrap layout in the
+ * block markup itself.
+ */
+@media (width <= 480px) {
+	.wp-block-gatherpress-venue .wp-block-group.is-nowrap {
+		flex-wrap: wrap;
+	}
+}

--- a/src/blocks/venue/templates/venue-details.js
+++ b/src/blocks/venue/templates/venue-details.js
@@ -67,7 +67,9 @@ const VENUE_DETAILS = [
 			},
 			layout: {
 				type: 'flex',
-				flexWrap: 'nowrap',
+				// Wrap so phone + website stack instead of forcing
+				// horizontal scroll at narrow widths (WCAG 1.4.10).
+				flexWrap: 'wrap',
 				justifyContent: 'left',
 			},
 		},


### PR DESCRIPTION
Fixes #2095

## Proposed changes:

* **New venue-block frontend stylesheet** (`src/blocks/venue/style.scss`, wired via
  `block.json` + `index.js` per the dropdown block's convention): below 480px,
  nowrap flex rows inside `.wp-block-gatherpress-venue` may wrap. Scoped to the
  venue wrapper so core's `is-nowrap` behavior is unchanged anywhere else, and
  `flex-wrap: wrap` only engages when a row actually runs out of room. This is what
  fixes **existing** content, where the nowrap layout is serialized into saved
  markup.
* **Template default** (`venue-details.js`): the outer phone+website row becomes
  `flexWrap: 'wrap'` for newly inserted venue blocks. Patterns are one-time stamps,
  so this has no block-validation impact on existing content.
* Verified at 320px: `scrollWidth` 348 → **320**, zero horizontal scroll; at 1280px
  the row still computes `nowrap` (media-queried override, desktop untouched).

Screenshot before fix:
<img width="320" height="800" alt="Event page at 320px before the fix: phone number broken across three lines, website URL clipped at the viewport edge" src="https://github.com/user-attachments/assets/f39a4d13-91dc-4e66-b420-8629a7d537b1" />

Screenshot after fix:
<img width="320" height="800" alt="Event page at 320px after the fix: phone and website each on their own intact line, no horizontal scrolling" src="https://github.com/user-attachments/assets/abbf5182-c823-46b5-8ec8-a3f9f831a795" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No new tests — the change is CSS plus a template constant; no venue-template test
harness exists. Before/after screenshots at 320px are attached to the issue, and the
scrollWidth numbers are in the issue body.

## Testing instructions:
1. `npm install && npm run build`, activate the plugin, create an event with a venue
   that has address + phone + website.
2. View the event page in the device toolbar at **320×800** (or zoom desktop to
   400%).
3. On `develop`: the page scrolls horizontally
   (`document.documentElement.scrollWidth` → ~348), the phone number wraps oddly and
   the URL clips at the edge. On this branch: `scrollWidth` → 320, no horizontal
   scroll, each venue detail on its own line.
4. Widen to desktop: layout identical to `develop` (phone + website side by side —
   the override lives behind a 480px media query).
5. Editor: insert a fresh Venue Details pattern — the phone/website row now carries
   `flexWrap: wrap` in its layout attributes.
### Credit (for release notes)

My WordPress.org username: matthewneilcowan

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Let venue details wrap at narrow viewports instead of forcing horizontal scrolling.

</details>
