### PR TITLE
Guard array-to-string casts that can warn or throw in production

### DIFF
--- a/.github/changelog/fix-array-to-string-post-type-query-var
+++ b/.github/changelog/fix-array-to-string-post-type-query-var
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a PHP `Array to string conversion` warning on the event archive redirect handler. The `post_type` query var can come back as an array on multi-post-type archive queries, and casting it directly to a string triggered the warning; the handler now bails when the queried post type isn't a single string.

--- a/.github/changelog/fix-array-to-string-post-type-query-var
+++ b/.github/changelog/fix-array-to-string-post-type-query-var
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fixed a PHP `Array to string conversion` warning on the event archive redirect handler. The `post_type` query var can come back as an array on multi-post-type archive queries, and casting it directly to a string triggered the warning; the handler now bails when the queried post type isn't a single string.
+Fixed several PHP `Array to string conversion` warnings (and one latent TypeError) triggered when a value that WordPress or a malformed request can legitimately deliver as an array reached an unguarded `(string)` cast: the event archive redirect handler's `post_type` query var, the venue map REST endpoint's `aspect_ratio`/`map_type` params, the settings page sanitizer's scalar fields, and the venue map prewarm job's `aspectRatio` block attribute. Each now guards with `is_string()`/`is_scalar()` before casting, consistent with the existing pattern already used elsewhere in the codebase (`Admin_List::handle_column_sorting()`, `Geocoding`'s Photon property extraction).

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -662,10 +662,16 @@ class Settings {
 					// Width/Height "Auto") can round-trip blank without
 					// silently saving 0.
 					'number'       => ( '' === $value || null === $value ) ? '' : intval( $value ),
-					'autocomplete' => $this->sanitize_autocomplete( $value ),
+					// sanitize_autocomplete() takes a strictly-typed string
+					// argument — a malformed submission delivering an array
+					// here would otherwise throw a TypeError.
+					'autocomplete' => $this->sanitize_autocomplete( is_string( $value ) ? $value : '' ),
 					// password, text, select and any unrecognized type are
-					// sanitized as plain text.
-					default        => sanitize_text_field( (string) $value ),
+					// sanitized as plain text. A malformed submission (e.g.
+					// a field name suffixed with `[]`) can deliver an array
+					// here — is_scalar() guards the (string) cast so that
+					// doesn't emit an "Array to string conversion" warning.
+					default        => sanitize_text_field( is_scalar( $value ) ? (string) $value : '' ),
 				};
 			}
 

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -370,11 +370,20 @@ final class Setup {
 			return;
 		}
 
-		// Bail when not on a post type archive at all, or when the
-		// queried post type doesn't declare event-date support.
-		$post_type = (string) get_query_var( 'post_type' );
+		// `post_type` comes back as an array on multi-post-type archives
+		// (e.g. a combined archive query across several event-supporting
+		// post types); the is_string() guard below keeps that array out of
+		// post_type_supports(), which otherwise emits a PHP "Array to
+		// string conversion" warning when it casts its argument to string.
+		$post_type = get_query_var( 'post_type' );
 
-		if ( ! is_post_type_archive() || ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+		// Bail when not on a post type archive at all, when the queried
+		// post type isn't a single string, or when it doesn't declare
+		// event-date support.
+		if ( ! is_post_type_archive()
+			|| ! is_string( $post_type )
+			|| ! post_type_supports( $post_type, 'gatherpress-event-date' )
+		) {
 			return;
 		}
 

--- a/includes/core/classes/venue/map/class-prewarm.php
+++ b/includes/core/classes/venue/map/class-prewarm.php
@@ -602,8 +602,8 @@ final class Prewarm {
 			'height'       => isset( $attrs['height'] )
 				? (int) $attrs['height']
 				: Map::DEFAULT_HEIGHT,
-			'aspect_ratio' => isset( $attrs['aspectRatio'] )
-				? (string) $attrs['aspectRatio']
+			'aspect_ratio' => is_string( $attrs['aspectRatio'] ?? null )
+				? $attrs['aspectRatio']
 				: Map::DEFAULT_ASPECT_RATIO,
 		);
 	}

--- a/includes/core/classes/venue/map/class-rest-api.php
+++ b/includes/core/classes/venue/map/class-rest-api.php
@@ -160,10 +160,14 @@ final class Rest_Api {
 					if ( '' === $value || null === $value ) {
 						return true;
 					}
-					return (bool) preg_match(
-						Map::ASPECT_RATIO_PATTERN,
-						(string) $value
-					);
+					// A malformed request (e.g. `aspect_ratio[]=`) delivers
+					// an array here — reject it instead of letting the
+					// (string) cast below emit an "Array to string
+					// conversion" warning.
+					if ( ! is_string( $value ) ) {
+						return false;
+					}
+					return (bool) preg_match( Map::ASPECT_RATIO_PATTERN, $value );
 				},
 			),
 			'map_type'     => array(
@@ -174,8 +178,15 @@ final class Rest_Api {
 					if ( '' === $value || null === $value ) {
 						return true;
 					}
+					// A malformed request (e.g. `map_type[]=`) delivers an
+					// array here — reject it instead of letting the
+					// (string) cast below emit an "Array to string
+					// conversion" warning.
+					if ( ! is_string( $value ) ) {
+						return false;
+					}
 					return in_array(
-						(string) $value,
+						$value,
 						array( 'roadmap', 'satellite', 'hybrid', 'terrain' ),
 						true
 					);
@@ -208,12 +219,15 @@ final class Rest_Api {
 		$raw_width  = $request['width'] ?? null;
 		$raw_height = $request['height'] ?? null;
 
+		$raw_aspect_ratio = $request['aspect_ratio'] ?? '';
+		$raw_map_type     = $request['map_type'] ?? '';
+
 		return array(
 			'zoom'         => ( null !== $raw_zoom && (int) $raw_zoom > 0 ) ? (int) $raw_zoom : null,
 			'width'        => ( null !== $raw_width && (int) $raw_width >= 0 ) ? (int) $raw_width : null,
 			'height'       => ( null !== $raw_height && (int) $raw_height >= 0 ) ? (int) $raw_height : null,
-			'aspect_ratio' => (string) ( $request['aspect_ratio'] ?? '' ),
-			'map_type'     => (string) ( $request['map_type'] ?? '' ),
+			'aspect_ratio' => is_string( $raw_aspect_ratio ) ? $raw_aspect_ratio : '',
+			'map_type'     => is_string( $raw_map_type ) ? $raw_map_type : '',
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -1285,6 +1285,54 @@ class Test_Settings extends Base {
 	}
 
 	/**
+	 * A malformed submission (e.g. a field name suffixed with `[]`) can
+	 * deliver an array value for a scalar-typed field. The default (text)
+	 * arm must not emit a PHP "Array to string conversion" warning, and the
+	 * autocomplete arm must not throw a TypeError from its string-typed
+	 * parameter.
+	 *
+	 * @since 0.35.0
+	 * @covers ::sanitize_page_settings
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_page_settings_handles_array_value_for_scalar_fields(): void {
+		$instance = Settings::get_instance();
+
+		delete_option( 'gatherpress_settings' );
+
+		$field_type_map = array(
+			'text_field'         => 'text',
+			'autocomplete_field' => 'autocomplete',
+		);
+
+		$callback = $instance->sanitize_page_settings( $field_type_map );
+
+		$result = $callback(
+			array(
+				'text_field'         => array( 'unexpected' ),
+				'autocomplete_field' => array( 'unexpected' ),
+			)
+		);
+
+		// Sanitizes to '' — which matches the (unregistered) field's default,
+		// so the strip-defaults pass below removes the key entirely. That's
+		// the same outcome a legitimate empty-string submission would get;
+		// the assertion here is that no "Array" sentinel string survives.
+		$this->assertArrayNotHasKey(
+			'text_field',
+			$result,
+			'Failed to assert an array value for a text field sanitizes away instead of storing "Array".'
+		);
+
+		$this->assertSame(
+			'[]',
+			$result['autocomplete_field'],
+			'Failed to assert an array value for an autocomplete field sanitizes to an empty list.'
+		);
+	}
+
+	/**
 	 * Empty-string submissions for number fields round-trip as '' instead
 	 * of getting coerced to 0 via intval — a field that accepts empty (e.g.
 	 * Width/Height "Auto") would otherwise silently save 0 on every post.

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -1291,7 +1291,8 @@ class Test_Settings extends Base {
 	 * autocomplete arm must not throw a TypeError from its string-typed
 	 * parameter.
 	 *
-	 * @since 0.35.0
+	 * @since 0.36.0
+	 *
 	 * @covers ::sanitize_page_settings
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -1422,6 +1422,33 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * Tests handle_event_archive_redirect returns early when post_type is an array.
+	 *
+	 * Exercises the is_string($post_type) guard, which prevents a PHP "Array to
+	 * string conversion" warning when `get_query_var( 'post_type' )` returns an
+	 * array on a multi-post-type archive query.
+	 *
+	 * @covers ::handle_event_archive_redirect
+	 * @return void
+	 */
+	public function test_handle_event_archive_redirect_array_post_type(): void {
+		global $wp_query;
+
+		$instance = Setup::get_instance();
+
+		$wp_query->is_post_type_archive = true;
+		$wp_query->set( 'post_type', array( Event::POST_TYPE, 'post' ) );
+
+		$instance->handle_event_archive_redirect();
+
+		$this->assertFalse( $wp_query->is_404(), 'Should not 404 for an array post_type.' );
+		$this->assertEmpty(
+			$wp_query->get( Query::EVENT_QUERY_PARAM ),
+			'Should return early before the archive mode fallback runs.'
+		);
+	}
+
+	/**
 	 * Tests handle_event_archive_redirect serves page when page exists with same slug.
 	 *
 	 * @covers ::handle_event_archive_redirect

--- a/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-setup.php
@@ -1428,6 +1428,8 @@ class Test_Setup extends Base {
 	 * string conversion" warning when `get_query_var( 'post_type' )` returns an
 	 * array on a multi-post-type archive query.
 	 *
+	 * @since 0.36.0
+	 *
 	 * @covers ::handle_event_archive_redirect
 	 * @return void
 	 */

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
@@ -212,6 +212,28 @@ class Test_Prewarm extends Base {
 	}
 
 	/**
+	 * A hand-edited or malformed post_content can carry a non-string
+	 * `aspectRatio` attribute (e.g. `["16/9"]`); the site default must be
+	 * used instead of casting the array and emitting a PHP "Array to
+	 * string conversion" warning.
+	 *
+	 * @covers ::extract_block_combo
+	 *
+	 * @return void
+	 */
+	public function test_extract_block_combo_falls_back_to_default_for_non_string_aspect_ratio(): void {
+		$instance = Prewarm::get_instance();
+
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'extract_block_combo',
+			array( array( 'aspectRatio' => array( '16/9' ) ) )
+		);
+
+		$this->assertSame( Map::DEFAULT_ASPECT_RATIO, $result['aspect_ratio'] );
+	}
+
+	/**
 	 * Dedupe collapses identical (zoom, width, height, aspect_ratio) tuples.
 	 *
 	 * @covers ::dedupe_combos

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
@@ -217,6 +217,8 @@ class Test_Prewarm extends Base {
 	 * used instead of casting the array and emitting a PHP "Array to
 	 * string conversion" warning.
 	 *
+	 * @since 0.36.0
+	 *
 	 * @covers ::extract_block_combo
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-rest-api.php
@@ -143,6 +143,10 @@ class Test_Rest_Api extends Base {
 		$this->assertTrue( $aspect_validate( null ) );
 		$this->assertTrue( $aspect_validate( '16/9' ) );
 		$this->assertFalse( $aspect_validate( 'not-a-ratio' ) );
+		$this->assertFalse(
+			$aspect_validate( array( '16/9' ) ),
+			'A malformed request (e.g. aspect_ratio[]=) delivering an array must be rejected, not cast.'
+		);
 
 		$type_validate = $args['map_type']['validate_callback'];
 		$this->assertTrue( $type_validate( '' ) );
@@ -152,6 +156,10 @@ class Test_Rest_Api extends Base {
 		$this->assertTrue( $type_validate( 'hybrid' ) );
 		$this->assertTrue( $type_validate( 'terrain' ) );
 		$this->assertFalse( $type_validate( 'invalid' ) );
+		$this->assertFalse(
+			$type_validate( array( 'roadmap' ) ),
+			'A malformed request (e.g. map_type[]=) delivering an array must be rejected, not cast.'
+		);
 	}
 
 	/**
@@ -203,6 +211,25 @@ class Test_Rest_Api extends Base {
 				'map_type'     => '',
 			),
 			Rest_Api::parse_request( $zero_zoom )
+		);
+
+		// set_param() bypasses validate_callback, so directly exercise
+		// parse_request()'s own is_string() guard against a non-string
+		// value reaching the request (defense in depth for callers other
+		// than the registered REST route).
+		$array_params = new \WP_REST_Request( 'POST', '/test' );
+		$array_params->set_param( 'aspect_ratio', array( '16/9' ) );
+		$array_params->set_param( 'map_type', array( 'hybrid' ) );
+		$this->assertSame(
+			array(
+				'zoom'         => null,
+				'width'        => null,
+				'height'       => null,
+				'aspect_ratio' => '',
+				'map_type'     => '',
+			),
+			Rest_Api::parse_request( $array_params ),
+			'Array-valued aspect_ratio/map_type params must fall back to an empty string.'
 		);
 	}
 


### PR DESCRIPTION
## Summary
Reported bug: `handle_event_archive_redirect()` cast `get_query_var( 'post_type' )` straight to `(string)`, but that query var can come back as an array on multi-post-type archive queries — triggering a PHP `Array to string conversion` E_WARNING in production (from a live site's error log at `includes/core/classes/event/class-setup.php:375`).

- Replaced the blind cast with an `is_string()` guard, so the handler bails early on a multi-post-type archive instead of warning. This mirrors the existing `is_array( $post_type )` guard already used in `Admin_List::handle_column_sorting()` for the same underlying WP quirk.
- Audited the rest of the codebase for the same shape of bug — a value that can legitimately arrive as an array reaching an unguarded `(string)` cast — and fixed four more:
  - **`Venue\Map\Rest_Api::route_args()`**: the `aspect_ratio`/`map_type` REST `validate_callback`s cast the raw request value before checking its type, so a malformed `?aspect_ratio[]=x` request warned before being correctly rejected. `parse_request()` got the same guard for defense in depth.
  - **`Settings::sanitize_page_settings()`**: an array-valued POST field for a text/select/password field warned in the default sanitize arm; an array-valued `autocomplete` field would have thrown a `TypeError` against `sanitize_autocomplete()`'s string-typed parameter (a fatal error, not just a warning).
  - **`Venue\Map\Prewarm::extract_block_combo()`**: a hand-edited or malformed `post_content` block attribute for `aspectRatio` warned when cast during the prewarm scan.
  - All other `(string)` casts in the codebase were checked and operate on values that cannot be arrays (`get_post_type()`, `WP_Screen::$post_type`, WP object properties, REST params registered with `type => 'string'` and no overriding `validate_callback`, etc.).
- Each fix guards with `is_string()`/`is_scalar()` before casting, matching the pattern already established elsewhere in the codebase (`Admin_List::handle_column_sorting()`, `Geocoding`'s Photon property extraction).

## Test plan
- [x] Added regression tests for every new guard branch (event archive redirect, REST validate callbacks + `parse_request()`, settings sanitizer text/autocomplete arms, prewarm block attribute).
- [x] `npm run test:unit:php` (filtered to the touched test classes) — 472 tests, 1175 assertions, all passing.
- [x] `npm run lint:php` — no errors/warnings on the changed files.
- [x] `npm run lint:phpstan` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
