### PR TITLE
Create the venue detail cursor range from the canvas document

### DIFF
--- a/.github/changelog/venue-detail-canvas-range
+++ b/.github/changelog/venue-detail-canvas-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Create the venue detail block's cursor-position range from the editor canvas document instead of the admin document.

--- a/src/blocks/venue-detail/hooks/use-block-insertion.js
+++ b/src/blocks/venue-detail/hooks/use-block-insertion.js
@@ -55,8 +55,11 @@ export function useBlockInsertion( clientId, insertBlocksAfter ) {
 				const range = selection.getRangeAt( 0 );
 				const textContent = contentElement.textContent || '';
 
-				// Calculate cursor position.
-				const preRange = document.createRange();
+				// Calculate cursor position. The range comes from the
+				// element's own document, since the block renders inside the
+				// editor canvas iframe rather than the admin document.
+				const preRange =
+					contentElement.ownerDocument.createRange();
 				preRange.selectNodeContents( contentElement );
 				preRange.setEnd( range.startContainer, range.startOffset );
 				const cursorPosition = preRange.toString().length;


### PR DESCRIPTION
Closes the last cross-document hit from the WordPress 7.1 iframe review on #2098.

`useBlockInsertion`'s keydown handler is already canvas-aware — it takes its selection from `contentElement.ownerDocument.defaultView` — but the range that measures the cursor position was created with `document.createRange()` against the admin document, then pointed at canvas nodes.

One word changes: the range now comes from `contentElement.ownerDocument`.

**Severity is low, and the body of the commit says why.** DOM4 removed `WrongDocumentError`, so modern browsers tolerate a cross-document range and the cursor math likely worked by leniency. But it is exactly the boundary the [7.1 iframed-editor guidance](https://make.wordpress.org/core/2026/08/03/iframed-editor-changes-in-wordpress-7-1/) says to respect, and the same class of defect as #2124 — in a file that got it right two lines earlier.

With this, every `document.` / `window.` hit in `src/` is either fixed or verifiably intentional (front-end bundles, settings screen, deliberate admin-document modals, and the canonical parent-to-canvas iframe query). Full triage table on #2098.

## Testing

- `wp-scripts lint-js` clean
- venue-detail suites: 6 passed, 97 tests
- No behavioral test added: jsdom tolerates cross-document ranges the same way modern browsers do, so a test cannot distinguish the two forms — the same limitation documented on #2124 for the teardown guard.

Might grow additional 7.1-review items; starting with this one.