### PR TITLE
Reject open RSVP to unpublished or RSVP-disabled events

### DIFF
--- a/.github/changelog/rsvp-form-event-state-checks
+++ b/.github/changelog/rsvp-form-event-state-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Reject open RSVP submissions to events that are not publicly published or that have RSVP disabled.

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -934,12 +934,12 @@ final class Rest_Api {
 		}
 
 		// Pre-flight: bail with a structured error before processing if the
-		// event is not publicly available, open RSVP is disabled or the event has already passed.
+		// event is not viewable, open RSVP is disabled or the event has already passed.
 		$event = new Event( $data['post_id'] );
 		$rsvp  = new Rsvp( $data['post_id'] );
 		$bail  = null;
 
-		if ( 'publish' !== get_post_status( $data['post_id'] ) ) {
+		if ( ! Event::is_viewable( $data['post_id'] ) ) {
 			$bail = array( __( 'Event not found.', 'gatherpress' ), 404 );
 		} elseif ( ! $rsvp->is_enabled() ) {
 			$bail = array( __( 'RSVP is disabled for this event.', 'gatherpress' ), 403 );

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -933,12 +933,17 @@ final class Rest_Api {
 			}
 		}
 
-		// Pre-flight: bail with a structured error before processing if open
-		// RSVP is disabled or the event has already passed.
+		// Pre-flight: bail with a structured error before processing if the
+		// event is not publicly available, open RSVP is disabled or the event has already passed.
 		$event = new Event( $data['post_id'] );
+		$rsvp  = new Rsvp( $data['post_id'] );
 		$bail  = null;
 
-		if ( ! ( new Rsvp( $data['post_id'] ) )->allows_open_rsvp() ) {
+		if ( 'publish' !== get_post_status( $data['post_id'] ) ) {
+			$bail = array( __( 'Event not found.', 'gatherpress' ), 404 );
+		} elseif ( ! $rsvp->is_enabled() ) {
+			$bail = array( __( 'RSVP is disabled for this event.', 'gatherpress' ), 403 );
+		} elseif ( ! $rsvp->allows_open_rsvp() ) {
 			$bail = array( __( 'Open RSVP is disabled for this event.', 'gatherpress' ), 403 );
 		} elseif ( $event->has_event_past() ) {
 			$bail = array( __( 'Registration for this event is now closed.', 'gatherpress' ), 400 );

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -861,6 +861,84 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
+	 * Data provider of non-public post statuses for RSVP form submission.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function data_unpublished_event_statuses(): array {
+		return array(
+			'draft event'   => array( 'draft' ),
+			'private event' => array( 'private' ),
+		);
+	}
+
+	/**
+	 * Tests handle_rsvp_form_submission returns 404 for an event that is not published.
+	 *
+	 * @dataProvider data_unpublished_event_statuses
+	 *
+	 * @covers ::handle_rsvp_form_submission
+	 *
+	 * @param string $post_status Non-public post status to submit against.
+	 *
+	 * @return void
+	 */
+	public function test_handle_rsvp_form_submission_unpublished_event( string $post_status ): void {
+		$instance = Rest_Api::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_status' => $post_status,
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'comment_post_ID', $post_id );
+		$request->set_param( 'author', 'Test Author' );
+		$request->set_param( 'email', 'test@example.com' );
+
+		$response = $instance->handle_rsvp_form_submission( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['success'] );
+		$this->assertStringContainsString( 'not found', $data['message'] );
+	}
+
+	/**
+	 * Tests handle_rsvp_form_submission returns 403 when RSVP is disabled for the event.
+	 *
+	 * @covers ::handle_rsvp_form_submission
+	 *
+	 * @return void
+	 */
+	public function test_handle_rsvp_form_submission_rsvp_disabled(): void {
+		$instance = Rest_Api::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+
+		// Disable RSVP sitewide so Rsvp::is_enabled() returns false for the event.
+		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'comment_post_ID', $post_id );
+		$request->set_param( 'author', 'Test Author' );
+		$request->set_param( 'email', 'test@example.com' );
+
+		$response = $instance->handle_rsvp_form_submission( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['success'] );
+		$this->assertSame( 'RSVP is disabled for this event.', $data['message'] );
+	}
+
+	/**
 	 * Coverage for handle_email_send_action method.
 	 *
 	 * @covers ::handle_email_send_action


### PR DESCRIPTION
## Proposed changes:
The public `POST /wp-json/gatherpress/v1/event/rsvp-form` endpoint accepts an unauthenticated RSVP after checking only whether "Open RSVP" is allowed and whether the event is past. It never verifies that the event is published or that RSVP is enabled, so a logged-out request can:

- RSVP to a **draft or private** event by knowing/guessing its ID, and
- RSVP to an event where **RSVP has been disabled**.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. RSVP to a non-public event → now blocked
- Create an event, leave it as **Draft**, give it a future date, and note its post ID (`…post=<ID>` in the editor URL).
- Send:
```bash
curl -i -X POST "https://example.test/wp-json/gatherpress/v1/event/rsvp-form" \
   --data-urlencode "comment_post_ID=<ID>" \
   --data-urlencode "author=Test Visitor" \
   --data-urlencode "email=visitor@example.com"
```

- Before: 200 OK, {"success":true,"message":"Your RSVP has been submitted successfully! ..."}
- After: 404, {"success":false,"message":"Event not found."}
- Set the event to Private and repeat → 404 as well.

2. RSVP where RSVP is disabled → now blocked
- In Events → Settings → RSVP, set RSVP mode to Disabled (or use a per-event mode and disable RSVP on the event).
- Create/publish a future event and note its ID.
- Send the same request → After: 403, {"success":false,"message":"RSVP is disabled for this event."}

### Credit (for release notes)

My WordPress.org username: vanyukov

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [x] Security - in case of vulnerabilities

#### Message

Reject open RSVP submissions to events that are not publicly published or that have RSVP disabled.

</details>
