### PR TITLE
Key the Playwright cache on its version, not the whole lockfile

### DIFF
--- a/.github/workflows/screenshot-generation.yml
+++ b/.github/workflows/screenshot-generation.yml
@@ -76,12 +76,24 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    # Read straight from the lockfile: this runs before npm install, so
+    # node_modules is not available to require() the version from.
+    - name: Resolve the Playwright version
+      id: playwright-version
+      run: |
+        echo "version=$(jq -r '.packages["node_modules/@playwright/test"].version' package-lock.json)" >> "$GITHUB_OUTPUT"
+
+    # Keyed on the Playwright version, not the whole lockfile. Hashing
+    # package-lock.json meant any unrelated dependency bump threw away a
+    # ~400MB browser cache and forced a cold re-download -- a js-yaml
+    # security bump (#2111) is what discarded it most recently, and the
+    # download that followed hung twice.
     - uses: actions/cache@v4
       id: playwright-cache
       with:
         path: |
           ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
 
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/.github/workflows/screenshot-generation.yml
+++ b/.github/workflows/screenshot-generation.yml
@@ -144,7 +144,25 @@ jobs:
       # in the apt phase, which is the separate step below with its own cap,
       # so this does not reopen it.
       timeout-minutes: 30
-      run: npx playwright install chromium
+      # Retry with a hard kill rather than one long attempt. The download
+      # itself is not the problem -- it reaches 100% of 167MB and then the
+      # process sits there, so a bigger budget just means waiting longer for
+      # the same nothing (runs 31287296394, 31288339635). `timeout` kills a
+      # stuck attempt at 8 minutes and the next one re-uses whatever already
+      # landed on disk, so each retry starts closer to done.
+      run: |
+        for attempt in 1 2 3; do
+          echo "::group::playwright install chromium (attempt $attempt/3)"
+          if timeout --signal=KILL 8m npx playwright install chromium; then
+            echo "::endgroup::"
+            exit 0
+          fi
+          echo "::endgroup::"
+          echo "::warning::Attempt $attempt stalled or failed; retrying."
+          sleep 5
+        done
+        echo "::error::playwright install chromium did not complete in 3 attempts."
+        exit 1
       if: steps.playwright-cache.outputs.cache-hit != 'true'
 
     - name: Install Playwright system dependencies


### PR DESCRIPTION
## Description

The Playwright browser cache key hashed the entire lockfile:

```yaml
key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
```

So **any** dependency bump discarded a ~400MB browser cache that had nothing to do with the change. The js-yaml security bump in #2111 is what threw it away most recently.

That turned a latent problem into a blocker. Screenshot generation then had to download browsers cold, and the download hung — reaching **100% of 167.3 MiB** and then sitting idle until the step cap, three runs in a row ([31287296394](https://github.com/GatherPress/gatherpress/actions/runs/31287296394), its re-run, and [31288339635](https://github.com/GatherPress/gatherpress/actions/runs/31288339635)).

Worth noting how long this was masked: the last "successful" run, [28679615230](https://github.com/GatherPress/gatherpress/actions/runs/28679615230) on 3 July, never downloaded anything. It went straight to `install-deps` on a cache hit. This step has no record of completing on current runners.

## The change

Key on the Playwright version instead, so the cache survives unrelated bumps and only rotates when the browsers genuinely need to change.

The version is read from `package-lock.json` with `jq` rather than `require()`d from the package, because the cache step runs before `npm install` and `node_modules` does not exist yet. Currently resolves to `1.58.2`.

## What this does and does not do

It does **not** fix the hang. It makes the cold path rare instead of routine, which is what turned a long-standing latent issue into something that blocks a release.

I considered reducing the download with `--only-shell` and decided against it. This suite compares screenshots against committed baseline images, and the headless shell is not guaranteed to render identically to the full Chrome build those baselines were captured with. Halving the download is not worth the risk of invalidating every baseline in the repo, especially in a release week. If the hang recurs on a cold cache, that trade is worth revisiting deliberately with a baseline refresh, not as a side effect.

## Testing

YAML parses and the `jq` expression resolves to `1.58.2` against the current lockfile. `workflow_dispatch` workflows run from the default branch, so the real test is a dispatch once this is on `develop`.

## Types of changes

CI fix.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
