### PR TITLE
Fix screenshot generation: Node install deadlock and stale settings slugs

### DIFF
--- a/.github/scripts/docs-screenshots/docs.spec.ts
+++ b/.github/scripts/docs-screenshots/docs.spec.ts
@@ -24,7 +24,7 @@ test.describe( 'Documentation screenshots', () => {
 	test( 'GatherPress settings: Events tab', async ( { admin, page } ) => {
 		await admin.visitAdminPage(
 			'edit.php',
-			'post_type=gatherpress_event&page=gatherpress_events'
+			'post_type=gatherpress_event&page=gatherpress_events_settings'
 		);
 
 		await expect( page ).toHaveScreenshot( 'settings-events-tab.png', {
@@ -53,7 +53,7 @@ test.describe( 'Documentation screenshots', () => {
 	test( 'GatherPress settings: Venues tab', async ( { admin, page } ) => {
 		await admin.visitAdminPage(
 			'edit.php',
-			'post_type=gatherpress_event&page=gatherpress_venues'
+			'post_type=gatherpress_event&page=gatherpress_venues_settings'
 		);
 
 		await expect( page ).toHaveScreenshot( 'settings-venues-tab.png', {

--- a/.github/scripts/docs-screenshots/docs.spec.ts
+++ b/.github/scripts/docs-screenshots/docs.spec.ts
@@ -27,6 +27,14 @@ test.describe( 'Documentation screenshots', () => {
 			'post_type=gatherpress_event&page=gatherpress_events_settings'
 		);
 
+		// Assert the tab actually loaded before capturing. A permission page is
+		// still a valid PNG, so without this the suite screenshots the error and
+		// reports success (#2122). Matching the href rather than the label keeps
+		// the assertion locale-independent.
+		await expect(
+			page.locator( 'a.nav-tab-active[href*="page=gatherpress_events_settings"]' )
+		).toBeVisible();
+
 		await expect( page ).toHaveScreenshot( 'settings-events-tab.png', {
 			fullPage: true,
 		} );
@@ -40,6 +48,14 @@ test.describe( 'Documentation screenshots', () => {
 			'edit.php',
 			'post_type=gatherpress_event&page=gatherpress_rsvp_settings'
 		);
+
+		// Assert the tab actually loaded before capturing. A permission page is
+		// still a valid PNG, so without this the suite screenshots the error and
+		// reports success (#2122). Matching the href rather than the label keeps
+		// the assertion locale-independent.
+		await expect(
+			page.locator( 'a.nav-tab-active[href*="page=gatherpress_rsvp_settings"]' )
+		).toBeVisible();
 
 		// Draw attention to the RSVP Mode select, the setting the docs
 		// section explains first.
@@ -55,6 +71,14 @@ test.describe( 'Documentation screenshots', () => {
 			'edit.php',
 			'post_type=gatherpress_event&page=gatherpress_venues_settings'
 		);
+
+		// Assert the tab actually loaded before capturing. A permission page is
+		// still a valid PNG, so without this the suite screenshots the error and
+		// reports success (#2122). Matching the href rather than the label keeps
+		// the assertion locale-independent.
+		await expect(
+			page.locator( 'a.nav-tab-active[href*="page=gatherpress_venues_settings"]' )
+		).toBeVisible();
 
 		await expect( page ).toHaveScreenshot( 'settings-venues-tab.png', {
 			fullPage: true,

--- a/.github/scripts/wordpress-org-screenshots/wporg.spec.ts
+++ b/.github/scripts/wordpress-org-screenshots/wporg.spec.ts
@@ -156,8 +156,16 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
     }) => {
         await admin.visitAdminPage(
             'edit.php',
-            'post_type=gatherpress_event&page=gatherpress_events'
+            'post_type=gatherpress_event&page=gatherpress_events_settings'
         );
+
+        // Assert the tab actually loaded before capturing. A permission page
+        // is still a valid PNG, so without this the suite screenshots the
+        // error and reports success (#2122). Matched on the href rather than
+        // the tab label so it holds across all eight locales.
+        await expect(
+            page.locator( 'a.nav-tab-active[href*="page=gatherpress_events_settings"]' )
+        ).toBeVisible();
 
         // Wait for 2 seconds
         await page.waitForTimeout(2000);
@@ -175,8 +183,16 @@ test.describe( 'Screenshots for the wordpress.org/plugins repository', () => {
     }) => {
         await admin.visitAdminPage(
             'edit.php',
-            'post_type=gatherpress_event&page=gatherpress_roles'
+            'post_type=gatherpress_event&page=gatherpress_roles_settings'
         );
+
+        // Assert the tab actually loaded before capturing. A permission page
+        // is still a valid PNG, so without this the suite screenshots the
+        // error and reports success (#2122). Matched on the href rather than
+        // the tab label so it holds across all eight locales.
+        await expect(
+            page.locator( 'a.nav-tab-active[href*="page=gatherpress_roles_settings"]' )
+        ).toBeVisible();
 
         // Wait for 2 seconds
         await page.waitForTimeout(2000);

--- a/.github/workflows/screenshot-generation.yml
+++ b/.github/workflows/screenshot-generation.yml
@@ -127,43 +127,38 @@ jobs:
           ./node_modules
         key: ${{ steps.node_modules-cache.outputs.cache-primary-key }}
 
-    # The browser download and the apt-based system-dependency install are
-    # deliberately separate steps with their own timeouts: the combined
-    # `install --with-deps` hung indefinitely inside its apt phase (after the
-    # browser download had already completed) and every locale job burned
-    # GitHub's 6h limit — see run 27881952586. Step-level timeouts fail fast
-    # AND keep the post-job cache save alive, so the next locale job can hit
-    # the browser cache instead of repeating the download.
-    - name: Install Playwright browser
-      # 30, not 10: a cold download genuinely needs it. Runs 31287296394 and
-      # its re-run both hit the 10-minute cap mid-download, saved no cache,
-      # and so left the next run just as cold -- the cap was reproducing the
-      # condition it fired on. Generous on purpose: it only applies until one
-      # run populates the cache, after which the cache-hit guard below skips
-      # the step entirely. The 6h hang this file's timeouts guard against was
-      # in the apt phase, which is the separate step below with its own cap,
-      # so this does not reopen it.
-      timeout-minutes: 30
-      # Retry with a hard kill rather than one long attempt. The download
-      # itself is not the problem -- it reaches 100% of 167MB and then the
-      # process sits there, so a bigger budget just means waiting longer for
-      # the same nothing (runs 31287296394, 31288339635). `timeout` kills a
-      # stuck attempt at 8 minutes and the next one re-uses whatever already
-      # landed on disk, so each retry starts closer to done.
-      run: |
-        for attempt in 1 2 3; do
-          echo "::group::playwright install chromium (attempt $attempt/3)"
-          if timeout --signal=KILL 8m npx playwright install chromium; then
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "::endgroup::"
-          echo "::warning::Attempt $attempt stalled or failed; retrying."
-          sleep 5
-        done
-        echo "::error::playwright install chromium did not complete in 3 attempts."
-        exit 1
+    # playwright-core's bundled yauzl deadlocks unpacking the browser archive
+    # on Node 24.16/24.17: the extract stream never emits `close`, so the
+    # forked oopDownloadBrowserMain.js wedges silently *after* the transfer
+    # reaches 100% (nodejs/node#63487, microsoft/playwright#41133). Playwright
+    # vendored the fix in 1.60.0; 1.58.x never got it.
+    #
+    # .nvmrc pins 24.17.0 (#1962, to dodge a 24.18.0 `wp-scripts build`
+    # corruption), which is squarely in the broken range -- that pin is why
+    # runs 31287296394, 31288339635 and 31313721827 all hung after reaching
+    # 100%. Node 24.18.0 carries the libuv revert, so run the install (and
+    # only the install) on a Node past it, then restore the pinned one before
+    # anything builds.
+    #
+    # The apt phase below stays a separate step with its own timeout: the
+    # combined `install --with-deps` once hung indefinitely inside it and
+    # burned GitHub's 6h limit across every locale (run 27881952586).
+    - name: Use a Node without the extraction deadlock
       if: steps.playwright-cache.outputs.cache-hit != 'true'
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24.19.0'
+
+    - name: Install Playwright browser
+      timeout-minutes: 15
+      run: npx playwright install chromium
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+
+    - name: Restore the pinned Node
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
 
     - name: Install Playwright system dependencies
       timeout-minutes: 10

--- a/.github/workflows/screenshot-generation.yml
+++ b/.github/workflows/screenshot-generation.yml
@@ -283,6 +283,10 @@ jobs:
     # Size is a crude but effective proxy: a real full-page screenshot of an
     # admin screen is tens of KB, and every error/permission page is a few.
     # Fail here, before the PR exists, rather than reverting from develop.
+    #
+    # git status rather than git diff: a locale whose images are new to the
+    # repo is untracked, and git diff would not list it -- exempting exactly
+    # the case with no baseline to compare against.
     - name: Sanity-check the regenerated screenshots
       if: ${{ inputs.update-all || steps.screenshot-tests.outcome == 'failure' }}
       run: |
@@ -297,7 +301,7 @@ jobs:
           else
             echo "ok: ${image} (${size} bytes)"
           fi
-        done <<< "$(git diff --name-only --diff-filter=d -- '${{ inputs.output-path }}/*.png')"
+        done <<< "$(git status --porcelain -- '${{ inputs.output-path }}/*.png' | awk '$1 != "D" { print $NF }')"
 
         if [ "$suspect" -ne 0 ]; then
           echo "::error::Refusing to open a screenshot PR: at least one regenerated image looks like an error page."

--- a/.github/workflows/screenshot-generation.yml
+++ b/.github/workflows/screenshot-generation.yml
@@ -274,6 +274,36 @@ jobs:
         done
         exit 1
 
+    # A screenshot of an error page is still a valid PNG, so the suite
+    # captures it, passes, and auto-merge ships it -- which is exactly what
+    # happened in #2122, where two settings screens came back as WordPress's
+    # "Sorry, you are not allowed to access this page" at 2,203 bytes against
+    # a ~40,000 byte norm. Nothing downstream distinguishes the two.
+    #
+    # Size is a crude but effective proxy: a real full-page screenshot of an
+    # admin screen is tens of KB, and every error/permission page is a few.
+    # Fail here, before the PR exists, rather than reverting from develop.
+    - name: Sanity-check the regenerated screenshots
+      if: ${{ inputs.update-all || steps.screenshot-tests.outcome == 'failure' }}
+      run: |
+        min_bytes=10000
+        suspect=0
+        while IFS= read -r image; do
+          [ -n "$image" ] || continue
+          size=$(wc -c < "$image")
+          if [ "$size" -lt "$min_bytes" ]; then
+            echo "::error file=${image}::${image} is ${size} bytes, under the ${min_bytes} byte floor -- almost certainly an error page rather than a screenshot."
+            suspect=1
+          else
+            echo "ok: ${image} (${size} bytes)"
+          fi
+        done <<< "$(git diff --name-only --diff-filter=d -- '${{ inputs.output-path }}/*.png')"
+
+        if [ "$suspect" -ne 0 ]; then
+          echo "::error::Refusing to open a screenshot PR: at least one regenerated image looks like an error page."
+          exit 1
+        fi
+
     - name: Compress Images
       if: ${{ inputs.update-all || steps.screenshot-tests.outcome == 'failure' }}
       id: compress-images


### PR DESCRIPTION
## Description

Screenshot generation had two independent bugs stacked. Neither was visible on its own, and a warm cache had been hiding the first for months.

### 1. The workflow could not install browsers at all

`npx playwright install chromium` reached **100% of 167 MB** and then hung forever. Four runs, three different mitigations, all failed — including three 8-minute retries that stalled at the identical point, which is what proved it deterministic rather than flaky.

Cause: `playwright-core`'s bundled `yauzl` deadlocks unpacking the archive on Node **24.16/24.17** — the extract stream never emits `close`, so the forked `oopDownloadBrowserMain.js` wedges after the transfer completes ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487), [microsoft/playwright#41133](https://github.com/microsoft/playwright/issues/41133)). Playwright vendored the fix in 1.60.0; we are on 1.58.2.

`.nvmrc` pins **24.17.0** (#1962, dodging a 24.18.0 `wp-scripts build` corruption) — squarely in the broken range. Run the install, and only the install, on 24.19.0, then restore the pinned Node before anything builds.

### 2. Two of three screenshots were the permission page

#1970 renamed the settings sub-page slugs to carry a `_settings` suffix. Neither spec was updated:

| spec | was | now |
| --- | --- | --- |
| `docs.spec.ts` | `gatherpress_events` | `gatherpress_events_settings` |
| `docs.spec.ts` | `gatherpress_venues` | `gatherpress_venues_settings` |
| `wporg.spec.ts` | `gatherpress_events` | `gatherpress_events_settings` |
| `wporg.spec.ts` | `gatherpress_roles` | `gatherpress_roles_settings` |

`rsvp_settings` already matched, which is exactly why one of the three docs screenshots was fine. In the wp.org suite this is **16 images across 8 locales**.

## Two guards, because a screenshot of an error page is still a valid PNG

The suite captured `wp_die()` output, passed, and auto-merged it (#2122, reverted in #2123). `visitAdminPage` only throws on a login redirect or a PHP error; a permission page is neither.

- **In-spec:** assert the intended tab is active before capturing. Matched on the `href`, not the label, so it holds across all eight locales — and it also catches navigating to the *wrong* tab, which a byte count never would.
- **In-workflow:** a size floor before the PR is created. Real full-page admin screenshots are tens of KB; error pages are ~2 KB. Uses `git status` rather than `git diff` so a locale whose images are new to the repo is not exempt.

## Release ordering for the wp.org suite

That suite installs GatherPress **from wordpress.org**, not from the working tree. Until 0.35.0 ships, wp.org serves 0.34.1, which still has the *old* slugs.

**Deploy 0.35.0 first, then dispatch.** Dispatching before the deploy now fails loudly on the new tab assertion instead of quietly producing 16 error pages, which is the point of adding it here.

## Testing

Verified by dispatching against this branch with `gh workflow run docs-screenshots.yml --ref …` — no merge required, which is worth knowing since three earlier attempts assumed otherwise.

- [Run 31316984045](https://github.com/GatherPress/gatherpress/actions/runs/31316984045): green end to end. `Install Playwright browser` succeeded for the first time.
- [Run 31318123448](https://github.com/GatherPress/gatherpress/actions/runs/31318123448): green, browser install **skipped on a cache hit**, sanity check passed at 156 KB / 130 KB / 143 KB.
- Opened the resulting PNGs and confirmed they are the real settings screens with the correct tab active, rather than trusting file size alone.

## Types of changes

Bug fix (CI).

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
