### PR TITLE
Convey the disabled state of the RSVP response filter

### DIFF
--- a/.github/changelog/2102-select-dropdown-aria-disabled
+++ b/.github/changelog/2102-select-dropdown-aria-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Convey the disabled state of the RSVP response filter to assistive technology, so a collapsed single-option dropdown is no longer announced as an operable button.

--- a/src/blocks/rsvp-response/view.js
+++ b/src/blocks/rsvp-response/view.js
@@ -213,9 +213,15 @@ const { state, actions } = store( 'gatherpress', {
 			) {
 				triggerElement.classList.add( 'gatherpress--is-disabled' );
 				triggerElement.setAttribute( 'tabindex', '-1' );
+				// The trigger keeps role="button" and aria-expanded, so the
+				// disabled state has to be conveyed too. Without this an
+				// assistive technology announces an operable collapsed button
+				// that cannot be operated.
+				triggerElement.setAttribute( 'aria-disabled', 'true' );
 			} else {
 				triggerElement.classList.remove( 'gatherpress--is-disabled' );
 				triggerElement.setAttribute( 'tabindex', '0' );
+				triggerElement.removeAttribute( 'aria-disabled' );
 			}
 
 			// Clean up any existing event handlers and focus traps

--- a/test/unit/js/src/blocks/rsvp-response/view.test.js
+++ b/test/unit/js/src/blocks/rsvp-response/view.test.js
@@ -1,0 +1,146 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+/**
+ * Mock the Interactivity API with a namespace-merging store so every
+ * module contributing to the `gatherpress` namespace shares one registry,
+ * mirroring the real runtime.
+ */
+jest.mock(
+	'@wordpress/interactivity',
+	() => {
+		const registries = {};
+
+		return {
+			store: ( name, config = {} ) => {
+				if ( ! registries[ name ] ) {
+					registries[ name ] = {
+						state: {},
+						actions: {},
+						callbacks: {},
+					};
+				}
+
+				const registry = registries[ name ];
+
+				Object.assign( registry.state, config.state );
+				Object.assign( registry.actions, config.actions );
+				Object.assign( registry.callbacks, config.callbacks );
+
+				return registry;
+			},
+			getElement: jest.fn(),
+			getContext: jest.fn(),
+		};
+	},
+	{ virtual: true }
+);
+
+/**
+ * WordPress dependencies
+ */
+import { store, getElement, getContext } from '@wordpress/interactivity';
+
+/**
+ * Internal dependencies
+ */
+import '@src/blocks/rsvp-response/view';
+
+/**
+ * Regression coverage for #2102. When the RSVP response filter collapses to a
+ * single selectable option the trigger is disabled, but the disabled state was
+ * never exposed to assistive technology. The trigger keeps `role="button"` and
+ * `aria-expanded`, so without `aria-disabled` a screen reader announces an
+ * operable collapsed button that cannot be operated.
+ */
+describe( 'rsvp-response processRsvpDropdown trigger disabled state', () => {
+	let state;
+	let callbacks;
+
+	beforeEach( () => {
+		( { state, callbacks } = store( 'gatherpress' ) );
+
+		// Reset shared registry state between tests.
+		delete state.posts;
+	} );
+
+	/**
+	 * Builds the RSVP response dropdown markup in select mode.
+	 *
+	 * @param {Object} counts Response counts keyed as the block emits them.
+	 * @return {Object} The trigger element and the item anchors.
+	 */
+	function setupDom( counts ) {
+		const countsJson = JSON.stringify( counts );
+
+		document.body.innerHTML = `
+			<div class="wp-block-gatherpress-rsvp-response" data-counts='${ countsJson }'>
+				<div class="wp-block-gatherpress-dropdown" data-dropdown-mode="select">
+					<a class="wp-block-gatherpress-dropdown__trigger" href="#" role="button" aria-expanded="false" tabindex="0">Attending (%d)</a>
+					<div class="wp-block-gatherpress-dropdown__menu">
+						<div class="wp-block-gatherpress-dropdown-item gatherpress--is-attending"><a href="#" data-status="attending">Attending (%d)</a></div>
+						<div class="wp-block-gatherpress-dropdown-item gatherpress--is-waiting-list"><a href="#" data-status="waiting_list">Waiting List (%d)</a></div>
+						<div class="wp-block-gatherpress-dropdown-item gatherpress--is-not-attending"><a href="#" data-status="not_attending">Not Attending (%d)</a></div>
+					</div>
+				</div>
+			</div>
+		`;
+
+		return {
+			trigger: document.querySelector(
+				'.wp-block-gatherpress-dropdown__trigger'
+			),
+			items: Array.from(
+				document.querySelectorAll(
+					'.wp-block-gatherpress-dropdown-item a'
+				)
+			),
+		};
+	}
+
+	/**
+	 * Runs the callback once per dropdown item, as the runtime does.
+	 *
+	 * @param {HTMLElement[]} items The item anchors to process.
+	 */
+	function processItems( items ) {
+		getContext.mockReturnValue( { postId: 123 } );
+
+		items.forEach( ( item ) => {
+			getElement.mockReturnValue( { ref: item } );
+			callbacks.processRsvpDropdown();
+		} );
+	}
+
+	it( 'marks the trigger aria-disabled when attending is the only option', () => {
+		const { trigger, items } = setupDom( {
+			attending: 2,
+			waiting_list: 0,
+			not_attending: 0,
+		} );
+
+		processItems( items );
+
+		expect(
+			trigger.classList.contains( 'gatherpress--is-disabled' )
+		).toBe( true );
+		expect( trigger.getAttribute( 'aria-disabled' ) ).toBe( 'true' );
+	} );
+
+	it( 'leaves the trigger operable when another option has responses', () => {
+		const { trigger, items } = setupDom( {
+			attending: 2,
+			waiting_list: 1,
+			not_attending: 0,
+		} );
+
+		processItems( items );
+
+		expect(
+			trigger.classList.contains( 'gatherpress--is-disabled' )
+		).toBe( false );
+		expect( trigger.hasAttribute( 'aria-disabled' ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
Fixes #2102, at the narrower scope established in [this comment](https://github.com/GatherPress/gatherpress/issues/2102#issuecomment-5225611866) rather than the original report.

### What this is not

My original report claimed the RSVP response filter could be opened with a mouse but not a keyboard. That was wrong, and worth stating plainly so this PR is not read as fixing a keyboard trap. The dropdown is disabled deliberately when the filter collapses to a single selectable option, and `.gatherpress--is-disabled` carries `pointer-events: none`, so a mouse user cannot open it either. Nothing about that behaviour changes here.

### The actual defect

The disabled state is never exposed to assistive technology. `processRsvpDropdown` adds the class and sets `tabindex="-1"`, but the trigger keeps `role="button"` and `aria-expanded="false"` and gains no `aria-disabled`. A screen reader therefore announces an operable collapsed button that cannot be operated, with nothing indicating why. That is WCAG 2.1 4.1.2 (Name, Role, Value), a state-not-conveyed issue.

The sibling menu-item branch a few lines above in the same callback already handles this correctly, setting all three:

```js
element.ref.classList.add( 'gatherpress--is-disabled' );
element.ref.setAttribute( 'tabindex', '-1' );
element.ref.setAttribute( 'aria-disabled', 'true' );
```

### Changes

- Set `aria-disabled="true"` on the trigger in the disabled branch, and remove it in the `else` branch when the filter regains a second option.
- Add `test/unit/js/src/blocks/rsvp-response/view.test.js` covering both branches.

### Testing instructions

1. Open an event where every RSVP is "Attending", so Waiting List and Not Attending are both 0 and get hidden.
2. Inspect the `.wp-block-gatherpress-dropdown__trigger` for the response filter. It should now carry `aria-disabled="true"` alongside the existing `gatherpress--is-disabled` class.
3. Add a waiting-list or not-attending response so a second option becomes visible. The attribute should be gone and the filter operable again.

Both states are covered by the new unit tests. I confirmed the first test fails on `develop` without the source change (`aria-disabled` reads `null`) and passes with it, and the full JS suite is green locally at 998 tests across 54 suites.

Props motylanogha
