### PR TITLE
Add the 0.35.0-beta.2 credits file

### DIFF
--- a/.github/scripts/release/credits/0.35.0-beta.2.json
+++ b/.github/scripts/release/credits/0.35.0-beta.2.json
@@ -1,0 +1,22 @@
+{
+    "leads": [
+        "mauteri",
+        "patricia70"
+    ],
+    "team": [
+        "hrmervin",
+        "jmarx75",
+        "stephenerdelyi",
+        "carstenbach",
+        "supernovia"
+    ],
+    "contributors": [
+        "andremenrath",
+        "bor0",
+        "linewebdigital",
+        "w3lld1",
+        "fahimmurshed",
+        "lheroorg",
+        "matthewneilcowan"
+    ]
+}


### PR DESCRIPTION
## Description

First of the three release-train PRs for `0.35.0-beta.2`, per [the release process](https://github.com/GatherPress/gatherpress/blob/develop/docs/contributor/release-process.md#pre-release-flow).

Straight copy forward of `0.35.0-beta.1.json`. The one pending name in `credits/unreleased.json` (`motylanogha`) is folded in automatically by `generate-version.php` at bump time, which also resets `unreleased.json`.

## Roster check

Contributors who landed PRs on `develop` since the beta.1 tag:

| GitHub | Credited as | Status |
| --- | --- | --- |
| `mattcowan` | `matthewneilcowan` | already in the roster |
| `wppoland` | `motylanogha` | pending in `unreleased.json`, folds in at bump |
| `PuvaanRaaj` | — | **not creditable yet**, see below |

[#2081](https://github.com/GatherPress/gatherpress/pull/2081) (docs) was merged by `PuvaanRaaj`, but Props Bot lists them under **Unlinked Accounts** — they have not linked their GitHub account to a WordPress.org profile, so `credits-sync` had no wp.org slug to record and resolved props to `mauteri` alone. Credits files store wp.org slugs and `generate-version.php` validates each against profiles.wordpress.org, so the name cannot be added until that link exists.

Not a blocker for a beta. Worth resolving before the stable `0.35.0` credits file.

## Types of changes

Release tooling.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)