### PR TITLE
Update @wordpress/blocks to drop the unpatched showdown dependency

### DIFF
--- a/.github/changelog/showdown-xss-advisories
+++ b/.github/changelog/showdown-xss-advisories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update @wordpress/blocks so the unpatched showdown dependency leaves the tree. Development-only; showdown was never shipped or executed.

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,10 @@ module.exports = {
 		'^@src/(.*)$': '<rootDir>/src/$1',
 		...defaultConfig.moduleNameMapper,
 	},
+	// These ship ESM only, so Jest has to transform them rather than skip
+	// node_modules wholesale. `marked` arrived with @wordpress/blocks 15.25.0,
+	// which dropped showdown for it (GHSA-cr32-g25g-vxjj, GHSA-22g5-r2x5-97cx).
 	transformIgnorePatterns: [
-		'node_modules/(?!(?:parsel-js|uuid)/)',
+		'node_modules/(?!(?:parsel-js|uuid|marked)/)',
 	],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10065,14 +10065,14 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.42.0.tgz",
-			"integrity": "sha512-7NdHXJt3XDBXujkhoZkuBzZJIY+LrG0r2aPSJVujoHwioBR3V+HgdcGa1xydAnKtdiNnYa8fEdlWqk49EEQ0MA==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.52.0.tgz",
+			"integrity": "sha512-0KlDa/vSASriu84+z+a/XA2teaau6t6rCH6PEqMXoW5a6EbP2e/REpZRumbu0VzV5MRO5kpxfD+fVYNYz9BdlA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/dom-ready": "^4.42.0",
-				"@wordpress/i18n": "^6.15.0"
+				"@wordpress/dom-ready": "^4.52.0",
+				"@wordpress/i18n": "^6.25.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10119,9 +10119,9 @@
 			}
 		},
 		"node_modules/@wordpress/autop": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.42.0.tgz",
-			"integrity": "sha512-cda5C9P15fUUQZmdYUnOxKTbZqoCX9oeo0UHaSmSsJcuoj3jFvGr5NxjTHKPxwS/2p/mIdfb3VDS4klBx9uraw==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.52.0.tgz",
+			"integrity": "sha512-BZUmljM4MFod1p01dRVsZUoW5GR9JfwIBrJ1kYG3nPtTwyVHZcgCo2An9n+oUQbXv3gA+ah/ZJ4DIZrqEFf0IQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10165,9 +10165,9 @@
 			}
 		},
 		"node_modules/@wordpress/blob": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.42.0.tgz",
-			"integrity": "sha512-UwUUrdmjEJTgvelFdVg7c7s/240Siv6bFIurv0o9XY4Bu46z4NHJI96nUiziKRNTRm0lcvzS6CZxeRTT/m1Fig==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.52.0.tgz",
+			"integrity": "sha512-IBC0lVXiGioaeLXlX092Xqr6WNQiNoYYf60LnE23YGMy1e4unpiCHtW3kcqBmiKuLdkrDitC55uV6EMHnUOM3g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10264,9 +10264,9 @@
 			}
 		},
 		"node_modules/@wordpress/block-serialization-default-parser": {
-			"version": "5.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.42.0.tgz",
-			"integrity": "sha512-XcX6gOeQOuG0RrUqJV1dadPBUi77uhLhpGfQH/s8vmAEGSWqgJAbjWwUKD8RP6wCGY+IE3Gayd5zu48aVRlB4A==",
+			"version": "5.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.52.0.tgz",
+			"integrity": "sha512-k+kOLRTS5sYSFLC1Pe4kSwrflTfelKhAEm4+MUyjsrQL3WtewC1eUKyLcBZy/n5LOy1UoGMDtnjkVB/ZbjwGYQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10275,45 +10275,72 @@
 			}
 		},
 		"node_modules/@wordpress/blocks": {
-			"version": "15.15.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.15.0.tgz",
-			"integrity": "sha512-xUlxCqIV8UuH5MjtPQBnxEwvhe2CCrZ+WqGJ+ffLxQQGHbe513zXl8sr79FdE2noec4Bj8VdOp1oH8zlESQEUA==",
+			"version": "15.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.25.0.tgz",
+			"integrity": "sha512-u1QOrS1/ljWCovuJu90EAJUPfhsxgzSbF4j8eE82FiW/VglqqH2ASr60V3BhIR4GNVpZPgNiVGwVsGu5iIf9Tw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/autop": "^4.42.0",
-				"@wordpress/blob": "^4.42.0",
-				"@wordpress/block-serialization-default-parser": "^5.42.0",
-				"@wordpress/data": "^10.42.0",
-				"@wordpress/deprecated": "^4.42.0",
-				"@wordpress/dom": "^4.42.0",
-				"@wordpress/element": "^6.42.0",
-				"@wordpress/hooks": "^4.42.0",
-				"@wordpress/html-entities": "^4.42.0",
-				"@wordpress/i18n": "^6.15.0",
-				"@wordpress/is-shallow-equal": "^5.42.0",
-				"@wordpress/private-apis": "^1.42.0",
-				"@wordpress/rich-text": "^7.42.0",
-				"@wordpress/shortcode": "^4.42.0",
-				"@wordpress/warning": "^3.42.0",
+				"@wordpress/autop": "^4.52.0",
+				"@wordpress/blob": "^4.52.0",
+				"@wordpress/block-serialization-default-parser": "^5.52.0",
+				"@wordpress/data": "^10.52.0",
+				"@wordpress/deprecated": "^4.52.0",
+				"@wordpress/dom": "^4.52.0",
+				"@wordpress/element": "^8.4.0",
+				"@wordpress/hooks": "^4.52.0",
+				"@wordpress/html-entities": "^4.52.0",
+				"@wordpress/i18n": "^6.25.0",
+				"@wordpress/is-shallow-equal": "^5.52.0",
+				"@wordpress/private-apis": "^1.52.0",
+				"@wordpress/rich-text": "^7.52.0",
+				"@wordpress/shortcode": "^4.52.0",
+				"@wordpress/warning": "^3.52.0",
 				"change-case": "^4.1.2",
-				"colord": "^2.7.0",
+				"colord": "^2.9.3",
 				"fast-deep-equal": "^3.1.3",
 				"hpq": "^1.3.0",
 				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
+				"marked": "^18.0.3",
+				"memize": "^2.1.1",
 				"react-is": "^18.3.0",
 				"remove-accents": "^0.5.0",
-				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/blocks/node_modules/@wordpress/element": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.4.0.tgz",
+			"integrity": "sha512-/LzW+0MpSmKfYiESoXUQtjBPqOPyvqUm17GigQR5c0Z8Wj2NiklP72x4XaF02uSkau1ru1Z9lP8NWEGjwBwLsA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.52.0",
+				"@wordpress/escape-html": "^3.52.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
@@ -10525,20 +10552,20 @@
 			}
 		},
 		"node_modules/@wordpress/data": {
-			"version": "10.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.42.0.tgz",
-			"integrity": "sha512-YHBnNmMSclYvCS6QjwmbtdpGVbN4v0VZIq25n4a6HxG0Co6LTnvhAvgtnw+NZpEiDHibH8JcSjbCQEBtToWSFQ==",
+			"version": "10.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.52.0.tgz",
+			"integrity": "sha512-7Nx66TfUkYZDdXL4wn2/DjIJOYRsKdi8Gvv24Warv9rZ1pwTNoFXFDagvc3UoCOjn0pM8+pFNbd7a9TJH8oQzg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^7.42.0",
-				"@wordpress/deprecated": "^4.42.0",
-				"@wordpress/element": "^6.42.0",
-				"@wordpress/is-shallow-equal": "^5.42.0",
-				"@wordpress/priority-queue": "^3.42.0",
-				"@wordpress/private-apis": "^1.42.0",
-				"@wordpress/redux-routine": "^5.42.0",
-				"deepmerge": "^4.3.0",
+				"@wordpress/compose": "^8.5.0",
+				"@wordpress/deprecated": "^4.52.0",
+				"@wordpress/element": "^8.4.0",
+				"@wordpress/is-shallow-equal": "^5.52.0",
+				"@wordpress/priority-queue": "^3.52.0",
+				"@wordpress/private-apis": "^1.52.0",
+				"@wordpress/redux-routine": "^5.52.0",
+				"deepmerge": "^4.3.1",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
@@ -10551,7 +10578,68 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/data/node_modules/@wordpress/compose": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.5.0.tgz",
+			"integrity": "sha512-giYS22Tbhtr3Lj4lK6lxzGqV6EkM2QeVBiP7+c9r2F9rnQN3F6A8cN4gQM5sVGdgIOlps9tw+dsn9OHzIFVwIg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.52.0",
+				"@wordpress/dom": "^4.52.0",
+				"@wordpress/element": "^8.4.0",
+				"@wordpress/is-shallow-equal": "^5.52.0",
+				"@wordpress/keycodes": "^4.52.0",
+				"@wordpress/priority-queue": "^3.52.0",
+				"@wordpress/private-apis": "^1.52.0",
+				"@wordpress/undo-manager": "^1.52.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/data/node_modules/@wordpress/element": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.4.0.tgz",
+			"integrity": "sha512-/LzW+0MpSmKfYiESoXUQtjBPqOPyvqUm17GigQR5c0Z8Wj2NiklP72x4XaF02uSkau1ru1Z9lP8NWEGjwBwLsA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.52.0",
+				"@wordpress/escape-html": "^3.52.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/dataviews": {
@@ -10676,13 +10764,13 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.42.0.tgz",
-			"integrity": "sha512-p0MjfkaworM9gYrab7JYwikGnQw88PaISdxVI3TiSyloRdlYU1p8UXSGHwn0vk55ty32YhSsPqtr0xMTgtW1xw==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.52.0.tgz",
+			"integrity": "sha512-94oHBKPty4pp6L5510LWDwJwNqFhikxLfwN6VUcDOQzj3itkc0MQ4ZQhmsfBy3Y6IRxSGx+p2bjSQvA4D+M96A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/hooks": "^4.42.0"
+				"@wordpress/hooks": "^4.52.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10690,13 +10778,13 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.42.0.tgz",
-			"integrity": "sha512-LRyfQEkAcDyVvFt7pMO9jOVE1X32N9Kef/WBUFfdT0NjPPLHG/iYIDmiyXNrvpxcLrBPxWZqr0jvuFEudlrwXw==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.52.0.tgz",
+			"integrity": "sha512-LUY9nI9h6blk4xBuG83KgyfTnx7PMs/g6ZVzY/SOaCcOc2P3zOfzacADq/vxQydbZpcwtLM6juzgnNta6AX95w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.42.0"
+				"@wordpress/deprecated": "^4.52.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10704,9 +10792,9 @@
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.42.0.tgz",
-			"integrity": "sha512-ujShJCmo9Y6yqX9tD7100M7MwiEPiDsaN2OQzX1vA+2lp099muq73376zv9ISBkK0C8uUbMZzw2B+JTmBiyGtw==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.52.0.tgz",
+			"integrity": "sha512-dAsch1oeyRV4kwoQuqdr6dXisGAs09OtvGOk09Ke+QC0fTTPzxdKUw+c4M1nk0AmCeyZfqAqYYGCMm4n241QeQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10930,9 +11018,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.42.0.tgz",
-			"integrity": "sha512-dykrMeKAxhwfEImrXfTqKREYGJP2qVIU8q3daUNyNLzrOdwhulAlBzUWXH9zYyY5qEQWrWsnjq4M9f77dO0p4w==",
+			"version": "3.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.52.0.tgz",
+			"integrity": "sha512-sW8X839Xu8aiJlCGF48MM3iYrcXspuiY0By8iTpXKpnUdd2u0SL9HRR0ALSAsOf2ujOeWm/x58ODMSchovRWGw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11606,9 +11694,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.42.0.tgz",
-			"integrity": "sha512-isdznPKo+LEAGrP/o6SnWjxKYKn4KNzb5dmpnYPTbLh13gE/p8KctpLyzMsgR2GBXF8soAL+hpXMxxKoTQSabA==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.52.0.tgz",
+			"integrity": "sha512-EbV/nJTerhqwNW3DLvvGutJfNyXcmBHXuWyJpv1NypzT80k21jPGP79HBE5Z0A2oAI2kIBp6Klaa4O8uEjq/sw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11617,9 +11705,9 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.42.0.tgz",
-			"integrity": "sha512-uI1vF5+KCdxQiPY4rzkaM1oZY5SX1lvSB+Uxndv2WCmc3lvTwabYos7wfXVYySxHRMOrG6KsqOWDzaK7h/b3NQ==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.52.0.tgz",
+			"integrity": "sha512-SM0XH+EgCi20Ptqv5WGkM8d2CAlThWRO/BVMeXzu6RLlcHKLMXNQZvW2waXCZtUpto8hlVZT9Dzg8z37sj4OiQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11628,16 +11716,15 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.15.0.tgz",
-			"integrity": "sha512-ZkGJbZIRhtcQmynb1jb+rRXrw9+SSV0y6KE2R4eex6MzFN0PoNKJcjlOtMLiyMsXd5KFYzfzVj14EGsx5XgG/w==",
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.25.0.tgz",
+			"integrity": "sha512-UcyUT8CJgEkhjzEGTVV6kw0Qi4OraF0I9J9FBLmTda/1Wi1o6rLAXZBm2aJrP740ezFxPneHH92aQF4Z5xZqcQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.42.0",
+				"@wordpress/hooks": "^4.52.0",
 				"gettext-parser": "^1.3.1",
-				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
 			},
 			"bin": {
@@ -11772,9 +11859,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.42.0.tgz",
-			"integrity": "sha512-o2nEnBeUvGv5vT6uV2ed/7UcFWlSMFmRRtcDqQomPledVOHpAZfrRWawuSFEC61PMFqclp7kGfNLSHfhoG1J+A==",
+			"version": "5.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.52.0.tgz",
+			"integrity": "sha512-LMIBLLTZ+vvq0DlYebL4d9XaCu16PNnhPGSn8QqsMPmBzwBYOjO0/btMLpYbs9rRc8k1QKBDWvw8eddvRVsYxA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11910,17 +11997,25 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.42.0.tgz",
-			"integrity": "sha512-QV82RsOYL3qWXxVTU7T6zk5LU1ad4YP6DDH4czQR8mJECoDsblf2gSjYcGDHkPUK30SXJ7/x/ZOnhGkyJSVaKw==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.52.0.tgz",
+			"integrity": "sha512-KRvwViTTdxUDgikYaCm+qnXSH2UlFuCDjAIvtjjcen8oRviSkeMv6bPn1T2vqFRKcVgt88xTtKlvI8l5U99o2Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.15.0"
+				"@wordpress/i18n": "^6.25.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/media-editor": {
@@ -12270,9 +12365,9 @@
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.42.0.tgz",
-			"integrity": "sha512-XNi5PWOCz6Y8YSNl7PDNx+CPoADxzRvYhfxCdzJbX4Za5HZi7/qfrIIUI6GIETRPRvWSCI9TZmctRFjBg1mq3Q==",
+			"version": "3.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.52.0.tgz",
+			"integrity": "sha512-aYnVXxV5j4D73tRld2n1D3G6cKLfSwKWcTnktJ7XlmiswW7xlaAqvn4FyBjwmIe20pZw0A7xLH5xCuQcqOM7nw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -12284,9 +12379,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.42.0.tgz",
-			"integrity": "sha512-IDpyCszdnBECvkejn2vyGPHn4aWtROFq0yFaVGPAvYCadnlpWsQC0oJodppBOE7sftYiIDnTw6/rnv+mp29/Kg==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.52.0.tgz",
+			"integrity": "sha512-gFcmBXSti73Y4uEx++5qUNDaH/o0/2ijrHEJkY5e/df4RtmxVSQOIVxftRiI4m9thCWfJMoehMMreJxhwx6Qtg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -12295,9 +12390,9 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "5.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.42.0.tgz",
-			"integrity": "sha512-rT81HPHH8USZHUYb6slGawmhZN71iBB6ACSDK+hWc3PxApTPlOYcc7MzfTEiOzYPGolWfm+NamBNgks9YISEhg==",
+			"version": "5.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.52.0.tgz",
+			"integrity": "sha512-MpyNAKpfQAk8IWJ3Cwzc/p1dVEUl/iYxL6GCTX/y7K3c8qYd7csU4o5kuK9lfeqgVVI+d0y6rzBZiTaL2Z6Ojw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -12362,31 +12457,91 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.42.0.tgz",
-			"integrity": "sha512-BmX2JZd5a53/FdAjuHJDswQD1YEmHrx8fhf921K8YbP/h043qwfjTPp1FVBxAmXP02QWGrgE2iSZEZWzbG+ACw==",
+			"version": "7.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.52.0.tgz",
+			"integrity": "sha512-zyd7w4hs8TV+nWrC/hbULg4lKJQyxpd5AolFfOHAJmKM2LrU/Lvlobz9oyGuTrZ/HXdkFs3wzPMwS/VGydSjHw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/a11y": "^4.42.0",
-				"@wordpress/compose": "^7.42.0",
-				"@wordpress/data": "^10.42.0",
-				"@wordpress/deprecated": "^4.42.0",
-				"@wordpress/dom": "^4.42.0",
-				"@wordpress/element": "^6.42.0",
-				"@wordpress/escape-html": "^3.42.0",
-				"@wordpress/i18n": "^6.15.0",
-				"@wordpress/keycodes": "^4.42.0",
-				"@wordpress/private-apis": "^1.42.0",
-				"colord": "2.9.3",
-				"memize": "^2.1.0"
+				"@wordpress/a11y": "^4.52.0",
+				"@wordpress/compose": "^8.5.0",
+				"@wordpress/data": "^10.52.0",
+				"@wordpress/deprecated": "^4.52.0",
+				"@wordpress/dom": "^4.52.0",
+				"@wordpress/element": "^8.4.0",
+				"@wordpress/escape-html": "^3.52.0",
+				"@wordpress/i18n": "^6.25.0",
+				"@wordpress/keycodes": "^4.52.0",
+				"@wordpress/private-apis": "^1.52.0",
+				"colord": "^2.9.3"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.5.0.tgz",
+			"integrity": "sha512-giYS22Tbhtr3Lj4lK6lxzGqV6EkM2QeVBiP7+c9r2F9rnQN3F6A8cN4gQM5sVGdgIOlps9tw+dsn9OHzIFVwIg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.52.0",
+				"@wordpress/dom": "^4.52.0",
+				"@wordpress/element": "^8.4.0",
+				"@wordpress/is-shallow-equal": "^5.52.0",
+				"@wordpress/keycodes": "^4.52.0",
+				"@wordpress/priority-queue": "^3.52.0",
+				"@wordpress/private-apis": "^1.52.0",
+				"@wordpress/undo-manager": "^1.52.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.4.0.tgz",
+			"integrity": "sha512-/LzW+0MpSmKfYiESoXUQtjBPqOPyvqUm17GigQR5c0Z8Wj2NiklP72x4XaF02uSkau1ru1Z9lP8NWEGjwBwLsA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.52.0",
+				"@wordpress/escape-html": "^3.52.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/route": {
@@ -12702,13 +12857,13 @@
 			}
 		},
 		"node_modules/@wordpress/shortcode": {
-			"version": "4.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.42.0.tgz",
-			"integrity": "sha512-vaXEGjis5IqvPtSMYZgrT2zg5HwjePrs5fgWCwYfX5r/uiizfkeOSedpTBSH/FLpQQTMMeFsr22DLcuF0qdyeA==",
+			"version": "4.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.52.0.tgz",
+			"integrity": "sha512-6vTLq3WxPMaE6pvxvvUzbcSeNzvqcghF4ngX1bXlSVIwMXVDgwsTFA4yc6LoI9BFBDZt9UZ+KN22wcdqnDr9Ug==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"memize": "^2.0.1"
+				"memize": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12847,13 +13002,13 @@
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.42.0.tgz",
-			"integrity": "sha512-FczZFHqFY0R5z2PyYEa/Dsc7mR2PhWAX05at274m0Z/wlPeOx2VnZn0L5Vs4mDEOlF13r17Mn+7VRLtjm5lxTQ==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.52.0.tgz",
+			"integrity": "sha512-6hI0WWDOtLLVEkWqQokCoQRz5Pba9UNtgt5MV4hHGe5x0mzsowj+GWHedppf8UCVZ2ex3cde7fThaRKMCackrQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.42.0"
+				"@wordpress/is-shallow-equal": "^5.52.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12936,9 +13091,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.42.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.42.0.tgz",
-			"integrity": "sha512-LMsbWI57IkVRoco+HTQezSzf3FW97AJH3QllwQdk+Ge5y2mJ2jkfIgwZP7uDeMozA1HVUAW+TgmybLloS9xHzg==",
+			"version": "3.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.52.0.tgz",
+			"integrity": "sha512-BjJ+Jte1g2nMITI1IHq0NwMpm/qlFOV1L+gNe0vFQmGKEcXiQ0DjrHQNtA8hV+Mgt9zSWRNS71Fgonht3r72Ew==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -25081,6 +25236,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/marked": {
+			"version": "18.0.9",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+			"integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
 		"node_modules/marky": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
@@ -28893,13 +29061,6 @@
 				"node": ">=8.6.0"
 			}
 		},
-		"node_modules/require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/requireindex": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -29684,13 +29845,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -29849,245 +30003,6 @@
 			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
 			"dev": true,
 			"license": "BSD-2-Clause"
-		},
-		"node_modules/showdown": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
-			"integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"yargs": "^14.2"
-			},
-			"bin": {
-				"showdown": "bin/showdown.js"
-			}
-		},
-		"node_modules/showdown/node_modules/ansi-regex": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/showdown/node_modules/camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/cliui": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^3.1.0",
-				"strip-ansi": "^5.2.0",
-				"wrap-ansi": "^5.1.0"
-			}
-		},
-		"node_modules/showdown/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/showdown/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/showdown/node_modules/emoji-regex": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/showdown/node_modules/find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"locate-path": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/showdown/node_modules/locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/showdown/node_modules/p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/showdown/node_modules/string-width": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^7.0.1",
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^5.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/strip-ansi": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/wrap-ansi": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^3.2.0",
-				"string-width": "^3.0.0",
-				"strip-ansi": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/showdown/node_modules/y18n": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/showdown/node_modules/yargs": {
-			"version": "14.2.3",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-			"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^5.0.0",
-				"decamelize": "^1.2.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^15.0.1"
-			}
-		},
-		"node_modules/showdown/node_modules/yargs-parser": {
-			"version": "15.0.3",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
-			"integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			}
 		},
 		"node_modules/side-channel": {
 			"version": "1.1.0",
@@ -33610,13 +33525,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/which-module": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/which-typed-array": {
 			"version": "1.1.20",


### PR DESCRIPTION
## Description

Removes `showdown` from the dependency tree, clearing two [Dependabot alerts](https://github.com/GatherPress/gatherpress/security/dependabot).

**This is dependency hygiene, not a security fix.** Worth being explicit, because the alerts make it look more urgent than it is.

## Why it isn't a security fix

The vulnerable code never reaches anything:

- **`@wordpress/blocks` is externalized at build time.** `build/editor.asset.php` declares `wp-blocks` as a dependency, so the browser loads WordPress core's copy. Our `node_modules` copy is never bundled into shipped assets.
- **We import only `registerBlockType`.** showdown backs the editor's Markdown paste handling, which we don't touch.
- **`node_modules` is excluded from distribution** by `.distignore`, and `package.json`'s `files` allowlist is `build`, `includes`, `gatherpress.php`, `CHANGELOG.md`, `SECURITY.md`.
- **Nothing in the build or test suite invokes it**, so the usual developer-machine supply-chain argument needs a code path that doesn't exist here.

So: never shipped, never executed on a site because of us, not reachable from CI. The value in removing it is keeping the alert list meaningful, so a genuine finding later isn't buried in noise.

## Why the fix is a parent bump

| alert | advisory | issue |
| --- | --- | --- |
| #268 | [GHSA-cr32-g25g-vxjj](https://github.com/advisories/GHSA-cr32-g25g-vxjj) | metadata title handling allows XSS |
| #267 | [GHSA-22g5-r2x5-97cx](https://github.com/advisories/GHSA-22g5-r2x5-97cx) | stored XSS via table header ID injection |

Both are `vulnerable: <= 2.1.0` with **`patched: none`**, and 2.1.0 is current — so bumping showdown resolves nothing. The realistic options were removing it or dismissing the alerts.

It reaches us through one path, and `@wordpress/blocks` dropped it in 15.25.0:

| version | `dependencies.showdown` |
| --- | --- |
| 15.15.0 | `^1.9.1` |
| 15.20.0 | `^1.9.1` |
| **15.25.0** | **none** |

Our range is already `^15.14.0`, so the lockfile was simply pinned to an older resolution. **No `package.json` change.**

## Why jest.config.js is here

15.25.0 replaced showdown with **`marked` 18.0.9**, which ships ESM only. Jest could not parse it and a suite silently stopped running:

```
SyntaxError: Unexpected token 'export'
  node_modules/marked/lib/marked.esm.js
```

`marked` joins `parsel-js` and `uuid` in `transformIgnorePatterns` so Jest transforms it rather than skipping it with the rest of `node_modules`.

## Scope

51 packages move — the `@wordpress/*` set advances roughly `.42.0` → `.52.0` as a group, since `@wordpress/blocks` pulls its siblings forward. That is the real reason to review this rather than rubber-stamp it, and it is a fair argument for deferring: the alerts are noise, so there is no urgency forcing a 51-package bump on any particular timeline.

## Testing

- `npm ls showdown` → gone from the tree
- `npm audit` no longer lists showdown
- `npm run test:unit:js` → **54 suites, 998 tests passing** (53 passing / 1 failing to run before the Jest change)
- `npm run lint:js`, `npm run lint:css` clean
- `npm run build` compiles

## Types of changes

Dependency update.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
