### PR TITLE
Point every demo-data reference at the 0.35.0 dataset

### DIFF
--- a/.github/scripts/docs-screenshots/blueprint.json
+++ b/.github/scripts/docs-screenshots/blueprint.json
@@ -58,7 +58,7 @@
       "step": "importWxr",
       "file": {
         "resource": "url",
-        "url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.33.0.xml"
+        "url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.35.0.xml"
       }
     }
   ]

--- a/.github/scripts/playground-preview/index.js
+++ b/.github/scripts/playground-preview/index.js
@@ -241,7 +241,7 @@ function createBlueprint(context, number, zipArtifactUrl, phpVersion, override) 
 				step: 'importWxr',
 				file: {
 					resource: 'url',
-					url: 'https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.34.0.xml',
+					url: 'https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.35.0.xml',
 				},
 			},
 			/**

--- a/.github/scripts/wordpress-org-screenshots/blueprint.json
+++ b/.github/scripts/wordpress-org-screenshots/blueprint.json
@@ -64,7 +64,7 @@
 			"step": "importWxr",
 			"file": {
 				"resource": "url",
-				"url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.33.0.xml"
+				"url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.35.0.xml"
 			}
 		}
 	]

--- a/.wordpress-org/blueprints/blueprint-nightly.json
+++ b/.wordpress-org/blueprints/blueprint-nightly.json
@@ -62,7 +62,7 @@
       "step": "importWxr",
       "file": {
         "resource": "url",
-        "url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.34.0.xml"
+        "url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.35.0.xml"
       }
     }
   ]

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -62,7 +62,7 @@
       "step": "importWxr",
       "file": {
         "resource": "url",
-        "url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.34.0.xml"
+        "url": "https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.35.0.xml"
       }
     }
   ]

--- a/test/e2e/RSVP-TESTS-TODO.md
+++ b/test/e2e/RSVP-TESTS-TODO.md
@@ -66,7 +66,7 @@ Three potential solutions have been explored. Each has blockers that need resolu
 
 **Resources**:
 
-- Demo data URL: <https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.33.0.xml>
+- Demo data URL: <https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.35.0.xml>
 - Contains "Christmas 2025" event with complete RSVP block
 - Reference implementation: `.github/scripts/playground-preview/index.js`
 
@@ -186,7 +186,7 @@ All tests should run in CI without manual intervention.
 - **Main test file**: `test/e2e/rsvp-tests/rsvp-flows.spec.js`
 - **Helper attempts**: `test/e2e/helpers/create-event-*.js` and `create-event-with-rsvp.php`
 - **Blueprint reference**: `.github/scripts/playground-preview/index.js`
-- **Demo data**: <https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.33.0.xml>
+- **Demo data**: <https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.35.0.xml>
 
 ## Questions?
 

--- a/test/e2e/rsvp-tests/rsvp-flows.spec.js
+++ b/test/e2e/rsvp-tests/rsvp-flows.spec.js
@@ -32,7 +32,7 @@ const { test, expect } = require( '@playwright/test' );
  *
  * ### Option 1: WordPress Playground Blueprint Approach
  * - Use WXR import similar to `.github/scripts/playground-preview/index.js`
- * - Demo data available at: https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.33.0.xml
+ * - Demo data available at: https://raw.githubusercontent.com/GatherPress/gatherpress-demo-data/main/GatherPress-demo-data-0.35.0.xml
  * - Contains "Christmas 2025" event with complete RSVP block
  * - Challenge: Docker volume mounting in wp-env makes file access difficult
  *


### PR DESCRIPTION
## Description

Eight references across seven files, moved to `GatherPress-demo-data-0.35.0.xml`.

They had drifted apart. The 0.34.0 round updated three and left the rest behind, so **both screenshot blueprints have been generating against 0.33.0 demo content** — two versions stale.

| was | file |
| --- | --- |
| 0.33.0 | `.github/scripts/docs-screenshots/blueprint.json` |
| 0.33.0 | `.github/scripts/wordpress-org-screenshots/blueprint.json` |
| 0.33.0 | `test/e2e/rsvp-tests/rsvp-flows.spec.js` |
| 0.33.0 | `test/e2e/RSVP-TESTS-TODO.md` (×2) |
| 0.34.0 | `.wordpress-org/blueprints/blueprint.json` |
| 0.34.0 | `.wordpress-org/blueprints/blueprint-nightly.json` |
| 0.34.0 | `.github/scripts/playground-preview/index.js` |

The 0.35.0 dataset is the one whose `gatherpress/icon` blocks were migrated to `core/icon` in [gatherpress-demo-data#76](https://github.com/GatherPress/gatherpress-demo-data/pull/76). Without this, our own Playgrounds render missing blocks once 0.35.0 ships — the same breakage reported in #2108.

## :warning: Merge after the wp.org release

`.wordpress-org/blueprints/blueprint.json` is the public Playground button and installs GatherPress **from wordpress.org**. Until 0.35.0 is live there, merging pairs 0.35.0-shaped demo content with the 0.34.1 plugin, which is not a combination worth shipping to the plugin page.

The other seven are safe any time. Keeping them in one PR so the set stays consistent rather than drifting again.

## Testing

- All four JSON blueprints still parse.
- The target URL is already live: `GatherPress-demo-data-0.35.0.xml` returns 200 on demo-data `main`.
- No `GatherPress-demo-data-0.33.0` or `-0.34.0` reference remains anywhere in the repo.
- The two e2e references are documentation inside a TODO block, nothing fetches them. I checked the surrounding prose still holds: it cites a "Christmas 2025" event, which is present in the 0.35.0 dataset as well as 0.33.0.
- `eslint` on the changed JS reports only the pre-existing "File ignored by default" notice, identical on develop.

## Types of changes

CI configuration and documentation.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)