### PR TITLE
Stop an email address standing in for a responder's name

### DIFF
--- a/.github/changelog/rsvp-display-name-handling
+++ b/.github/changelog/rsvp-display-name-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve how RSVP responses resolve the name shown for a responder.

--- a/.github/changelog/rsvp-display-name-handling
+++ b/.github/changelog/rsvp-display-name-handling
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: security
 
-Improve how RSVP responses resolve the name shown for a responder.
+Stop an email address standing in for a responder's name. A provider that can only identify a responder reported that identifier as the display name, so a response saved against an address published the address to every reader. Providers without a name now report none, callers show a neutral label in its place, and responses already stored that way are withheld from readers who do not manage RSVPs.

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -338,13 +338,18 @@ final class Query {
 
 		// Responses saved before the store stopped writing an address into the
 		// display-name column still carry one, and every reader of a comment
-		// takes the name from there. That write put the same address in both
-		// columns, so match on their equality rather than on the name merely
-		// looking like an address: display names are an address whenever the
-		// account was registered with one, and core publishes those.
+		// takes the name from there. Two conditions, each excluding a case the
+		// other lets through: the equality is what marks the legacy write,
+		// since only an email identity ever filled the address column and it
+		// filled both with the same value, while a display name that merely
+		// looks like an address belongs to an account registered with one and
+		// is core's to publish. The address check then keeps a row whose two
+		// columns happen to match on something that is not an address — not
+		// reachable through this store, but imports and migrations write here
+		// too — from being renamed over nothing.
 		$withhold_address = ! $withhold
 			&& ! $manages_rsvps
-			&& '' !== $comment->comment_author_email
+			&& is_email( $comment->comment_author )
 			&& $comment->comment_author === $comment->comment_author_email;
 
 		// Only fill a URL the store never wrote, so a response identified by

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -338,10 +338,14 @@ final class Query {
 
 		// Responses saved before the store stopped writing an address into the
 		// display-name column still carry one, and every reader of a comment
-		// takes the name from there.
+		// takes the name from there. That write put the same address in both
+		// columns, so match on their equality rather than on the name merely
+		// looking like an address: display names are an address whenever the
+		// account was registered with one, and core publishes those.
 		$withhold_address = ! $withhold
 			&& ! $manages_rsvps
-			&& is_email( $comment->comment_author );
+			&& '' !== $comment->comment_author_email
+			&& $comment->comment_author === $comment->comment_author_email;
 
 		// Only fill a URL the store never wrote, so a response identified by
 		// its URL keeps the one it was saved with.
@@ -361,10 +365,17 @@ final class Query {
 			$prepared->comment_author       = __( 'Anonymous', 'gatherpress' );
 			$prepared->comment_author_email = '';
 			$prepared->comment_author_url   = '';
-		} elseif ( $withhold_address ) {
-			$prepared->comment_author = __( 'Attendee', 'gatherpress' );
 		} else {
-			$prepared->comment_author_url = (string) get_author_posts_url( (int) $comment->user_id );
+			// Independent conditions, so a response that matches both gets
+			// both. Branching them apart would drop the URL for any responder
+			// whose stored name is an address.
+			if ( $withhold_address ) {
+				$prepared->comment_author = __( 'Attendee', 'gatherpress' );
+			}
+
+			if ( $resolve ) {
+				$prepared->comment_author_url = (string) get_author_posts_url( (int) $comment->user_id );
+			}
 		}
 
 		return $prepared;

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -337,16 +337,10 @@ final class Query {
 			&& ! $manages_rsvps;
 
 		// Responses saved before the store stopped writing an address into the
-		// display-name column still carry one, and every reader of a comment
-		// takes the name from there. Two conditions, each excluding a case the
-		// other lets through: the equality is what marks the legacy write,
-		// since only an email identity ever filled the address column and it
-		// filled both with the same value, while a display name that merely
-		// looks like an address belongs to an account registered with one and
-		// is core's to publish. The address check then keeps a row whose two
-		// columns happen to match on something that is not an address — not
-		// reachable through this store, but imports and migrations write here
-		// too — from being renamed over nothing.
+		// display-name column still carry one, and every reader takes the name
+		// from there. The equality marks that write, which filled both columns
+		// with the same value; a name that only looks like an address belongs
+		// to an account registered with one.
 		$withhold_address = ! $withhold
 			&& ! $manages_rsvps
 			&& is_email( $comment->comment_author )

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -332,8 +332,16 @@ final class Query {
 			return $comment;
 		}
 
-		$withhold = get_comment_meta( (int) $comment->comment_ID, Rsvp::ANONYMOUS_META_KEY, true )
-			&& ! current_user_can( Rsvp::CAPABILITY );
+		$manages_rsvps = current_user_can( Rsvp::CAPABILITY );
+		$withhold      = get_comment_meta( (int) $comment->comment_ID, Rsvp::ANONYMOUS_META_KEY, true )
+			&& ! $manages_rsvps;
+
+		// Responses saved before the store stopped writing an address into the
+		// display-name column still carry one, and every reader of a comment
+		// takes the name from there.
+		$withhold_address = ! $withhold
+			&& ! $manages_rsvps
+			&& is_email( $comment->comment_author );
 
 		// Only fill a URL the store never wrote, so a response identified by
 		// its URL keeps the one it was saved with.
@@ -341,7 +349,7 @@ final class Query {
 			&& '' === $comment->comment_author_url
 			&& intval( $comment->user_id );
 
-		if ( ! $withhold && ! $resolve ) {
+		if ( ! $withhold && ! $resolve && ! $withhold_address ) {
 			return $comment;
 		}
 
@@ -353,6 +361,8 @@ final class Query {
 			$prepared->comment_author       = __( 'Anonymous', 'gatherpress' );
 			$prepared->comment_author_email = '';
 			$prepared->comment_author_url   = '';
+		} elseif ( $withhold_address ) {
+			$prepared->comment_author = __( 'Attendee', 'gatherpress' );
 		} else {
 			$prepared->comment_author_url = (string) get_author_posts_url( (int) $comment->user_id );
 		}

--- a/includes/core/classes/rsvp/response/class-serializer.php
+++ b/includes/core/classes/rsvp/response/class-serializer.php
@@ -56,6 +56,16 @@ final class Serializer {
 			$identifier = Identity_Type::EMAIL === $identity->type && ! current_user_can( Rsvp::CAPABILITY )
 				? 0
 				: $identity->value;
+
+			// A responder identified only by an address has no name to show, so
+			// the record says what it can: whoever manages RSVPs sees the
+			// address the response was saved with, and everyone else sees that
+			// someone is attending.
+			if ( '' === $name ) {
+				$name = current_user_can( Rsvp::CAPABILITY ) && ! empty( $state->comment->comment_author_email )
+					? (string) $state->comment->comment_author_email
+					: __( 'Attendee', 'gatherpress' );
+			}
 		}
 
 		$data = array(

--- a/includes/core/classes/rsvp/response/provider/class-base.php
+++ b/includes/core/classes/rsvp/response/provider/class-base.php
@@ -67,24 +67,30 @@ abstract class Base {
 	 */
 	abstract public static function get_label(): string;
 
+	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found -- overrides read the identity.
 	/**
-	 * Get the best displayable name for an identity.
+	 * Get the display name for an identity.
 	 *
-	 * "Display name" follows WordPress semantics — the best available
-	 * name to show, not necessarily a proper human name. Providers with
-	 * no real name to offer fall back to the identity value itself (the
-	 * email provider returns the address), mirroring how core's
-	 * `WP_User::display_name` falls back to the login or email. This is
-	 * the fallback source for `Identity::$display_name` when a stored
-	 * response carries no explicit author name.
+	 * Providers that can name a responder override this, the way the user
+	 * provider reports an account's display name. The rest inherit nothing to
+	 * show, because an identity that only identifies someone — an address, a
+	 * URL, an external ID — has no name in it, and this answer is stored and
+	 * displayed as one. Callers decide what to show in its place, so that an
+	 * identifier is never presented as a name.
 	 *
 	 * @since 0.35.0
+	 * @since 0.35.2 No longer abstract; providers without a name return an empty string.
 	 *
 	 * @param Identity $identity The identity.
 	 *
-	 * @return string The display name for the identity.
+	 * @return string The display name, or an empty string when there is none to give.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) Overrides read the identity.
 	 */
-	abstract public function get_display_name( Identity $identity ): string;
+	public function get_display_name( Identity $identity ): string {
+		return '';
+	}
+	// phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.Found
 
 	/**
 	 * Get the avatar URL for an RSVP identity.

--- a/includes/core/classes/rsvp/response/provider/class-email.php
+++ b/includes/core/classes/rsvp/response/provider/class-email.php
@@ -57,23 +57,4 @@ final class Email extends Base {
 	public static function get_label(): string {
 		return __( 'Email', 'gatherpress' );
 	}
-
-	/**
-	 * Get the display name for an email-based RSVP.
-	 *
-	 * The address is the best displayable name an email identity has.
-	 * No sanitization is needed here: the Identity constructor already
-	 * rejected anything that is not a valid address, and sanitizing on
-	 * read could silently return a modified string that diverges from
-	 * the stored identity value.
-	 *
-	 * @since 0.35.0
-	 *
-	 * @param Identity $identity The identity.
-	 *
-	 * @return string The email address.
-	 */
-	public function get_display_name( Identity $identity ): string {
-		return (string) $identity->value;
-	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
@@ -1258,4 +1258,43 @@ class Test_Query extends Base {
 			'And the link the store never wrote is still resolved.'
 		);
 	}
+
+	/**
+	 * Two columns that match on something other than an address are left
+	 * alone, since there is no address to keep back.
+	 *
+	 * @covers ::prepare_rsvp_comment
+	 *
+	 * @return void
+	 */
+	public function test_prepare_rsvp_comment_keeps_matching_columns_that_are_not_an_address(): void {
+		global $wpdb;
+
+		$instance   = Query::get_instance();
+		$comment_id = $this->factory->comment->create(
+			array(
+				'comment_type'   => Rsvp::COMMENT_TYPE,
+				'comment_author' => 'Bob Smith',
+				'user_id'        => 0,
+			)
+		);
+
+		// Written directly because the comment API sanitizes the address
+		// column; only an import or a migration reaches this shape.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			$wpdb->comments,
+			array( 'comment_author_email' => 'Bob Smith' ),
+			array( 'comment_ID' => $comment_id )
+		);
+		clean_comment_cache( $comment_id );
+
+		wp_set_current_user( 0 );
+
+		$this->assertSame(
+			'Bob Smith',
+			$instance->prepare_rsvp_comment( WP_Comment::get_instance( $comment_id ) )->comment_author,
+			'Matching columns holding a name rather than an address are not renamed.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
@@ -1143,4 +1143,43 @@ class Test_Query extends Base {
 
 		wp_set_current_user( 0 );
 	}
+
+	/**
+	 * A response saved before the store stopped writing an address into the
+	 * display-name column still carries one, so it is withheld on read.
+	 *
+	 * @covers ::prepare_rsvp_comment
+	 *
+	 * @return void
+	 */
+	public function test_prepare_rsvp_comment_withholds_a_stored_address(): void {
+		$instance = Query::get_instance();
+		$email    = 'legacy-row@example.test';
+		$comment  = WP_Comment::get_instance(
+			$this->factory->comment->create(
+				array(
+					'comment_type'         => Rsvp::COMMENT_TYPE,
+					'comment_author'       => $email,
+					'comment_author_email' => $email,
+					'user_id'              => 0,
+				)
+			)
+		);
+
+		wp_set_current_user( 0 );
+		$this->assertSame(
+			__( 'Attendee', 'gatherpress' ),
+			$instance->prepare_rsvp_comment( $comment )->comment_author,
+			'An address standing in for a name is withheld.'
+		);
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->assertSame(
+			$email,
+			$instance->prepare_rsvp_comment( $comment )->comment_author,
+			'Whoever manages RSVPs still sees what was saved.'
+		);
+
+		wp_set_current_user( 0 );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
@@ -1182,4 +1182,80 @@ class Test_Query extends Base {
 
 		wp_set_current_user( 0 );
 	}
+
+	/**
+	 * An account whose display name is an address keeps it, because that is
+	 * what core publishes for anyone who registered with one.
+	 *
+	 * @covers ::prepare_rsvp_comment
+	 *
+	 * @return void
+	 */
+	public function test_prepare_rsvp_comment_keeps_a_display_name_that_is_an_address(): void {
+		$instance = Query::get_instance();
+		$user_id  = $this->factory->user->create(
+			array(
+				'display_name' => 'login@example.test',
+				'user_email'   => 'account@example.test',
+			)
+		);
+		$comment  = WP_Comment::get_instance(
+			$this->factory->comment->create(
+				array(
+					'comment_type'         => Rsvp::COMMENT_TYPE,
+					'comment_author'       => 'login@example.test',
+					'comment_author_email' => 'account@example.test',
+					'user_id'              => $user_id,
+				)
+			)
+		);
+
+		wp_set_current_user( 0 );
+
+		$this->assertSame(
+			'login@example.test',
+			$instance->prepare_rsvp_comment( $comment )->comment_author,
+			'A name that merely looks like an address is not the legacy write, so it stands.'
+		);
+	}
+
+	/**
+	 * A response that both carries a stored address and lacks a URL gets both
+	 * treatments, because the two conditions are independent.
+	 *
+	 * @covers ::prepare_rsvp_comment
+	 *
+	 * @return void
+	 */
+	public function test_prepare_rsvp_comment_withholds_an_address_and_still_resolves_the_url(): void {
+		$instance = Query::get_instance();
+		$email    = 'both@example.test';
+		$user_id  = $this->factory->user->create( array( 'user_email' => $email ) );
+		$comment  = WP_Comment::get_instance(
+			$this->factory->comment->create(
+				array(
+					'comment_type'         => Rsvp::COMMENT_TYPE,
+					'comment_author'       => $email,
+					'comment_author_email' => $email,
+					'comment_author_url'   => '',
+					'user_id'              => $user_id,
+				)
+			)
+		);
+
+		wp_set_current_user( 0 );
+
+		$prepared = $instance->prepare_rsvp_comment( $comment );
+
+		$this->assertSame(
+			__( 'Attendee', 'gatherpress' ),
+			$prepared->comment_author,
+			'The stored address is still withheld.'
+		);
+		$this->assertSame(
+			get_author_posts_url( $user_id ),
+			$prepared->comment_author_url,
+			'And the link the store never wrote is still resolved.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-storage.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-storage.php
@@ -529,4 +529,36 @@ class Test_Storage extends Base {
 		$this->assertInstanceOf( State::class, $found, 'The term-less row resolves when a provider is passed.' );
 		$this->assertSame( $comment_id, (int) $found->comment->comment_ID );
 	}
+
+	/**
+	 * An email response has no name to save, and the provider answers with the
+	 * address, so nothing is stored in the column read as a display name.
+	 *
+	 * @covers ::save
+	 *
+	 * @return void
+	 */
+	public function test_save_never_stores_an_address_as_the_author(): void {
+		list( $event_id, $storage ) = $this->make_storage();
+
+		$email  = 'no-name-given@example.test';
+		$intent = new Intent(
+			new Data( new Identity( Identity_Type::EMAIL, $email ), Status::ATTENDING ),
+			new Email()
+		);
+		$state  = $storage->save( $intent, null );
+
+		$this->assertInstanceOf( State::class, $state );
+		$this->assertSame(
+			'',
+			$state->comment->comment_author,
+			'The address is not stored as the display name.'
+		);
+		$this->assertSame(
+			$email,
+			$state->comment->comment_author_email,
+			'It is still stored where an address belongs.'
+		);
+		$this->assertSame( $event_id, (int) $state->comment->comment_post_ID );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/response/class-test-serializer.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/response/class-test-serializer.php
@@ -287,4 +287,57 @@ class Test_Serializer extends Base {
 
 		wp_set_current_user( 0 );
 	}
+
+	/**
+	 * A responder identified only by an address has no name to show, so the
+	 * record reports the address to whoever manages RSVPs and a generic label
+	 * to everyone else.
+	 *
+	 * @covers ::to_array
+	 *
+	 * @return void
+	 */
+	public function test_to_array_names_a_responder_with_no_name(): void {
+		$email      = 'no-name-to-show@example.test';
+		$comment_id = $this->factory->comment->create(
+			array(
+				'comment_type'         => Rsvp::COMMENT_TYPE,
+				'comment_author'       => '',
+				'comment_author_email' => $email,
+				'user_id'              => 0,
+			)
+		);
+		$state      = new State(
+			new Data(
+				new Identity( Identity_Type::EMAIL, $email ),
+				Status::ATTENDING,
+				0,
+				false,
+				'2026-01-02 03:04:05'
+			),
+			new Email(),
+			get_comment( $comment_id )
+		);
+
+		wp_set_current_user( 0 );
+
+		$public = Serializer::to_array( $state );
+
+		$this->assertSame( __( 'Attendee', 'gatherpress' ), $public['name'] );
+		$this->assertStringNotContainsString(
+			$email,
+			wp_json_encode( $public ),
+			'The address appears nowhere in a public record.'
+		);
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertSame(
+			$email,
+			Serializer::to_array( $state )['name'],
+			'Whoever manages RSVPs sees the address the response was saved with.'
+		);
+
+		wp_set_current_user( 0 );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/response/provider/class-test-providers.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/response/provider/class-test-providers.php
@@ -79,7 +79,9 @@ class Test_Providers extends Base {
 	public function test_email_provider_display_name(): void {
 		$identity = new Identity( Identity_Type::EMAIL, 'display@example.test' );
 
-		$this->assertSame( 'display@example.test', ( new Email() )->get_display_name( $identity ) );
+		// The answer is stored and displayed as a name, and an address names
+		// nobody, so the provider reports that it has none to give.
+		$this->assertSame( '', ( new Email() )->get_display_name( $identity ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Stops an email address standing in for a responder's name.

`Rsvp::save()` takes no name, so a response saved through it had nothing to store, and the store fell back to asking the provider what to call the identity. For an email identity the provider answered with the address itself, so that address was written into the display-name column — and every reader takes the name from there. The attendee list, the responses endpoint, and the core comments route all published it.

* **`Rsvp\Response\Provider\Base`** — `get_display_name()` is no longer abstract and returns an empty string. An identity that only identifies someone — an address, a URL, an external ID — has no name in it, so providers that cannot name a responder now say so rather than handing back the identifier.
* **`Rsvp\Response\Provider\Email`** — its override is deleted; the address was never a name.
* **`Rsvp\Storage`** — a response with no name to save no longer fills that column with the provider's answer.
* **`Rsvp\Query`** — read-side cover for rows already stored that way: a response whose display-name column holds the same value as its email column reads as the neutral label for anyone who does not manage RSVPs. Scoped to that equality rather than to a name merely looking like an address, since core defaults `display_name` to `user_login` and publishes it.
* **`Rsvp\Response\Serializer`** — checks the name it resolved rather than trusting the fallback.

Responses with nothing to show read as **"Attendee"**, already the label the RSVP admin table uses for that column ([class-list-table.php:112](https://github.com/GatherPress/gatherpress/blob/develop/includes/core/classes/rsvp/class-list-table.php#L112)). "Guest" would collide with the guest count, which is a different thing.

Responses saved with a real name still report it, and RSVP managers still see what a response was actually saved with.

## Testing instructions

* `npm run test:unit:php` — green. New cases cover the store, the comment filter, and the serializer, plus a response saved with a real name so the fallback cannot swallow one, an account whose display name is an address but does not match its account email, and a response that needs both the name withheld and the profile URL resolved.
* `npm run lint:php`, `composer test:phpmd`, `npm run lint:phpstan` clean.
* Verified against a live site for three shapes — a response saved with no name, one saved before this change, and one saved with a name — as both a logged-out visitor and an administrator.

### Changelog entry

`.github/changelog/rsvp-display-name-handling` — `Type: security`.
