### PR TITLE
Surface the resolved RSVP filter count in the editor

### DIFF
--- a/.github/changelog/2055-rsvp-filter-count-hint
+++ b/.github/changelog/2055-rsvp-filter-count-hint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Show what the RSVP response filter labels resolve to in the editor, so the raw %d placeholder is explained rather than just displayed.

--- a/src/blocks/dropdown-item/block.json
+++ b/src/blocks/dropdown-item/block.json
@@ -14,6 +14,7 @@
 		}
 	},
 	"parent": ["gatherpress/dropdown"],
+	"usesContext": ["postId"],
 	"supports": {
 		"color": {
 			"background": true,

--- a/src/blocks/dropdown-item/edit.js
+++ b/src/blocks/dropdown-item/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	RichText,
@@ -10,6 +10,14 @@ import {
 import { createBlock } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
 import { dispatch, select } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { EVENT_REST_API } from '../../helpers/namespace';
+import { getResolvedLabelPreview, getRsvpFilterKey } from './helpers';
 
 /**
  * Edit Component
@@ -19,12 +27,58 @@ import { dispatch, select } from '@wordpress/data';
  * @param {Function} props.setAttributes     Function to update attributes.
  * @param {string}   props.clientId          Unique ID of the block.
  * @param {Function} props.insertBlocksAfter Function to insert blocks after this block.
+ * @param {Object}   props.context           Block context data.
  *
  * @return {JSX.Element} The rendered edit component.
  */
-const Edit = ( { attributes, setAttributes, clientId, insertBlocksAfter } ) => {
+const Edit = ( {
+	attributes,
+	setAttributes,
+	clientId,
+	insertBlocksAfter,
+	context,
+} ) => {
 	const { text } = attributes;
 	const blockProps = useBlockProps();
+
+	// The RSVP Response filter seeds its labels with a `%d` placeholder that is
+	// only substituted on the front end, so the editor shows the raw token. Keep
+	// the token in the content and surface what it resolves to instead.
+	const rsvpFilterKey = getRsvpFilterKey( attributes.className );
+	const postId = context?.postId ?? null;
+	const [ rsvpCounts, setRsvpCounts ] = useState( null );
+
+	useEffect( () => {
+		if ( ! rsvpFilterKey || ! postId ) {
+			setRsvpCounts( null );
+			return;
+		}
+
+		let ignore = false;
+
+		apiFetch( {
+			path: `${ EVENT_REST_API }/rsvp-responses?post_id=${ postId }`,
+		} )
+			.then( ( response ) => {
+				if ( ! ignore ) {
+					setRsvpCounts( response.data );
+				}
+			} )
+			.catch( () => {
+				if ( ! ignore ) {
+					setRsvpCounts( null );
+				}
+			} );
+
+		return () => {
+			ignore = true;
+		};
+	}, [ rsvpFilterKey, postId ] );
+
+	const rsvpCount = rsvpCounts?.[ rsvpFilterKey ]?.count ?? 0;
+	const resolvedLabel = rsvpFilterKey
+		? getResolvedLabelPreview( text, rsvpCount )
+		: null;
 
 	return (
 		<>
@@ -36,6 +90,22 @@ const Edit = ( { attributes, setAttributes, clientId, insertBlocksAfter } ) => {
 							'gatherpress',
 						) }
 					</p>
+					{ resolvedLabel && (
+						<p>
+							{
+								// translators: %d is the placeholder text to be used in the label.
+								__(
+									'Use %d as a placeholder for the response count.',
+									'gatherpress',
+								)
+							}{ ' ' }
+							{ sprintf(
+								// translators: %s is the label as visitors see it, with the count substituted.
+								__( 'Visitors see “%s”.', 'gatherpress' ),
+								resolvedLabel,
+							) }
+						</p>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<RichText

--- a/src/blocks/dropdown-item/helpers.js
+++ b/src/blocks/dropdown-item/helpers.js
@@ -1,0 +1,73 @@
+/**
+ * Maps the classes the RSVP Response filter seeds onto its dropdown items to
+ * the response key each one counts.
+ *
+ * `rsvp-response/view.js` resolves the `%d` placeholder on the front end by
+ * matching these same classes, so the editor hint has to key off them too.
+ *
+ * @since 0.35.0
+ *
+ * @type {Object<string, string>}
+ */
+export const RSVP_FILTER_CLASS_MAP = {
+	'gatherpress--is-attending': 'attending',
+	'gatherpress--is-waiting-list': 'waiting_list',
+	'gatherpress--is-not-attending': 'not_attending',
+};
+
+/**
+ * Resolves the RSVP response key for a dropdown item's class list.
+ *
+ * @since 0.35.0
+ *
+ * @param {string} className The block's class name attribute.
+ *
+ * @return {string|null} The response key, or null when the item is not an RSVP filter.
+ */
+export function getRsvpFilterKey( className ) {
+	const classes = String( className ?? '' )
+		.split( /\s+/ )
+		.filter( Boolean );
+
+	const match = classes.find( ( name ) => RSVP_FILTER_CLASS_MAP[ name ] );
+
+	return match ? RSVP_FILTER_CLASS_MAP[ match ] : null;
+}
+
+/**
+ * Strips the anchor markup a dropdown item stores around its label.
+ *
+ * @since 0.35.0
+ *
+ * @param {string} text The block's text attribute.
+ *
+ * @return {string} The label without markup.
+ */
+export function getLabelText( text ) {
+	return String( text ?? '' )
+		.replace( /<[^>]*>/g, '' )
+		.trim();
+}
+
+/**
+ * Builds the editor-only preview of a label once its count is substituted.
+ *
+ * Returns null when there is nothing useful to preview, so callers can skip
+ * rendering the hint entirely rather than showing an empty one.
+ *
+ * @since 0.35.0
+ *
+ * @param {string} text  The block's text attribute.
+ * @param {number} count The response count for this filter.
+ *
+ * @return {string|null} The resolved label, or null when it holds no placeholder.
+ */
+export function getResolvedLabelPreview( text, count ) {
+	const label = getLabelText( text );
+
+	if ( ! label || ! label.includes( '%d' ) ) {
+		return null;
+	}
+
+	return label.replace( '%d', String( count ?? 0 ) );
+}

--- a/test/unit/js/src/blocks/dropdown-item/helpers.test.js
+++ b/test/unit/js/src/blocks/dropdown-item/helpers.test.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * Internal dependencies
+ */
+import {
+	RSVP_FILTER_CLASS_MAP,
+	getLabelText,
+	getResolvedLabelPreview,
+	getRsvpFilterKey,
+} from '@src/blocks/dropdown-item/helpers';
+
+describe( 'getRsvpFilterKey', () => {
+	it( 'maps each seeded RSVP filter class to its response key', () => {
+		Object.entries( RSVP_FILTER_CLASS_MAP ).forEach(
+			( [ className, key ] ) => {
+				expect( getRsvpFilterKey( className ) ).toBe( key );
+			}
+		);
+	} );
+
+	it( 'finds the filter class among unrelated classes', () => {
+		expect(
+			getRsvpFilterKey( 'has-large-font-size gatherpress--is-waiting-list' )
+		).toBe( 'waiting_list' );
+	} );
+
+	it( 'returns null for a dropdown item that is not an RSVP filter', () => {
+		expect( getRsvpFilterKey( 'is-style-outline' ) ).toBeNull();
+	} );
+
+	it( 'returns null for undefined, null, and empty class names', () => {
+		expect( getRsvpFilterKey( undefined ) ).toBeNull();
+		expect( getRsvpFilterKey( null ) ).toBeNull();
+		expect( getRsvpFilterKey( '' ) ).toBeNull();
+	} );
+} );
+
+describe( 'getLabelText', () => {
+	it( 'strips the anchor markup the block stores around the label', () => {
+		expect( getLabelText( '<a href="#">Attending (%d)</a>' ) ).toBe(
+			'Attending (%d)'
+		);
+	} );
+
+	it( 'returns an empty string for undefined and null', () => {
+		expect( getLabelText( undefined ) ).toBe( '' );
+		expect( getLabelText( null ) ).toBe( '' );
+	} );
+} );
+
+describe( 'getResolvedLabelPreview', () => {
+	it( 'substitutes the count into the label', () => {
+		expect(
+			getResolvedLabelPreview( '<a href="#">Attending (%d)</a>', 3 )
+		).toBe( 'Attending (3)' );
+	} );
+
+	it( 'falls back to zero when the count is missing', () => {
+		expect(
+			getResolvedLabelPreview( '<a href="#">Attending (%d)</a>', null )
+		).toBe( 'Attending (0)' );
+		expect(
+			getResolvedLabelPreview(
+				'<a href="#">Attending (%d)</a>',
+				undefined
+			)
+		).toBe( 'Attending (0)' );
+	} );
+
+	it( 'returns null when the author has removed the placeholder', () => {
+		expect(
+			getResolvedLabelPreview( '<a href="#">Who is coming</a>', 3 )
+		).toBeNull();
+	} );
+
+	it( 'returns null when the label is empty', () => {
+		expect( getResolvedLabelPreview( '<a href="#"></a>', 3 ) ).toBeNull();
+		expect( getResolvedLabelPreview( '', 3 ) ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Fixes #2055, taking option 2 as you directed.

### What it does

The filter labels keep their raw `%d`, and the editor gains hint text that names the token and shows the label as visitors will see it:

> Use %d as a placeholder for the response count. Visitors see “Attending (3)”.

The count comes from the same `rsvp-responses` endpoint the RSVP Count block already uses, and the wording follows that block's Inspector help text as you suggested. Nothing about the saved content changes, so the canvas and the post body never disagree, which was your objection to option 1.

Detection is gated on the `gatherpress--is-attending` / `gatherpress--is-waiting-list` / `gatherpress--is-not-attending` classes the RSVP Response template seeds, the same classes `view.js` matches on. Unrelated dropdown items such as Add to calendar are unaffected.

### Two things to flag before review

**1. Placement is genuinely open, and I would value your call.** I put the hint in the dropdown item's Inspector panel. While testing I found that panel awkward to reach for a deeply nested item, which makes me unsure it lands where the problem actually shows up. The complaint in the issue is the raw `%d` sitting visible in the canvas, and a hint behind a panel an author may never open does not obviously answer that. Moving the preview inline under the label in the canvas is a small change if you would rather have it there.

**2. I could not render that Inspector panel in my test environment**, so I have not seen the hint on screen. I confirmed the built script loads with the new strings and that `usesContext` registers, but the panel itself never appeared, including the block's pre-existing "This item behaves like a button" text, so something in my setup keeps the nested item from mounting rather than anything in this change. It needs a visual check in review, and I did not want to imply otherwise.

The logic is covered by unit tests either way, and the full JS suite is green locally at 1006 tests across 54 suites.

### Changes

- `src/blocks/dropdown-item/helpers.js`: `getRsvpFilterKey`, `getLabelText` and `getResolvedLabelPreview`, kept separate so the logic is directly testable.
- `src/blocks/dropdown-item/edit.js`: fetch the counts for RSVP filter items and render the hint.
- `src/blocks/dropdown-item/block.json`: `usesContext: ["postId"]`, needed to resolve the count.
- `test/unit/js/src/blocks/dropdown-item/helpers.test.js`: 10 tests, covering the null/undefined class names, a non-filter item, an author who has deleted the placeholder, and an empty label.

### Testing instructions

1. Create an event from the "Event with RSVP" starter pattern.
2. Select one of the attendee filter items, for example "Attending (%d)", and open its block settings.
3. The panel should name `%d` and show the resolved label, for example `Visitors see “Attending (0)”`.
4. Confirm the label in the canvas still shows the raw `%d`, and that the saved content is unchanged.
5. Select an Add to calendar dropdown item and confirm no hint appears.

Props motylanogha
