### PR TITLE
Scope radio option focus to the field being edited

### DIFF
--- a/.github/changelog/radio-option-focus-iframe
+++ b/.github/changelog/radio-option-focus-iframe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the caret in the right place when adding or removing radio options in the editor. The option lookup now starts from the field being edited rather than the whole page, so it works in the iframed editor WordPress 7.1 makes unconditional, and a second radio field on the same post no longer steals the focus.

--- a/src/blocks/form-field/types/radio.js
+++ b/src/blocks/form-field/types/radio.js
@@ -111,9 +111,15 @@ export default function RadioField( {
 				return;
 			}
 
-			// Move cursor to end of text.
+			// Move cursor to end of text. The canvas can be torn down inside
+			// the timer, which leaves the element without a view to select in.
 			const ownerDocument = element.ownerDocument;
-			const selection = ownerDocument.defaultView.getSelection();
+			const selection = ownerDocument.defaultView?.getSelection();
+
+			if ( ! selection ) {
+				return;
+			}
+
 			const range = ownerDocument.createRange();
 
 			range.selectNodeContents( element );

--- a/src/blocks/form-field/types/radio.js
+++ b/src/blocks/form-field/types/radio.js
@@ -81,23 +81,56 @@ export default function RadioField( {
 		}
 	};
 
-	const addRadioOption = () => {
-		const newOptions = [ ...radioOptions, { label: '', value: '', id: uuidv4() } ];
-		setAttributes( { radioOptions: newOptions } );
+	// Moves focus to one option's editable label once React has re-rendered
+	// the group, optionally dropping the caret at the end of the text.
+	//
+	// The lookup starts from an element inside the group rather than from the
+	// global `document` for two reasons. The editor canvas is an iframe, so the
+	// options live in that iframe's document and a top-level `document` query
+	// matches nothing. Scoping to this block's own group also stops a second
+	// radio field on the same post from swallowing the focus.
+	const focusOption = ( scopeElement, targetIndex, placeCaretAtEnd = false ) => {
+		const group = scopeElement?.closest( '.gatherpress-radio-group' );
+
+		if ( ! group ) {
+			return;
+		}
 
 		setTimeout( () => {
-			const radioOptionElements = document.querySelectorAll(
+			const element = group.querySelectorAll(
 				'.gatherpress-radio-option .rich-text',
-			);
-			const lastOption =
-				radioOptionElements[ radioOptionElements.length - 1 ];
-			if ( lastOption ) {
-				lastOption.focus();
+			)[ targetIndex ];
+
+			if ( ! element ) {
+				return;
 			}
+
+			element.focus();
+
+			if ( ! placeCaretAtEnd ) {
+				return;
+			}
+
+			// Move cursor to end of text.
+			const ownerDocument = element.ownerDocument;
+			const selection = ownerDocument.defaultView.getSelection();
+			const range = ownerDocument.createRange();
+
+			range.selectNodeContents( element );
+			range.collapse( false );
+			selection.removeAllRanges();
+			selection.addRange( range );
 		}, 50 );
 	};
 
-	const removeRadioOption = ( index ) => {
+	const addRadioOption = ( scopeElement ) => {
+		const newOptions = [ ...radioOptions, { label: '', value: '', id: uuidv4() } ];
+		setAttributes( { radioOptions: newOptions } );
+
+		focusOption( scopeElement, newOptions.length - 1 );
+	};
+
+	const removeRadioOption = ( scopeElement, index ) => {
 		const optionToRemove = radioOptions[ index ];
 		const newOptions = radioOptions.filter( ( _, i ) => i !== index );
 
@@ -110,38 +143,20 @@ export default function RadioField( {
 		setAttributes( updates );
 
 		// Focus the previous option after removal and set cursor to end.
-		setTimeout( () => {
-			const targetIndex = Math.max( 0, index - 1 );
-			const radioOptionElements = document.querySelectorAll(
-				'.gatherpress-radio-option .rich-text',
-			);
-			if ( radioOptionElements[ targetIndex ] ) {
-				const element = radioOptionElements[ targetIndex ];
-				element.focus();
-
-				// Move cursor to end of text.
-				const range = document.createRange();
-				const selection = getSelection();
-
-				range.selectNodeContents( element );
-				range.collapse( false );
-				selection.removeAllRanges();
-				selection.addRange( range );
-			}
-		}, 50 );
+		focusOption( scopeElement, Math.max( 0, index - 1 ), true );
 	};
 
 	const handleKeyDown = ( event, index ) => {
 		if ( 'Enter' === event.key ) {
 			event.preventDefault();
-			addRadioOption();
+			addRadioOption( event.target );
 		} else if ( 'Backspace' === event.key || 'Delete' === event.key ) {
 			const currentOption = radioOptions[ index ];
 
 			// Only remove if the option is empty and it's not the last remaining option.
 			if ( ! currentOption.label && 1 < radioOptions.length ) {
 				event.preventDefault();
-				removeRadioOption( index );
+				removeRadioOption( event.target, index );
 			}
 		}
 	};

--- a/test/unit/js/src/blocks/form-field/types/radio.test.js
+++ b/test/unit/js/src/blocks/form-field/types/radio.test.js
@@ -183,4 +183,42 @@ describe( 'RadioField option focus', () => {
 		expect( remaining ).toHaveLength( 1 );
 		expect( document.activeElement ).toBe( remaining[ 0 ] );
 	} );
+
+	it( 'does not throw when the canvas loses its view before the caret is placed', () => {
+		const { container } = render(
+			<StatefulRadioField
+				fieldName="noView"
+				options={ [
+					{ label: 'One', value: 'one', id: 'a' },
+					{ label: '', value: '', id: 'b' },
+				] }
+			/>,
+		);
+
+		const block = container.querySelector( '.block-noView' );
+
+		fireEvent.keyDown( optionsOf( block )[ 1 ], { key: 'Backspace' } );
+
+		// A browser discards the browsing context when the canvas goes away
+		// (Code Editor switch, device-preview toggle), which leaves the
+		// document without a defaultView while the timer is still pending.
+		const ownerDocument = block.ownerDocument;
+		const view = ownerDocument.defaultView;
+
+		Object.defineProperty( ownerDocument, 'defaultView', {
+			configurable: true,
+			value: null,
+		} );
+
+		expect( () => {
+			act( () => {
+				jest.advanceTimersByTime( 50 );
+			} );
+		} ).not.toThrow();
+
+		Object.defineProperty( ownerDocument, 'defaultView', {
+			configurable: true,
+			value: view,
+		} );
+	} );
 } );

--- a/test/unit/js/src/blocks/form-field/types/radio.test.js
+++ b/test/unit/js/src/blocks/form-field/types/radio.test.js
@@ -1,0 +1,186 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import { render, fireEvent, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import RadioField from '@src/blocks/form-field/types/radio';
+
+// Mock RichText with a focusable stand-in that keeps the `rich-text` class the
+// option lookup selects on, and forwards the keydown the component listens for.
+jest.mock( '@wordpress/block-editor', () => ( {
+	RichText: ( { tagName: Tag, value, placeholder, className, onKeyDown } ) => (
+		<Tag
+			className={ [ 'rich-text', className ].filter( Boolean ).join( ' ' ) }
+			tabIndex={ 0 }
+			onKeyDown={ onKeyDown }
+		>
+			{ value || placeholder }
+		</Tag>
+	),
+} ) );
+
+/**
+ * Renders a radio field that owns its attributes, so adding an option actually
+ * re-renders the group the way it does in the editor.
+ *
+ * @param {Object} props           Component props.
+ * @param {string} props.fieldName Field name, used to tell two blocks apart.
+ * @param {Array}  props.options   Initial radio options.
+ *
+ * @return {JSX.Element} The stateful radio field.
+ */
+function StatefulRadioField( { fieldName, options } ) {
+	const [ attributes, setAttributes ] = useState( {
+		fieldType: 'radio',
+		fieldName,
+		fieldValue: '',
+		label: 'Group',
+		required: false,
+		radioOptions: options,
+	} );
+
+	return (
+		<RadioField
+			attributes={ attributes }
+			setAttributes={ ( update ) =>
+				setAttributes( ( current ) => ( { ...current, ...update } ) )
+			}
+			blockProps={ { className: `block-${ fieldName }` } }
+			generateFieldName={ () => '' }
+		/>
+	);
+}
+
+/**
+ * Reads the editable option labels belonging to one radio block.
+ *
+ * @param {HTMLElement} block The block wrapper element.
+ *
+ * @return {HTMLElement[]} The option label elements, in document order.
+ */
+function optionsOf( block ) {
+	return Array.from(
+		block.querySelectorAll( '.gatherpress-radio-option .rich-text' ),
+	);
+}
+
+describe( 'RadioField option focus', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'focuses the new option in the block that was typed in, not the last one on the page', () => {
+		const { container } = render(
+			<>
+				<StatefulRadioField
+					fieldName="first"
+					options={ [
+						{ label: 'One', value: 'one', id: 'a' },
+						{ label: 'Two', value: 'two', id: 'b' },
+					] }
+				/>
+				<StatefulRadioField
+					fieldName="second"
+					options={ [
+						{ label: 'Alpha', value: 'alpha', id: 'c' },
+						{ label: 'Beta', value: 'beta', id: 'd' },
+					] }
+				/>
+			</>,
+		);
+
+		const firstBlock = container.querySelector( '.block-first' );
+		const secondBlock = container.querySelector( '.block-second' );
+
+		// Enter at the end of the first block's first option adds an option there.
+		fireEvent.keyDown( optionsOf( firstBlock )[ 0 ], { key: 'Enter' } );
+
+		act( () => {
+			jest.advanceTimersByTime( 50 );
+		} );
+
+		const firstBlockOptions = optionsOf( firstBlock );
+
+		expect( firstBlockOptions ).toHaveLength( 3 );
+		expect( optionsOf( secondBlock ) ).toHaveLength( 2 );
+
+		// The caret belongs in the option just created, which is in this block.
+		expect( document.activeElement ).toBe( firstBlockOptions[ 2 ] );
+		expect( secondBlock.contains( document.activeElement ) ).toBe( false );
+	} );
+
+	it( 'focuses options inside the canvas document when the editor is iframed', () => {
+		// WordPress 7.1 always iframes the post editor, so the block renders in
+		// a document that is not the admin one. Focus must still resolve.
+		const iframe = document.createElement( 'iframe' );
+
+		document.body.appendChild( iframe );
+
+		const canvas = iframe.contentDocument;
+		const container = canvas.createElement( 'div' );
+
+		canvas.body.appendChild( container );
+
+		render(
+			<StatefulRadioField
+				fieldName="framed"
+				options={ [ { label: 'One', value: 'one', id: 'a' } ] }
+			/>,
+			{ container, baseElement: canvas.body },
+		);
+
+		const block = canvas.querySelector( '.block-framed' );
+
+		fireEvent.keyDown( optionsOf( block )[ 0 ], { key: 'Enter' } );
+
+		act( () => {
+			jest.advanceTimersByTime( 50 );
+		} );
+
+		const framedOptions = optionsOf( block );
+
+		expect( framedOptions ).toHaveLength( 2 );
+		expect( canvas.activeElement ).toBe( framedOptions[ 1 ] );
+
+		iframe.remove();
+	} );
+
+	it( 'moves focus back a step when an empty option is removed', () => {
+		const { container } = render(
+			<StatefulRadioField
+				fieldName="removal"
+				options={ [
+					{ label: 'One', value: 'one', id: 'a' },
+					{ label: '', value: '', id: 'b' },
+				] }
+			/>,
+		);
+
+		const block = container.querySelector( '.block-removal' );
+
+		// Backspace in the trailing empty option removes it.
+		fireEvent.keyDown( optionsOf( block )[ 1 ], { key: 'Backspace' } );
+
+		act( () => {
+			jest.advanceTimersByTime( 50 );
+		} );
+
+		const remaining = optionsOf( block );
+
+		expect( remaining ).toHaveLength( 1 );
+		expect( document.activeElement ).toBe( remaining[ 0 ] );
+	} );
+} );


### PR DESCRIPTION
Found while checking GatherPress against the WordPress 7.1 field guide, specifically the line that plugins "relying on reaching across the editor document boundary should review their JavaScript and CSS for compatibility".

All 20 blocks are already `apiVersion: 3`, so the headline iframe item costs nothing. This is the one place that reaches across the boundary.

### The defect

`addRadioOption()` and `removeRadioOption()` locate the option to focus with a page-wide query against the global `document`:

```js
const radioOptionElements = document.querySelectorAll(
	'.gatherpress-radio-option .rich-text',
);
```

That is wrong in two independent ways.

**It does not see the canvas.** The options render inside the editor iframe, so they live in the iframe's document, not the admin one. The query returns an empty list and focus never moves: press Enter to add an option and the caret stays where it was. Under 7.0 this already affects anyone whose post editor is iframed. [WordPress 7.1 makes the post editor iframed unconditionally](https://make.wordpress.org/core/2026/08/03/iframed-editor-changes-in-wordpress-7-1/), so it stops being conditional.

**It ignores which block you are editing.** The selector matches every radio option in the post. With two radio fields in one form, adding an option to the first focuses the *last option of the last block*, and removing one moves the caret into the wrong field. That part is a plain bug today, iframe or not.

The same applies to `document.createRange()` and the bare `getSelection()` in the removal path, which operate on the admin document while the element belongs to the canvas.

### The change

The lookup now starts from the element that received the keystroke and is scoped to its own `.gatherpress-radio-group`, with the range and selection taken from `element.ownerDocument`. This is the `ownerDocument` approach the dev note recommends, and it fixes the cross-block case for free.

No markup changed, only the three handlers. That is deliberate: #2112 rewrites this component's JSX, and this PR does not touch a single line of it, so the two should merge in either order without conflicting.

### Tests

`test/unit/js/src/blocks/form-field/types/radio.test.js`, three cases:

- two radio fields on one page, Enter in the first, focus must land on the new option in *that* block
- the block rendered inside an iframe document, focus must resolve in the canvas
- removing an empty option moves focus back a step

The first two fail on `develop` and pass with this change. The third passes either way and is there to hold the refactored removal path.

```
Tests:       3 passed, 3 total
```

Full JS suite stays green (54 suites, 999 tests). `wp-scripts lint-js` clean. `src/blocks/*/types/**/*` sits in the coverage gate's exclude list, so these are not gate-mandated, they are the evidence.

I have not run this against a live 7.1 build, so the iframe half is verified by the jsdom test and the dev note rather than by hand in the editor. The cross-block half reproduces on any current version.

Part of #2098 (WordPress 7.1 readiness). Deliberately not `Fixes`, since that issue also needs the `Tested up to` bump, which is a release-time edit — see the full checklist audit in https://github.com/GatherPress/gatherpress/issues/2098#issuecomment-5268453334