### PR TITLE
Bump js-yaml to clear the Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2943,9 +2943,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8313,9 +8313,9 @@
 			}
 		},
 		"node_modules/@svgr/core/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8433,9 +8433,9 @@
 			}
 		},
 		"node_modules/@svgr/plugin-svgo/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -17687,9 +17687,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -23940,9 +23940,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+			"integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -25032,9 +25032,9 @@
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -25937,9 +25937,9 @@
 			}
 		},
 		"node_modules/npm-package-json-lint/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -31323,9 +31323,9 @@
 			"license": "ISC"
 		},
 		"node_modules/stylelint/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
## Description

Both open [Dependabot alerts](https://github.com/GatherPress/gatherpress/security/dependabot) are the same advisory, [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (CVE-2026-59870), quadratic CPU consumption when resolving `!!omap`. It affects both js-yaml majors we carry transitively, hence two alerts for one package.

| alert | range | was | now |
| --- | --- | --- | --- |
| #265 | `>= 3.0.0, < 3.15.1` | 3.15.0 | **3.15.1** |
| #264 | `>= 4.0.0, < 4.3.1` | 4.3.0 | **4.3.1** |

Eight instances in the tree, all development scope:

- **3.x** — one, via `@wordpress/env`
- **4.x** — seven, via `eslint`, `stylelint`, `markdownlint-cli`, `npm-package-json-lint`, `@svgr/core` and `@svgr/plugin-svgo`

## Scope

Lockfile only. Both are patch bumps inside ranges the parents already declare, so nothing in `package.json` changed and no dependency other than js-yaml moved. Verified by diffing every package version in `package-lock.json` before and after: 8 changed, all js-yaml.

## Testing

Ran a real `npm install` rather than trusting `--package-lock-only`, then:

- `npm ls js-yaml --all` resolves to only 3.15.1 and 4.3.1 on disk
- `npm audit` no longer lists js-yaml at all
- `npm run lint:js`, `lint:css`, `lint:md:docs`, `lint:pkg-json` all clean — these are the js-yaml consumers, so they are the things a bad bump would break
- `npm run build` compiles successfully
- `npx wp-env --version` still reports 11.2.0, confirming the `patch-package` patch at `patches/@wordpress+env+11.2.0.patch` still applies

## Note

`npm audit` reports other advisories in the dev tree that Dependabot is not alerting on. Out of scope here; this PR closes the two open alerts and nothing else.

## Types of changes

Dependency security update.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)