### PR TITLE
Fix/#2140 reduced motion

### DIFF
--- a/.github/changelog/2140-prefers-reduced-motion
+++ b/.github/changelog/2140-prefers-reduced-motion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+GatherPress now honors the operating system's reduced-motion preference: the modal no longer scales open and the loading indicator no longer pulses, while both keep the state they were communicating through a cross-fade and a static dim.

--- a/.github/changelog/2140-prefers-reduced-motion
+++ b/.github/changelog/2140-prefers-reduced-motion
@@ -1,4 +1,4 @@
 Significance: patch
-Type: added
+Type: changed
 
 GatherPress now honors the operating system's reduced-motion preference: the modal no longer scales open and the loading indicator no longer pulses, while both keep the state they were communicating through a cross-fade and a static dim.

--- a/src/blocks/modal/style.scss
+++ b/src/blocks/modal/style.scss
@@ -61,3 +61,17 @@
 		transform: translate(-50%, -50%) scale(1);
 	}
 }
+
+// Respect a reduced-motion preference: drop the scale, keep the fade.
+// The appear animation scales the dialog from 97%, the kind of movement
+// that can trigger symptoms for people with vestibular disorders — the
+// reason they set the OS preference in the first place. Removing the
+// animation leaves the content at its final position (the base transform
+// still centers it), so the dialog simply appears. The opacity
+// transitions above stay: a cross-fade carries no movement, and keeping
+// it avoids replacing gentle motion with an abrupt snap.
+@media (prefers-reduced-motion: reduce) {
+	.wp-block-gatherpress-modal.gatherpress--is-visible > div {
+		animation: none;
+	}
+}

--- a/src/utility.scss
+++ b/src/utility.scss
@@ -35,6 +35,21 @@
 	}
 }
 
+// Respect a reduced-motion preference without losing the loading state.
+// The pulse repeats indefinitely while a request is in flight, and
+// continuous looping animation is a common trigger for people who set the
+// preference. Stopping it outright would leave the control looking
+// completely idle, so a static dim stands in: the element still reads as
+// busy, it just no longer pulses. 0.7 is deliberately milder than the 0.4
+// trough the animation already passes through, so the dimmed state costs
+// no more contrast than the original.
+@media (prefers-reduced-motion: reduce) {
+	.gatherpress--is-loading {
+		animation: none;
+		opacity: 0.7;
+	}
+}
+
 // Event Query variation overrides.
 .gatherpress-event-query {
 	.wp-block-media-text {


### PR DESCRIPTION
Fixes #2140 

## Proposed changes:
* **Modal** (`src/blocks/modal/style.scss`): under `prefers-reduced-motion: reduce`, `gatherpress-modal-content-appear` is disabled so the dialog no longer scales up from 97% on open. The opacity transitions are deliberately kept — a cross-fade isn't movement, and dropping it would replace gentle motion with an abrupt snap. The inner element's base `transform: translate(-50%, -50%)` still centers it, so removing the animation simply lands the content in its final position.
* **Loading pulse** (`src/utility.scss`): under the same query, `.gatherpress--is-loading` stops animating and takes a static `opacity: 0.7` instead. Stopping the pulse outright would leave a control looking completely idle while its request is in flight, so the static dim preserves the "busy" affordance; 0.7 is milder than the 0.4 trough the pulse already passes through, so it costs no additional contrast.
* **Scope**: these are the plugin's only two motion-bearing animations. The remaining transitions — the editor PatternPicker's 120ms `border-color` and tooltips' 200ms opacity/visibility — are colour and opacity only and are left alone on purpose.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

No new tests — the change is two CSS media queries and there's no stylesheet test harness. Verified instead by reading computed styles under emulation (table below), which is reproducible from the testing steps.

## Testing instructions:
1. `npm install && npm run build`, activate the plugin, and open an event page with an RSVP block (the modal) — e.g. any upcoming event.
2. In Chrome DevTools, open **Rendering** → **Emulate CSS media feature prefers-reduced-motion** and set it to `reduce`.
3. Open the RSVP modal: the dialog fades in without the scale-up. Set the emulation back to *no preference* and reopen: the scale animation returns. On `develop`, the scale plays in both states.
4. Loading state: with `reduce` active, add the class in the console — `document.querySelector('.gatherpress-rsvp--trigger-update').classList.add('gatherpress--is-loading')` — the control dims to 0.7 and holds steady instead of pulsing. Without the preference it pulses as before.
5. Computed-style check for either state:
   `getComputedStyle(document.querySelector('.wp-block-gatherpress-modal').firstElementChild).animationName`

Verified values:

| | no preference | `reduce` |
|---|---|---|
| modal content | `gatherpress-modal-content-appear`, 0.25s, `transitionProperty: opacity` | `animation: none`, `transitionProperty: opacity` |
| `.gatherpress--is-loading` | `gatherpress-pulse`, opacity 1 | `animation: none`, opacity 0.7 |

### Credit (for release notes)

My WordPress.org username: matthewneilcowan

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [x] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Honor the prefers-reduced-motion setting: the modal no longer scales open and the loading pulse holds a static dim instead of looping.

</details>