### PR TITLE
Add the 0.35.1 and 0.35.2 credits files to develop

### DIFF
--- a/.github/scripts/release/credits/0.35.1.json
+++ b/.github/scripts/release/credits/0.35.1.json
@@ -1,0 +1,23 @@
+{
+    "leads": [
+        "mauteri",
+        "patricia70"
+    ],
+    "noteworthy": [
+        "hrmervin",
+        "jmarx75",
+        "carstenbach",
+        "supernovia",
+        "matthewneilcowan"
+    ],
+    "contributors": [
+        "andremenrath",
+        "bor0",
+        "linewebdigital",
+        "w3lld1",
+        "fahimmurshed",
+        "lheroorg",
+        "motylanogha",
+        "puvaanraaj2001"
+    ]
+}


### PR DESCRIPTION
Release credits JSON files are authored on release branches, so they land on `main` and never reach `develop` — the archive there stopped at 0.35.0. This backfills both patch releases, copied verbatim from `main`:

- `credits/0.35.1.json`
- `credits/0.35.2.json` (Mariusz Szatkowski promoted to noteworthy; Anton Vanyukov added)

No functional effect — `includes/data/credits.php` is regenerated per release and only carries the current version. This is archive completeness so the per-release history on develop has no holes.