### PR TITLE
Sync the 0.35.2 changelog rollup to main

### DIFF
--- a/.github/changelog/radio-option-focus-iframe
+++ b/.github/changelog/radio-option-focus-iframe
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Keep the caret in the right place when adding or removing radio options in the editor. The option lookup now starts from the field being edited rather than the whole page, so it works in the iframed editor WordPress 7.1 makes unconditional, and a second radio field on the same post no longer steals the focus.

--- a/.github/changelog/rsvp-display-name-handling
+++ b/.github/changelog/rsvp-display-name-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Stop an email address standing in for a responder's name. A provider that can only identify a responder reported that identifier as the display name, so a response saved against an address published the address to every reader. Providers without a name now report none, callers show a neutral label in its place, and responses already stored that way are withheld from readers who do not manage RSVPs.

--- a/.github/changelog/rsvp-form-event-state-checks
+++ b/.github/changelog/rsvp-form-event-state-checks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Reject open RSVP submissions to events that are not publicly published or that have RSVP disabled.

--- a/.github/changelog/tested-up-to-7-1
+++ b/.github/changelog/tested-up-to-7-1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Confirm compatibility with WordPress 7.1.

--- a/.github/changelog/venue-detail-canvas-range
+++ b/.github/changelog/venue-detail-canvas-range
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Create the venue detail block's cursor-position range from the editor canvas document instead of the admin document.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Pending entries for the next release live as individual files under
 [`.github/changelog/`](.github/changelog/) and get rolled up into a new
 version section by `composer changelog:write` at release time.
 
+## [0.35.2] - 2026-08-16
+### Security
+- Reject open RSVP submissions to events that are not publicly published or that have RSVP disabled. [#2155](https://github.com/GatherPress/gatherpress/pull/2155)
+- Stop an email address standing in for a responder's name. A provider that can only identify a responder reported that identifier as the display name, so a response saved against an address published the address to every reader. Providers without a name now report none, callers show a neutral label in its place, and responses already stored that way are withheld from readers who do not manage RSVPs. [#2152](https://github.com/GatherPress/gatherpress/pull/2152)
+
+### Changed
+- Confirm compatibility with WordPress 7.1. [#2157](https://github.com/GatherPress/gatherpress/pull/2157)
+
+### Fixed
+- Create the venue detail block's cursor-position range from the editor canvas document instead of the admin document. [#2163](https://github.com/GatherPress/gatherpress/pull/2163)
+- Keep the caret in the right place when adding or removing radio options in the editor. The option lookup now starts from the field being edited rather than the whole page, so it works in the iframed editor WordPress 7.1 makes unconditional, and a second radio field on the same post no longer steals the focus. [#2124](https://github.com/GatherPress/gatherpress/pull/2124)
+
 ## [0.35.1] - 2026-08-13
 ### Security
 - Complete the redaction of RSVP responses marked anonymous. The responder's identity remained recoverable to unauthenticated visitors through the avatar URL's email hash, the raw identifier and site role in the REST response, the alt text the avatar block builds from the comment author, and the comments REST route. Anonymity now yields only to the capability that manages RSVPs, so contributors and authors no longer see through it. [#2148](https://github.com/GatherPress/gatherpress/pull/2148)


### PR DESCRIPTION
Post-release parity for 0.35.2, same shape as [#2160](https://github.com/GatherPress/gatherpress/pull/2160) was for 0.35.1. Cherry-pick of the [#2164](https://github.com/GatherPress/gatherpress/pull/2164) rollup: adds the `## [0.35.2]` section to `CHANGELOG.md` and deletes the five consumed entry files, so the next patch branch cut from `main` starts clean instead of inheriting them.