### PR TITLE
CodeRabbit follow-ups: distignore entry and comment-triggered reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,10 +1,15 @@
 # CodeRabbit config for GatherPress
 # Reference: https://docs.coderabbit.ai/reference/configuration
-# Defaults already match: chill profile, no poem, auto-review on, drafts skipped.
+# Defaults already match: chill profile, no poem, drafts skipped.
 # AGENTS.md is picked up automatically as code guidelines, so project
 # conventions live there; these instructions only add per-path emphasis.
 
 reviews:
+  auto_review:
+    # Reviews are triggered intentionally, never automatically, so the
+    # hourly rate limit is spent on request: comment '@coderabbitai review'
+    # on the PR (or 'full review' to redo from scratch).
+    enabled: false
   path_filters:
     - "!build/**"
     - "!vendor/**"

--- a/.distignore
+++ b/.distignore
@@ -3,6 +3,7 @@
 # Configuration and Build Files
 .babelrc
 .claude
+.coderabbit.yaml
 .deployignore
 .distignore
 .editorconfig


### PR DESCRIPTION
## Proposed changes:

Two commits that missed the #2145 squash (they were pushed to the branch right around the merge):

* **`.distignore` entry for `.coderabbit.yaml`** — the GitHub zip was already safe via `package.json`'s `files` allowlist, but `.distignore` lists dotfiles individually, so without this the config ships to wp.org SVN (the #1920 rule).
* **Comment-triggered reviews** — `auto_review.enabled: false`, so CodeRabbit never reviews automatically and the hourly rate limit is spent intentionally. Ask for a review by commenting `@coderabbitai review` on the PR (or `@coderabbitai full review` to redo from scratch).

## Testing instructions:

* After merge, open any PR: CodeRabbit should stay silent until someone comments `@coderabbitai review`.

### Changelog entry

Carries the `Skip Changelog` label — CI/tooling only, nothing ships.
