### PR TITLE
Promote from the waiting list by walking the queue

### DIFF
--- a/.github/changelog/waiting-list-promotion-bounds
+++ b/.github/changelog/waiting-list-promotion-bounds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed waiting-list promotion counting off free spots instead of walking the queue. An event with an attendance limit raised a fatal `TypeError` the moment its waiting list was shorter than the number of open spots, which is any event where someone is waiting and a seat frees up. The same loop also stopped before a longer queue had filled the room, leaving seats empty with people still waiting.

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -353,8 +353,15 @@ final class Rsvp {
 		// #1771 does not apply to this design.
 		$promoted_count = 0;
 
-		for ( $i = 0; $i < $remaining_spots; $i++ ) {
-			$state = $waiting_list[ $i ];
+		// Walk the queue itself rather than counting off free spots: the two are
+		// different quantities, and indexing the list by the spot count either
+		// ran off the end of a short queue or stopped before a long one had
+		// filled the room.
+		foreach ( $waiting_list as $state ) {
+			if ( $remaining_spots <= 0 ) {
+				break;
+			}
+
 			$state = $this->storage->save( Intent::attend( $state ), (int) $state->comment->comment_ID );
 
 			if ( $state instanceof State ) {

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
@@ -263,6 +263,90 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
+	 * Test check waiting list when the free spots outnumber the waiting list.
+	 *
+	 * The promotion loop walked one index per free spot, so a waiting list
+	 * shorter than the number of open spots ran off the end of the array.
+	 *
+	 * @since  0.36.0
+	 * @covers ::check_waiting_list
+	 *
+	 * @return void
+	 */
+	public function test_check_waiting_list_with_more_spots_than_waiting(): void {
+		$event_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+		$rsvp     = new Rsvp( $event_id );
+		$user_id  = $this->factory->user->create();
+
+		Utility::set_and_get_hidden_property( $rsvp, 'max_attendance_limit', 10 );
+
+		// Saving runs the promotion sweep itself, which is where the overrun
+		// used to raise a TypeError rather than returning.
+		$rsvp->save( $user_id, 'waiting_list' );
+
+		$this->assertSame(
+			'attending',
+			$rsvp->get( $user_id )['status'],
+			'The waiting member should have moved to attending'
+		);
+
+		$this->assertEquals(
+			0,
+			$rsvp->check_waiting_list(),
+			'Should report nothing left to promote once the queue is empty'
+		);
+	}
+
+	/**
+	 * Test check waiting list fills every free spot.
+	 *
+	 * The loop compared its index against the shrinking spot count, so it
+	 * stopped early and left seats empty with people still waiting.
+	 *
+	 * @since  0.36.0
+	 * @covers ::check_waiting_list
+	 *
+	 * @return void
+	 */
+	public function test_check_waiting_list_fills_every_free_spot(): void {
+		$event_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+		$rsvp     = new Rsvp( $event_id );
+		$user_ids = array();
+
+		Utility::set_and_get_hidden_property( $rsvp, 'max_attendance_limit', 1 );
+
+		// Five people queue up behind a single seat.
+		for ( $i = 0; $i < 5; $i++ ) {
+			$user_ids[] = $this->factory->user->create();
+		}
+
+		foreach ( $user_ids as $user_id ) {
+			$rsvp->save( $user_id, 'waiting_list' );
+		}
+
+		// Widen the event to three seats, one of which the first promotion took.
+		Utility::set_and_get_hidden_property( $rsvp, 'max_attendance_limit', 3 );
+
+		$this->assertEquals(
+			2,
+			$rsvp->check_waiting_list(),
+			'Should fill both remaining spots rather than stopping early'
+		);
+
+		$this->assertSame(
+			'attending',
+			$rsvp->get( $user_ids[2] )['status'],
+			'The third in line should have taken the last free spot'
+		);
+
+		$this->assertSame(
+			'waiting_list',
+			$rsvp->get( $user_ids[3] )['status'],
+			'The fourth in line should still be waiting'
+		);
+	}
+
+	/**
 	 * Test check waiting list with limited attendance.
 	 *
 	 * @since  0.34.0


### PR DESCRIPTION
Fixes #2172.

### The bug

`check_waiting_list()` walked the queue with an index bounded by the number of free spots, and decremented that bound inside the loop. `$i` counts queue positions, `$remaining_spots` counts seats, and mixing them breaks in both directions.

**Short queue, fatal.** Fewer people waiting than free spots runs `$waiting_list[ $i ]` past the end of the array and hands `null` to `Intent::attend()`, which is typed `State`. An event with an attendance limit hits this as soon as one person is waiting and a seat is free, and since `Rsvp::save()` calls `check_waiting_list()`, it fatals on the next RSVP.

**Long queue, silent under-promotion.** Three free spots and five waiting promotes only two: the bound shrinks as the index grows and they meet in the middle. A seat stays empty with people still queued.

### The fix

Walk the queue and stop when the room is full, which is what the code above it already does for the unlimited case:

```php
foreach ( $waiting_list as $state ) {
	if ( $remaining_spots <= 0 ) {
		break;
	}

	$state = $this->storage->save( Intent::attend( $state ), (int) $state->comment->comment_ID );

	if ( $state instanceof State ) {
		++$promoted_count;
		$remaining_spots -= $state->get_attendee_count();
	}
}
```

`Collection::waiting_list()` already returns a sorted, `array_values`-reindexed list, so ordering is unchanged: oldest first, same as before.

Deliberately unchanged: an entry whose party is larger than the remaining spots is still promoted rather than skipped in favour of a smaller one behind it. That overshoot is existing behaviour and changing it is a fairness decision, not a bug fix. Happy to follow up if you want it.

### Testing

Two regression tests, one per direction, in `Test_Rsvp`:

- `test_check_waiting_list_with_more_spots_than_waiting`, ten seats and one person waiting. Errors with a `TypeError` before the fix.
- `test_check_waiting_list_fills_every_free_spot`, five queued and the limit widened to three. Returns 1 instead of 2 before the fix.

Both verified to fail against unpatched `develop` and pass after, so neither is vacuous:

```
# fix reverted
Tests: 2, Assertions: 1, Errors: 1, Failures: 1.

# fix applied
OK (2 tests, 5 assertions)
```

Whole suite green, single site and multisite:

```
OK (1719 tests, 7088 assertions)
OK (323 tests, 856 assertions)
```

`includes/core/classes/rsvp/class-rsvp.php` stays at 100% coverage, 201/201 statements. PHPCS and PHPStan clean.
