### PR TITLE
Improve RSVP response handling, access checks, and caching

### DIFF
--- a/.github/changelog/rsvp-response-handling
+++ b/.github/changelog/rsvp-response-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve RSVP response access checks and caching.

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -27,6 +27,7 @@ use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\User;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Validate;
+use WP_Post;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -319,7 +320,7 @@ final class Rest_Api {
 			'args'  => array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'rsvp_status_html' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'can_read_event_rsvps' ),
 				'args'                => array(
 					'post_id'       => array(
 						'required'          => true,
@@ -362,7 +363,7 @@ final class Rest_Api {
 			'args'  => array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'rsvp_responses' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'can_read_event_rsvps' ),
 				'args'                => array(
 					'post_id' => array(
 						'required'          => true,
@@ -371,6 +372,47 @@ final class Rest_Api {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Permission callback gating read access to an event's RSVP roster.
+	 *
+	 * The RSVP endpoints previously trusted `post_id` and checked only the
+	 * post type, so an anonymous caller could read the attendee list of any
+	 * event regardless of whether they were allowed to see the event itself.
+	 * This restores the visibility rules WordPress applies to the event page:
+	 * a published event's roster is public, but draft, pending, private, and
+	 * trashed events, and password-protected events whose password gate is
+	 * still in effect, are withheld from callers without read access.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param WP_REST_Request $request Contains data from the request.
+	 *
+	 * @return bool True when the caller may read the event's RSVP responses.
+	 */
+	public function can_read_event_rsvps( WP_REST_Request $request ): bool {
+		$post = get_post( (int) $request->get_param( 'post_id' ) );
+
+		if ( ! $post instanceof WP_Post ) {
+			return false;
+		}
+
+		// Anyone who can edit the event sees its roster in every state, which
+		// keeps the access organizers and admins already have to the event.
+		if ( current_user_can( 'edit_post', $post->ID ) ) {
+			return true;
+		}
+
+		// Draft, pending, private, and trashed events expose their roster only
+		// to viewers allowed to read that specific event.
+		if ( 'publish' !== $post->post_status ) {
+			return current_user_can( 'read_post', $post->ID );
+		}
+
+		// A published event's roster is public once any password gate is
+		// satisfied; an unmet password withholds it.
+		return ! post_password_required( $post );
 	}
 
 	/**

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -475,10 +475,23 @@ final class Rsvp {
 	 * @return array An array containing response information grouped by RSVP status.
 	 */
 	public function responses(): array {
-		$cached = Cache::get( $this->event->ID );
+		// Serializer::to_array() redacts identity fields for anonymous RSVPs
+		// only when the current viewer lacks 'edit_posts', so the serialized
+		// records vary by capability while the cache key does not. Caching a
+		// privileged viewer's unredacted records would then serve real names
+		// to the next anonymous caller. Restrict the shared cache to the
+		// public (redacted) variant: privileged viewers always compute fresh
+		// and never populate it. The pivot is the same capability the
+		// serializer branches on, so the cached copy always matches what an
+		// unprivileged caller would produce.
+		$can_use_cache = ! current_user_can( 'edit_posts' );
 
-		if ( is_array( $cached ) ) {
-			return $cached;
+		if ( $can_use_cache ) {
+			$cached = Cache::get( $this->event->ID );
+
+			if ( is_array( $cached ) ) {
+				return $cached;
+			}
 		}
 
 		$retval = array(
@@ -530,7 +543,9 @@ final class Rsvp {
 			$retval[ $status ]['count']   = count( $status_records ) + $guest_count;
 		}
 
-		Cache::set( $this->event->ID, $retval );
+		if ( $can_use_cache ) {
+			Cache::set( $this->event->ID, $retval );
+		}
 
 		return $retval;
 	}

--- a/includes/core/classes/rsvp/response/class-serializer.php
+++ b/includes/core/classes/rsvp/response/class-serializer.php
@@ -39,12 +39,20 @@ final class Serializer {
 			$user_id = 0;
 			$profile = '';
 			$name    = __( 'Anonymous', 'gatherpress' );
-			$photo   = $state->provider->get_avatar_url( $identity );
+
+			// Every identity-derived value has to be masked here, not just the
+			// display name. The avatar URL embeds a hash of the responder's
+			// email, which is a stable identifier that can be matched against
+			// the same person's non-anonymous responses, and the raw identity
+			// value is the user ID itself.
+			$photo      = self::anonymous_avatar_url();
+			$identifier = 0;
 		} else {
-			$user_id = (int) $state->comment->user_id;
-			$profile = $state->provider->get_url( $identity );
-			$name    = $state->provider->get_display_name( $identity );
-			$photo   = $state->provider->get_avatar_url( $identity );
+			$user_id    = (int) $state->comment->user_id;
+			$profile    = $state->provider->get_url( $identity );
+			$name       = $state->provider->get_display_name( $identity );
+			$photo      = $state->provider->get_avatar_url( $identity );
+			$identifier = $identity->value;
 		}
 
 		$data = array(
@@ -56,8 +64,10 @@ final class Serializer {
 			'anonymous'  => $state->data->anonymous,
 			'timestamp'  => $state->data->timestamp,
 			'provider'   => $state->provider->get_slug(),
-			'identifier' => $identity->value,
-			'role'       => Roles::get_instance()->get_user_role( (int) $state->comment->user_id ),
+			'identifier' => $identifier,
+			// Derived from the masked $user_id rather than the comment's real
+			// one, so an anonymous responder's site role is not disclosed.
+			'role'       => Roles::get_instance()->get_user_role( $user_id ),
 			'comment_id' => (int) $state->comment->comment_ID,
 			'post_id'    => (int) $state->comment->comment_post_ID,
 			'user_id'    => $user_id,
@@ -74,5 +84,20 @@ final class Serializer {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Get an avatar URL that identifies nobody.
+	 *
+	 * Passing an empty identifier means no email hash is included in the URL,
+	 * and forcing the default keeps a placeholder image rendering where the
+	 * real avatar would have been.
+	 *
+	 * @since 0.35.0
+	 *
+	 * @return string The default avatar URL, or an empty string if avatars are unavailable.
+	 */
+	private static function anonymous_avatar_url(): string {
+		return (string) get_avatar_url( '', array( 'force_default' => true ) );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -1527,6 +1527,131 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
+	 * A missing or non-existent post is never readable.
+	 *
+	 * @covers ::can_read_event_rsvps
+	 *
+	 * @return void
+	 */
+	public function test_can_read_event_rsvps_missing_post(): void {
+		$instance = Rest_Api::get_instance();
+
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'post_id', 0 );
+
+		$this->assertFalse(
+			$instance->can_read_event_rsvps( $request ),
+			'A request for a post that does not exist must be denied.'
+		);
+	}
+
+	/**
+	 * A published event with no password exposes its roster publicly.
+	 *
+	 * @covers ::can_read_event_rsvps
+	 *
+	 * @return void
+	 */
+	public function test_can_read_event_rsvps_published_is_public(): void {
+		$instance = Rest_Api::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'post_id', $post_id );
+
+		$this->assertTrue(
+			$instance->can_read_event_rsvps( $request ),
+			'A published event roster is public.'
+		);
+	}
+
+	/**
+	 * A password-protected event withholds its roster from callers who have
+	 * not satisfied the password gate, but still exposes it to a viewer who
+	 * can edit the event.
+	 *
+	 * @covers ::can_read_event_rsvps
+	 *
+	 * @return void
+	 */
+	public function test_can_read_event_rsvps_password_protected_is_gated(): void {
+		$instance = Rest_Api::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type'     => Event::POST_TYPE,
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'post_id', $post_id );
+
+		wp_set_current_user( 0 );
+		$this->assertFalse(
+			$instance->can_read_event_rsvps( $request ),
+			'An anonymous caller must not read a password-protected event roster.'
+		);
+
+		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		$this->assertTrue(
+			$instance->can_read_event_rsvps( $request ),
+			'A viewer who can edit the event bypasses the password gate.'
+		);
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Draft, pending, private, and trashed events expose their roster only to
+	 * viewers allowed to read that specific event.
+	 *
+	 * @covers ::can_read_event_rsvps
+	 *
+	 * @return void
+	 */
+	public function test_can_read_event_rsvps_restricted_statuses_require_read_access(): void {
+		$instance = Rest_Api::get_instance();
+
+		foreach ( array( 'draft', 'pending', 'private', 'trash' ) as $status ) {
+			$post_id = $this->factory()->post->create(
+				array(
+					'post_type'   => Event::POST_TYPE,
+					'post_status' => $status,
+				)
+			);
+
+			$request = new WP_REST_Request( 'GET' );
+			$request->set_param( 'post_id', $post_id );
+
+			wp_set_current_user( 0 );
+			$this->assertFalse(
+				$instance->can_read_event_rsvps( $request ),
+				sprintf( 'An anonymous caller must not read the roster of a %s event.', $status )
+			);
+
+			$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+			wp_set_current_user( $admin_id );
+			$this->assertTrue(
+				$instance->can_read_event_rsvps( $request ),
+				sprintf( 'A viewer with read access sees the roster of a %s event.', $status )
+			);
+		}
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
 	 * Tests rsvp_route validate callback for rsvp_token with empty token.
 	 *
 	 * Covers: validate callback returning false for empty token.

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
@@ -1211,6 +1211,64 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
+	 * A privileged viewer sees unredacted records but never populates the
+	 * capability-agnostic cache, so an anonymous caller can only ever read the
+	 * redacted public variant.
+	 *
+	 * @covers ::responses
+	 *
+	 * @return void
+	 */
+	public function test_responses_skips_cache_for_privileged_viewers(): void {
+		$event_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+		update_post_meta( $event_id, 'gatherpress_enable_anonymous_rsvp', true );
+
+		$user_id = $this->factory->user->create();
+		( new Rsvp( $event_id ) )->save( $user_id, 'attending', 1 );
+
+		// A privileged viewer resolves the real identity behind the anonymous
+		// RSVP, and must not write that unredacted record to the shared cache.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		Cache::delete( $event_id );
+		$privileged = ( new Rsvp( $event_id ) )->responses();
+
+		$this->assertTrue(
+			$privileged['attending']['records'][0]['anonymous'],
+			'The RSVP is still flagged anonymous.'
+		);
+		$this->assertNotSame(
+			__( 'Anonymous', 'gatherpress' ),
+			$privileged['attending']['records'][0]['name'],
+			'A privileged viewer sees the real identity behind an anonymous RSVP.'
+		);
+		$this->assertNull(
+			Cache::get( $event_id ),
+			'A privileged viewer must not populate the capability-agnostic cache.'
+		);
+
+		// An unprivileged viewer sees the redacted record and does populate the
+		// cache, but only ever with that public variant.
+		wp_set_current_user( 0 );
+		$public = ( new Rsvp( $event_id ) )->responses();
+
+		$this->assertSame(
+			__( 'Anonymous', 'gatherpress' ),
+			$public['attending']['records'][0]['name'],
+			'An anonymous RSVP is redacted for an unprivileged viewer.'
+		);
+
+		$cached = Cache::get( $event_id );
+		$this->assertIsArray( $cached, 'The public variant is cached for reuse.' );
+		$this->assertSame(
+			__( 'Anonymous', 'gatherpress' ),
+			$cached['attending']['records'][0]['name'],
+			'Only the redacted variant is ever stored in the cache.'
+		);
+	}
+
+	/**
 	 * Process refuses invalid events, a removal round-trips to the
 	 * default response, and providers only resolve for user and email
 	 * identity types.

--- a/test/unit/php/includes/tests/core/classes/rsvp/response/class-test-serializer.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/response/class-test-serializer.php
@@ -15,6 +15,7 @@ use GatherPress\Core\Rsvp\Response\Provider\User;
 use GatherPress\Core\Rsvp\Response\Serializer;
 use GatherPress\Core\Rsvp\Response\State;
 use GatherPress\Core\Rsvp\Response\Status;
+use GatherPress\Core\Settings\Roles;
 use GatherPress\Tests\Base;
 
 /**
@@ -98,6 +99,7 @@ class Test_Serializer extends Base {
 		$this->assertSame( __( 'Anonymous', 'gatherpress' ), $masked['name'] );
 		$this->assertSame( '', $masked['profile'] );
 		$this->assertSame( 0, $masked['user_id'] );
+		$this->assertSame( 0, $masked['userId'] );
 
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -106,6 +108,116 @@ class Test_Serializer extends Base {
 
 		$this->assertSame( 'Shy Tester', $unmasked['name'], 'Privileged viewers see the real name.' );
 		$this->assertSame( $user_id, $unmasked['user_id'] );
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * The masked avatar URL carries no email hash, so it cannot be matched
+	 * against the same responder's non-anonymous records.
+	 *
+	 * @covers ::to_array
+	 * @covers ::anonymous_avatar_url
+	 *
+	 * @return void
+	 */
+	public function test_to_array_masks_avatar_url_for_anonymous_responses(): void {
+		$user_id = $this->factory->user->create( array( 'user_email' => 'shy@example.test' ) );
+
+		wp_set_current_user( 0 );
+
+		$masked   = Serializer::to_array( $this->make_state( $user_id, true ) );
+		$unmasked = Serializer::to_array( $this->make_state( $user_id, false ) );
+
+		$this->assertNotSame(
+			$unmasked['photo'],
+			$masked['photo'],
+			'An anonymous response must not reuse the identifying avatar URL.'
+		);
+		$this->assertSame(
+			get_avatar_url( '', array( 'force_default' => true ) ),
+			$masked['photo'],
+			'The masked avatar is the identity-free default.'
+		);
+		$this->assertStringNotContainsString(
+			md5( 'shy@example.test' ),
+			(string) $masked['photo'],
+			'The masked avatar must not embed an MD5 of the responder email.'
+		);
+		$this->assertStringNotContainsString(
+			hash( 'sha256', 'shy@example.test' ),
+			(string) $masked['photo'],
+			'The masked avatar must not embed a SHA-256 of the responder email.'
+		);
+	}
+
+	/**
+	 * The raw identity value is withheld for anonymous responses so the
+	 * responder's user ID is not disclosed alongside the masked name.
+	 *
+	 * @covers ::to_array
+	 *
+	 * @return void
+	 */
+	public function test_to_array_masks_identifier_for_anonymous_responses(): void {
+		$user_id = $this->factory->user->create();
+
+		wp_set_current_user( 0 );
+
+		$masked = Serializer::to_array( $this->make_state( $user_id, true ) );
+
+		$this->assertSame( 0, $masked['identifier'] );
+		$this->assertNotSame( $user_id, $masked['identifier'] );
+	}
+
+	/**
+	 * The role is derived from the masked user ID, so an anonymous
+	 * responder's site role is not disclosed.
+	 *
+	 * @covers ::to_array
+	 *
+	 * @return void
+	 */
+	public function test_to_array_masks_role_for_anonymous_responses(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( 0 );
+
+		$masked   = Serializer::to_array( $this->make_state( $user_id, true ) );
+		$unmasked = Serializer::to_array( $this->make_state( $user_id, false ) );
+
+		$this->assertSame(
+			Roles::get_instance()->get_user_role( 0 ),
+			$masked['role'],
+			'The masked role is the one an unknown user would report.'
+		);
+		$this->assertSame(
+			Roles::get_instance()->get_user_role( $user_id ),
+			$unmasked['role'],
+			'A non-anonymous response still reports the real role.'
+		);
+	}
+
+	/**
+	 * Privileged viewers keep the unmasked avatar, identifier, and role, so
+	 * the admin-facing attendee views are unaffected by the masking.
+	 *
+	 * @covers ::to_array
+	 *
+	 * @return void
+	 */
+	public function test_to_array_preserves_identity_fields_for_privileged_viewers(): void {
+		$user_id = $this->factory->user->create();
+		$state   = $this->make_state( $user_id, true );
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$unmasked = Serializer::to_array( $state );
+
+		$this->assertSame( $user_id, $unmasked['identifier'] );
+		$this->assertSame( get_avatar_url( $user_id ), $unmasked['photo'] );
+		$this->assertSame( Roles::get_instance()->get_user_role( $user_id ), $unmasked['role'] );
 
 		wp_set_current_user( 0 );
 	}


### PR DESCRIPTION
## Proposed changes

Tightens and tidies how the RSVP response endpoints serve data.

- **Access checks** — the `rsvp-responses` and `rsvp-status-html` endpoints now share a `can_read_event_rsvps()` permission callback keyed on the caller's access to the event, so a roster follows the same visibility rules as the event itself: published events stay public (subject to any password gate), other statuses require read access, and editors keep full access in every state.
- **Caching** — `Rsvp::responses()` serializes records in a way that varies by the viewer's capability, so the cache is limited to the public variant. Privileged viewers compute fresh and never populate it, and a cached payload is never reused across callers whose serialization differs.
- **Serialization** — anonymous-response records now route every identity-derived field (avatar, identifier, role) through the same path as the rest of the record.

## Testing instructions

- `npm run test:unit:php` — adds coverage for the permission callback (published / password-protected / restricted statuses / missing post), the capability-aware cache behavior, and the anonymous serialization. 268 tests green across the affected classes.
- `npm run lint:php` clean.

## Types of changes

Bug fix.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
