### PR TITLE
Give the Playwright browser download enough time to finish

### DIFF
--- a/.github/workflows/screenshot-generation.yml
+++ b/.github/workflows/screenshot-generation.yml
@@ -118,7 +118,13 @@ jobs:
     # AND keep the post-job cache save alive, so the next locale job can hit
     # the browser cache instead of repeating the download.
     - name: Install Playwright browser
-      timeout-minutes: 10
+      # 20, not 10: a cold download genuinely needs it. Runs 31287296394 and
+      # its re-run both hit the 10-minute cap mid-download, saved no cache,
+      # and so left the next run just as cold -- the cap was reproducing the
+      # condition it fired on. The 6h hang this file's timeouts guard against
+      # was in the apt phase, which is the separate step below with its own
+      # cap, so this does not reopen it.
+      timeout-minutes: 20
       run: npx playwright install chromium
       if: steps.playwright-cache.outputs.cache-hit != 'true'
 

--- a/.github/workflows/screenshot-generation.yml
+++ b/.github/workflows/screenshot-generation.yml
@@ -60,7 +60,12 @@ jobs:
     # Backstop against hangs: with max-parallel 1, a job silently stuck at
     # GitHub's 6h default limit stalls every locale behind it — one hung
     # apt phase turned into ~48h of dead runner time (run 27881952586).
-    timeout-minutes: 40
+    #
+    # 60 so a cold first locale actually fits: the browser download can take
+    # 30 and the apt phase 10, which at the previous 40 left nothing for the
+    # screenshots themselves. Later locales reuse the caches and finish in
+    # well under 10 (run 28679615230 took 6 end to end).
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 1 # Prevent parallel runs to make use of the caching for node_modules and playwright browsers
@@ -118,13 +123,15 @@ jobs:
     # AND keep the post-job cache save alive, so the next locale job can hit
     # the browser cache instead of repeating the download.
     - name: Install Playwright browser
-      # 20, not 10: a cold download genuinely needs it. Runs 31287296394 and
+      # 30, not 10: a cold download genuinely needs it. Runs 31287296394 and
       # its re-run both hit the 10-minute cap mid-download, saved no cache,
       # and so left the next run just as cold -- the cap was reproducing the
-      # condition it fired on. The 6h hang this file's timeouts guard against
-      # was in the apt phase, which is the separate step below with its own
-      # cap, so this does not reopen it.
-      timeout-minutes: 20
+      # condition it fired on. Generous on purpose: it only applies until one
+      # run populates the cache, after which the cache-hit guard below skips
+      # the step entirely. The 6h hang this file's timeouts guard against was
+      # in the apt phase, which is the separate step below with its own cap,
+      # so this does not reopen it.
+      timeout-minutes: 30
       run: npx playwright install chromium
       if: steps.playwright-cache.outputs.cache-hit != 'true'
 


### PR DESCRIPTION
## Description

Documentation screenshot generation failed twice in a row on the same step:

```
Cache not found for input keys: Linux-playwright-584f230e...
##[error]The action 'Install Playwright browser' has timed out after 10 minutes.
```

Runs [31287296394](https://github.com/GatherPress/gatherpress/actions/runs/31287296394) and its re-run. The npm cache restores fine; there is just no Playwright browser cache, so `npx playwright install chromium` downloads from scratch — and on the current runners that does not finish inside 10 minutes.

## Why the cap was self-perpetuating

It fires mid-download, so no browser cache is saved. I checked the Actions cache API directly and there is **no** `playwright` entry at all. The next run is therefore just as cold and hits the same wall. The comment above the step assumed a timed-out step would still leave a usable cache for the next job; in practice it leaves nothing.

## Two changes, not one

| | was | now |
| --- | --- | --- |
| `Install Playwright browser` step | 10 | **30** |
| `screenshot` job | 40 | **60** |

Raising the step alone would have been a trap. At a 40-minute job cap, a 30-minute download plus the 10-minute apt phase consumes the entire budget and leaves nothing for the screenshots themselves — the job would die having done no work.

The step figure is deliberately generous because it only applies until one run populates the cache. After that the existing `cache-hit != 'true'` guard skips the step outright, so it costs nothing ongoing. Later locales in the same matrix reuse the cache and finish quickly — [run 28679615230](https://github.com/GatherPress/gatherpress/actions/runs/28679615230) took 6 minutes end to end.

## This does not reopen the 6-hour hang

The timeouts in this file were added because the combined `install --with-deps` hung indefinitely **inside its apt phase**, after the browser download had already completed ([run 27881952586](https://github.com/GatherPress/gatherpress/actions/runs/27881952586)). That phase is already split into its own `Install Playwright system dependencies` step and keeps its own 10-minute cap. The job cap stays far below GitHub's 6h default, so it remains a real backstop.

## Impact

Both screenshot workflows use this reusable job, so this currently blocks documentation screenshots **and** the WordPress.org screenshot run that is part of the 0.35.0 release.

## Testing

YAML parses. The real test is a dispatch of `Documentation screenshot generation` once this is on `develop` — `workflow_dispatch` workflows run from the default branch, so it cannot be verified from the PR branch.

## Types of changes

CI fix.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
