### PR TITLE
DO NOT MERGE until the 0.35.0 version bump lands: drop the team credits fallback

### DIFF
--- a/includes/templates/admin/settings/credits/index.php
+++ b/includes/templates/admin/settings/credits/index.php
@@ -41,13 +41,7 @@ if ( ! isset( $credits ) ) {
 					true
 				);
 			endforeach;
-			// `team` was renamed to `noteworthy` in 0.35.0. Read both so the
-			// page keeps rendering against an includes/data/credits.php that
-			// was generated before the rename; the fallback can go once
-			// 0.35.0 has shipped and every generated file carries the new key.
-			$gatherpress_noteworthy = $credits['noteworthy'] ?? $credits['team'] ?? array();
-
-			foreach ( $gatherpress_noteworthy as $gatherpress_contributor ) :
+			foreach ( $credits['noteworthy'] as $gatherpress_contributor ) :
 				Utility::render_template(
 					sprintf( '%s/includes/templates/admin/settings/credits/contributor-card.php', GATHERPRESS_CORE_PATH ),
 					array(


### PR DESCRIPTION
## ⛔ Do not merge until the 0.35.0 version bump has landed on `develop`

This removes the transition fallback added in #2129. It is only safe once `includes/data/credits.php` on `develop` carries the `noteworthy` key, which happens when the Version Bump regenerates it from `credits/0.35.0.json`.

**Merge order tomorrow:**

1. Version Bump → `0.35.0`, core version PR merges → `credits.php` now has `noteworthy`
2. **This PR**
3. develop → main release merge

Merged before step 1, the Credits page has no group to read and the top block renders empty.

**How to check it is safe:**

```bash
grep -oE "'(team|noteworthy)' =>" includes/data/credits.php
```

`'noteworthy' =>` means go. `'team' =>` means the bump has not landed yet.

## Description

#2129 renamed the `team` credits group to `noteworthy` and left the template reading `$credits['noteworthy'] ?? $credits['team'] ?? array()`, so the page kept rendering against a `credits.php` generated before the rename. Verified at the time: the new template against the old `credits.php` rendered 9 cards with zero PHP notices.

Once 0.35.0 generates, the second branch is dead. This drops it.

## Testing

`php -l` clean. The real check is the one above — this is a seven-line deletion whose correctness is entirely about when it merges, not what it does.

If it turns out to be inconvenient to slot between steps 1 and 3, this is equally safe to merge any time after 0.35.0 ships. Nothing depends on it.

## Types of changes

Cleanup.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
