### PR TITLE
Bump "Tested up to" to WordPress 7.1

### DIFF
--- a/.github/changelog/tested-up-to-7-1
+++ b/.github/changelog/tested-up-to-7-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Confirm compatibility with WordPress 7.1.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mauteri, patricia70, hrmervin, jmarx75, carstenbach, supernovia, matthewneilcowan
 Tags: events, rsvp, meetup, community, calendar
 Requires at least: 7.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 8.1
 Stable tag: 0.35.0
 License: GPL v2 or later


### PR DESCRIPTION
WordPress 7.1 is at [RC3](https://make.wordpress.org/core/2026/08/12/wordpress-7-1-release-candidate-3/) with final release scheduled for August 19, 2026.

Bumps `readme.txt` so the wp.org listing reports 7.1 compatibility. `Requires at least` stays at 7.0.

Born on develop so it can be cherry-picked onto `version-0.35.2` with `git cherry-pick -x`, keeping provenance and avoiding a duplicate-line conflict when develop merges to main for 0.36.0.