### PR TITLE
Stop the seeded datetime default clobbering duplicated events

### DIFF
--- a/.github/changelog/2116-cloned-event-datetime
+++ b/.github/changelog/2116-cloned-event-datetime
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop a duplicated or imported event losing its date. The default seeded for an event saved without one is now decided at shutdown rather than mid-insert, so dates that arrive after the post is created win over it.

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -52,6 +52,18 @@ final class Setup {
 	protected string $archive_title = '';
 
 	/**
+	 * Post IDs awaiting a datetime decision at shutdown.
+	 *
+	 * Keyed by post ID so a post saved more than once in a request is only
+	 * resolved once. See `set_datetimes()` for why the decision is deferred.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @var array<int, bool>
+	 */
+	protected array $pending_datetimes = array();
+
+	/**
 	 * Class constructor.
 	 *
 	 * Instantiates the sibling Event\* singletons before wiring hooks so
@@ -745,37 +757,108 @@ final class Setup {
 
 		$data = get_post_meta( $post_id, 'gatherpress_datetime', true );
 
-		if ( empty( $data ) ) {
-			// No meta means the editor never wrote one, which is the normal
-			// path for an event saved without touching the date controls
-			// (#2054), and for any programmatic insert that omits it. Without
-			// a fallback such an event gets no row in the events table and is
-			// invisible to every upcoming / past query while still looking
-			// correct in the editor.
-			//
-			// Seed the default only when nothing is stored yet. Recomputing it
-			// on every save would walk the event's date forward a day at a
-			// time, and the meta itself is deliberately left alone so a caller
-			// that inserts the post first and sets `gatherpress_datetime`
-			// afterwards is not overwritten.
-			if ( '' !== (string) get_post_meta( $post_id, 'gatherpress_datetime_start', true ) ) {
-				return;
-			}
+		if ( ! empty( $data ) ) {
+			$this->write_datetimes( $post_id, json_decode( (string) $data, true ) ?? array() );
 
-			$data = $this->get_default_datetime();
-		} else {
-			$data = json_decode( (string) $data, true ) ?? array();
+			return;
 		}
 
-		$event  = new Event( $post_id );
-		$params = array(
-			'post_id'        => $post_id,
-			'datetime_start' => $data['dateTimeStart'] ?? '',
-			'datetime_end'   => $data['dateTimeEnd'] ?? '',
-			'timezone'       => $data['timezone'] ?? '',
-		);
+		// Nothing stored yet, but that does not mean nothing is coming. This
+		// hook fires from inside wp_insert_post(), and every caller writes the
+		// meta afterwards: REST does, and so does anything that duplicates or
+		// imports a post. Seeding a default here would win over values that
+		// arrive moments later, because those callers use add_post_meta(),
+		// which appends rather than replaces -- so the seeded row stays first
+		// and a single-value read never sees the real date (#2116).
+		//
+		// Decide at shutdown instead, once the request's meta writes are done.
+		$this->pending_datetimes[ $post_id ] = true;
 
-		$event->save_datetimes( $params );
+		add_action( 'shutdown', array( $this, 'resolve_pending_datetimes' ) );
+	}
+
+	/**
+	 * Write the events-table row and datetime meta for a post.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param int   $post_id The post to write.
+	 * @param array $data    Datetime payload keyed dateTimeStart / dateTimeEnd / timezone.
+	 *
+	 * @return void
+	 */
+	protected function write_datetimes( int $post_id, array $data ): void {
+		$event = new Event( $post_id );
+
+		$event->save_datetimes(
+			array(
+				'post_id'        => $post_id,
+				'datetime_start' => $data['dateTimeStart'] ?? '',
+				'datetime_end'   => $data['dateTimeEnd'] ?? '',
+				'timezone'       => $data['timezone'] ?? '',
+			)
+		);
+	}
+
+	/**
+	 * Resolve every post that finished its save without a stored datetime.
+	 *
+	 * Runs on shutdown, so the meta `resolve_datetime_payload()` reads is
+	 * whatever the request actually ended up with rather than what existed
+	 * mid-insert.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return void
+	 */
+	public function resolve_pending_datetimes(): void {
+		$pending                 = $this->pending_datetimes;
+		$this->pending_datetimes = array();
+
+		foreach ( array_keys( $pending ) as $post_id ) {
+			// The post can be gone by shutdown -- a duplicate that failed, or
+			// an insert rolled back after this hook ran.
+			if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
+				continue;
+			}
+
+			$this->write_datetimes( $post_id, $this->resolve_datetime_payload( $post_id ) );
+		}
+	}
+
+	/**
+	 * Decide which datetime a post that saved without one should end up with.
+	 *
+	 * Split out from `resolve_pending_datetimes()` so each outcome can be
+	 * asserted directly rather than through a shutdown run.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @param int $post_id The post to resolve.
+	 *
+	 * @return array{dateTimeStart: string, dateTimeEnd: string, timezone: string} Datetime payload.
+	 */
+	protected function resolve_datetime_payload( int $post_id ): array {
+		$data = get_post_meta( $post_id, 'gatherpress_datetime', true );
+
+		if ( ! empty( $data ) ) {
+			return json_decode( (string) $data, true ) ?? array();
+		}
+
+		// Only the individual keys arrived, which is what copying meta key by
+		// key produces when the JSON blob is filtered out. Rebuild from those
+		// rather than discarding a real date.
+		$start = (string) get_post_meta( $post_id, 'gatherpress_datetime_start', true );
+
+		if ( '' !== $start ) {
+			return array(
+				'dateTimeStart' => $start,
+				'dateTimeEnd'   => (string) get_post_meta( $post_id, 'gatherpress_datetime_end', true ),
+				'timezone'      => (string) get_post_meta( $post_id, 'gatherpress_timezone', true ),
+			);
+		}
+
+		return $this->get_default_datetime();
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -10,6 +10,7 @@ namespace GatherPress\Tests\Core\Event;
 
 use GatherPress\Core\Event;
 use GatherPress\Core\Event\Admin_List;
+use GatherPress\Core\Event\Setup as Event_Setup;
 use GatherPress\Core\Rsvp;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
@@ -775,13 +776,16 @@ class Test_Admin_List extends Base {
 
 		// An event created without dates is seeded with the editor's default,
 		// which is tomorrow, so it counts as upcoming rather than falling out
-		// of both buckets the way a datetime-less event used to (#2054).
+		// of both buckets the way a datetime-less event used to (#2054). The
+		// seed runs at shutdown so late-arriving meta wins over it (#2116).
 		$this->mock->post(
 			array(
 				'post_type'   => Event::POST_TYPE,
 				'post_status' => 'publish',
 			)
 		)->get();
+
+		Event_Setup::get_instance()->resolve_pending_datetimes();
 
 		$counts = Utility::invoke_hidden_method( $instance, 'get_event_counts' );
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -11,6 +11,7 @@ namespace GatherPress\Tests\Core\Event;
 use DateTime;
 use DateTimeZone;
 use GatherPress\Core\Event\Event;
+use GatherPress\Core\Event\Setup as Event_Setup;
 use GatherPress\Core\Rsvp\Rsvp;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
@@ -307,7 +308,11 @@ class Test_Event extends Base {
 		$event = new Event( $post->ID );
 
 		// A new event is seeded with the editor's default rather than left
-		// datetime-less, so it always lands in the events table (#2054).
+		// datetime-less, so it always lands in the events table (#2054). The
+		// seed is decided at shutdown, so meta written after the insert wins
+		// over it (#2116).
+		Event_Setup::get_instance()->resolve_pending_datetimes();
+
 		$seeded = $event->get_datetime();
 
 		$this->assertNotEmpty(

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -519,8 +519,10 @@ class Test_Setup extends Base {
 
 		// An event with no stored datetime gets the default filled in rather
 		// than no row at all, which would leave it invisible to every
-		// upcoming / past query (#2054).
+		// upcoming / past query (#2054). The decision happens at shutdown so
+		// meta arriving after the insert wins over the default (#2116).
 		$instance->set_datetimes( $post_id );
+		$instance->resolve_pending_datetimes();
 		$this->assertNotEmpty(
 			get_post_meta( $post_id, 'gatherpress_datetime_start', true ),
 			'Failed to assert that a missing datetime falls back to the default.'
@@ -1097,6 +1099,8 @@ class Test_Setup extends Base {
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
 
+		Setup::get_instance()->resolve_pending_datetimes();
+
 		$this->assertEmpty(
 			get_post_meta( $post_id, 'gatherpress_datetime', true ),
 			'Failed to assert the seed leaves the editor-owned meta alone.'
@@ -1137,15 +1141,215 @@ class Test_Setup extends Base {
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
 
+		$instance->resolve_pending_datetimes();
+
 		$first = get_post_meta( $post_id, 'gatherpress_datetime_start', true );
 
 		$instance->set_datetimes( $post_id );
+		$instance->resolve_pending_datetimes();
 		$second = get_post_meta( $post_id, 'gatherpress_datetime_start', true );
 
 		$this->assertSame(
 			$first,
 			$second,
 			'Failed to assert that re-saving leaves the seeded default unchanged.'
+		);
+	}
+
+	/**
+	 * A duplicated event keeps the source event's date.
+	 *
+	 * Duplicate and import tooling inserts the post first and copies meta
+	 * afterwards with add_post_meta(), which appends rather than replaces.
+	 * Seeding a default during the insert therefore left a row in front of
+	 * the copied one, and every single-value read returned the seed instead
+	 * of the real date (#2116).
+	 *
+	 * @covers ::set_datetimes
+	 * @covers ::resolve_pending_datetimes
+	 * @covers ::write_datetimes
+	 *
+	 * @return void
+	 */
+	public function test_set_datetimes_keeps_a_duplicated_events_date(): void {
+		$instance = Setup::get_instance();
+		$post_id  = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		// The insert fires set_datetimes with no meta present, exactly as it
+		// does for the duplicate's wp_insert_post() call.
+		$this->assertEmpty(
+			get_post_meta( $post_id, 'gatherpress_datetime_start', true ),
+			'Failed to assert the insert left no seeded row to collide with.'
+		);
+
+		// The duplicate's meta copy lands next.
+		add_post_meta( $post_id, 'gatherpress_datetime_start', '2020-05-11 15:00:00' );
+		add_post_meta( $post_id, 'gatherpress_datetime_end', '2020-05-11 17:00:00' );
+		add_post_meta( $post_id, 'gatherpress_timezone', 'America/New_York' );
+
+		$instance->resolve_pending_datetimes();
+
+		$this->assertSame(
+			array( '2020-05-11 15:00:00' ),
+			get_post_meta( $post_id, 'gatherpress_datetime_start', false ),
+			'Failed to assert the copied date is the only stored value.'
+		);
+		$this->assertSame(
+			'2020-05-11 15:00:00',
+			( new Event( $post_id ) )->get_datetime()['datetime_start'],
+			'Failed to assert the events table took the copied date, not a default.'
+		);
+	}
+
+	/**
+	 * A datetime blob arriving after the insert wins over the default.
+	 *
+	 * The REST controller writes meta once wp_insert_post() has returned, so
+	 * the blob is absent while `set_datetimes()` runs and present by the time
+	 * the deferred resolution reads it.
+	 *
+	 * @covers ::set_datetimes
+	 * @covers ::resolve_pending_datetimes
+	 *
+	 * @return void
+	 */
+	public function test_set_datetimes_prefers_a_late_arriving_blob(): void {
+		$instance = Setup::get_instance();
+		$post_id  = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		update_post_meta(
+			$post_id,
+			'gatherpress_datetime',
+			'{"dateTimeStart":"2021-03-04 09:00:00","dateTimeEnd":"2021-03-04 10:00:00","timezone":"America/New_York"}'
+		);
+
+		$instance->resolve_pending_datetimes();
+
+		$this->assertSame(
+			'2021-03-04 09:00:00',
+			get_post_meta( $post_id, 'gatherpress_datetime_start', true ),
+			'Failed to assert the late blob was used instead of the default.'
+		);
+	}
+
+	/**
+	 * The stored blob wins when resolving a payload.
+	 *
+	 * Invoked directly: xdebug does not trace these branches through the
+	 * shutdown run, since they reach a protected method in the same class.
+	 *
+	 * @covers ::resolve_datetime_payload
+	 *
+	 * @return void
+	 */
+	public function test_resolve_datetime_payload_prefers_the_stored_blob(): void {
+		$post_id = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		update_post_meta(
+			$post_id,
+			'gatherpress_datetime',
+			'{"dateTimeStart":"2022-06-07 08:00:00","dateTimeEnd":"2022-06-07 09:00:00","timezone":"UTC"}'
+		);
+
+		$this->assertSame(
+			'2022-06-07 08:00:00',
+			Utility::invoke_hidden_method(
+				Setup::get_instance(),
+				'resolve_datetime_payload',
+				array( $post_id )
+			)['dateTimeStart'],
+			'Failed to assert the stored blob was preferred.'
+		);
+	}
+
+	/**
+	 * Individual meta keys are rebuilt into a payload when no blob exists.
+	 *
+	 * @covers ::resolve_datetime_payload
+	 *
+	 * @return void
+	 */
+	public function test_resolve_datetime_payload_rebuilds_from_individual_keys(): void {
+		$post_id = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		update_post_meta( $post_id, 'gatherpress_datetime_start', '2023-07-08 10:00:00' );
+		update_post_meta( $post_id, 'gatherpress_datetime_end', '2023-07-08 12:00:00' );
+		update_post_meta( $post_id, 'gatherpress_timezone', 'America/New_York' );
+
+		$this->assertSame(
+			array(
+				'dateTimeStart' => '2023-07-08 10:00:00',
+				'dateTimeEnd'   => '2023-07-08 12:00:00',
+				'timezone'      => 'America/New_York',
+			),
+			Utility::invoke_hidden_method(
+				Setup::get_instance(),
+				'resolve_datetime_payload',
+				array( $post_id )
+			),
+			'Failed to assert the payload was rebuilt from the individual keys.'
+		);
+	}
+
+	/**
+	 * The editor's default is used when nothing at all is stored.
+	 *
+	 * @covers ::resolve_datetime_payload
+	 * @covers ::get_default_datetime
+	 *
+	 * @return void
+	 */
+	public function test_resolve_datetime_payload_falls_back_to_the_default(): void {
+		$post_id = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		$payload = Utility::invoke_hidden_method(
+			Setup::get_instance(),
+			'resolve_datetime_payload',
+			array( $post_id )
+		);
+
+		$this->assertSame(
+			'18:00:00',
+			gmdate( 'H:i:s', (int) strtotime( $payload['dateTimeStart'] ) ),
+			'Failed to assert the default starts at 18:00, matching the editor.'
+		);
+		$this->assertSame(
+			2 * HOUR_IN_SECONDS,
+			strtotime( $payload['dateTimeEnd'] ) - strtotime( $payload['dateTimeStart'] ),
+			'Failed to assert the default runs for two hours, matching the editor.'
+		);
+	}
+
+	/**
+	 * A post deleted before shutdown is skipped rather than resurrected.
+	 *
+	 * @covers ::resolve_pending_datetimes
+	 *
+	 * @return void
+	 */
+	public function test_resolve_pending_datetimes_skips_deleted_posts(): void {
+		$instance = Setup::get_instance();
+		$post_id  = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+
+		wp_delete_post( $post_id, true );
+
+		$instance->resolve_pending_datetimes();
+
+		$this->assertEmpty(
+			get_post_meta( $post_id, 'gatherpress_datetime_start', true ),
+			'Failed to assert a deleted post gained no datetime meta.'
 		);
 	}
 


### PR DESCRIPTION
## Description

Cloning an event lost its date. The clone opened showing tomorrow at 18:00 instead of the source event's time. `git bisect` lands on #2074.

`set_datetimes()` runs on `wp_after_insert_post`, which fires from **inside** `wp_insert_post()` — before anything the caller does with meta afterwards. Every caller writes it later: REST does, and so does anything duplicating or importing a post.

That was harmless until #2074 added a default seed for events saved without a datetime. REST writes meta with `update_post_meta()`, which replaces, so the editor was unaffected. Duplicate and import tooling uses `add_post_meta()`, which **appends** — so the seeded row stays in front of the copied one, and every single-value read finds it first:

```
after insert   -> rows: ["2026-08-09 18:00:00"]                        seeded default
after copy     -> rows: ["2026-08-09 18:00:00", "2026-08-09 13:00:00"]
read (single)  -> 2026-08-09 18:00:00                                  wrong
```

The real date was never lost, just stranded in a second meta row where nothing looks.

## Blast radius

Not only clone plugins. The **WXR importer takes the same path**, so importing events strands their dates too — including the 0.35.0 demo data that every Playground pulls in.

## The fix

Defer the decision to `shutdown`, once the request's meta writes have settled, and prefer whatever actually arrived:

1. the `gatherpress_datetime` blob, if it landed after the insert
2. the individual `gatherpress_datetime_*` keys, if only those were copied
3. otherwise the editor's default, exactly as #2074 intended

| case | before | after |
| --- | --- | --- |
| New event, dates untouched | table row seeded | table row seeded, unchanged |
| New event in the editor | never dirty | never dirty, unchanged |
| Cloned event | **loses its date** | keeps its date |
| Imported event | **loses its date** | keeps its date |

The JS half of #2074 is untouched, so a new event still doesn't report unsaved changes before the author edits anything.

Checked before deferring that nothing reads the events table in-request: the other `wp_after_insert_post` hooks are RSVP waiting lists and venue maps, and neither touches datetimes.

## Testing

Reproduced the clone flow against a real site first, then against the fix:

```
after insert  -> meta rows: []
after copy    -> meta rows: ["2026-08-09 13:00:00"]
after shutdown-> meta single: 2026-08-09 13:00:00
                 events table: 2026-08-09 13:00:00
                 SOURCE was  : 2026-08-09 13:00:00
```

- `npm run test:unit:php` → **OK (1665 tests, 6929 assertions)**
- New tests cover the clone flow, a late-arriving blob, individual-keys-only, and a post deleted before shutdown
- `npm run lint:php` clean, `npm run lint:phpstan` no errors
- `coverage.xml` reports **no** uncovered lines in `event/class-setup.php`

`resolve_datetime_payload()` is split out for a specific reason: xdebug does not trace these branches through a shutdown run, because they reach a protected method in the same class. I confirmed with a `file_put_contents` probe that the code executes (`resolve called, pending=1` / `SEED branch for 4`) while `coverage.xml` reported `count=0` — the exact gap documented in AGENTS.md. Each branch now has a direct `invoke_hidden_method` test.

Three existing tests from #2074 asserted the seed landed synchronously and now trigger the deferred resolution explicitly.

## Types of changes

Bug fix.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
