### PR TITLE
Allow noteworthy promotions to be queued between releases

### DIFF
--- a/.github/changelog/credits-queue-noteworthy-promotions
+++ b/.github/changelog/credits-queue-noteworthy-promotions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Let a lead queue a noteworthy-group promotion in credits/unreleased.json when they decide it, instead of having to remember it at the next version bump.

--- a/.github/scripts/release/credits/unreleased.json
+++ b/.github/scripts/release/credits/unreleased.json
@@ -3,5 +3,6 @@
         "faisalahammad",
         "matthewneilcowan",
         "vanyukov"
-    ]
+    ],
+    "noteworthy": []
 }

--- a/.github/scripts/release/credits/unreleased.json
+++ b/.github/scripts/release/credits/unreleased.json
@@ -4,5 +4,7 @@
         "matthewneilcowan",
         "vanyukov"
     ],
-    "noteworthy": []
+    "noteworthy": [
+        "motylanogha"
+    ]
 }

--- a/.github/scripts/release/generate-version.php
+++ b/.github/scripts/release/generate-version.php
@@ -106,17 +106,25 @@ function fetch_wporg_profile( $username ) {
 }
 
 /**
- * Fold pending credits/unreleased.json contributors into the version entry.
+ * Fold pending credits/unreleased.json entries into the version entry.
  *
  * The credits-sync automation (#1828) accumulates newly-merged contributors
  * in credits/unreleased.json between releases. At bump time they move into
  * the target version's file (which stays the source of truth) and the
  * staging file is emptied — both writes land in the version-bump commit.
  *
+ * The optional `noteworthy` array in the same file lets a lead queue a
+ * promotion when they decide it, rather than having to remember it at the
+ * next bump. It is hand-edited: the sync automation only ever appends to
+ * `contributors`, because who belongs in noteworthy is a judgment call the
+ * leads make and no tool can see. A queued name already sitting in
+ * `contributors` moves groups rather than appearing twice, and anyone
+ * already in `leads` is left alone.
+ *
  * @param array  $entry        The decoded credits entry for the version.
  * @param string $credits_file Absolute path to the version's credits file.
  * @param string $version      The plugin version (for messages).
- * @return array The entry with pending contributors folded in.
+ * @return array The entry with pending credits folded in.
  */
 function fold_unreleased_credits( $entry, $credits_file, $version ) {
 	$unreleased_file = SCRIPT_ROOT . '/credits/unreleased.json';
@@ -129,40 +137,82 @@ function fold_unreleased_credits( $entry, $credits_file, $version ) {
 	$pending    = isset( $unreleased['contributors'] ) && is_array( $unreleased['contributors'] )
 		? $unreleased['contributors']
 		: array();
+	$promoting  = isset( $unreleased['noteworthy'] ) && is_array( $unreleased['noteworthy'] )
+		? $unreleased['noteworthy']
+		: array();
+
+	$leads    = isset( $entry['leads'] ) ? $entry['leads'] : array();
+	$promoted = array_values(
+		array_diff(
+			array_unique( $promoting ),
+			$leads,
+			isset( $entry['noteworthy'] ) ? $entry['noteworthy'] : array()
+		)
+	);
+
+	if ( ! empty( $promoted ) ) {
+		$entry['noteworthy'] = array_merge(
+			isset( $entry['noteworthy'] ) ? $entry['noteworthy'] : array(),
+			$promoted
+		);
+
+		// A promoted name credited for this release as a contributor moves
+		// groups instead of being listed in both.
+		if ( isset( $entry['contributors'] ) ) {
+			$entry['contributors'] = array_values( array_diff( $entry['contributors'], $promoted ) );
+		}
+	}
 
 	// Already-credited people (any group) don't get re-added.
 	$credited = array_merge(
-		isset( $entry['leads'] ) ? $entry['leads'] : array(),
+		$leads,
 		isset( $entry['noteworthy'] ) ? $entry['noteworthy'] : array(),
 		isset( $entry['contributors'] ) ? $entry['contributors'] : array()
 	);
 	$new      = array_values( array_diff( array_unique( $pending ), $credited ) );
 
-	if ( empty( $new ) ) {
-		return $entry;
+	if ( ! empty( $new ) ) {
+		$entry['contributors'] = array_merge(
+			isset( $entry['contributors'] ) ? $entry['contributors'] : array(),
+			$new
+		);
 	}
 
-	$entry['contributors'] = array_merge(
-		isset( $entry['contributors'] ) ? $entry['contributors'] : array(),
-		$new
-	);
+	if ( empty( $new ) && empty( $promoted ) ) {
+		return $entry;
+	}
 
 	$json_flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
 
 	if ( file_put_contents( $credits_file, json_encode( $entry, $json_flags ) . "\n" ) === false ) {
-		fail( "Failed to fold unreleased contributors into credits/{$version}.json." );
+		fail( "Failed to fold unreleased credits into credits/{$version}.json." );
 	}
 
-	$reset_json = json_encode( array( 'contributors' => array() ), $json_flags ) . "\n";
+	$reset_json = json_encode(
+		array(
+			'contributors' => array(),
+			'noteworthy'   => array(),
+		),
+		$json_flags
+	) . "\n";
 
 	if ( file_put_contents( $unreleased_file, $reset_json ) === false ) {
 		fail( 'Failed to reset credits/unreleased.json.' );
 	}
 
-	success(
-		'Folded ' . count( $new ) . " unreleased contributor(s) into credits/{$version}.json: "
-		. implode( ', ', $new ) . '.'
-	);
+	if ( ! empty( $promoted ) ) {
+		success(
+			'Promoted ' . count( $promoted ) . " contributor(s) to noteworthy in credits/{$version}.json: "
+			. implode( ', ', $promoted ) . '.'
+		);
+	}
+
+	if ( ! empty( $new ) ) {
+		success(
+			'Folded ' . count( $new ) . " unreleased contributor(s) into credits/{$version}.json: "
+			. implode( ', ', $new ) . '.'
+		);
+	}
 
 	return $entry;
 }


### PR DESCRIPTION
### Why

`generate-version.php` builds `readme.txt`'s `Contributors:` line from **leads + noteworthy** only, and deliberately leaves the `contributors` group out — the comment at `generate_credits()` explains that reasoning and I am not proposing to change it. That part is working as designed.

The gap is upstream of it. The credits-sync automation only ever appends to `unreleased.json`'s `contributors` array. There is no way to record "this person should move to noteworthy next release", because the file that would hold it (`credits/0.36.0.json`) does not exist yet at the moment the decision gets made. So a promotion depends on someone remembering it at bump time, weeks later, while assembling a release.

### What this does

`fold_unreleased_credits()` now also reads an optional `noteworthy` array from `unreleased.json`:

- a queued name already credited as a contributor for the release **moves groups** rather than being listed twice
- names already in `noteworthy`, or in `leads`, are no-ops
- the staging file resets both arrays after a fold
- when nothing is queued the version file is left untouched, exactly as before

It stays hand-edited on purpose. The sync automation should keep appending only to `contributors`, because who belongs in noteworthy is a judgment call `contributing.md` puts with the leads, and no tool can see it.

I exercised the function directly against fixture files rather than trusting a read: promote-someone-already-a-contributor, promote-and-fold-in-the-same-run, already-promoted plus a lead in the queue, and nothing-queued. All four behave as described above.

### The second commit is yours to drop

`a69874c4` queues `motylanogha` — me. I want to be straightforward about that rather than bury it.

The background: I asked in Slack whether I could be added to Contributors & Developers on the plugin page, and @mauteri answered "yes, you will be listed in next version for sure". Since that section is generated from leads + noteworthy, this commit is what actually implements that answer, and it seemed more useful to show the mechanism than to ask again and leave someone to hand-edit a file at bump time.

Group assignment is entirely the leads' call. It is a separate commit precisely so you can drop it and keep the tooling, and I would rather you did that than felt any pressure from the PR being open. Equally happy if you would prefer the queue to start empty and to add names yourselves when you decide them.

### Not covered

`docs/contributor/release-process.md` does not describe `unreleased.json`'s shape today, so there was nothing to update. Say the word if you would like the new key documented there.

Props motylanogha
