### PR TITLE
Filter adjacent post queries to join and sort by event datetime

### DIFF
--- a/.github/changelog/2168-fix-join-and-sort-on-adjacent-queries
+++ b/.github/changelog/2168-fix-join-and-sort-on-adjacent-queries
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added an INNER_JOIN for the typical adjacent queries made by WP core, and add an ORDERBY for the event-date. So the normal core/post-navigation-link blocks follow the event-date, instead of the publication date.

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -638,7 +638,6 @@ final class Query {
 		}
 
 		global $wpdb;
-		$table          = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 		$current_filter = current_filter();
 		$is_previous    = ( 'get_previous_post_where' === $current_filter );
 

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -601,16 +601,14 @@ final class Query {
 		string $taxonomy,
 		WP_Post $post
 	): string {
-		if ( ! post_type_supports( $post->post_type, 'gatherpress-event-date' ) ) {
+		if ( ! $this->follows_event_datetime( $post ) ) {
 			return $join;
 		}
 
 		global $wpdb;
 		$table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 
-		$join .= " INNER JOIN {$table} AS gpe ON p.ID = gpe.post_id";
-
-		return $join;
+		return $join . $wpdb->prepare( ' INNER JOIN %i AS gpe ON p.ID = gpe.post_id', $table );
 	}
 
 	/**
@@ -643,39 +641,60 @@ final class Query {
 		string $taxonomy,
 		WP_Post $post
 	): string {
-		if ( ! post_type_supports( $post->post_type, 'gatherpress-event-date' ) ) {
+		if ( ! $this->follows_event_datetime( $post ) ) {
 			return $where;
 		}
 
 		global $wpdb;
-		$current_filter = current_filter();
-		$is_previous    = ( 'get_previous_post_where' === $current_filter );
+		// One event is read through its own API; the candidates come from
+		// the joined events table.
+		$current = ( new Event( $post->ID ) )->get_datetime()['datetime_start_gmt'];
 
-		// Get the current event's datetime_start_gmt.
-		$current_datetime = get_post_meta( $post->ID, 'gatherpress_datetime_start_gmt', true );
-
-		if ( ! $current_datetime ) {
-			return $where;
+		// Core compares the publish date and, since 6.9, breaks a tie on ID.
+		// Swap the date for the event start and keep the tiebreak, so events
+		// that start at the same moment can still reach each other.
+		if ( 'get_previous_post_where' === current_filter() ) {
+			$comparison = $wpdb->prepare(
+				'(gpe.datetime_start_gmt < %s OR (gpe.datetime_start_gmt = %s AND p.ID < %d))',
+				$current,
+				$current,
+				$post->ID
+			);
+		} else {
+			$comparison = $wpdb->prepare(
+				'(gpe.datetime_start_gmt > %s OR (gpe.datetime_start_gmt = %s AND p.ID > %d))',
+				$current,
+				$current,
+				$post->ID
+			);
 		}
 
-		// Previous = earlier events (less than), Next = later events (greater than).
-		$op = $is_previous ? '<' : '>';
-		// It's intended, to not quote the comparison sign.
-		$sql = $wpdb->prepare(
-			'gpe.datetime_start_gmt %1s %s', // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder, Generic.Files.LineLength.TooLong
-			$op,
-			$current_datetime
+		return (string) preg_replace(
+			"/\(p\.post_date\s*[<>]\s*'[^']*' OR \(p\.post_date\s*=\s*'[^']*' AND p\.ID\s*[<>]\s*\d+\)\)/",
+			$comparison,
+			$where,
+			1
 		);
+	}
 
-		// Replace the default post_date comparison with event datetime comparison.
-		// The default WHERE looks like: WHERE p.post_date < '2024-01-01 00:00:00' AND p.post_type = ...
-		$where = preg_replace(
-			"/p\.post_date\s*[<>]\s*'[^']+'/",
-			$sql,
-			$where
-		);
-
-		return (string) $where;
+	/**
+	 * Whether an adjacent-post query for this post follows the event start.
+	 *
+	 * All three adjacent-post filters read this, so they switch together. A
+	 * post with no event start yet, such as one on a post type that gained
+	 * event support after it already had posts, keeps core's publish-date
+	 * navigation throughout, rather than joining and sorting on a column its
+	 * WHERE clause never compares.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param WP_Post $post The post being navigated from.
+	 *
+	 * @return bool Whether to join, compare, and sort by the event start.
+	 */
+	protected function follows_event_datetime( WP_Post $post ): bool {
+		return post_type_supports( $post->post_type, 'gatherpress-event-date' )
+			&& '' !== ( new Event( $post->ID ) )->get_datetime()['datetime_start_gmt'];
 	}
 
 	/**
@@ -695,15 +714,14 @@ final class Query {
 	 * @return string The modified ORDER BY clause for adjacent post queries.
 	 */
 	public function get_adjacent_post_sort( string $sort, WP_Post $post, string $order ): string {
-		if ( ! post_type_supports( $post->post_type, 'gatherpress-event-date' ) ) {
+		if ( ! $this->follows_event_datetime( $post ) ) {
 			return $sort;
 		}
 
-		// Replace post_date ordering with event datetime ordering.
-		// Default sort is: ORDER BY p.post_date DESC LIMIT 1
-		// $order is 'DESC' for previous, 'ASC' for next.
-		$sort = "ORDER BY gpe.datetime_start_gmt {$order} LIMIT 1";
+		// Core hands over 'DESC' for previous and 'ASC' for next. A keyword
+		// has no prepare() placeholder, so it is allowed through by name.
+		$order = 'ASC' === strtoupper( $order ) ? 'ASC' : 'DESC';
 
-		return $sort;
+		return "ORDER BY gpe.datetime_start_gmt {$order}, p.ID {$order} LIMIT 1";
 	}
 }

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -582,12 +582,14 @@ final class Query {
 	 * @since 0.36.0
 	 *
 	 * @param string       $join           The JOIN clause in the SQL.
-	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term.
-	 * @param array|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
-	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
+	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term (unused; part of the hook signature).
+	 * @param array|string $excluded_terms Array of excluded term IDs. Empty string if none were provided (unused; part of the hook signature).
+	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true (unused; part of the hook signature).
 	 * @param WP_Post      $post           The current post object.
 	 *
 	 * @return string The modified JOIN clause for adjacent post queries.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) Required by WP's get_{$adjacent}_post_join hook signature.
 	 */
 	public function get_adjacent_post_join(
 		string $join,
@@ -619,12 +621,14 @@ final class Query {
 	 * @since 0.36.0
 	 *
 	 * @param string       $where          The WHERE clause in the SQL.
-	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term.
-	 * @param array|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
-	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
+	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term (unused; part of the hook signature).
+	 * @param array|string $excluded_terms Array of excluded term IDs. Empty string if none were provided (unused; part of the hook signature).
+	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true (unused; part of the hook signature).
 	 * @param WP_Post      $post           The current post object.
 	 *
 	 * @return string The modified WHERE clause for adjacent post queries.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) Required by WP's get_{$adjacent}_post_where hook signature.
 	 */
 	public function get_adjacent_post_where(
 		string $where,

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -73,12 +73,12 @@ final class Query {
 		add_filter( 'posts_clauses', array( $this, 'adjust_admin_event_sorting' ), 9, 2 );
 
 		// Filter adjacent post queries to join and sort by event datetime.
-		add_filter( 'get_previous_post_join', array($this, 'gatherpress_adjacent_post_join'), 10, 5 );
-		add_filter( 'get_next_post_join', array($this, 'gatherpress_adjacent_post_join'), 10, 5 );
-		add_filter( 'get_previous_post_where', array($this, 'gatherpress_adjacent_post_where'), 10, 5 );
-		add_filter( 'get_next_post_where', array($this, 'gatherpress_adjacent_post_where'), 10, 5 );
-		add_filter( 'get_previous_post_sort', array($this, 'gatherpress_adjacent_post_sort'), 10, 3 );
-		add_filter( 'get_next_post_sort', array($this, 'gatherpress_adjacent_post_sort'), 10, 3 );
+		add_filter( 'get_previous_post_join', array( $this, 'gatherpress_adjacent_post_join' ), 10, 5 );
+		add_filter( 'get_next_post_join', array( $this, 'gatherpress_adjacent_post_join' ), 10, 5 );
+		add_filter( 'get_previous_post_where', array( $this, 'gatherpress_adjacent_post_where' ), 10, 5 );
+		add_filter( 'get_next_post_where', array( $this, 'gatherpress_adjacent_post_where' ), 10, 5 );
+		add_filter( 'get_previous_post_sort', array( $this, 'gatherpress_adjacent_post_sort' ), 10, 3 );
+		add_filter( 'get_next_post_sort', array( $this, 'gatherpress_adjacent_post_sort' ), 10, 3 );
 	}
 
 	/**
@@ -589,7 +589,13 @@ final class Query {
 	 *
 	 * @return string The modified JOIN clause for adjacent post queries.
 	 */
-	public function gatherpress_adjacent_post_join( string $join, bool $in_same_term, array|string $excluded_terms, string $taxonomy, WP_Post $post ): string {
+	public function gatherpress_adjacent_post_join(
+		string $join,
+		bool $in_same_term,
+		array|string $excluded_terms,
+		string $taxonomy,
+		WP_Post $post
+	): string {
 		if ( ! post_type_supports( $post->post_type, 'gatherpress-event-date' ) ) {
 			return $join;
 		}
@@ -613,14 +619,20 @@ final class Query {
 	 * @since 0.36.0
 	 *
 	 * @param string       $where          The WHERE clause in the SQL.
-	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term
+	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term.
 	 * @param array|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
 	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
 	 * @param WP_Post      $post           The current post object.
 	 *
 	 * @return string The modified WHERE clause for adjacent post queries.
 	 */
-	public function gatherpress_adjacent_post_where( string $where, bool $in_same_term, array|string $excluded_terms, string $taxonomy, WP_Post $post ): string {
+	public function gatherpress_adjacent_post_where(
+		string $where,
+		bool $in_same_term,
+		array|string $excluded_terms,
+		string $taxonomy,
+		WP_Post $post
+	): string {
 		if ( ! post_type_supports( $post->post_type, 'gatherpress-event-date' ) ) {
 			return $where;
 		}
@@ -631,12 +643,7 @@ final class Query {
 		$is_previous    = ( 'get_previous_post_where' === $current_filter );
 
 		// Get the current event's datetime_start_gmt.
-		$current_datetime = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT datetime_start_gmt FROM {$table} WHERE post_id = %d LIMIT 1",
-				$post->ID
-			)
-		);
+		$current_datetime = get_post_meta( $post->ID, 'gatherpress_datetime_start_gmt', true );
 
 		if ( ! $current_datetime ) {
 			return $where;
@@ -644,12 +651,18 @@ final class Query {
 
 		// Previous = earlier events (less than), Next = later events (greater than).
 		$op = $is_previous ? '<' : '>';
+		// It's intended, to not quote the comparison sign.
+		$sql = $wpdb->prepare(
+			'gpe.datetime_start_gmt %1s %s', // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder, Generic.Files.LineLength.TooLong
+			$op,
+			$current_datetime
+		);
 
 		// Replace the default post_date comparison with event datetime comparison.
 		// The default WHERE looks like: WHERE p.post_date < '2024-01-01 00:00:00' AND p.post_type = ...
 		$where = preg_replace(
 			"/p\.post_date\s*[<>]\s*'[^']+'/",
-			$wpdb->prepare( "gpe.datetime_start_gmt {$op} %s", $current_datetime ),
+			$sql,
 			$where
 		);
 

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -71,6 +71,14 @@ final class Query {
 		add_action( 'pre_get_posts', array( $this, 'prepare_event_query_before_execution' ) );
 		// Priority 9 to run before the upcoming/past adjustments at priority 10.
 		add_filter( 'posts_clauses', array( $this, 'adjust_admin_event_sorting' ), 9, 2 );
+
+		// Filter adjacent post queries to join and sort by event datetime.
+		add_filter( 'get_previous_post_join', array($this, 'gatherpress_adjacent_post_join'), 10, 5 );
+		add_filter( 'get_next_post_join', array($this, 'gatherpress_adjacent_post_join'), 10, 5 );
+		add_filter( 'get_previous_post_where', array($this, 'gatherpress_adjacent_post_where'), 10, 5 );
+		add_filter( 'get_next_post_where', array($this, 'gatherpress_adjacent_post_where'), 10, 5 );
+		add_filter( 'get_previous_post_sort', array($this, 'gatherpress_adjacent_post_sort'), 10, 3 );
+		add_filter( 'get_next_post_sort', array($this, 'gatherpress_adjacent_post_sort'), 10, 3 );
 	}
 
 	/**
@@ -561,5 +569,119 @@ final class Query {
 		// - Upcoming events, without running events.
 		// - Past events, that are still running.
 		return 'datetime_start_gmt';
+	}
+
+	/**
+	 * Join the GatherPress events table for adjacent post queries.
+	 *
+	 * This method modifies the SQL JOIN clause for adjacent post queries (previous and next)
+	 * to include the GatherPress events table.
+	 *
+	 * @see https://developer.wordpress.org/reference/hooks/get_adjacent_post_join/
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string       $join           The JOIN clause in the SQL.
+	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term.
+	 * @param array|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
+	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
+	 * @param WP_Post      $post           The current post object.
+	 *
+	 * @return string The modified JOIN clause for adjacent post queries.
+	 */
+	public function gatherpress_adjacent_post_join( string $join, bool $in_same_term, array|string $excluded_terms, string $taxonomy, WP_Post $post ): string {
+		if ( ! post_type_supports( $post->post_type, 'gatherpress-event-date' ) ) {
+			return $join;
+		}
+
+		global $wpdb;
+		$table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+
+		$join .= " INNER JOIN {$table} AS gpe ON p.ID = gpe.post_id";
+
+		return $join;
+	}
+
+	/**
+	 * Modify the WHERE clause to compare by event datetime instead of post_date for adjacent post queries.
+	 *
+	 * This method modifies the SQL WHERE clause for adjacent post queries (previous and next)
+	 * to compare by event datetime instead of the default post_date.
+	 *
+	 * @see https://developer.wordpress.org/reference/hooks/get_adjacent_post_where/
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string       $where          The WHERE clause in the SQL.
+	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term
+	 * @param array|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
+	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
+	 * @param WP_Post      $post           The current post object.
+	 *
+	 * @return string The modified WHERE clause for adjacent post queries.
+	 */
+	public function gatherpress_adjacent_post_where( string $where, bool $in_same_term, array|string $excluded_terms, string $taxonomy, WP_Post $post ): string {
+		if ( ! post_type_supports( $post->post_type, 'gatherpress-event-date' ) ) {
+			return $where;
+		}
+
+		global $wpdb;
+		$table          = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+		$current_filter = current_filter();
+		$is_previous    = ( 'get_previous_post_where' === $current_filter );
+
+		// Get the current event's datetime_start_gmt.
+		$current_datetime = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT datetime_start_gmt FROM {$table} WHERE post_id = %d LIMIT 1",
+				$post->ID
+			)
+		);
+
+		if ( ! $current_datetime ) {
+			return $where;
+		}
+
+		// Previous = earlier events (less than), Next = later events (greater than).
+		$op = $is_previous ? '<' : '>';
+
+		// Replace the default post_date comparison with event datetime comparison.
+		// The default WHERE looks like: WHERE p.post_date < '2024-01-01 00:00:00' AND p.post_type = ...
+		$where = preg_replace(
+			"/p\.post_date\s*[<>]\s*'[^']+'/",
+			$wpdb->prepare( "gpe.datetime_start_gmt {$op} %s", $current_datetime ),
+			$where
+		);
+
+		return $where;
+	}
+
+	/**
+	 * Modify the ORDER BY clause to sort by event datetime for adjacent post queries.
+	 *
+	 * This method modifies the SQL ORDER BY clause for adjacent post queries (previous and next)
+	 * to sort by event datetime instead of the default post_date.
+	 *
+	 * @see https://developer.wordpress.org/reference/hooks/get_adjacent_post_sort/
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string  $sort  The ORDER BY clause in the SQL.
+	 * @param WP_Post $post  The current post object.
+	 * @param string  $order Sort order. 'DESC' for previous post, 'ASC' for next.
+	 *
+	 * @return string The modified ORDER BY clause for adjacent post queries.
+	 */
+	public function gatherpress_adjacent_post_sort( string $sort, WP_Post $post, string $order ): string {
+		if ( ! post_type_supports( $post->post_type, 'gatherpress-event-date' ) ) {
+			return $sort;
+		}
+
+		// Replace post_date ordering with event datetime ordering.
+		// Default sort is: ORDER BY p.post_date DESC LIMIT 1
+		// $order is 'DESC' for previous, 'ASC' for next.
+		$sort = "ORDER BY gpe.datetime_start_gmt {$order} LIMIT 1";
+
+		return $sort;
 	}
 }

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -73,12 +73,12 @@ final class Query {
 		add_filter( 'posts_clauses', array( $this, 'adjust_admin_event_sorting' ), 9, 2 );
 
 		// Filter adjacent post queries to join and sort by event datetime.
-		add_filter( 'get_previous_post_join', array( $this, 'gatherpress_adjacent_post_join' ), 10, 5 );
-		add_filter( 'get_next_post_join', array( $this, 'gatherpress_adjacent_post_join' ), 10, 5 );
-		add_filter( 'get_previous_post_where', array( $this, 'gatherpress_adjacent_post_where' ), 10, 5 );
-		add_filter( 'get_next_post_where', array( $this, 'gatherpress_adjacent_post_where' ), 10, 5 );
-		add_filter( 'get_previous_post_sort', array( $this, 'gatherpress_adjacent_post_sort' ), 10, 3 );
-		add_filter( 'get_next_post_sort', array( $this, 'gatherpress_adjacent_post_sort' ), 10, 3 );
+		add_filter( 'get_previous_post_join', array( $this, 'get_adjacent_post_join' ), 10, 5 );
+		add_filter( 'get_next_post_join', array( $this, 'get_adjacent_post_join' ), 10, 5 );
+		add_filter( 'get_previous_post_where', array( $this, 'get_adjacent_post_where' ), 10, 5 );
+		add_filter( 'get_next_post_where', array( $this, 'get_adjacent_post_where' ), 10, 5 );
+		add_filter( 'get_previous_post_sort', array( $this, 'get_adjacent_post_sort' ), 10, 3 );
+		add_filter( 'get_next_post_sort', array( $this, 'get_adjacent_post_sort' ), 10, 3 );
 	}
 
 	/**
@@ -589,7 +589,7 @@ final class Query {
 	 *
 	 * @return string The modified JOIN clause for adjacent post queries.
 	 */
-	public function gatherpress_adjacent_post_join(
+	public function get_adjacent_post_join(
 		string $join,
 		bool $in_same_term,
 		array|string $excluded_terms,
@@ -626,7 +626,7 @@ final class Query {
 	 *
 	 * @return string The modified WHERE clause for adjacent post queries.
 	 */
-	public function gatherpress_adjacent_post_where(
+	public function get_adjacent_post_where(
 		string $where,
 		bool $in_same_term,
 		array|string $excluded_terms,
@@ -685,7 +685,7 @@ final class Query {
 	 *
 	 * @return string The modified ORDER BY clause for adjacent post queries.
 	 */
-	public function gatherpress_adjacent_post_sort( string $sort, WP_Post $post, string $order ): string {
+	public function get_adjacent_post_sort( string $sort, WP_Post $post, string $order ): string {
 		if ( ! post_type_supports( $post->post_type, 'gatherpress-event-date' ) ) {
 			return $sort;
 		}

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -582,9 +582,12 @@ final class Query {
 	 * @since 0.36.0
 	 *
 	 * @param string       $join           The JOIN clause in the SQL.
-	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term (unused; part of the hook signature).
-	 * @param array|string $excluded_terms Array of excluded term IDs. Empty string if none were provided (unused; part of the hook signature).
-	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true (unused; part of the hook signature).
+	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term
+	 *                                     (unused; part of the hook signature).
+	 * @param int[]|string $excluded_terms Array of excluded term IDs. Empty string if none were provided
+	 *                                     (unused; part of the hook signature).
+	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true
+	 *                                     (unused; part of the hook signature).
 	 * @param WP_Post      $post           The current post object.
 	 *
 	 * @return string The modified JOIN clause for adjacent post queries.
@@ -621,9 +624,12 @@ final class Query {
 	 * @since 0.36.0
 	 *
 	 * @param string       $where          The WHERE clause in the SQL.
-	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term (unused; part of the hook signature).
-	 * @param array|string $excluded_terms Array of excluded term IDs. Empty string if none were provided (unused; part of the hook signature).
-	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true (unused; part of the hook signature).
+	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term
+	 *                                     (unused; part of the hook signature).
+	 * @param int[]|string $excluded_terms Array of excluded term IDs. Empty string if none were provided
+	 *                                     (unused; part of the hook signature).
+	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true
+	 *                                     (unused; part of the hook signature).
 	 * @param WP_Post      $post           The current post object.
 	 *
 	 * @return string The modified WHERE clause for adjacent post queries.
@@ -669,7 +675,7 @@ final class Query {
 			$where
 		);
 
-		return $where;
+		return (string) $where;
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -1950,9 +1950,12 @@ class Test_Query extends Base {
 		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', $datetime );
 
 		// Simulate get_previous_post_where filter.
-		$wp_current_filter[] = 'get_previous_post_where';
+		// Temporarily replace the global wp_current_filter.
+		$wp_current_filter[] = 'get_previous_post_where'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, Generic.Files.LineLength.TooLong -- Testing requires global manipulation.
 
-		$initial_where  = "WHERE p.post_date < '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+		// phpcs:ignore Generic.Files.LineLength.TooLong
+		$initial_where = "WHERE p.post_date < '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+		// phpcs:ignore Generic.Files.LineLength.TooLong
 		$expected_where = "WHERE gpe.datetime_start_gmt < '{$datetime}' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
 
 		$instance = Query::get_instance();
@@ -1991,9 +1994,12 @@ class Test_Query extends Base {
 		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', $datetime );
 
 		// Simulate get_next_post_where filter.
-		$wp_current_filter[] = 'get_next_post_where';
+		// Temporarily replace the global wp_current_filter.
+		$wp_current_filter[] = 'get_next_post_where'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, Generic.Files.LineLength.TooLong -- Testing requires global manipulation.
 
-		$initial_where  = "WHERE p.post_date > '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+		// phpcs:ignore Generic.Files.LineLength.TooLong
+		$initial_where = "WHERE p.post_date > '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+		// phpcs:ignore Generic.Files.LineLength.TooLong
 		$expected_where = "WHERE gpe.datetime_start_gmt > '{$datetime}' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
 
 		$instance = Query::get_instance();
@@ -2031,9 +2037,10 @@ class Test_Query extends Base {
 		$datetime = '2024-06-15 10:00:00';
 		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', $datetime );
 
-		$wp_current_filter[] = 'get_previous_post_where';
+		// Simulate get_next_post_where filter.
+		// Temporarily replace the global wp_current_filter.
+		$wp_current_filter[] = 'get_previous_post_where'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, Generic.Files.LineLength.TooLong -- Testing requires global manipulation.
 
-		// No spaces around operator: p.post_date<'...'
 		$initial_where  = "WHERE p.post_date < '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event'";
 		$expected_where = "WHERE gpe.datetime_start_gmt < '{$datetime}' AND p.post_type = 'gatherpress_event'";
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -1776,7 +1776,7 @@ class Test_Query extends Base {
 
 	/**
 	 * Test that join query remains unchanged when the post type does not support 'gatherpress-event-date'.
-	 * 
+	 *
 	 * @covers ::get_adjacent_post_join
 	 *
 	 * @return void
@@ -1795,7 +1795,7 @@ class Test_Query extends Base {
 		$result = $this->instance->get_adjacent_post_join(
 			$initial_join,
 			false,
-			[],
+			array(),
 			'category',
 			$post
 		);
@@ -1805,7 +1805,7 @@ class Test_Query extends Base {
 
 	/**
 	 * Test that join query is properly appended when the post type supports 'gatherpress-event-date'.
-	 * 
+	 *
 	 * @covers ::get_adjacent_post_join
 	 *
 	 * @return void
@@ -1841,7 +1841,7 @@ class Test_Query extends Base {
 
 	/**
 	 * Test that the join clause appends correctly to an existing non-empty join string.
-	 * 
+	 *
 	 * @covers ::get_adjacent_post_join
 	 *
 	 * @return void
@@ -1859,13 +1859,13 @@ class Test_Query extends Base {
 		add_post_type_support( 'gatherpress_event', 'gatherpress-event-date' );
 
 		$expected_table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
-		$initial_join   = ' INNER JOIN other_table AS ot ON p.ID = ot.post_id';
+		$initial_join   = ' INNER JOIN other_table AS otta ON p.ID = otta.post_id';
 		$expected_join  = $initial_join . " INNER JOIN {$expected_table} AS gpe ON p.ID = gpe.post_id";
 
 		$result = $this->instance->get_adjacent_post_join(
 			$initial_join,
 			true,
-			[ 1, 2, 3 ],
+			array( 1, 2, 3 ),
 			'event_category',
 			$post
 		);

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -48,6 +48,42 @@ class Test_Query extends Base {
 				'priority' => 9,
 				'callback' => array( $instance, 'adjust_admin_event_sorting' ),
 			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'get_previous_post_join',
+				'priority' => 10,
+				'callback' => array( $instance, 'get_adjacent_post_join' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'get_next_post_join',
+				'priority' => 10,
+				'callback' => array( $instance, 'get_adjacent_post_join' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'get_previous_post_where',
+				'priority' => 10,
+				'callback' => array( $instance, 'get_adjacent_post_where' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'get_next_post_where',
+				'priority' => 10,
+				'callback' => array( $instance, 'get_adjacent_post_where' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'get_previous_post_sort',
+				'priority' => 10,
+				'callback' => array( $instance, 'get_adjacent_post_sort' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'get_next_post_sort',
+				'priority' => 10,
+				'callback' => array( $instance, 'get_adjacent_post_sort' ),
+			),
 		);
 
 		$this->assert_hooks( $hooks, $instance );

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -1868,4 +1868,187 @@ class Test_Query extends Base {
 
 		$this->assertSame( $expected_join, $result );
 	}
+
+	/**
+	 * Test that WHERE clause remains unchanged when the post type does not support 'gatherpress-event-date'.
+	 *
+	 * @covers ::get_adjacent_post_where
+	 *
+	 * @return void
+	 */
+	public function test_returns_original_where_when_post_type_not_supported(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'post',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', '2024-06-15 10:00:00' );
+
+		$initial_where = "WHERE p.post_date < '2024-06-15 10:00:00' AND p.post_type = 'post'";
+
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_where(
+			$initial_where,
+			false,
+			array(),
+			'',
+			$post
+		);
+
+		$this->assertSame( $initial_where, $result );
+	}
+
+	/**
+	 * Test that WHERE clause remains unchanged when the post has no 'gatherpress_datetime_start_gmt' meta.
+	 *
+	 * @covers ::get_adjacent_post_where
+	 *
+	 * @return void
+	 */
+	public function test_returns_original_where_when_post_datetime_meta_missing(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'gatherpress_event',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$initial_where = "WHERE p.post_date < '2024-06-15 10:00:00' AND p.post_type = 'gatherpress_event'";
+
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_where(
+			$initial_where,
+			false,
+			array(),
+			'',
+			$post
+		);
+
+		$this->assertSame( $initial_where, $result );
+	}
+
+	/**
+	 * Test that WHERE clause replaces post_date comparison with '<' for previous post query.
+	 *
+	 * @covers ::get_adjacent_post_where
+	 *
+	 * @return void
+	 */
+	public function test_replaces_post_date_with_datetime_start_gmt_for_previous_post(): void {
+		global $wp_current_filter;
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'gatherpress_event',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$datetime = '2024-06-15 10:00:00';
+		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', $datetime );
+
+		// Simulate get_previous_post_where filter.
+		$wp_current_filter[] = 'get_previous_post_where';
+
+		$initial_where  = "WHERE p.post_date < '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+		$expected_where = "WHERE gpe.datetime_start_gmt < '{$datetime}' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_where(
+			$initial_where,
+			false,
+			'',
+			'',
+			$post
+		);
+
+		// Clean up simulated filter.
+		array_pop( $wp_current_filter );
+
+		$this->assertSame( $expected_where, $result );
+	}
+
+	/**
+	 * Test that WHERE clause replaces post_date comparison with '>' for next post query.
+	 *
+	 * @covers ::get_adjacent_post_where
+	 *
+	 * @return void
+	 */
+	public function test_replaces_post_date_with_datetime_start_gmt_for_next_post(): void {
+		global $wp_current_filter;
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'gatherpress_event',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$datetime = '2024-06-15 10:00:00';
+		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', $datetime );
+
+		// Simulate get_next_post_where filter.
+		$wp_current_filter[] = 'get_next_post_where';
+
+		$initial_where  = "WHERE p.post_date > '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+		$expected_where = "WHERE gpe.datetime_start_gmt > '{$datetime}' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_where(
+			$initial_where,
+			false,
+			'',
+			'',
+			$post
+		);
+
+		// Clean up simulated filter.
+		array_pop( $wp_current_filter );
+
+		$this->assertSame( $expected_where, $result );
+	}
+
+	/**
+	 * Test that WHERE clause handles spacing differences around the comparison operator.
+	 *
+	 * @covers ::get_adjacent_post_where
+	 *
+	 * @return void
+	 */
+	public function test_replaces_post_date_with_varied_spacing(): void {
+		global $wp_current_filter;
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'gatherpress_event',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$datetime = '2024-06-15 10:00:00';
+		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', $datetime );
+
+		$wp_current_filter[] = 'get_previous_post_where';
+
+		// No spaces around operator: p.post_date<'...'
+		$initial_where  = "WHERE p.post_date < '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event'";
+		$expected_where = "WHERE gpe.datetime_start_gmt < '{$datetime}' AND p.post_type = 'gatherpress_event'";
+
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_where(
+			$initial_where,
+			false,
+			'',
+			'',
+			$post
+		);
+
+		array_pop( $wp_current_filter );
+
+		$this->assertSame( $expected_where, $result );
+	}
+
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -2192,7 +2192,7 @@ class Test_Query extends Base {
 	 *
 	 * New events default to 6:00 PM the next day, so identical starts are
 	 * common. A strict comparison alone would leave each of them with no
-	 * neighbours; the ID tiebreak core uses for publish dates applies here.
+	 * neighbors; the ID tiebreak core uses for publish dates applies here.
 	 *
 	 * @covers ::get_adjacent_post_where
 	 * @covers ::get_adjacent_post_sort
@@ -2222,7 +2222,7 @@ class Test_Query extends Base {
 	/**
 	 * A post without an event start keeps core's navigation, in all three clauses.
 	 *
-	 * From an undated event the neighbours are found by publish date, as core
+	 * From an undated event the neighbors are found by publish date, as core
 	 * would. Switching the join and sort to the events table while the WHERE
 	 * still compared the publish date would answer with the wrong post.
 	 *
@@ -2270,7 +2270,7 @@ class Test_Query extends Base {
 		$this->assertSame(
 			'ORDER BY gpe.datetime_start_gmt ASC, p.ID ASC LIMIT 1',
 			Query::get_instance()->get_adjacent_post_sort( '', $post, 'asc' ),
-			'Failed to assert a lower-case order is normalised.'
+			'Failed to assert a lower-case order is normalized.'
 		);
 		$this->assertSame(
 			'ORDER BY gpe.datetime_start_gmt DESC, p.ID DESC LIMIT 1',

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -2051,4 +2051,86 @@ class Test_Query extends Base {
 		$this->assertSame( $expected_where, $result );
 	}
 
+	/**
+	 * Test that sort clause remains unchanged when the post type does not support 'gatherpress-event-date'.
+	 *
+	 * @covers ::get_adjacent_post_sort
+	 *
+	 * @return void
+	 */
+	public function test_returns_original_sort_when_post_type_not_supported(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'post',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$initial_sort = 'ORDER BY p.post_date DESC LIMIT 1';
+
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_sort(
+			$initial_sort,
+			$post,
+			'DESC'
+		);
+
+		$this->assertSame( $initial_sort, $result );
+	}
+
+	/**
+	 * Test that sort clause orders by event datetime DESC for previous post query.
+	 *
+	 * @covers ::get_adjacent_post_sort
+	 *
+	 * @return void
+	 */
+	public function test_returns_event_datetime_sort_desc_when_post_type_supported(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'gatherpress_event',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$initial_sort  = 'ORDER BY p.post_date DESC LIMIT 1';
+		$expected_sort = 'ORDER BY gpe.datetime_start_gmt DESC LIMIT 1';
+
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_sort(
+			$initial_sort,
+			$post,
+			'DESC'
+		);
+
+		$this->assertSame( $expected_sort, $result );
+	}
+
+	/**
+	 * Test that sort clause orders by event datetime ASC for next post query.
+	 *
+	 * @covers ::get_adjacent_post_sort
+	 *
+	 * @return void
+	 */
+	public function test_returns_event_datetime_sort_asc_when_post_type_supported(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'gatherpress_event',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$initial_sort  = 'ORDER BY p.post_date ASC LIMIT 1';
+		$expected_sort = 'ORDER BY gpe.datetime_start_gmt ASC LIMIT 1';
+
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_sort(
+			$initial_sort,
+			$post,
+			'ASC'
+		);
+
+		$this->assertSame( $expected_sort, $result );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -1820,9 +1820,12 @@ class Test_Query extends Base {
 		);
 		$post    = get_post( $post_id );
 
+		// The filters only switch to the events table once a start exists.
+		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', '2024-06-15 10:00:00' );
+
 		$expected_table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 		$initial_join   = '';
-		$expected_join  = " INNER JOIN {$expected_table} AS gpe ON p.ID = gpe.post_id";
+		$expected_join  = " INNER JOIN `{$expected_table}` AS gpe ON p.ID = gpe.post_id";
 
 		$instance = Query::get_instance();
 		$result   = $instance->get_adjacent_post_join(
@@ -1853,9 +1856,12 @@ class Test_Query extends Base {
 		);
 		$post    = get_post( $post_id );
 
+		// The filters only switch to the events table once a start exists.
+		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', '2024-06-15 10:00:00' );
+
 		$expected_table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 		$initial_join   = ' INNER JOIN other_table AS otta ON p.ID = otta.post_id';
-		$expected_join  = $initial_join . " INNER JOIN {$expected_table} AS gpe ON p.ID = gpe.post_id";
+		$expected_join  = $initial_join . " INNER JOIN `{$expected_table}` AS gpe ON p.ID = gpe.post_id";
 
 		$instance = Query::get_instance();
 		$result   = $instance->get_adjacent_post_join(
@@ -1900,34 +1906,6 @@ class Test_Query extends Base {
 		$this->assertSame( $initial_where, $result );
 	}
 
-	/**
-	 * Test that WHERE clause remains unchanged when the post has no 'gatherpress_datetime_start_gmt' meta.
-	 *
-	 * @covers ::get_adjacent_post_where
-	 *
-	 * @return void
-	 */
-	public function test_returns_original_where_when_post_datetime_meta_missing(): void {
-		$post_id = $this->factory->post->create(
-			array(
-				'post_type' => 'gatherpress_event',
-			)
-		);
-		$post    = get_post( $post_id );
-
-		$initial_where = "WHERE p.post_date < '2024-06-15 10:00:00' AND p.post_type = 'gatherpress_event'";
-
-		$instance = Query::get_instance();
-		$result   = $instance->get_adjacent_post_where(
-			$initial_where,
-			false,
-			array(),
-			'',
-			$post
-		);
-
-		$this->assertSame( $initial_where, $result );
-	}
 
 	/**
 	 * Test that WHERE clause replaces post_date comparison with '<' for previous post query.
@@ -1954,9 +1932,9 @@ class Test_Query extends Base {
 		$wp_current_filter[] = 'get_previous_post_where'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, Generic.Files.LineLength.TooLong -- Testing requires global manipulation.
 
 		// phpcs:ignore Generic.Files.LineLength.TooLong
-		$initial_where = "WHERE p.post_date < '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+		$initial_where = "WHERE (p.post_date < '2024-01-01 00:00:00' OR (p.post_date = '2024-01-01 00:00:00' AND p.ID < {$post_id})) AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
 		// phpcs:ignore Generic.Files.LineLength.TooLong
-		$expected_where = "WHERE gpe.datetime_start_gmt < '{$datetime}' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+		$expected_where = "WHERE (gpe.datetime_start_gmt < '{$datetime}' OR (gpe.datetime_start_gmt = '{$datetime}' AND p.ID < {$post_id})) AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
 
 		$instance = Query::get_instance();
 		$result   = $instance->get_adjacent_post_where(
@@ -1998,9 +1976,9 @@ class Test_Query extends Base {
 		$wp_current_filter[] = 'get_next_post_where'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, Generic.Files.LineLength.TooLong -- Testing requires global manipulation.
 
 		// phpcs:ignore Generic.Files.LineLength.TooLong
-		$initial_where = "WHERE p.post_date > '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+		$initial_where = "WHERE (p.post_date > '2024-01-01 00:00:00' OR (p.post_date = '2024-01-01 00:00:00' AND p.ID > {$post_id})) AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
 		// phpcs:ignore Generic.Files.LineLength.TooLong
-		$expected_where = "WHERE gpe.datetime_start_gmt > '{$datetime}' AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
+		$expected_where = "WHERE (gpe.datetime_start_gmt > '{$datetime}' OR (gpe.datetime_start_gmt = '{$datetime}' AND p.ID > {$post_id})) AND p.post_type = 'gatherpress_event' AND p.post_status = 'publish'";
 
 		$instance = Query::get_instance();
 		$result   = $instance->get_adjacent_post_where(
@@ -2041,8 +2019,10 @@ class Test_Query extends Base {
 		// Temporarily replace the global wp_current_filter.
 		$wp_current_filter[] = 'get_previous_post_where'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, Generic.Files.LineLength.TooLong -- Testing requires global manipulation.
 
-		$initial_where  = "WHERE p.post_date < '2024-01-01 00:00:00' AND p.post_type = 'gatherpress_event'";
-		$expected_where = "WHERE gpe.datetime_start_gmt < '{$datetime}' AND p.post_type = 'gatherpress_event'";
+		// phpcs:ignore Generic.Files.LineLength.TooLong
+		$initial_where = "WHERE (p.post_date<'2024-01-01 00:00:00' OR (p.post_date='2024-01-01 00:00:00' AND p.ID<{$post_id})) AND p.post_type = 'gatherpress_event'";
+		// phpcs:ignore Generic.Files.LineLength.TooLong
+		$expected_where = "WHERE (gpe.datetime_start_gmt < '{$datetime}' OR (gpe.datetime_start_gmt = '{$datetime}' AND p.ID < {$post_id})) AND p.post_type = 'gatherpress_event'";
 
 		$instance = Query::get_instance();
 		$result   = $instance->get_adjacent_post_where(
@@ -2100,8 +2080,11 @@ class Test_Query extends Base {
 		);
 		$post    = get_post( $post_id );
 
+		// The filters only switch to the events table once a start exists.
+		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', '2024-06-15 10:00:00' );
+
 		$initial_sort  = 'ORDER BY p.post_date DESC LIMIT 1';
-		$expected_sort = 'ORDER BY gpe.datetime_start_gmt DESC LIMIT 1';
+		$expected_sort = 'ORDER BY gpe.datetime_start_gmt DESC, p.ID DESC LIMIT 1';
 
 		$instance = Query::get_instance();
 		$result   = $instance->get_adjacent_post_sort(
@@ -2128,8 +2111,11 @@ class Test_Query extends Base {
 		);
 		$post    = get_post( $post_id );
 
+		// The filters only switch to the events table once a start exists.
+		update_post_meta( $post_id, 'gatherpress_datetime_start_gmt', '2024-06-15 10:00:00' );
+
 		$initial_sort  = 'ORDER BY p.post_date ASC LIMIT 1';
-		$expected_sort = 'ORDER BY gpe.datetime_start_gmt ASC LIMIT 1';
+		$expected_sort = 'ORDER BY gpe.datetime_start_gmt ASC, p.ID ASC LIMIT 1';
 
 		$instance = Query::get_instance();
 		$result   = $instance->get_adjacent_post_sort(
@@ -2139,5 +2125,157 @@ class Test_Query extends Base {
 		);
 
 		$this->assertSame( $expected_sort, $result );
+	}
+
+	/**
+	 * Create a published event that starts at the given UTC datetime.
+	 *
+	 * @param string $start      Event start, `Y-m-d H:i:s` in UTC.
+	 * @param string $post_date  Publish date, in the past so the post publishes, and
+	 *                           deliberately unrelated to the start.
+	 *
+	 * @return int The event ID.
+	 */
+	private function make_dated_event( string $start, string $post_date ): int {
+		$event_id = $this->factory->post->create(
+			array(
+				'post_type' => 'gatherpress_event',
+				'post_date' => $post_date,
+			)
+		);
+
+		( new Event( $event_id ) )->save_datetimes(
+			array(
+				'post_id'        => $event_id,
+				'datetime_start' => $start,
+				'datetime_end'   => gmdate( 'Y-m-d H:i:s', strtotime( $start ) + HOUR_IN_SECONDS ),
+				'timezone'       => 'UTC',
+			)
+		);
+
+		return $event_id;
+	}
+
+	/**
+	 * Previous and next follow the event start, not the publish date.
+	 *
+	 * The publish order is the reverse of the event order, so a navigation
+	 * that still followed `post_date` would point the other way.
+	 *
+	 * @covers ::get_adjacent_post_join
+	 * @covers ::get_adjacent_post_where
+	 * @covers ::get_adjacent_post_sort
+	 *
+	 * @return void
+	 */
+	public function test_adjacent_events_follow_the_event_start(): void {
+		$earliest = $this->make_dated_event( '2030-01-10 18:00:00', '2020-03-03 00:00:00' );
+		$middle   = $this->make_dated_event( '2030-02-10 18:00:00', '2020-02-02 00:00:00' );
+		$latest   = $this->make_dated_event( '2030-03-10 18:00:00', '2020-01-01 00:00:00' );
+
+		$this->go_to( get_permalink( $middle ) );
+
+		$this->assertSame(
+			$earliest,
+			get_previous_post()->ID,
+			'Failed to assert the previous event is the one that starts before this one.'
+		);
+		$this->assertSame(
+			$latest,
+			get_next_post()->ID,
+			'Failed to assert the next event is the one that starts after this one.'
+		);
+	}
+
+	/**
+	 * Events that start at the same moment can still reach each other.
+	 *
+	 * New events default to 6:00 PM the next day, so identical starts are
+	 * common. A strict comparison alone would leave each of them with no
+	 * neighbours; the ID tiebreak core uses for publish dates applies here.
+	 *
+	 * @covers ::get_adjacent_post_where
+	 * @covers ::get_adjacent_post_sort
+	 *
+	 * @return void
+	 */
+	public function test_adjacent_events_break_a_tie_on_id(): void {
+		$first  = $this->make_dated_event( '2030-06-01 18:00:00', '2020-01-01 00:00:00' );
+		$second = $this->make_dated_event( '2030-06-01 18:00:00', '2020-01-01 00:00:00' );
+		$third  = $this->make_dated_event( '2030-06-01 18:00:00', '2020-01-01 00:00:00' );
+
+		$this->go_to( get_permalink( $second ) );
+
+		$this->assertSame(
+			$first,
+			get_previous_post()->ID,
+			'Failed to assert the earlier ID is the previous event on a tied start.'
+		);
+		$this->assertSame(
+			$third,
+			get_next_post()->ID,
+			'Failed to assert the later ID is the next event on a tied start.'
+		);
+	}
+
+
+	/**
+	 * A post without an event start keeps core's navigation, in all three clauses.
+	 *
+	 * From an undated event the neighbours are found by publish date, as core
+	 * would. Switching the join and sort to the events table while the WHERE
+	 * still compared the publish date would answer with the wrong post.
+	 *
+	 * @covers ::get_adjacent_post_join
+	 * @covers ::get_adjacent_post_where
+	 * @covers ::get_adjacent_post_sort
+	 * @covers ::follows_event_datetime
+	 *
+	 * @return void
+	 */
+	public function test_undated_event_keeps_core_navigation(): void {
+		$older_by_publish = $this->make_dated_event( '2030-03-10 18:00:00', '2020-01-01 00:00:00' );
+		$undated          = $this->factory->post->create(
+			array(
+				'post_type' => 'gatherpress_event',
+				'post_date' => '2020-02-02 00:00:00',
+			)
+		);
+		$newer_by_publish = $this->make_dated_event( '2030-01-10 18:00:00', '2020-03-03 00:00:00' );
+
+		$this->go_to( get_permalink( $undated ) );
+
+		$this->assertSame(
+			$older_by_publish,
+			get_previous_post()->ID,
+			'Failed to assert core publish-date order is kept.'
+		);
+		$this->assertSame(
+			$newer_by_publish,
+			get_next_post()->ID,
+			'Failed to assert core publish-date order is kept.'
+		);
+	}
+
+	/**
+	 * The sort order is allowed through by name, never interpolated raw.
+	 *
+	 * @covers ::get_adjacent_post_sort
+	 *
+	 * @return void
+	 */
+	public function test_adjacent_sort_only_accepts_a_known_order(): void {
+		$post = get_post( $this->make_dated_event( '2030-06-01 18:00:00', '2020-01-01 00:00:00' ) );
+
+		$this->assertSame(
+			'ORDER BY gpe.datetime_start_gmt ASC, p.ID ASC LIMIT 1',
+			Query::get_instance()->get_adjacent_post_sort( '', $post, 'asc' ),
+			'Failed to assert a lower-case order is normalised.'
+		);
+		$this->assertSame(
+			'ORDER BY gpe.datetime_start_gmt DESC, p.ID DESC LIMIT 1',
+			Query::get_instance()->get_adjacent_post_sort( '', $post, 'DESC; DROP TABLE wp_posts' ),
+			'Failed to assert anything that is not ASC falls back to DESC.'
+		);
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -1773,4 +1773,103 @@ class Test_Query extends Base {
 
 		wp_delete_post( $venue_post_id, true );
 	}
+
+	/**
+	 * Test that join query remains unchanged when the post type does not support 'gatherpress-event-date'.
+	 * 
+	 * @covers ::get_adjacent_post_join
+	 *
+	 * @return void
+	 */
+	public function test_returns_original_join_when_post_type_not_supported(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'post',
+				'post_name' => 'skip-join',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$initial_join = ' INNER JOIN wp_term_relationships ON (wp_posts.ID = wp_term_relationships.object_id)';
+
+		$result = $this->instance->get_adjacent_post_join(
+			$initial_join,
+			false,
+			[],
+			'category',
+			$post
+		);
+
+		$this->assertSame( $initial_join, $result );
+	}
+
+	/**
+	 * Test that join query is properly appended when the post type supports 'gatherpress-event-date'.
+	 * 
+	 * @covers ::get_adjacent_post_join
+	 *
+	 * @return void
+	 */
+	public function test_appends_event_table_join_when_post_type_supported(): void {
+		global $wpdb;
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'post',
+				'post_name' => 'skip-join',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		// Enable feature support
+		add_post_type_support( 'post', 'gatherpress-event-date' );
+
+		$expected_table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+		$initial_join   = '';
+		$expected_join  = " INNER JOIN {$expected_table} AS gpe ON p.ID = gpe.post_id";
+
+		$result = $this->instance->get_adjacent_post_join(
+			$initial_join,
+			false,
+			'',
+			'',
+			$post
+		);
+
+		$this->assertSame( $expected_join, $result );
+	}
+
+	/**
+	 * Test that the join clause appends correctly to an existing non-empty join string.
+	 * 
+	 * @covers ::get_adjacent_post_join
+	 *
+	 * @return void
+	 */
+	public function test_appends_to_existing_join_string(): void {
+		global $wpdb;
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'gatherpress_event',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		add_post_type_support( 'gatherpress_event', 'gatherpress-event-date' );
+
+		$expected_table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+		$initial_join   = ' INNER JOIN other_table AS ot ON p.ID = ot.post_id';
+		$expected_join  = $initial_join . " INNER JOIN {$expected_table} AS gpe ON p.ID = gpe.post_id";
+
+		$result = $this->instance->get_adjacent_post_join(
+			$initial_join,
+			true,
+			[ 1, 2, 3 ],
+			'event_category',
+			$post
+		);
+
+		$this->assertSame( $expected_join, $result );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -1785,7 +1785,6 @@ class Test_Query extends Base {
 		$post_id = $this->factory->post->create(
 			array(
 				'post_type' => 'post',
-				'post_name' => 'skip-join',
 			)
 		);
 		$post    = get_post( $post_id );
@@ -1816,14 +1815,10 @@ class Test_Query extends Base {
 
 		$post_id = $this->factory->post->create(
 			array(
-				'post_type' => 'post',
-				'post_name' => 'skip-join',
+				'post_type' => 'gatherpress_event',
 			)
 		);
 		$post    = get_post( $post_id );
-
-		// Enable feature support
-		add_post_type_support( 'post', 'gatherpress-event-date' );
 
 		$expected_table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 		$initial_join   = '';
@@ -1857,8 +1852,6 @@ class Test_Query extends Base {
 			)
 		);
 		$post    = get_post( $post_id );
-
-		add_post_type_support( 'gatherpress_event', 'gatherpress-event-date' );
 
 		$expected_table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
 		$initial_join   = ' INNER JOIN other_table AS otta ON p.ID = otta.post_id';

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -1792,7 +1792,8 @@ class Test_Query extends Base {
 
 		$initial_join = ' INNER JOIN wp_term_relationships ON (wp_posts.ID = wp_term_relationships.object_id)';
 
-		$result = $this->instance->get_adjacent_post_join(
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_join(
 			$initial_join,
 			false,
 			array(),
@@ -1828,7 +1829,8 @@ class Test_Query extends Base {
 		$initial_join   = '';
 		$expected_join  = " INNER JOIN {$expected_table} AS gpe ON p.ID = gpe.post_id";
 
-		$result = $this->instance->get_adjacent_post_join(
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_join(
 			$initial_join,
 			false,
 			'',
@@ -1862,7 +1864,8 @@ class Test_Query extends Base {
 		$initial_join   = ' INNER JOIN other_table AS otta ON p.ID = otta.post_id';
 		$expected_join  = $initial_join . " INNER JOIN {$expected_table} AS gpe ON p.ID = gpe.post_id";
 
-		$result = $this->instance->get_adjacent_post_join(
+		$instance = Query::get_instance();
+		$result   = $instance->get_adjacent_post_join(
 			$initial_join,
 			true,
 			array( 1, 2, 3 ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes non-working `core/post-navigation-link` blocks for previous and next event links.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
  * Improved navigation between adjacent events by using event start dates and times.
  * Adjacent event links now correctly identify the previous and next events.
  * Standard post navigation behavior remains unchanged for non-event content.
 
<img width="1898" height="934" alt="image" src="https://github.com/user-attachments/assets/999a7a1d-0e32-4d72-86ed-c3e2c4426b53" />


### Other information:

- [x] Have you written new tests for your changes, if applicable? 
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create at least three events
   * First: upcoming 2026
   * Second: past 2025
   * Third: upcoming 2027  
* Themes > Editor > (Create new or Edit) single-gatherpress_event
* Add a "Post Navigation Link" block to the template
* View one of the events in the frontend
* Confirm the blocks are linking to the correct next or previous event, following the event-dates, not the published date

### Credit (for release notes)

<!-- First time contributing? Add your WordPress.org profile so we can credit you in the -->
<!-- release and on the in-plugin Credits screen. -->
<!-- Your profile URL looks like: https://profiles.wordpress.org/USERNAME/ -->
<!-- Enter just the USERNAME (the last part of that URL) below. -->
<!-- Please open the link first to confirm it loads — credits are generated from this exact -->
<!-- username, so a typo or a non-existent profile gets skipped. -->
<!-- Don't have a WordPress.org account? Create a free one at https://login.wordpress.org/register -->

My WordPress.org username:
carstenbach

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->

<!-- Due to org permissions, the job may fail for PRs created from a fork under GitHub organizations. -->
<!-- In this case, you can create the entry manually with `composer changelog:add` and push it into the branch. -->

<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

</details>
