### PR TITLE
Cover the two uncovered branches in Event

### DIFF
--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -359,6 +359,58 @@ class Test_Event extends Base {
 	}
 
 	/**
+	 * Coverage for get_datetime method with partially missing meta.
+	 *
+	 * Events created before #2054 seeded a default datetime, and events built
+	 * outside the editor, can be missing some of the five datetime meta keys.
+	 * Each absent key is skipped and keeps its empty default rather than
+	 * poisoning the whole array.
+	 *
+	 * @covers ::get_datetime
+	 *
+	 * @return void
+	 */
+	public function test_get_datetime_skips_missing_meta(): void {
+		$post  = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+		$event = new Event( $post->ID );
+
+		$event->save_datetimes(
+			array(
+				'datetime_start' => '2020-05-11 15:00:00',
+				'datetime_end'   => '2020-05-12 17:00:00',
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		delete_post_meta( $post->ID, 'gatherpress_datetime_end' );
+		delete_post_meta( $post->ID, 'gatherpress_datetime_end_gmt' );
+
+		// A fresh instance so the read is not served from datetime_cache.
+		$datetime = ( new Event( $post->ID ) )->get_datetime();
+
+		$this->assertSame(
+			'2020-05-11 15:00:00',
+			$datetime['datetime_start'],
+			'Failed to assert that a present meta key still populates.'
+		);
+		$this->assertSame(
+			'America/New_York',
+			$datetime['timezone'],
+			'Failed to assert that timezone survives a missing datetime key.'
+		);
+		$this->assertSame(
+			'',
+			$datetime['datetime_end'],
+			'Failed to assert that a missing meta key keeps its empty default.'
+		);
+		$this->assertSame(
+			'',
+			$datetime['datetime_end_gmt'],
+			'Failed to assert that a missing gmt meta key keeps its empty default.'
+		);
+	}
+
+	/**
 	 * Coverage for get_gmt_datetime method.
 	 *
 	 * @covers ::get_gmt_datetime
@@ -941,6 +993,26 @@ class Test_Event extends Base {
 		$this->assertFalse(
 			$event->is_same_date(),
 			'Failed to assert event spans multiple days.'
+		);
+	}
+
+	/**
+	 * Coverage for is_same_date method without datetimes.
+	 *
+	 * A post that is not an event resolves to no datetimes at all, so there is
+	 * no date to compare and the answer is false rather than a spurious true
+	 * from two empty strings matching each other.
+	 *
+	 * @covers ::is_same_date
+	 *
+	 * @return void
+	 */
+	public function test_is_same_date_is_false_without_datetimes(): void {
+		$event = new Event( 0 );
+
+		$this->assertFalse(
+			$event->is_same_date(),
+			'Failed to assert that an event with no datetimes is not on the same date.'
 		);
 	}
 


### PR DESCRIPTION
## Description

[SonarCloud](https://sonarcloud.io/component_measures?metric=new_coverage&selected=GatherPress_gatherpress%3Aincludes%2Fcore%2Fclasses%2Fevent%2Fclass-event.php&view=list&branch=develop&id=GatherPress_gatherpress) reports `includes/core/classes/event/class-event.php` as the **only** file on `develop` with uncovered new lines. Two branches, one of them a regression of mine:

**`get_datetime()` line 482** — the `continue` that skips an absent meta key. [#2074](https://github.com/GatherPress/gatherpress/pull/2074) started seeding new events with a default datetime so they always land in the events table, and that incidentally removed the only test that read an event with missing datetime meta (`test_get_datetime` used to build a dateless event; now every event it builds is fully populated). The branch is still live in production: events created before #2074, and events built outside the editor, can be missing keys.

**`is_same_date()` line 267** — the empty-datetime guard. Never covered.

Both are worth asserting on their own terms rather than as coverage padding:

- a partially-populated event keeps its other keys instead of the whole array collapsing
- a dateless event is not "the same date" just because two empty strings compare equal

## Testing

- `npm run test:unit:php` → `OK (1659 tests, 6920 assertions)`
- Pulled `coverage.xml` off the wp-env container and confirmed lines 267 and 482 both trace to `count=1`, leaving `class-event.php` with **no** uncovered lines.
- `npm run lint:php` → 0 errors, 0 warnings.

Queried the Sonar `component_tree` measure across the project to confirm no other file has an uncovered-new-lines gap, so this closes the whole new-coverage finding rather than one instance of it.

## Types of changes

Test coverage.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)