### PR TITLE
Mark the calendar cache hashes as non-cryptographic

### DIFF
--- a/includes/core/classes/calendar/class-cache.php
+++ b/includes/core/classes/calendar/class-cache.php
@@ -218,7 +218,7 @@ final class Cache {
 	 * @return string Versioned transient name.
 	 */
 	public function get_versioned_key( string $key ): string {
-		return self::TRANSIENT_PREFIX . md5( $this->get_last_modified() . ':' . $key );
+		return self::TRANSIENT_PREFIX . md5( $this->get_last_modified() . ':' . $key ); // NOSONAR.
 	}
 
 	/**

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -873,7 +873,7 @@ final class Setup {
 			$scope['type'] = (string) $queried_object->name;
 		}
 
-		return sprintf( 'ics:%s', md5( (string) wp_json_encode( $scope ) ) );
+		return sprintf( 'ics:%s', md5( (string) wp_json_encode( $scope ) ) ); // NOSONAR.
 	}
 
 	/**
@@ -886,7 +886,7 @@ final class Setup {
 	 * @return string Quoted entity tag, per RFC 9110.
 	 */
 	public function get_etag( string $body ): string {
-		return sprintf( '"%s"', md5( $body ) );
+		return sprintf( '"%s"', md5( $body ) ); // NOSONAR.
 	}
 
 	/**


### PR DESCRIPTION
Clears three open [code scanning alerts](https://github.com/GatherPress/gatherpress/security/code-scanning) (#78, #79, #80), all `php:S4790` "Weak hashing algorithms should not be used".

| alert | location | what the hash does |
| --- | --- | --- |
| #80 | `class-cache.php:221` | transient cache key |
| #79 | `class-setup.php:889` | HTTP entity tag for a cached ICS response |
| #78 | `class-setup.php:876` | ICS cache key derived from the request scope |

None of the three protect anything. Two discriminate a cache entry and the third validates one, so collision resistance is not what they are being asked for.

This follows the pattern already in the codebase for exactly this situation, rather than inventing a new one: `class-geocoding.php:662`/`:807` and `class-map.php:1300` mark their cache-key hashes with `// NOSONAR` and a short comment. The calendar caching added in #2067 simply did not get the same treatment.

The alternative would be switching to sha256, which changes every cache key and every ETag, forcing a one-time full cache miss and a round of client revalidation to satisfy a scanner about a non-security use.

## Testing instructions

* Comment-only change, no behaviour affected. Full PHP suite green, `npm run lint:php` clean.

### Changelog entry

`Skip Changelog` — nothing user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)