### PR TITLE
Rename the team credits group to noteworthy, and add 0.35.0 credits

### DIFF
--- a/.github/changelog/credits-noteworthy-group
+++ b/.github/changelog/credits-noteworthy-group
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Rename the "team" credits group to "noteworthy", matching how WordPress presents its own release credits, and add the 0.35.0 credits file.

--- a/.github/scripts/release/credits/0.35.0.json
+++ b/.github/scripts/release/credits/0.35.0.json
@@ -1,0 +1,22 @@
+{
+    "leads": [
+        "mauteri",
+        "patricia70"
+    ],
+    "noteworthy": [
+        "hrmervin",
+        "jmarx75",
+        "carstenbach",
+        "supernovia",
+        "matthewneilcowan"
+    ],
+    "contributors": [
+        "andremenrath",
+        "bor0",
+        "linewebdigital",
+        "w3lld1",
+        "fahimmurshed",
+        "lheroorg",
+        "motylanogha"
+    ]
+}

--- a/.github/scripts/release/generate-version.php
+++ b/.github/scripts/release/generate-version.php
@@ -133,7 +133,7 @@ function fold_unreleased_credits( $entry, $credits_file, $version ) {
 	// Already-credited people (any group) don't get re-added.
 	$credited = array_merge(
 		isset( $entry['leads'] ) ? $entry['leads'] : array(),
-		isset( $entry['team'] ) ? $entry['team'] : array(),
+		isset( $entry['noteworthy'] ) ? $entry['noteworthy'] : array(),
 		isset( $entry['contributors'] ) ? $entry['contributors'] : array()
 	);
 	$new      = array_values( array_diff( array_unique( $pending ), $credited ) );
@@ -193,16 +193,16 @@ function generate_credits( $version ) {
 	$data['version'] = $version;
 	$contributors    = array();
 
-	// Fixed group order: leads and team drive readme.txt's Contributors
+	// Fixed group order: leads and noteworthy drive readme.txt's Contributors
 	// line and the credits page ordering regardless of file key order.
-	foreach ( array( 'leads', 'team', 'contributors' ) as $group ) {
+	foreach ( array( 'leads', 'noteworthy', 'contributors' ) as $group ) {
 		$users = isset( $entry[ $group ] ) && is_array( $entry[ $group ] ) ? $entry[ $group ] : array();
 
 		if ( 'contributors' === $group ) {
 			sort( $users );
 		}
 
-		// Only leads + team land in the wp.org plugin header's
+		// Only leads + noteworthy land in the wp.org plugin header's
 		// `Contributors:` line. The contributors group still appears on
 		// the credits page (via $data below), but it gets churn-y as more
 		// people land single-PR contributions, and wp.org's plugin

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -48,6 +48,26 @@ Maintainers can force the bot to refresh its list by adding the `Props Bot` labe
 
 Crediting is automated from there: when a pull request merges into `develop`, the Credits Sync workflow reads the Props Bot comment and appends anyone not yet credited for the current release cycle to `.github/scripts/release/credits/unreleased.json`, via a small auto-merging PR. At the next version bump those names move into the release's credits file and appear on the in-plugin Credits screen. Contributors the bot couldn't resolve (no linked GitHub account) are skipped by the automation — maintainers add them by hand to `unreleased.json` or the version's credits file.
 
+### How credits are grouped
+
+The Credits screen has three groups, and every release is credited on its own terms.
+
+**Leads** are the people responsible for the direction of the project. This is a standing role and changes rarely.
+
+**Noteworthy Contributors** are the people whose work shaped a given release. The bar is not the size of any single contribution, it is showing up repeatedly across a cycle: pull requests landing, issues opened and triaged, reviews given, discussion that moves decisions forward. It also covers work that never appears in git — helping in Slack, shaping ideas, organizing, translating, supporting other contributors. The leads make that call, because it is the part no tool can see.
+
+**Contributors to GatherPress X.Y.Z** is everyone who contributed to that release, however small. A single typo fix belongs here, and belongs here genuinely — it is a real credit, sized to the contribution.
+
+### Moving between groups
+
+Getting into Noteworthy takes a pattern of contribution, not one good week. Staying there is deliberately easier than getting there: a quiet release does not cost you your place, because contribution comes in waves and people have jobs and lives.
+
+Someone comes off the Noteworthy list after roughly three consecutive releases with no contribution of any kind. That is a few months of dormancy, and it is a statement about the release being credited rather than a judgement about the person. Anyone who returns and contributes goes back on.
+
+Two things worth being direct about. This is not a permanent status and is not meant to be — the list describes who is currently building GatherPress, and it stays honest by changing. And the leads' judgement is genuinely part of it, particularly for contribution that happens outside the repository. We would rather say that plainly than dress it up as a formula.
+
+If you want to be in that group, the route is the same one everyone took: pick up issues, review other people's work, and keep showing up. We would much rather grow this list than prune it.
+
 ---
 
 Thanks for helping make GatherPress better! 💜

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -62,9 +62,9 @@ The Credits screen has three groups, and every release is credited on its own te
 
 Getting into Noteworthy takes a pattern of contribution, not one good week. Staying there is deliberately easier than getting there: a quiet release does not cost you your place, because contribution comes in waves and people have jobs and lives.
 
-Someone comes off the Noteworthy list after roughly three consecutive releases with no contribution of any kind. That is a few months of dormancy, and it is a statement about the release being credited rather than a judgement about the person. Anyone who returns and contributes goes back on.
+Someone comes off the Noteworthy list after roughly three consecutive releases with no contribution of any kind. That is a few months of dormancy, and it is a statement about the release being credited rather than a judgment about the person. Anyone who returns and contributes goes back on.
 
-Two things worth being direct about. This is not a permanent status and is not meant to be — the list describes who is currently building GatherPress, and it stays honest by changing. And the leads' judgement is genuinely part of it, particularly for contribution that happens outside the repository. We would rather say that plainly than dress it up as a formula.
+Two things worth being direct about. This is not a permanent status and is not meant to be — the list describes who is currently building GatherPress, and it stays honest by changing. And the leads' judgment is genuinely part of it, particularly for contribution that happens outside the repository. We would rather say that plainly than dress it up as a formula.
 
 If you want to be in that group, the route is the same one everyone took: pick up issues, review other people's work, and keep showing up. We would much rather grow this list than prune it.
 

--- a/includes/templates/admin/settings/credits/index.php
+++ b/includes/templates/admin/settings/credits/index.php
@@ -3,8 +3,8 @@
  * Render the Credits section in GatherPress settings.
  *
  * This code snippet is responsible for rendering the "Credits" section in the
- * GatherPress settings. It displays information about the project leaders, GatherPress team,
- * and contributors. It also includes links to contributors' profiles.
+ * GatherPress settings. It displays the project leads, the noteworthy
+ * contributors for this release, and everyone who contributed to it. It also includes links to contributors' profiles.
  *
  * @package GatherPress\Core
  * @param array $credits An array containing contributor information.
@@ -28,7 +28,7 @@ if ( ! isset( $credits ) ) {
 		<a href="https://github.com/GatherPress/gatherpress" rel="noopener" target="_blank"><?php esc_html_e( 'Get Involved', 'gatherpress' ); ?></a>.
 	</p>
 	<div class="gatherpress-settings__credits-wrapper">
-		<h3><?php esc_html_e( 'GatherPress Team', 'gatherpress' ); ?></h3>
+		<h3><?php esc_html_e( 'Noteworthy Contributors', 'gatherpress' ); ?></h3>
 		<ul class="gatherpress-settings__credits-featured">
 			<?php
 			foreach ( $credits['leads'] as $gatherpress_contributor ) :
@@ -41,7 +41,13 @@ if ( ! isset( $credits ) ) {
 					true
 				);
 			endforeach;
-			foreach ( $credits['team'] as $gatherpress_contributor ) :
+			// `team` was renamed to `noteworthy` in 0.35.0. Read both so the
+			// page keeps rendering against an includes/data/credits.php that
+			// was generated before the rename; the fallback can go once
+			// 0.35.0 has shipped and every generated file carries the new key.
+			$gatherpress_noteworthy = $credits['noteworthy'] ?? $credits['team'] ?? array();
+
+			foreach ( $gatherpress_noteworthy as $gatherpress_contributor ) :
 				Utility::render_template(
 					sprintf( '%s/includes/templates/admin/settings/credits/contributor-card.php', GATHERPRESS_CORE_PATH ),
 					array(


### PR DESCRIPTION
## Description

Renames the `team` credits group to `noteworthy`, and adds the `0.35.0` credits file.

## Why this name

I checked what WordPress actually does. The [props handbook](https://make.wordpress.org/core/handbook/best-practices/contributor-attribution-props/) defines no tiers at all — the structure lives in the credits API. For 6.8:

| group | heading | count |
| --- | --- | --- |
| `core-developers` | **Noteworthy Contributors** | 28, each with a release role (Release Lead, Tech Lead, Triage Lead, Design Lead…) |
| `contributing-developers` | *(no heading, shuffled)* | 20 |
| `props` | **Core Contributors to WordPress 6.8** | 920 |

The first two render as one block. Our page already has exactly that shape — leads + team under one heading, then "Contributors to GatherPress X.Y.Z". Only the name differed, and "Team" reads as standing membership rather than what the group actually is.

**The more useful finding:** WordPress has no demotion problem because its top group is rebuilt every release from who held a role that cycle. Nobody is removed; they are credited for the releases they worked on. Adopting the name is the first step toward adopting that rule.

## 0.35.0 credits

A release prerequisite regardless. Changes against `0.35.0-beta.2`:

- **`matthewneilcowan` moves up to noteworthy.** Second most active person in the project this cycle: 7 PRs, 17 reviews, 9 issues opened.
- **`stephenerdelyi` comes off.**
- `hrmervin`, `jmarx75`, `carstenbach`, `supernovia` stay — including contributions that do not show up as commits.
- `motylanogha` carries over in contributors. `puvaanraaj2001` is pending in `unreleased.json` and folds in at bump time — they linked their WordPress.org account after being asked on #2081.

Resulting `readme.txt` `Contributors:` line:

```
mauteri, patricia70, hrmervin, jmarx75, carstenbach, supernovia, matthewneilcowan
```

## Transition detail

`includes/data/credits.php` is generated, and the copy on `develop` still carries `team` until the 0.35.0 version bump regenerates it. The template reads `noteworthy ?? team` so the Credits page keeps rendering in the meantime. That fallback should come out once 0.35.0 has shipped.

## Testing

- `npm run test:unit:php --filter 'Test_Credits|Test_Settings'` → **OK (117 tests, 280 assertions)**
- `npm run lint:php` clean
- Confirmed no test or other consumer referenced the old `team` key
- Verified the generator's group loop and readme.txt `Contributors:` construction produce the expected output

## Still open

Whether the noteworthy group carries per-release **titles** the way WordPress does. That is the piece that makes "noteworthy" self-justifying, and it means assigning roles each cycle. Not in this PR.

## Types of changes

Changed.

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
