### PR TITLE
Run screenshot generation in Playwright's own container

### DIFF
--- a/.github/workflows/screenshot-generation.yml
+++ b/.github/workflows/screenshot-generation.yml
@@ -86,11 +86,36 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
+        # Enable built-in functionality for caching and restoring dependencies, which is disabled by default.
+        # The actions/setup-node uses actions/cache under the hood.
+        # https://github.com/actions/setup-node#caching-global-packages-data
         cache: 'npm'
 
+    # Restoring the short lived node_modules cache
+    # to be used across all workflows running on the last commit.
+    # https://github.com/actions/cache/blob/main/caching-strategies.md#creating-a-short-lived-cache
+    - uses: actions/cache/restore@v4
+      id: node_modules-cache
+      with:
+        path: |
+          ./node_modules
+        key: ${{ runner.os }}-node_modules-${{ github.sha }}-${{ hashFiles('package-lock.json') }}
+
     - name: NPM install
+      if: steps.node_modules-cache.outputs.cache-hit != 'true'
       run: npm ci
 
+    # Creating a short lived node_modules cache
+    - uses: actions/cache/save@v4
+      if: steps.node_modules-cache.outputs.cache-hit != 'true'
+      continue-on-error: true
+      with:
+        path: |
+          ./node_modules
+        key: ${{ steps.node_modules-cache.outputs.cache-primary-key }}
+
+    # A mounted plugin serves its assets straight from the working tree, so
+    # they have to be built — the repository doesn't commit build output.
     - name: Build plugin assets
       if: ${{ inputs.mount-plugin }}
       run: npm run build

--- a/.github/workflows/screenshot-generation.yml
+++ b/.github/workflows/screenshot-generation.yml
@@ -57,15 +57,21 @@ on:
 jobs:
   screenshot:
     runs-on: ubuntu-latest
+    # Playwright's own image ships the browsers and their system libraries
+    # preinstalled. Downloading them at job time was never reliable here: the
+    # transfer reaches 100% of 167MB and then the process stalls, which no
+    # timeout, retry or cache key can fix (runs 31287296394, 31288339635,
+    # 31313721827). Keep this tag in step with @playwright/test in
+    # package-lock.json -- Playwright refuses to run against a mismatched
+    # browser build.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     # Backstop against hangs: with max-parallel 1, a job silently stuck at
     # GitHub's 6h default limit stalls every locale behind it — one hung
-    # apt phase turned into ~48h of dead runner time (run 27881952586).
-    #
-    # 60 so a cold first locale actually fits: the browser download can take
-    # 30 and the apt phase 10, which at the previous 40 left nothing for the
-    # screenshots themselves. Later locales reuse the caches and finish in
-    # well under 10 (run 28679615230 took 6 end to end).
-    timeout-minutes: 60
+    # apt phase turned into ~48h of dead runner time (run 27881952586). With
+    # the browsers baked into the image there is no download or apt phase
+    # left, so 30 is ample: run 28679615230 took 6 minutes end to end.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       max-parallel: 1 # Prevent parallel runs to make use of the caching for node_modules and playwright browsers
@@ -76,103 +82,15 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    # Read straight from the lockfile: this runs before npm install, so
-    # node_modules is not available to require() the version from.
-    - name: Resolve the Playwright version
-      id: playwright-version
-      run: |
-        echo "version=$(jq -r '.packages["node_modules/@playwright/test"].version' package-lock.json)" >> "$GITHUB_OUTPUT"
-
-    # Keyed on the Playwright version, not the whole lockfile. Hashing
-    # package-lock.json meant any unrelated dependency bump threw away a
-    # ~400MB browser cache and forced a cold re-download -- a js-yaml
-    # security bump (#2111) is what discarded it most recently, and the
-    # download that followed hung twice.
-    - uses: actions/cache@v4
-      id: playwright-cache
-      with:
-        path: |
-          ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
-
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
-        # Enable built-in functionality for caching and restoring dependencies, which is disabled by default.
-        # The actions/setup-node uses actions/cache under the hood.
-        # https://github.com/actions/setup-node#caching-global-packages-data
         cache: 'npm'
 
-    # Restoring the short lived node_modules cache
-    # to be used across all workflows running on the last commit.
-    # https://github.com/actions/cache/blob/main/caching-strategies.md#creating-a-short-lived-cache
-    - uses: actions/cache/restore@v4
-      id: node_modules-cache
-      with:
-        path: |
-          ./node_modules
-        key: ${{ runner.os }}-node_modules-${{ github.sha }}-${{ hashFiles('package-lock.json') }}
-
     - name: NPM install
-      if: steps.node_modules-cache.outputs.cache-hit != 'true'
       run: npm ci
 
-    # Creating a short lived node_modules cache
-    - uses: actions/cache/save@v4
-      if: steps.node_modules-cache.outputs.cache-hit != 'true'
-      continue-on-error: true
-      with:
-        path: |
-          ./node_modules
-        key: ${{ steps.node_modules-cache.outputs.cache-primary-key }}
-
-    # The browser download and the apt-based system-dependency install are
-    # deliberately separate steps with their own timeouts: the combined
-    # `install --with-deps` hung indefinitely inside its apt phase (after the
-    # browser download had already completed) and every locale job burned
-    # GitHub's 6h limit — see run 27881952586. Step-level timeouts fail fast
-    # AND keep the post-job cache save alive, so the next locale job can hit
-    # the browser cache instead of repeating the download.
-    - name: Install Playwright browser
-      # 30, not 10: a cold download genuinely needs it. Runs 31287296394 and
-      # its re-run both hit the 10-minute cap mid-download, saved no cache,
-      # and so left the next run just as cold -- the cap was reproducing the
-      # condition it fired on. Generous on purpose: it only applies until one
-      # run populates the cache, after which the cache-hit guard below skips
-      # the step entirely. The 6h hang this file's timeouts guard against was
-      # in the apt phase, which is the separate step below with its own cap,
-      # so this does not reopen it.
-      timeout-minutes: 30
-      # Retry with a hard kill rather than one long attempt. The download
-      # itself is not the problem -- it reaches 100% of 167MB and then the
-      # process sits there, so a bigger budget just means waiting longer for
-      # the same nothing (runs 31287296394, 31288339635). `timeout` kills a
-      # stuck attempt at 8 minutes and the next one re-uses whatever already
-      # landed on disk, so each retry starts closer to done.
-      run: |
-        for attempt in 1 2 3; do
-          echo "::group::playwright install chromium (attempt $attempt/3)"
-          if timeout --signal=KILL 8m npx playwright install chromium; then
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "::endgroup::"
-          echo "::warning::Attempt $attempt stalled or failed; retrying."
-          sleep 5
-        done
-        echo "::error::playwright install chromium did not complete in 3 attempts."
-        exit 1
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-
-    - name: Install Playwright system dependencies
-      timeout-minutes: 10
-      env:
-        DEBIAN_FRONTEND: noninteractive
-      run: npx playwright install-deps chromium
-
-    # A mounted plugin serves its assets straight from the working tree, so
-    # they have to be built — the repository doesn't commit build output.
     - name: Build plugin assets
       if: ${{ inputs.mount-plugin }}
       run: npm run build


### PR DESCRIPTION
## Description

Browser downloads do not work on these runners. The transfer reaches **100% of 167 MB** and the process then stalls indefinitely.

| run | approach | result |
| --- | --- | --- |
| [31287296394](https://github.com/GatherPress/gatherpress/actions/runs/31287296394) | 10-minute cap | stalled mid-download |
| re-run | same | same |
| [31288339635](https://github.com/GatherPress/gatherpress/actions/runs/31288339635) | 30-minute cap | stalled **after** reaching 100% |
| [31313721827](https://github.com/GatherPress/gatherpress/actions/runs/31313721827) | 3 x 8-minute attempts | all three stalled identically |

That last one settles it. Three independent attempts failing at the same point means the failure is deterministic, so no timeout, retry or cache key can fix it.

The cache was only ever hiding this. The last green run, [28679615230](https://github.com/GatherPress/gatherpress/actions/runs/28679615230) on 3 July, never downloaded anything: it hit a warm cache. A dependabot bump rotated the key and exposed a problem that had been latent for months.

## The change

Run the job in `mcr.microsoft.com/playwright:v1.58.2-noble`, which ships the browsers and their system libraries preinstalled. The download, the apt phase and the browser cache all stop existing.

**Minus 95 lines.** Gone: the version-resolve step, the browser cache, the retry loop, `playwright install`, `playwright install-deps`, and the timeouts written to contain them. The job cap drops from 60 back to 30, since nothing slow is left.

## Keeping the tag in step

`v1.58.2-noble` must track `@playwright/test` in `package-lock.json` — Playwright refuses to run against a mismatched browser build. There is a comment above the image saying so. That is the one maintenance cost, and it is a visible one-line edit rather than a silent cache miss.

## Testing

YAML parses. `workflow_dispatch` runs from the default branch, so this can only be verified by merging and dispatching, same as every other attempt here. The difference is that this one removes the failing step rather than trying to survive it.

## Types of changes

CI fix.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
