### PR TITLE
Raise PHPStan to level 6

### DIFF
--- a/.github/changelog/phpstan-level-6
+++ b/.github/changelog/phpstan-level-6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Raise PHPStan to level 6 and document the shape of every array the plugin passes around.

--- a/includes/core/classes/blocks/class-add-to-calendar.php
+++ b/includes/core/classes/blocks/class-add-to-calendar.php
@@ -77,8 +77,8 @@ final class Add_To_Calendar {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The original block content.
-	 * @param array  $block         The block instance array, used to determine the event.
+	 * @param string               $block_content The original block content.
+	 * @param array<string, mixed> $block         The block instance array, used to determine the event.
 	 *
 	 * @return string The modified block content with calendar hrefs replaced.
 	 */

--- a/includes/core/classes/blocks/class-dropdown.php
+++ b/includes/core/classes/blocks/class-dropdown.php
@@ -100,8 +100,8 @@ final class Dropdown {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The original block content.
-	 * @param array  $block         The parsed block data containing block attributes.
+	 * @param string               $block_content The original block content.
+	 * @param array<string, mixed> $block         The parsed block data containing block attributes.
 	 *
 	 * @return string The modified block content with inline styles.
 	 */
@@ -183,8 +183,8 @@ final class Dropdown {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The original block content.
-	 * @param array  $block         The parsed block data.
+	 * @param string               $block_content The original block content.
+	 * @param array<string, mixed> $block         The parsed block data.
 	 *
 	 * @return string The modified block content with select mode attributes.
 	 */
@@ -251,8 +251,8 @@ final class Dropdown {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The HTML content of the block.
-	 * @param array  $block         The parsed block data.
+	 * @param string               $block_content The HTML content of the block.
+	 * @param array<string, mixed> $block         The parsed block data.
 	 *
 	 * @return string The modified block content with updated attributes.
 	 */

--- a/includes/core/classes/blocks/class-event-date.php
+++ b/includes/core/classes/blocks/class-event-date.php
@@ -75,8 +75,8 @@ final class Event_Date {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The original block content.
-	 * @param array  $block         The block instance array, used to determine the event.
+	 * @param string               $block_content The original block content.
+	 * @param array<string, mixed> $block         The block instance array, used to determine the event.
 	 *
 	 * @return string The block content if valid event, empty string otherwise.
 	 */

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -156,8 +156,8 @@ final class Event_Query {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string|null $pre_render   The pre-rendered content. Default null.
-	 * @param array       $parsed_block The block being rendered.
+	 * @param string|null          $pre_render   The pre-rendered content. Default null.
+	 * @param array<string, mixed> $parsed_block The block being rendered.
 	 *
 	 * @return string|null The pre-rendered content. Default null.
 	 */
@@ -230,7 +230,7 @@ final class Event_Query {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $attributes Event Query block attributes.
+	 * @param array<string, mixed> $attributes Event Query block attributes.
 	 *
 	 * @return int[] Array of post IDs to exclude.
 	 */
@@ -263,10 +263,12 @@ final class Event_Query {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array    $query Array containing parameters for <code>WP_Query</code> as parsed by the block context.
-	 * @param WP_Block $block Block instance.
+	 * @param array<string, mixed> $query Array containing parameters for <code>WP_Query</code> as parsed by the
+	 *                                    block context.
+	 * @param WP_Block             $block Block instance.
 	 *
-	 * @return array Array containing parameters for <code>WP_Query</code> as parsed by the block context.
+	 * @return array<string, mixed> Array containing parameters for <code>WP_Query</code> as parsed by the block
+	 *                              context.
 	 */
 	public function query_loop_block_query_vars( array $query, WP_Block $block ): array {
 		// Retrieve the query from the passed block context.
@@ -361,10 +363,11 @@ final class Event_Query {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array           $args    Array of arguments for WP_Query.
-	 * @param WP_REST_Request $request The REST API request object.
+	 * @param array<string, mixed> $args    Array of arguments for WP_Query.
+	 * @param WP_REST_Request      $request The REST API request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
-	 * @return array Array of arguments for WP_Query.
+	 * @return array<string, mixed> Array of arguments for WP_Query.
 	 */
 	public function rest_query( array $args, WP_REST_Request $request ): array {
 		// When a request explicitly asks for specific events by ID (`include`),
@@ -450,9 +453,9 @@ final class Event_Query {
 	 *
 	 * @see https://developer.wordpress.org/reference/classes/wp_rest_posts_controller/get_collection_params/
 	 *
-	 * @param array $query_params JSON Schema-formatted collection parameters.
+	 * @param array<string, array<string, mixed>> $query_params JSON Schema-formatted collection parameters.
 	 *
-	 * @return array JSON Schema-formatted collection parameters.
+	 * @return array<string, array<string, mixed>> JSON Schema-formatted collection parameters.
 	 */
 	public function rest_collection_params( array $query_params ): array {
 		// Add GatherPress-specific orderby options.
@@ -526,10 +529,10 @@ final class Event_Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $query_args  The query arguments being built.
-	 * @param array $block_query The block's query attributes.
+	 * @param array<string, mixed> $query_args  The query arguments being built.
+	 * @param array<string, mixed> $block_query The block's query attributes.
 	 *
-	 * @return array Modified query arguments.
+	 * @return array<string, mixed> Modified query arguments.
 	 */
 	public function aql_query_vars( array $query_args, array $block_query ): array {
 		// Only process if querying GatherPress events.

--- a/includes/core/classes/blocks/class-form-field.php
+++ b/includes/core/classes/blocks/class-form-field.php
@@ -30,7 +30,7 @@ final class Form_Field {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @var array
+	 * @var array<string, mixed>
 	 */
 	private array $attributes;
 
@@ -73,7 +73,7 @@ final class Form_Field {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $attributes The block attributes array.
+	 * @param array<string, mixed> $attributes The block attributes array.
 	 */
 	public function __construct( array $attributes ) {
 		$this->attributes = $this->process_attributes( $attributes );
@@ -91,9 +91,9 @@ final class Form_Field {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $raw_attributes Raw attributes from the block editor.
+	 * @param array<string, mixed> $raw_attributes Raw attributes from the block editor.
 	 *
-	 * @return array Processed attributes with defaults and proper formatting.
+	 * @return array<string, mixed> Processed attributes with defaults and proper formatting.
 	 */
 	private function process_attributes( array $raw_attributes ): array {
 		return array(
@@ -190,9 +190,9 @@ final class Form_Field {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array  $styles   Reference to the styles array to modify.
-	 * @param string $attr_key The attribute key to check in the attributes array.
-	 * @param string $format   The sprintf format string for the CSS property (e.g., 'color:%s').
+	 * @param string[] $styles   Reference to the styles array to modify.
+	 * @param string   $attr_key The attribute key to check in the attributes array.
+	 * @param string   $format   The sprintf format string for the CSS property (e.g., 'color:%s').
 	 *
 	 * @return void
 	 */
@@ -210,7 +210,7 @@ final class Form_Field {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $styles Array of CSS style declarations (e.g., ['color:red', 'font-size:16px']).
+	 * @param string[] $styles Array of CSS style declarations (e.g., ['color:red', 'font-size:16px']).
 	 *
 	 * @return string Formatted style attribute string or empty string if no styles.
 	 */
@@ -364,7 +364,7 @@ final class Form_Field {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @return array Array of CSS class names for the wrapper element.
+	 * @return string[] Array of CSS class names for the wrapper element.
 	 */
 	public function get_wrapper_classes(): array {
 		$field_type = $this->get_field_type();

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -74,8 +74,8 @@ final class General_Block {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The HTML content of the block.
-	 * @param array  $block         The parsed block data.
+	 * @param string               $block_content The HTML content of the block.
+	 * @param array<string, mixed> $block         The parsed block data.
 	 *
 	 * @return string The modified block content or an empty string if the block should be removed.
 	 */
@@ -108,8 +108,8 @@ final class General_Block {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The HTML content of the block.
-	 * @param array  $block         The parsed block data.
+	 * @param string               $block_content The HTML content of the block.
+	 * @param array<string, mixed> $block         The parsed block data.
 	 *
 	 * @return string The modified block content or an empty string if the block should be removed.
 	 */
@@ -144,8 +144,8 @@ final class General_Block {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param string $block_content The HTML content of the block.
-	 * @param array  $block         The parsed block data.
+	 * @param string               $block_content The HTML content of the block.
+	 * @param array<string, mixed> $block         The parsed block data.
 	 *
 	 * @return string The modified block content or an empty string if the block should be removed.
 	 */
@@ -184,8 +184,8 @@ final class General_Block {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The HTML content of the block.
-	 * @param array  $block         The parsed block data.
+	 * @param string               $block_content The HTML content of the block.
+	 * @param array<string, mixed> $block         The parsed block data.
 	 *
 	 * @return string The modified block content with submit button functionality.
 	 */
@@ -231,8 +231,8 @@ final class General_Block {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The block content.
-	 * @param array  $block         The block data.
+	 * @param string               $block_content The block content.
+	 * @param array<string, mixed> $block         The block data.
 	 *
 	 * @return string The processed block content.
 	 */
@@ -282,8 +282,8 @@ final class General_Block {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The block content.
-	 * @param array  $block         The block data.
+	 * @param string               $block_content The block content.
+	 * @param array<string, mixed> $block         The block data.
 	 *
 	 * @return string The processed block content.
 	 */

--- a/includes/core/classes/blocks/class-modal.php
+++ b/includes/core/classes/blocks/class-modal.php
@@ -78,8 +78,8 @@ final class Modal {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The HTML content of the block.
-	 * @param array  $block         The parsed block data.
+	 * @param string               $block_content The HTML content of the block.
+	 * @param array<string, mixed> $block         The parsed block data.
 	 *
 	 * @return string The modified block content with updated attributes.
 	 */
@@ -112,8 +112,8 @@ final class Modal {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The HTML content of the block.
-	 * @param array  $block         The parsed block data.
+	 * @param string               $block_content The HTML content of the block.
+	 * @param array<string, mixed> $block         The parsed block data.
 	 *
 	 * @return string The updated block content with the applied `z-index` styling.
 	 */
@@ -144,8 +144,8 @@ final class Modal {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The HTML content of the block.
-	 * @param array  $block         The parsed block data.
+	 * @param string               $block_content The HTML content of the block.
+	 * @param array<string, mixed> $block         The parsed block data.
 	 *
 	 * @return string The modified block content. Returns an empty string if the block should be removed.
 	 */
@@ -169,8 +169,8 @@ final class Modal {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The HTML content of the block.
-	 * @param array  $block         The parsed block data.
+	 * @param string               $block_content The HTML content of the block.
+	 * @param array<string, mixed> $block         The parsed block data.
 	 *
 	 * @return string The modified block content. Returns an empty string if the block should be removed.
 	 */

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -72,9 +72,9 @@ final class Online_Event {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param string|null $block_content The block content.
-	 * @param array|null  $block         The full block, including name and attributes.
-	 * @param WP_Block    $instance      The block instance.
+	 * @param string|null               $block_content The block content.
+	 * @param array<string, mixed>|null $block         The full block, including name and attributes.
+	 * @param WP_Block                  $instance      The block instance.
 	 *
 	 * @return string
 	 */

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -29,6 +29,18 @@ use WP_HTML_Tag_Processor;
  * including dynamic rendering and form processing.
  *
  * @since 0.33.0
+ *
+ * @phpstan-type FieldConfig array{
+ *     name: string,
+ *     type: string,
+ *     required: bool,
+ *     label: string,
+ *     placeholder: string,
+ *     validation?: string,
+ *     options?: string[],
+ *     max_length?: int
+ * }
+ * @phpstan-type FormSchema array{fields: array<string, FieldConfig>, hash: string}
  */
 final class Rsvp_Form {
 
@@ -51,7 +63,7 @@ final class Rsvp_Form {
 	 * These fields are handled by WordPress core or other parts of the RSVP system.
 	 *
 	 * @since 0.33.0
-	 * @var array
+	 * @var string[]
 	 */
 	const BUILT_IN_FIELDS = array(
 		'author',
@@ -105,8 +117,8 @@ final class Rsvp_Form {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The original block content.
-	 * @param array  $block         The block instance array, used to determine the event.
+	 * @param string               $block_content The original block content.
+	 * @param array<string, mixed> $block         The block instance array, used to determine the event.
 	 *
 	 * @return string The modified block content as a functional RSVP form.
 	 */
@@ -184,8 +196,8 @@ final class Rsvp_Form {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The rendered block content.
-	 * @param array  $block         The block instance array.
+	 * @param string               $block_content The rendered block content.
+	 * @param array<string, mixed> $block         The block instance array.
 	 *
 	 * @return string The modified block content or empty string if block should be hidden.
 	 */
@@ -255,7 +267,7 @@ final class Rsvp_Form {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $block The block instance array.
+	 * @param array<string, mixed> $block The block instance array.
 	 *
 	 * @return int|null The post ID or null if not found.
 	 */
@@ -442,9 +454,9 @@ final class Rsvp_Form {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $blocks Array of parsed blocks.
+	 * @param array<int, array<string, mixed>> $blocks Array of parsed blocks.
 	 *
-	 * @return array Array of form schemas keyed by form ID.
+	 * @return array<string, FormSchema> Array of form schemas keyed by form ID.
 	 */
 	private function extract_form_schemas_from_blocks( array $blocks ): array {
 		$schemas = array();
@@ -484,9 +496,9 @@ final class Rsvp_Form {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $inner_blocks Array of inner blocks.
+	 * @param array<int, array<string, mixed>> $inner_blocks Array of inner blocks.
 	 *
-	 * @return array Array of form field configurations.
+	 * @return array<string, FieldConfig> Array of form field configurations keyed by field name.
 	 */
 	private function extract_form_fields_from_inner_blocks( array $inner_blocks ): array {
 		$fields = array();
@@ -543,8 +555,8 @@ final class Rsvp_Form {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param int   $post_id The post ID.
-	 * @param array $block   The current block being rendered.
+	 * @param int                  $post_id The post ID.
+	 * @param array<string, mixed> $block   The current block being rendered.
 	 *
 	 * @return string The form schema ID (e.g., 'form_0', 'form_2').
 	 */
@@ -568,9 +580,9 @@ final class Rsvp_Form {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $blocks       Array of parsed blocks.
-	 * @param array $target_block The block we're looking for.
-	 * @param int   $base_index   Base index for nested blocks.
+	 * @param array<int, array<string, mixed>> $blocks       Array of parsed blocks.
+	 * @param array<string, mixed>             $target_block The block we're looking for.
+	 * @param int                              $base_index   Base index for nested blocks.
 	 *
 	 * @return int The index of the form block.
 	 */
@@ -608,8 +620,8 @@ final class Rsvp_Form {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $block1 First block to compare.
-	 * @param array $block2 Second block to compare.
+	 * @param array<string, mixed> $block1 First block to compare.
+	 * @param array<string, mixed> $block2 Second block to compare.
 	 *
 	 * @return bool True if blocks match.
 	 */
@@ -698,8 +710,9 @@ final class Rsvp_Form {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param mixed $value  The field value to sanitize.
-	 * @param array $config The field configuration from the schema.
+	 * @param mixed                $value  The field value to sanitize.
+	 * @param array<string, mixed> $config The field configuration from the schema.
+	 * @phpstan-param FieldConfig $config
 	 *
 	 * @return mixed|false The sanitized value, or false if sanitization fails.
 	 */
@@ -760,8 +773,8 @@ final class Rsvp_Form {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The block content.
-	 * @param array  $block         The block data.
+	 * @param string               $block_content The block content.
+	 * @param array<string, mixed> $block         The block data.
 	 *
 	 * @return string The processed block content.
 	 */

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -84,8 +84,9 @@ final class Rsvp_Response {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The original HTML content of the block.
-	 * @param array  $block         An associative array containing block data, including `blockName` and attributes.
+	 * @param string               $block_content The original HTML content of the block.
+	 * @param array<string, mixed> $block         An associative array containing block data, including
+	 *                                            `blockName` and attributes.
 	 *
 	 * @return string The modified block content with updated attributes.
 	 */
@@ -273,10 +274,10 @@ final class Rsvp_Response {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $args    Array of arguments for the avatar data.
-	 * @param mixed $comment The comment object or other data passed to the filter.
+	 * @param array<string, mixed> $args    Array of arguments for the avatar data.
+	 * @param mixed                $comment The comment object or other data passed to the filter.
 	 *
-	 * @return array Modified array of avatar arguments, including the correct URL for the avatar.
+	 * @return array<string, mixed> Modified array of avatar arguments, including the correct URL for the avatar.
 	 */
 	public function modify_avatar_for_gatherpress_rsvp( array $args, $comment ): array {
 		// Bail when the filter fires for a non-RSVP comment so the body
@@ -334,9 +335,9 @@ final class Rsvp_Response {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $metadata The block metadata for `core/comment-author-name`.
+	 * @param array<string, mixed> $metadata The block metadata for `core/comment-author-name`.
 	 *
-	 * @return array The modified block metadata with the updated ancestor property.
+	 * @return array<string, mixed> The modified block metadata with the updated ancestor property.
 	 */
 	public function add_rsvp_to_comment_ancestor( array $metadata ): array {
 		if ( isset( $metadata['name'] ) && 'core/comment-author-name' === $metadata['name'] ) {

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -114,9 +114,9 @@ final class Rsvp_Template {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string   $block_content The original block content.
-	 * @param array    $block         The parsed block data.
-	 * @param WP_Block $instance      The block instance.
+	 * @param string               $block_content The original block content.
+	 * @param array<string, mixed> $block         The parsed block data.
+	 * @param WP_Block             $instance      The block instance.
 	 *
 	 * @return string The dynamically generated block content.
 	 */
@@ -180,9 +180,12 @@ final class Rsvp_Template {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param array $parsed_block The parsed block data, typically from a block's JSON structure.
-	 * @param int   $response_id  The ID of the response used to populate the block's context.
-	 * @param array $args         Optional. Additional arguments for rendering. Default empty array.
+	 * @param array<string, mixed>                                  $parsed_block The parsed block data, typically from
+	 *                                                                            a block's JSON structure.
+	 * @param int                                                   $response_id  The ID of the response used to
+	 *                                                                            populate the block's context.
+	 * @param array{limit_enabled?: bool, limit?: int, index?: int} $args         Optional. Additional arguments for
+	 *                                                                            rendering. Default empty array.
 	 *
 	 * @return string The rendered block content wrapped in a `div` with a `data-id` attribute.
 	 */

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -93,8 +93,9 @@ final class Rsvp {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The original HTML content of the block.
-	 * @param array  $block         An associative array containing block data, including `blockName` and `attrs`.
+	 * @param string               $block_content The original HTML content of the block.
+	 * @param array<string, mixed> $block         An associative array containing block data, including `blockName`
+	 *                                            and `attrs`.
 	 *
 	 * @return string The updated block content with dynamically rendered inner blocks and attributes.
 	 */
@@ -342,8 +343,8 @@ final class Rsvp {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The form field block content.
-	 * @param array  $block         The block data including attributes.
+	 * @param string               $block_content The form field block content.
+	 * @param array<string, mixed> $block         The block data including attributes.
 	 *
 	 * @return string The modified block content or empty string if field should be hidden.
 	 */

--- a/includes/core/classes/blocks/class-setup.php
+++ b/includes/core/classes/blocks/class-setup.php
@@ -197,14 +197,14 @@ final class Setup {
 	 *
 	 * @see https://developer.wordpress.org/reference/hooks/hooked_block_types/
 	 *
-	 * @param string[]                $hooked_block_types The list of hooked block types.
-	 * @param string                  $relative_position  The relative position of the hooked blocks.
-	 *                                                    Can be one of 'before', 'after',
-	 *                                                    'first_child', or 'last_child'.
-	 * @param string                  $anchor_block_type  The anchor block type.
-	 * @param WP_Block_Template|array $context            The block template, template part, or pattern
-	 *                                                    that the anchor block belongs to.
-	 * @return string[]               The list of hooked block types.
+	 * @param string[]                               $hooked_block_types The list of hooked block types.
+	 * @param string                                 $relative_position  The relative position of the hooked
+	 *                                                                   blocks. Can be one of 'before', 'after',
+	 *                                                                   'first_child', or 'last_child'.
+	 * @param string                                 $anchor_block_type  The anchor block type.
+	 * @param WP_Block_Template|array<string, mixed> $context            The block template, template part, or
+	 *                                                                   pattern that the anchor block belongs to.
+	 * @return string[]                              The list of hooked block types.
 	 */
 	public function hook_blocks_into_patterns(
 		array $hooked_block_types,
@@ -248,16 +248,20 @@ final class Setup {
 	 *
 	 * @see https://developer.wordpress.org/reference/hooks/hooked_block_hooked_block_type/
 	 *
-	 * @param array|null                      $parsed_hooked_block The parsed block array for the given
-	 *                                                             hooked block type, or null to suppress the block.
-	 * @param string                          $hooked_block_type   The hooked block type name.
-	 * @param string                          $relative_position   The relative position of the hooked block.
-	 * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.
-	 * @param WP_Block_Template|WP_Post|array $context             The block template, template part,
-	 *                                                             `wp_navigation` post type, or pattern
-	 *                                                             that the anchor block belongs to.
-	 * @return array|null                     The parsed block array for the given hooked block type,
-	 *                                        or null to suppress the block.
+	 * @param array<string, mixed>|null                      $parsed_hooked_block The parsed block array for the
+	 *                                                                            given hooked block type, or null
+	 *                                                                            to suppress the block.
+	 * @param string                                         $hooked_block_type   The hooked block type name.
+	 * @param string                                         $relative_position   The relative position of the
+	 *                                                                            hooked block.
+	 * @param array<string, mixed>                           $parsed_anchor_block The anchor block, in parsed block
+	 *                                                                            array format.
+	 * @param WP_Block_Template|WP_Post|array<string, mixed> $context             The block template, template
+	 *                                                                            part, `wp_navigation` post type,
+	 *                                                                            or pattern that the anchor block
+	 *                                                                            belongs to.
+	 * @return array<string, mixed>|null                     The parsed block array for the given hooked block type,
+	 *                                                       or null to suppress the block.
 	 */
 	public function modify_hooked_blocks_in_patterns(
 		?array $parsed_hooked_block,
@@ -297,7 +301,7 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $block The block data.
+	 * @param array<string, mixed> $block The block data.
 	 *
 	 * @return int The resolved post ID.
 	 */
@@ -315,10 +319,10 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array  $args       The arguments for registering the block type.
-	 * @param string $block_type The name of the block type being registered.
+	 * @param array<string, mixed> $args       The arguments for registering the block type.
+	 * @param string               $block_type The name of the block type being registered.
 	 *
-	 * @return array Modified arguments for registering the block type.
+	 * @return array<string, mixed> Modified arguments for registering the block type.
 	 */
 	public function enable_context_for_core_query_block( array $args, string $block_type ): array {
 		// Only modify the Query block.

--- a/includes/core/classes/blocks/class-venue.php
+++ b/includes/core/classes/blocks/class-venue.php
@@ -117,7 +117,7 @@ final class Venue {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $block The full block, including name and attributes.
+	 * @param array<string, mixed> $block The full block, including name and attributes.
 	 *
 	 * @return string Shadow-source post type slug.
 	 */
@@ -139,7 +139,7 @@ final class Venue {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $block The full block, including name and attributes.
+	 * @param array<string, mixed> $block The full block, including name and attributes.
 	 *
 	 * @return WP_Post|null The source post or null if not found.
 	 */

--- a/includes/core/classes/calendar/class-cache.php
+++ b/includes/core/classes/calendar/class-cache.php
@@ -270,10 +270,10 @@ final class Cache {
 	 *
 	 * @since 0.36.0
 	 *
-	 * @param int|string $object_id  The object whose terms changed.
-	 * @param array      $terms      Terms set (unused; part of the hook signature).
-	 * @param array      $tt_ids     Term taxonomy IDs (unused; part of the hook signature).
-	 * @param string     $taxonomy   The taxonomy that changed.
+	 * @param int|string        $object_id  The object whose terms changed.
+	 * @param array<int|string> $terms      Terms set (unused; part of the hook signature).
+	 * @param int[]             $tt_ids     Term taxonomy IDs (unused; part of the hook signature).
+	 * @param string            $taxonomy   The taxonomy that changed.
 	 *
 	 * @return void
 	 *

--- a/includes/core/classes/calendar/class-endpoint.php
+++ b/includes/core/classes/calendar/class-endpoint.php
@@ -209,7 +209,7 @@ class Endpoint {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array The rewrite replacement attributes for add_rewrite_rule().
+	 * @return array<string, string> The rewrite replacement attributes for add_rewrite_rule().
 	 */
 	public function get_rewrite_atts(): array {
 		return array(
@@ -253,11 +253,11 @@ class Endpoint {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param string $type_name   The name of the post type or taxonomy to validate.
-	 * @param array  $types       Array of endpoint types to register (redirects/templates).
-	 * @param string $object_type The type of object ('post' or 'taxonomy').
+	 * @param string          $type_name   The name of the post type or taxonomy to validate.
+	 * @param Endpoint_Type[] $types       Array of endpoint types to register (redirects/templates).
+	 * @param string          $object_type The type of object ('post' or 'taxonomy').
 	 *
-	 * @return bool               Returns true if registration is valid, false otherwise.
+	 * @return bool                        Returns true if registration is valid, false otherwise.
 	 */
 	private function is_valid_registration( string $type_name, array $types, string $object_type ): bool {
 		if ( 0 === did_action( 'init' ) ) {

--- a/includes/core/classes/calendar/class-post-type-feed.php
+++ b/includes/core/classes/calendar/class-post-type-feed.php
@@ -84,7 +84,7 @@ final class Post_Type_Feed extends Endpoint {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array The rewrite replacement attributes for add_rewrite_rule().
+	 * @return array<string, string> The rewrite replacement attributes for add_rewrite_rule().
 	 */
 	public function get_rewrite_atts(): array {
 		return array(

--- a/includes/core/classes/calendar/class-post-type-single-feed.php
+++ b/includes/core/classes/calendar/class-post-type-single-feed.php
@@ -81,7 +81,7 @@ final class Post_Type_Single_Feed extends Endpoint {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array The rewrite replacement attributes for add_rewrite_rule().
+	 * @return array<string, string> The rewrite replacement attributes for add_rewrite_rule().
 	 */
 	public function get_rewrite_atts(): array {
 		return array(

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -38,6 +38,15 @@ use WP_Term;
  * sibling `Calendar` class, instantiated as `new Calendar( $event_id )`.
  *
  * @since 0.34.0
+ *
+ * @phpstan-type LabelArgs array{
+ *   blogtitle: string,
+ *   separator: string,
+ *   singletitle: string,
+ *   feedtitle: string,
+ *   posttypetitle: string,
+ *   taxtitle: string
+ * }
  */
 final class Setup {
 
@@ -233,7 +242,8 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Template descriptor with `file_name` (and optional `dir_path`) keys.
+	 * @return array{file_name: string, dir_path?: string} Template descriptor with `file_name` (and optional
+	 *                                                      `dir_path`) keys.
 	 */
 	public function get_ical_file_template(): array {
 		return array(
@@ -246,7 +256,8 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Template descriptor with `file_name` (and optional `dir_path`) keys.
+	 * @return array{file_name: string, dir_path?: string} Template descriptor with `file_name` (and optional
+	 *                                                      `dir_path`) keys.
 	 */
 	public function get_ical_feed_template(): array {
 		return array(
@@ -324,7 +335,7 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array{blogtitle:string,separator:string,singletitle:string,feedtitle:string,posttypetitle:string,taxtitle:string}
+	 * @return LabelArgs
 	 */
 	protected function alternate_link_label_args(): array {
 		return array(
@@ -350,6 +361,7 @@ final class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param array $args Label args from `alternate_link_label_args()`.
+	 * @phpstan-param LabelArgs $args
 	 *
 	 * @return array<int,array{url:string,attr:string}> One-element list.
 	 */
@@ -380,6 +392,7 @@ final class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param array $args Label args from `alternate_link_label_args()`.
+	 * @phpstan-param LabelArgs $args
 	 *
 	 * @return array<int,array{url:string,attr:string}> One entry per event-supporting post type.
 	 */
@@ -423,6 +436,7 @@ final class Setup {
 	 * @since 0.34.0
 	 *
 	 * @param array $args Label args from `alternate_link_label_args()`.
+	 * @phpstan-param LabelArgs $args
 	 *
 	 * @return array<int,array{url:string,attr:string}>
 	 */
@@ -454,6 +468,7 @@ final class Setup {
 	 *
 	 * @param WP_Post $event The queried event post.
 	 * @param array   $args  Label args from `alternate_link_label_args()`.
+	 * @phpstan-param LabelArgs $args
 	 *
 	 * @return array<int,array{url:string,attr:string}>
 	 */
@@ -484,6 +499,7 @@ final class Setup {
 	 *
 	 * @param WP_Post $post The queried shadow-source post (e.g. a venue).
 	 * @param array   $args Label args from `alternate_link_label_args()`.
+	 * @phpstan-param LabelArgs $args
 	 *
 	 * @return array<int,array{url:string,attr:string}>
 	 */
@@ -508,6 +524,7 @@ final class Setup {
 	 *
 	 * @param WP_Term $term The queried taxonomy term.
 	 * @param array   $args Label args from `alternate_link_label_args()`.
+	 * @phpstan-param LabelArgs $args
 	 *
 	 * @return array<int,array{url:string,attr:string}>
 	 */
@@ -535,6 +552,7 @@ final class Setup {
 	 *
 	 * @param WP_Post $event The queried event post.
 	 * @param array   $args  Label args from `alternate_link_label_args()`.
+	 * @phpstan-param LabelArgs $args
 	 *
 	 * @return array<int,array{url:string,attr:string}>
 	 */
@@ -569,6 +587,7 @@ final class Setup {
 	 *
 	 * @param WP_Term $term Term attached to the queried event.
 	 * @param array   $args Label args from `alternate_link_label_args()`.
+	 * @phpstan-param LabelArgs $args
 	 *
 	 * @return array<int,array{url:string,attr:string}> Empty for sentinel terms; otherwise one entry.
 	 */

--- a/includes/core/classes/calendar/class-sitewide-feed.php
+++ b/includes/core/classes/calendar/class-sitewide-feed.php
@@ -94,7 +94,7 @@ final class Sitewide_Feed extends Endpoint {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array
+	 * @return array<string, string> The rewrite replacement attributes for add_rewrite_rule().
 	 */
 	public function get_rewrite_atts(): array {
 		return array(

--- a/includes/core/classes/calendar/class-taxonomy-feed.php
+++ b/includes/core/classes/calendar/class-taxonomy-feed.php
@@ -84,7 +84,7 @@ final class Taxonomy_Feed extends Endpoint {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array The rewrite replacement attributes for add_rewrite_rule().
+	 * @return array<string, string> The rewrite replacement attributes for add_rewrite_rule().
 	 */
 	public function get_rewrite_atts(): array {
 		return array(

--- a/includes/core/classes/calendar/class-template.php
+++ b/includes/core/classes/calendar/class-template.php
@@ -142,7 +142,8 @@ class Template extends Endpoint_Type {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Template preset data including file_name and optional dir_path.
+	 * @return array{file_name: string, dir_path?: string} Template preset data including file_name and optional
+	 *                                                      dir_path.
 	 */
 	protected function get_template_presets(): array {
 		return ( $this->callback )();

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -35,7 +35,7 @@ final class Assets {
 	 * This property stores data assets in an array for efficient access and management.
 	 *
 	 * @since 0.27.0
-	 * @var array
+	 * @var array<string, array{dependencies?: string[], version?: string}>
 	 */
 	protected array $asset_data = array();
 
@@ -272,8 +272,8 @@ final class Assets {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string $block_content The block content.
-	 * @param array  $block         The block settings.
+	 * @param string               $block_content The block content.
+	 * @param array<string, mixed> $block         The block settings.
 	 *
 	 * @return string The block content.
 	 */
@@ -533,7 +533,7 @@ final class Assets {
 	 * @param string  $asset The file name of the asset.
 	 * @param ?string $path  (Optional) The absolute path to the asset file
 	 *                       or null to use the path based on the default naming scheme.
-	 * @return array An array containing asset-related data.
+	 * @return array{dependencies?: string[], version?: string} An array containing asset-related data.
 	 */
 	public function get_asset_data( string $asset, ?string $path = null ): array {
 		$path = $path ?? $this->path . sprintf( '%s.asset.php', $asset );
@@ -560,9 +560,13 @@ final class Assets {
 		}
 
 		if ( empty( $this->block_variation_names ) ) {
+			// scandir() returns false on an unreadable directory, which
+			// file_exists() above does not rule out.
+			$entries = scandir( $variations_directory );
+
 			$this->block_variation_names = array_values(
 				array_diff(
-					scandir( $variations_directory ),
+					false === $entries ? array() : $entries,
 					array( '..', '.' )
 				)
 			);

--- a/includes/core/classes/class-export.php
+++ b/includes/core/classes/class-export.php
@@ -168,10 +168,10 @@ final class Export extends Migrate {
 	/**
 	 * Render custom post_meta data into xml markup to be used while WordÜress' native export.
 	 *
-	 * @param  array   $callbacks Associative array with (import & export) callback functions for
-	 *                            the non-existent post_meta entry, named by $key.
-	 * @param string  $key       Name of the custom post_meta, that should be exported.
-	 * @param  WP_Post $post      The currently exported 'gatherpress_event' post.
+	 * @param  array<string, mixed> $callbacks Associative array with (import & export) callback functions for
+	 *                                         the non-existent post_meta entry, named by $key.
+	 * @param string               $key       Name of the custom post_meta, that should be exported.
+	 * @param  WP_Post              $post      The currently exported 'gatherpress_event' post.
 	 *
 	 * @return void
 	 * @since 0.30.0

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -128,7 +128,7 @@ final class Feed {
 	 *
 	 * @param Event $event The event object.
 	 *
-	 * @return array Array of event information strings.
+	 * @return string[] Array of event information strings.
 	 */
 	private function get_event_datetime_info( Event $event ): array {
 		$event_info       = array();

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -30,6 +30,20 @@ use WP_REST_Server;
  * Provides REST API endpoints for geocoding and address search.
  *
  * @since 0.34.0
+ *
+ * @phpstan-type GeocodeResult array{
+ *     latitude: string,
+ *     longitude: string,
+ *     error: string|null,
+ *     house_number: string,
+ *     street: string,
+ *     city: string,
+ *     county: string,
+ *     state: string,
+ *     postcode: string,
+ *     country: string,
+ *     country_code: string
+ * }
  */
 final class Geocoding {
 
@@ -398,9 +412,9 @@ final class Geocoding {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $settings The block editor settings array.
+	 * @param array<string, mixed> $settings The block editor settings array.
 	 *
-	 * @return array The modified settings.
+	 * @return array<string, mixed> The modified settings.
 	 */
 	public function add_editor_settings( array $settings ): array {
 		if ( ! isset( $settings['gatherpress'] ) ) {
@@ -582,6 +596,7 @@ final class Geocoding {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request The REST request object.
+	 * @phpstan-param WP_REST_Request<array{address: string}> $request
 	 *
 	 * @return WP_REST_Response|WP_Error Response with coordinates or error.
 	 */
@@ -635,19 +650,7 @@ final class Geocoding {
 	 *
 	 * @param string $address Address string to resolve.
 	 *
-	 * @return array{
-	 *     latitude: string,
-	 *     longitude: string,
-	 *     error: string|null,
-	 *     house_number: string,
-	 *     street: string,
-	 *     city: string,
-	 *     county: string,
-	 *     state: string,
-	 *     postcode: string,
-	 *     country: string,
-	 *     country_code: string
-	 * }|WP_Error Result payload, or WP_Error on Photon HTTP failure.
+	 * @return GeocodeResult|WP_Error Result payload, or WP_Error on Photon HTTP failure.
 	 */
 	public function geocode_to_result( string $address ): array|WP_Error {
 		// Cap oversize input for parity with search_addresses(); protects
@@ -752,7 +755,7 @@ final class Geocoding {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Result payload with empty fields and an error message.
+	 * @return GeocodeResult Result payload with empty fields and an error message.
 	 */
 	private function build_not_found_payload(): array {
 		return array_merge(
@@ -773,6 +776,7 @@ final class Geocoding {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request The REST request object.
+	 * @phpstan-param WP_REST_Request<array{q: string}> $request
 	 *
 	 * @return WP_REST_Response|WP_Error Suggestions or error.
 	 */
@@ -964,7 +968,7 @@ final class Geocoding {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $properties Photon `properties` object.
+	 * @param array<string, mixed> $properties Photon `properties` object.
 	 *
 	 * @return array{
 	 *     house_number: string,
@@ -1019,7 +1023,7 @@ final class Geocoding {
 	 *               `gatherpress_geocode_street_line` filter was replaced
 	 *               by `gatherpress_formatted_address`.
 	 *
-	 * @param array $properties Photon `properties` object.
+	 * @param array<string, mixed> $properties Photon `properties` object.
 	 *
 	 * @return string Non-empty label or empty string.
 	 */

--- a/includes/core/classes/class-import.php
+++ b/includes/core/classes/class-import.php
@@ -77,9 +77,9 @@ final class Import extends Migrate {
 	 *
 	 * @see https://github.com/WordPress/wordpress-importer/blob/71bdd41a2aa2c6a0967995ee48021037b39a1097/src/class-wp-import.php#L631
 	 *
-	 * @param  array $post_data_raw The result of 'wp_import_post_data_raw'.
+	 * @param  array<string, mixed> $post_data_raw The result of 'wp_import_post_data_raw'.
 	 *
-	 * @return array                Returns the unchanged result of 'wp_import_post_data_raw'.
+	 * @return array<string, mixed>                Returns the unchanged result of 'wp_import_post_data_raw'.
 	 */
 	public function prepare( array $post_data_raw ): array {
 		if ( $this->validate( $post_data_raw ) ) {
@@ -99,10 +99,10 @@ final class Import extends Migrate {
 	/**
 	 * Checks if the currently imported post is of type 'gatherpress_event'.
 	 *
-	 * @param  array $post_data_raw The result of 'wp_import_post_data_raw'.
+	 * @param  array<string, mixed> $post_data_raw The result of 'wp_import_post_data_raw'.
 	 *
-	 * @return bool                 True, when the currently imported post is of type 'gatherpress_event',
-	 *                              false otherwise.
+	 * @return bool                                True, when the currently imported post is of type
+	 *                                             'gatherpress_event', false otherwise.
 	 */
 	protected function validate( array $post_data_raw ): bool {
 		return ( isset( $post_data_raw['post_type'] ) && Event::POST_TYPE === $post_data_raw['post_type'] );

--- a/includes/core/classes/class-migrate.php
+++ b/includes/core/classes/class-migrate.php
@@ -27,7 +27,7 @@ class Migrate {
 	 * List of non-existent post_meta keys with array values containing getter and setter callback definitions.
 	 *
 	 * @since 0.30.0
-	 * @var array $pseudopostmetas
+	 * @var array<string, array<string, mixed>> $pseudopostmetas
 	 */
 	protected array $pseudopostmetas = array(
 		'gatherpress_datetimes' => array(
@@ -42,7 +42,7 @@ class Migrate {
 	 *
 	 * @since 0.30.0
 	 *
-	 * @return array
+	 * @return array<string, array<string, mixed>> Export- and import-callback definitions keyed by data-name.
 	 */
 	public function get_pseudopostmetas(): array {
 		/**

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -24,6 +24,37 @@ use GatherPress\Core\Traits\Singleton;
  * related to event display, roles, and credits.
  *
  * @since 0.27.0
+ *
+ * @phpstan-type SettingsFieldPreview array{template: string, suffix?: string}
+ * @phpstan-type SettingsFieldOptions array{
+ *     default?: bool|int|string,
+ *     items?: array<string, string>,
+ *     min?: int|string,
+ *     max?: int|string,
+ *     type?: string,
+ *     label?: string,
+ *     limit?: int
+ * }
+ * @phpstan-type SettingsField array{
+ *     type?: string,
+ *     label?: string,
+ *     size?: string,
+ *     placeholder?: string,
+ *     allow_empty?: bool,
+ *     rewrite?: bool,
+ *     options?: SettingsFieldOptions,
+ *     preview?: SettingsFieldPreview
+ * }
+ * @phpstan-type SettingsShowIf array<string, scalar|scalar[]|array{not: scalar|scalar[]}>
+ * @phpstan-type SettingsOption array{
+ *     labels: array<string, string>,
+ *     description?: string,
+ *     field: SettingsField,
+ *     show_if?: SettingsShowIf,
+ *     callback?: callable
+ * }
+ * @phpstan-type SettingsSection array{name: string, description?: string, options?: array<string, SettingsOption>}
+ * @phpstan-type SettingsSubPage array{name: string, priority?: int, sections?: array<string, SettingsSection>}
  */
 class Settings {
 
@@ -85,7 +116,7 @@ class Settings {
 	 * Cached flat map of option keys to their default values.
 	 *
 	 * @since 0.34.0
-	 * @var array|null
+	 * @var array<string, bool|int|string>|null
 	 */
 	protected ?array $defaults_cache = null;
 
@@ -160,9 +191,9 @@ class Settings {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $settings The block editor settings array.
+	 * @param array<string, mixed> $settings The block editor settings array.
 	 *
-	 * @return array The modified block editor settings array.
+	 * @return array<string, mixed> The modified block editor settings array.
 	 */
 	public function add_editor_settings( array $settings ): array {
 		if ( ! isset( $settings['gatherpress'] ) ) {
@@ -421,8 +452,8 @@ class Settings {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param string $sub_page Sub-page slug used to scope WP's settings API.
-	 * @param array  $sections Sections array from the sub-page settings.
+	 * @param string                         $sub_page Sub-page slug used to scope WP's settings API.
+	 * @param array<string, SettingsSection> $sections Sections array from the sub-page settings.
 	 *
 	 * @return void
 	 */
@@ -481,6 +512,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param array $option_settings The option settings array.
+	 * @phpstan-param SettingsOption $option_settings
 	 *
 	 * @return string Space-separated class names for the row.
 	 */
@@ -515,6 +547,7 @@ class Settings {
 	 * @since 0.35.0 Added the `array( 'not' => … )` negation form.
 	 *
 	 * @param array $conditions Map of controlling option key => expected value(s).
+	 * @phpstan-param SettingsShowIf $conditions
 	 *
 	 * @return bool True when every key matches the current saved value, false otherwise.
 	 */
@@ -564,6 +597,7 @@ class Settings {
 	 * @since 0.34.0
 	 *
 	 * @param array $conditions Map of controlling option key => expected value(s).
+	 * @phpstan-param SettingsShowIf $conditions
 	 *
 	 * @return void
 	 */
@@ -582,9 +616,9 @@ class Settings {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $sub_pages The sub-pages array from get_sub_pages().
+	 * @param array<string, SettingsSubPage> $sub_pages The sub-pages array from get_sub_pages().
 	 *
-	 * @return array Flat map of option_key => field_type.
+	 * @return array<string, string> Flat map of option_key => field_type.
 	 */
 	protected function build_field_type_map( array $sub_pages ): array {
 		$map        = array();
@@ -642,10 +676,10 @@ class Settings {
 	 * to the same state. Consumers rely on `get_flat_default()` as the
 	 * authoritative source of defaults in both read paths.
 	 *
-	 * @param array  $field_type_map Flat map of option_key => field_type.
-	 * @param string $scope          Storage scope: 'blog' (default) or 'network'.
-	 *                               Determines which option store the closure
-	 *                               reads from when merging with existing values.
+	 * @param array<string, string> $field_type_map Flat map of option_key => field_type.
+	 * @param string                $scope          Storage scope: 'blog' (default) or 'network'.
+	 *                                              Determines which option store the closure
+	 *                                              reads from when merging with existing values.
 	 * @return callable A callback function that sanitizes input based on field types.
 	 */
 	public function sanitize_page_settings( array $field_type_map, string $scope = 'blog' ): callable {
@@ -751,6 +785,7 @@ class Settings {
 	 *
 	 * @param string $option          The unique option key for the field.
 	 * @param array  $option_settings The option settings including field config.
+	 * @phpstan-param SettingsOption $option_settings
 	 *
 	 * @return void
 	 */
@@ -929,7 +964,7 @@ class Settings {
 			$config = Settings\Network::get_config();
 
 			if ( ! empty( $config['enabled'] ) ) {
-				$inherited = in_array( $option, (array) ( $config['inherited'] ?? array() ), true );
+				$inherited = in_array( $option, $config['inherited'], true );
 			}
 		}
 
@@ -980,7 +1015,7 @@ class Settings {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Flat map of option_key => default_value.
+	 * @return array<string, bool|int|string> Flat map of option_key => default_value.
 	 */
 	protected function get_defaults_map(): array {
 		if ( null !== $this->defaults_cache ) {
@@ -1039,7 +1074,7 @@ class Settings {
 	 *
 	 * @since 0.27.0
 	 *
-	 * @return array An array of sub-pages, each with settings and priority information.
+	 * @return array<string, SettingsSubPage> An array of sub-pages, each with settings and priority information.
 	 */
 	public function get_sub_pages(): array {
 		/**
@@ -1071,6 +1106,8 @@ class Settings {
 	 *
 	 * @param array $first  The first sub-page to compare by priority.
 	 * @param array $second The second sub-page to compare by priority.
+	 * @phpstan-param SettingsSubPage $first
+	 * @phpstan-param SettingsSubPage $second
 	 *
 	 * @return int Returns a negative number if the first sub-page has a lower priority,
 	 *             a positive number if the second sub-page has a lower priority,
@@ -1166,7 +1203,7 @@ class Settings {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array List of option keys that affect rewrite rules.
+	 * @return string[] List of option keys that affect rewrite rules.
 	 */
 	protected function get_rewrite_keys(): array {
 		$keys      = array();
@@ -1204,7 +1241,7 @@ class Settings {
 	 * @param string $scope Storage scope: 'blog' (default) or 'network'.
 	 *                      'network' reads the network-wide site option,
 	 *                      used when exporting from Network Admin.
-	 * @return array Export data with version, timestamp, scope, and settings.
+	 * @return array{version: string, exported_at: string, scope: string, settings: array<string, mixed>} Export data.
 	 */
 	public function export_settings( string $scope = 'blog' ): array {
 		return array(
@@ -1222,7 +1259,7 @@ class Settings {
 	 *
 	 * @param string $scope Storage scope: 'blog' or 'network'.
 	 *
-	 * @return array
+	 * @return array<string, mixed> Stored option values keyed by option key.
 	 */
 	protected function read_stored_options( string $scope ): array {
 		if ( 'network' === $scope ) {
@@ -1237,8 +1274,8 @@ class Settings {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param string $scope   Storage scope: 'blog' or 'network'.
-	 * @param array  $options Options array to persist.
+	 * @param string               $scope   Storage scope: 'blog' or 'network'.
+	 * @param array<string, mixed> $options Options array to persist.
 	 *
 	 * @return void
 	 */
@@ -1277,10 +1314,10 @@ class Settings {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array  $data  The parsed import data.
-	 * @param string $scope Storage scope: 'blog' (default) or 'network'.
+	 * @param array<string, mixed> $data  The parsed import data.
+	 * @param string               $scope Storage scope: 'blog' (default) or 'network'.
 	 *
-	 * @return array Validation result with 'valid', 'changes', 'unknown', and 'warnings' keys.
+	 * @return array{valid: bool, changes: string[], unknown: string[], warnings: string[]} Validation result.
 	 */
 	public function validate_import( array $data, string $scope = 'blog' ): array {
 		$result = array(
@@ -1336,11 +1373,11 @@ class Settings {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array  $data  The parsed import data.
-	 * @param string $mode  Import mode: 'merge' or 'replace'.
-	 * @param string $scope Storage scope: 'blog' (default) or 'network'.
+	 * @param array<string, mixed> $data  The parsed import data.
+	 * @param string               $mode  Import mode: 'merge' or 'replace'.
+	 * @param string               $scope Storage scope: 'blog' (default) or 'network'.
 	 *
-	 * @return array Result with 'success', 'imported', 'skipped', and 'warnings' keys.
+	 * @return array{success: bool, imported: string[], skipped: string[], warnings: string[]} Import result.
 	 */
 	public function import_settings( array $data, string $mode = 'merge', string $scope = 'blog' ): array {
 		$result = array(

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -131,9 +131,9 @@ final class Setup {
 	 *
 	 * @since 0.27.0
 	 *
-	 * @param array $actions An array of existing action links.
+	 * @param array<string, string> $actions An array of existing action links.
 	 *
-	 * @return array An updated array of action links, including the 'Settings' link.
+	 * @return array<string, string> An updated array of action links, including the 'Settings' link.
 	 */
 	public function filter_plugin_action_links( array $actions ): array {
 		$settings = Settings::get_instance();
@@ -312,9 +312,9 @@ final class Setup {
 	 *
 	 * @since 0.27.0
 	 *
-	 * @param array $classes Existing body classes.
+	 * @param string[] $classes Existing body classes.
 	 *
-	 * @return array An updated array of body classes.
+	 * @return string[] An updated array of body classes.
 	 */
 	public function add_gatherpress_body_classes( array $classes ): array {
 		$classes[] = 'gatherpress-enabled';
@@ -331,9 +331,9 @@ final class Setup {
 	 *
 	 * @since 0.27.0
 	 *
-	 * @param array $block_categories Array of registered block categories.
+	 * @param array<int, array<string, string|null>> $block_categories Array of registered block categories.
 	 *
-	 * @return array An updated array of block categories.
+	 * @return array<int, array<string, string|null>> An updated array of block categories.
 	 */
 	public function register_gatherpress_block_category( array $block_categories ): array {
 		$category = array(
@@ -438,9 +438,9 @@ final class Setup {
 	 *
 	 * @since 0.27.0
 	 *
-	 * @param array $tables An array of names of the site tables to be dropped.
+	 * @param string[] $tables An array of names of the site tables to be dropped.
 	 *
-	 * @return array An updated array of table names to be deleted during site deletion.
+	 * @return string[] An updated array of table names to be deleted during site deletion.
 	 */
 	public function on_site_delete( array $tables ): array {
 		global $wpdb;

--- a/includes/core/classes/class-shadow-source.php
+++ b/includes/core/classes/class-shadow-source.php
@@ -595,7 +595,7 @@ final class Shadow_Source {
 	 *
 	 * @param WP_Post $source_post The shadow-source post.
 	 *
-	 * @return array The tax_query clause.
+	 * @return array{taxonomy: string, field: string, terms: string[]} The tax_query clause.
 	 */
 	public function build_tax_query_clause( WP_Post $source_post ): array {
 		return array(

--- a/includes/core/classes/class-starter-pattern-loader.php
+++ b/includes/core/classes/class-starter-pattern-loader.php
@@ -81,10 +81,11 @@ final class Starter_Pattern_Loader {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @param array $patterns   Pattern definitions (`name`, `title`,
-	 *                          `description`, `content`, optional `postTypes`).
-	 * @param array $post_types Default post type slugs for definitions
-	 *                          without their own `postTypes` key.
+	 * @param array<int, mixed> $patterns   Pattern definitions (`name`, `title`,
+	 *                                      `description`, `content`, optional `postTypes`).
+	 *                                      Filter output, so non-array entries are tolerated.
+	 * @param string[]          $post_types Default post type slugs for definitions
+	 *                                      without their own `postTypes` key.
 	 * @return void
 	 */
 	public static function register( array $patterns, array $post_types ): void {

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -33,9 +33,9 @@ final class Utility {
 	 *
 	 * @since 0.27.0
 	 *
-	 * @param string $path      The path to the template file.
-	 * @param array  $variables An array of variables to pass to the template.
-	 * @param bool   $output    Whether to echo the template (true) or return it (false).
+	 * @param string               $path      The path to the template file.
+	 * @param array<string, mixed> $variables An array of variables to pass to the template.
+	 * @param bool                 $output    Whether to echo the template (true) or return it (false).
 	 *
 	 * @return string The rendered template as a string.
 	 */
@@ -308,7 +308,8 @@ final class Utility {
 	 *
 	 * @since 0.27.0
 	 *
-	 * @return array An array of time zones with labels as keys and time zone choices as values.
+	 * @return array<string, array<string, string>> An array of time zones with labels as keys and time zone choices
+	 *                                             as values.
 	 */
 	public static function timezone_choices(): array {
 		// Parse `wp_timezone_choice()` output through WordPress's HTML tag
@@ -382,7 +383,7 @@ final class Utility {
 	 *
 	 * @since 0.29.0
 	 *
-	 * @return array An array of timezone identifiers and UTC offsets.
+	 * @return string[] An array of timezone identifiers and UTC offsets.
 	 */
 	public static function list_timezone_and_utc_offsets(): array {
 		// Get a list of all available timezone identifiers.
@@ -806,9 +807,9 @@ final class Utility {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $blocks A parsed block, typically including `blockName` and `innerBlocks`.
+	 * @param array<string, mixed> $blocks A parsed block, typically including `blockName` and `innerBlocks`.
 	 *
-	 * @return array An array of block names found within the provided block structure.
+	 * @return string[] An array of block names found within the provided block structure.
 	 */
 	public static function get_block_names( array $blocks ): array {
 		$block_names = array();

--- a/includes/core/classes/commands/class-event-cli.php
+++ b/includes/core/classes/commands/class-event-cli.php
@@ -58,8 +58,8 @@ final class Event_Cli extends WP_CLI {
 	 *
 	 * @since 0.29.0
 	 *
-	 * @param array $args       Positional arguments for the script.
-	 * @param array $assoc_args Associative arguments for the script.
+	 * @param string[]                   $args       Positional arguments for the script.
+	 * @param array<string, string|bool> $assoc_args Associative arguments for the script.
 	 *
 	 * @return void
 	 *

--- a/includes/core/classes/commands/class-settings-cli.php
+++ b/includes/core/classes/commands/class-settings-cli.php
@@ -43,8 +43,8 @@ final class Settings_Cli extends WP_CLI {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $args       Positional arguments.
-	 * @param array $assoc_args Associative arguments.
+	 * @param string[]                   $args       Positional arguments.
+	 * @param array<string, string|bool> $assoc_args Associative arguments.
 	 *
 	 * @return void
 	 *
@@ -119,8 +119,8 @@ final class Settings_Cli extends WP_CLI {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $args       Positional arguments.
-	 * @param array $assoc_args Associative arguments.
+	 * @param string[]                   $args       Positional arguments.
+	 * @param array<string, string|bool> $assoc_args Associative arguments.
 	 *
 	 * @return void
 	 */

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -125,9 +125,9 @@ final class Admin_List {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $columns An array of sortable columns.
+	 * @param array<string, string|array<int, string|bool>> $columns An array of sortable columns.
 	 *
-	 * @return array An updated array of sortable columns.
+	 * @return array<string, string|array<int, string|bool>> An updated array of sortable columns.
 	 */
 	public function sortable_columns( array $columns ): array {
 		// Add 'datetime' as a sortable column.
@@ -154,9 +154,9 @@ final class Admin_List {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $view_links An array of available list table views.
+	 * @param array<string, string> $view_links An array of available list table views.
 	 *
-	 * @return array Updated list table views.
+	 * @return array<string, string> Updated list table views.
 	 */
 	public function views_edit( array $view_links ): array {
 		$screen = get_current_screen();
@@ -596,9 +596,9 @@ final class Admin_List {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $columns An associative array of column headings.
+	 * @param array<string, string> $columns An associative array of column headings.
 	 *
-	 * @return array An updated array of column headings, including the custom columns.
+	 * @return array<string, string> An updated array of column headings, including the custom columns.
 	 */
 	public function set_custom_columns( array $columns ): array {
 		// Remove the author column.
@@ -686,9 +686,9 @@ final class Admin_List {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $columns An array of column names.
+	 * @param array<string, string> $columns An array of column names.
 	 *
-	 * @return array The modified array of column names without the comments column.
+	 * @return array<string, string> The modified array of column names without the comments column.
 	 */
 	public function remove_comments_column( array $columns ): array {
 		$screen    = function_exists( 'get_current_screen' ) ? get_current_screen() : null;

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -32,6 +32,14 @@ use WP_Post;
  * Represents individual events within the GatherPress plugin and provides event-related functionality.
  *
  * @since 0.34.0
+ *
+ * @phpstan-type EventDatetime array{
+ *     datetime_start: string,
+ *     datetime_start_gmt: string,
+ *     datetime_end: string,
+ *     datetime_end_gmt: string,
+ *     timezone: string
+ * }
  */
 class Event {
 
@@ -111,7 +119,7 @@ class Event {
 	 * Non-time PHP DateTime formatting characters
 	 *
 	 * @since 0.34.0
-	 * @var array
+	 * @var string[]
 	 */
 	const PHP_NON_TIME_FORMAT_CHARS = array(
 		'd',
@@ -168,7 +176,7 @@ class Event {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @var array|null
+	 * @var EventDatetime|null
 	 */
 	private ?array $datetime_cache = null;
 
@@ -525,7 +533,7 @@ class Event {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array An associative array detailing the event's schedule and timezone, potentially
+	 * @return EventDatetime An associative array detailing the event's schedule and timezone, potentially
 	 * adjusted for user-specific preferences:
 	 *     - 'datetime_start'     (string) The event start date and time.
 	 *     - 'datetime_start_gmt' (string) The event start date and time in GMT.
@@ -613,12 +621,12 @@ class Event {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array An array containing venue information:
-	 *               - 'address' (string): The address of the venue.
-	 *               - 'name' (string): The name of the venue.
-	 *               - 'permalink' (string): The permalink (URL) of the venue.
-	 *               - 'phone' (string): The phone number of the venue.
-	 *               - 'website' (string): The website URL of the venue.
+	 * @return array<string, string> An array containing venue information:
+	 *                               - 'address' (string): The address of the venue.
+	 *                               - 'name' (string): The name of the venue.
+	 *                               - 'permalink' (string): The permalink (URL) of the venue.
+	 *                               - 'phone' (string): The phone number of the venue.
+	 *                               - 'website' (string): The website URL of the venue.
 	 */
 	public function get_venue_information(): array {
 		$venue_information = array(
@@ -683,7 +691,8 @@ class Event {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array An associative array containing supported calendar links:
+	 * @return array<string, array{name: string, link?: string, download?: string}> An associative array containing
+	 *     supported calendar links:
 	 *     - 'google'  (array) Google Calendar link information with 'name' and 'link' keys.
 	 *     - 'ical'    (array) iCal download link information with 'name' and 'download' keys.
 	 *     - 'outlook' (array) Outlook download link information with 'name' and 'download' keys.
@@ -742,7 +751,7 @@ class Event {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $params {
+	 * @param array{post_id?: int, datetime_start?: string, datetime_end?: string, timezone?: string} $params {
 	 *     An array of arguments used to save event data to the custom event table.
 	 *
 	 *     @type int    $post_id        The event's post ID.

--- a/includes/core/classes/event/class-meta.php
+++ b/includes/core/classes/event/class-meta.php
@@ -257,6 +257,7 @@ final class Meta {
 	 *
 	 * @param stdClass        $prepared_post An object representing a single post prepared for inserting or updating.
 	 * @param WP_REST_Request $request       Request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @return stdClass The prepared post object.
 	 */

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -112,10 +112,10 @@ final class Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param string $event_list_type Type of event list: 'upcoming' or 'past'.
-	 * @param int    $number          Maximum number of events to retrieve.
-	 * @param array  $topics          Array of topic slugs for additional filtering.
-	 * @param array  $venues          Array of venue slugs for additional filtering.
+	 * @param string   $event_list_type Type of event list: 'upcoming' or 'past'.
+	 * @param int      $number          Maximum number of events to retrieve.
+	 * @param string[] $topics          Array of topic slugs for additional filtering.
+	 * @param string[] $venues          Array of venue slugs for additional filtering.
 	 *
 	 * @return WP_Query A WordPress query object containing the list of events.
 	 */
@@ -300,10 +300,10 @@ final class Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array    $query_pieces An array containing pieces of the SQL query.
-	 * @param WP_Query $query        The WP_Query instance (passed by reference).
+	 * @param array<string, string> $query_pieces An array containing pieces of the SQL query.
+	 * @param WP_Query              $query        The WP_Query instance (passed by reference).
 	 *
-	 * @return array The modified SQL query pieces with adjusted sorting criteria for upcoming events.
+	 * @return array<string, string> The modified SQL query pieces with adjusted sorting criteria for upcoming events.
 	 */
 	public function adjust_sorting_for_upcoming_events( array $query_pieces, WP_Query $query ): array {
 		$include_unfinished = $query->get( 'include_unfinished' );
@@ -327,10 +327,10 @@ final class Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array    $query_pieces An array containing pieces of the SQL query.
-	 * @param WP_Query $query        The WP_Query instance (passed by reference).
+	 * @param array<string, string> $query_pieces An array containing pieces of the SQL query.
+	 * @param WP_Query              $query        The WP_Query instance (passed by reference).
 	 *
-	 * @return array The modified SQL query pieces with adjusted sorting criteria for past events.
+	 * @return array<string, string> The modified SQL query pieces with adjusted sorting criteria for past events.
 	 */
 	public function adjust_sorting_for_past_events( array $query_pieces, WP_Query $query ): array {
 		$include_unfinished = $query->get( 'include_unfinished' );
@@ -355,10 +355,10 @@ final class Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array    $query_pieces An array containing pieces of the SQL query.
-	 * @param WP_Query $wp_query     The WP_Query instance (passed by reference).
+	 * @param array<string, string> $query_pieces An array containing pieces of the SQL query.
+	 * @param WP_Query              $wp_query     The WP_Query instance (passed by reference).
 	 *
-	 * @return array The modified SQL query pieces with adjusted sorting criteria.
+	 * @return array<string, string> The modified SQL query pieces with adjusted sorting criteria.
 	 */
 	public function adjust_admin_event_sorting( array $query_pieces, WP_Query $wp_query ): array {
 		if ( ! is_admin() ) {
@@ -423,16 +423,18 @@ final class Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array           $pieces   An array of query pieces, including join, where, orderby,
-	 *                                  and more.
-	 * @param string          $type     The type of events to query (options: 'all', 'upcoming', 'past')
-	 *                                  (Default: 'all').
-	 * @param string          $order    The event order ('DESC' for descending or 'ASC' for ascending)
-	 *                                  (Default: 'DESC').
-	 * @param string[]|string $order_by List or singular string of ORDERBY statement(s) (Default: ['datetime']).
-	 * @param bool            $inclusive Whether to include currently running events in the query (Default: true).
+	 * @param array<string, string> $pieces    An array of query pieces, including join, where, orderby,
+	 *                                         and more.
+	 * @param string                $type      The type of events to query (options: 'all', 'upcoming', 'past')
+	 *                                         (Default: 'all').
+	 * @param string                $order     The event order ('DESC' for descending or 'ASC' for ascending)
+	 *                                         (Default: 'DESC').
+	 * @param string[]|string       $order_by  List or singular string of ORDERBY statement(s)
+	 *                                         (Default: ['datetime']).
+	 * @param bool                  $inclusive Whether to include currently running events in the query
+	 *                                         (Default: true).
 	 *
-	 * @return array An array containing adjusted SQL clauses for the Event query.
+	 * @return array<string, string> An array containing adjusted SQL clauses for the Event query.
 	 */
 	public function adjust_event_sql(
 		array $pieces,
@@ -518,9 +520,10 @@ final class Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $venues Array of venue slugs to filter by.
+	 * @param string[] $venues Array of venue slugs to filter by.
 	 *
-	 * @return array WP_Query compatible tax_query array.
+	 * @return array{relation: string, ...<int, array{taxonomy: string, field: string, terms: string[]}>}
+	 *               WP_Query compatible tax_query array.
 	 */
 	private function build_venue_tax_query( array $venues ): array {
 		$venue_tax_query = array( 'relation' => 'OR' );

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -42,6 +42,10 @@ use WP_User;
  * infrastructure.
  *
  * @since 0.34.0
+ *
+ * @phpstan-type RouteDefinition array{route: string, args: array<string, mixed>}
+ * @phpstan-type SendOptions array{all: bool, attending: bool, waiting_list: bool, not_attending: bool}
+ * @phpstan-type Recipient array{is_user: bool, user_id: int, comment_id: int|string, email: string, name: string}
  */
 final class Rest_Api {
 
@@ -106,7 +110,7 @@ final class Rest_Api {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array[] An array of route definitions for GatherPress events.
+	 * @return array<int, RouteDefinition> An array of route definitions for GatherPress events.
 	 */
 	protected function get_event_routes(): array {
 		return array(
@@ -126,7 +130,7 @@ final class Rest_Api {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array The REST route configuration.
+	 * @return RouteDefinition The REST route configuration.
 	 */
 	protected function email_route(): array {
 		return array(
@@ -171,7 +175,7 @@ final class Rest_Api {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Route configuration array.
+	 * @return RouteDefinition Route configuration array.
 	 */
 	protected function nonce_route(): array {
 		return array(
@@ -206,7 +210,7 @@ final class Rest_Api {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array The REST route configuration.
+	 * @return RouteDefinition The REST route configuration.
 	 */
 	protected function rsvp_route(): array {
 		return array(
@@ -256,7 +260,7 @@ final class Rest_Api {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array The REST route configuration.
+	 * @return RouteDefinition The REST route configuration.
 	 */
 	protected function rsvp_form_route(): array {
 		return array(
@@ -315,7 +319,7 @@ final class Rest_Api {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array The REST route configuration.
+	 * @return RouteDefinition The REST route configuration.
 	 */
 	protected function rsvp_status_html_route(): array {
 		return array(
@@ -358,7 +362,7 @@ final class Rest_Api {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Route configuration with path, methods, callback and arguments.
+	 * @return RouteDefinition Route configuration with path, methods, callback and arguments.
 	 */
 	protected function rsvp_responses_route(): array {
 		return array(
@@ -387,6 +391,7 @@ final class Rest_Api {
 	 * @since 0.35.1
 	 *
 	 * @param WP_REST_Request $request Contains data from the request.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @return bool True when the caller may read the event's RSVP responses.
 	 */
@@ -403,9 +408,10 @@ final class Rest_Api {
 	 *
 	 * @since 0.35.1
 	 *
-	 * @param array $responses The full payload from Rsvp::responses().
+	 * @param array<string, array{records: array<int, array<string, mixed>>, count: int}> $responses Full payload from
+	 *                                                                                               Rsvp::responses().
 	 *
-	 * @return array The same status keys, each carrying only its count.
+	 * @return array<string, array{count: int}> The same status keys, each carrying only its count.
 	 */
 	private function rsvp_response_counts( array $responses ): array {
 		return array_map(
@@ -424,6 +430,7 @@ final class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request Contains data from the request.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @return WP_REST_Response The response indicating the success of the email scheduling process.
 	 */
@@ -459,6 +466,7 @@ final class Rest_Api {
 	 * @param array  $send    Members to send the email to.
 	 * @param string $message Optional message to include in the email.
 	 * @param string $subject Optional subject line. Defaults to the existing `📅 {title}` template when empty.
+	 * @phpstan-param SendOptions $send
 	 *
 	 * @return void
 	 */
@@ -480,6 +488,7 @@ final class Rest_Api {
 	 * @param array  $send    Members to send the email to.
 	 * @param string $message Optional message to include in the email.
 	 * @param string $subject Optional subject line. Defaults to the existing `📅 {title}` template when empty.
+	 * @phpstan-param SendOptions $send
 	 *
 	 * @return bool True if emails were successfully sent, false otherwise.
 	 */
@@ -518,6 +527,7 @@ final class Rest_Api {
 	 * @param WP_User $current_user Originating editor (restored after locale/user switch).
 	 * @param string  $subject      Optional subject line. Empty falls back to the default template
 	 *                              and is then filtered via `gatherpress_email_subject`.
+	 * @phpstan-param Recipient $recipient
 	 *
 	 * @return void
 	 */
@@ -611,8 +621,9 @@ final class Rest_Api {
 	 *
 	 * @param array $send    An array specifying who to send emails to.
 	 * @param int   $post_id The Event Post ID.
+	 * @phpstan-param SendOptions $send
 	 *
-	 * @return array An array containing unified recipient data for both users and non-users.
+	 * @return array<int, Recipient> An array containing unified recipient data for both users and non-users.
 	 */
 	public function get_recipients( array $send, int $post_id ): array {
 		$recipients    = array();
@@ -685,7 +696,7 @@ final class Rest_Api {
 	 *
 	 * @param object $comment RSVP comment row from `Rsvp_Query::get_rsvps()`.
 	 *
-	 * @return array|null Recipient row, or null when no email is on file.
+	 * @return Recipient|null Recipient row, or null when no email is on file.
 	 */
 	protected function build_comment_recipient( $comment ): ?array {
 		$user_id = intval( $comment->user_id );
@@ -724,6 +735,7 @@ final class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request Contains data from the request.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @return WP_REST_Response An instance of WP_REST_Response containing the response data.
 	 */
@@ -833,6 +845,7 @@ final class Rest_Api {
 	 * @param WP_REST_Request $request The REST API request object containing parameters:
 	 *                                 - post_id (int): The ID of the post associated with the RSVP.
 	 *                                 - block_data (string): JSON-encoded block data used to render the RSVP content.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @return WP_REST_Response The REST API response containing:
 	 *                          - success (bool): Whether the content was successfully generated.
@@ -889,6 +902,7 @@ final class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request The REST API request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @return WP_REST_Response The response indicating success or failure.
 	 */
@@ -993,6 +1007,7 @@ final class Rest_Api {
 	 * @since 0.34.0
 	 *
 	 * @param WP_REST_Request $request REST API request object containing post_id parameter.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @return WP_REST_Response Response containing success status and RSVP data.
 	 */

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -667,9 +667,9 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param string   $block_content The block content.
-	 * @param array    $block         The full block, including name and attributes.
-	 * @param WP_Block $instance      The block instance.
+	 * @param string               $block_content The block content.
+	 * @param array<string, mixed> $block         The full block, including name and attributes.
+	 * @param WP_Block             $instance      The block instance.
 	 *
 	 * @return string The filtered block content with event datetime.
 	 *
@@ -719,10 +719,10 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array   $post_states An array of post display states.
-	 * @param WP_Post $post        The current post object.
+	 * @param array<string, string> $post_states An array of post display states.
+	 * @param WP_Post               $post        The current post object.
 	 *
-	 * @return array An updated array of post display states with custom labels if applicable.
+	 * @return array<string, string> An updated array of post display states with custom labels if applicable.
 	 */
 	public function set_event_archive_labels( array $post_states, WP_Post $post ): array {
 		// Retrieve archive page settings.
@@ -791,8 +791,10 @@ final class Setup {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @param int   $post_id The post to write.
-	 * @param array $data    Datetime payload keyed dateTimeStart / dateTimeEnd / timezone.
+	 * @param int                                                                    $post_id The post to write.
+	 * @param array{dateTimeStart?: string, dateTimeEnd?: string, timezone?: string} $data    Datetime payload keyed
+	 *                                                                                        dateTimeStart /
+	 *                                                                                        dateTimeEnd / timezone.
 	 *
 	 * @return void
 	 */

--- a/includes/core/classes/rsvp/class-cache.php
+++ b/includes/core/classes/rsvp/class-cache.php
@@ -51,7 +51,7 @@ final class Cache {
 	 *
 	 * @param int $post_id The WordPress post ID of the event.
 	 *
-	 * @return array|null The cached RSVP data, or null when no valid cache exists.
+	 * @return array<string, mixed>|null The cached RSVP data, or null when no valid cache exists.
 	 */
 	public static function get( int $post_id ): ?array {
 		$value = get_transient( self::cache_key( $post_id ) );

--- a/includes/core/classes/rsvp/class-cleanup.php
+++ b/includes/core/classes/rsvp/class-cleanup.php
@@ -162,8 +162,10 @@ final class Cleanup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $old_value The previous RSVP cleanup settings including interval and frequency.
-	 * @param array $new_value The updated RSVP cleanup settings including interval and frequency.
+	 * @param array<string, bool|int|string> $old_value The previous RSVP cleanup settings including interval and
+	 *                                                  frequency.
+	 * @param array<string, bool|int|string> $new_value The updated RSVP cleanup settings including interval and
+	 *                                                  frequency.
 	 *
 	 * @return void
 	 */

--- a/includes/core/classes/rsvp/class-form.php
+++ b/includes/core/classes/rsvp/class-form.php
@@ -146,9 +146,9 @@ final class Form {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $comment_data The comment data array.
+	 * @param array<string, mixed> $comment_data The comment data array.
 	 *
-	 * @return array Modified comment data array.
+	 * @return array<string, mixed> Modified comment data array.
 	 */
 	public function preprocess_rsvp_comment( array $comment_data ): array {
 		$author  = Utility::get_http_input( INPUT_POST, 'author' );
@@ -335,7 +335,7 @@ final class Form {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $data RSVP submission data containing post_id, author, email, and optional fields.
+	 * @param array<string, mixed> $data RSVP submission data containing post_id, author, email, and optional fields.
 	 *
 	 * @return array{success: bool, message: string, comment_id: int, error_code?: int} Processing result.
 	 */
@@ -436,7 +436,18 @@ final class Form {
 	 * @param string $author  The author name.
 	 * @param string $email   The email address.
 	 *
-	 * @return array Comment data array for wp_insert_comment().
+	 * @return array{
+	 *     comment_post_ID: int,
+	 *     comment_author_IP: string,
+	 *     comment_type: string,
+	 *     comment_content: string,
+	 *     comment_parent: int,
+	 *     user_id: int,
+	 *     comment_approved: int,
+	 *     comment_author: string,
+	 *     comment_author_email: string,
+	 *     comment_author_url: string
+	 * } Comment data array for wp_insert_comment().
 	 */
 	private function prepare_comment_data( int $post_id, string $author, string $email ): array {
 		$user = get_user_by( 'ID', get_current_user_id() );
@@ -497,8 +508,8 @@ final class Form {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param int   $comment_id The comment ID.
-	 * @param array $data       Submission data containing field values.
+	 * @param int                  $comment_id The comment ID.
+	 * @param array<string, mixed> $data       Submission data containing field values.
 	 *
 	 * @return void
 	 */
@@ -515,8 +526,8 @@ final class Form {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param int   $comment_id The comment ID.
-	 * @param array $data       Submission data containing meta field values.
+	 * @param int                  $comment_id The comment ID.
+	 * @param array<string, mixed> $data       Submission data containing meta field values.
 	 *
 	 * @return void
 	 */
@@ -566,8 +577,8 @@ final class Form {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param int   $comment_id The comment ID.
-	 * @param array $data       Submission data containing custom field values.
+	 * @param int                  $comment_id The comment ID.
+	 * @param array<string, mixed> $data       Submission data containing custom field values.
 	 *
 	 * @return void
 	 */
@@ -632,8 +643,8 @@ final class Form {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param int|false $comment_id_result The result from wp_insert_comment (comment ID or false).
-	 * @param array     $data              RSVP submission data.
+	 * @param int|false            $comment_id_result The result from wp_insert_comment (comment ID or false).
+	 * @param array<string, mixed> $data              RSVP submission data.
 	 *
 	 * @return array{success: bool, message: string, comment_id: int, error_code?: int} Processing result.
 	 */

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -72,10 +72,11 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $args Optional. Additional arguments to configure the list table.
-	 *                    Supports 'screen' to specify a particular screen context and
-	 *                    'post_type' to scope the table to one RSVP-supporting post
-	 *                    type (defaults to the event post type).
+	 * @param array{screen?: string|null, post_type?: string} $args Optional. Additional arguments to configure
+	 *                                                             the list table. Supports 'screen' to specify a
+	 *                                                             particular screen context and 'post_type' to
+	 *                                                             scope the table to one RSVP-supporting post
+	 *                                                             type (defaults to the event post type).
 	 */
 	public function __construct( $args = array() ) {
 		$this->post_type = ! empty( $args['post_type'] ) ? (string) $args['post_type'] : Event::POST_TYPE;
@@ -104,7 +105,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Array of column identifiers and their labels.
+	 * @return array<string, string> Array of column identifiers and their labels.
 	 */
 	public function get_columns(): array {
 		return array(
@@ -127,7 +128,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Filtered list of columns that can be hidden.
+	 * @return array<string, string> Filtered list of columns that can be hidden.
 	 */
 	public function get_hideable_columns(): array {
 		$essential_columns = array( 'attendee' );
@@ -179,7 +180,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array List of column identifiers that should be hidden from display.
+	 * @return string[] List of column identifiers that should be hidden from display.
 	 */
 	public function get_hidden_columns(): array {
 		$screen = get_current_screen();
@@ -211,7 +212,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Associative array of sortable column identifiers and their configurations.
+	 * @return array<string, array{0: string, 1: bool}> Sortable column identifiers and their configurations.
 	 */
 	protected function get_sortable_columns(): array {
 		return array(
@@ -287,7 +288,7 @@ final class List_Table extends WP_List_Table {
 	 * @param ?int $per_page    Optional. Number of items per page. Default null (uses DEFAULT_PER_PAGE).
 	 * @param int  $page_number Optional. Current page number. Default 1.
 	 *
-	 * @return array Array of RSVP comment data prepared for display.
+	 * @return array<int, array<string, mixed>> Array of RSVP comment data prepared for display.
 	 */
 	private function get_rsvps( ?int $per_page = null, int $page_number = 1 ): array {
 		$rsvp_query = Query::get_instance();
@@ -446,8 +447,8 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param object|array $item        RSVP comment data containing various properties like comment_ID.
-	 * @param string       $column_name The name of the column being rendered.
+	 * @param object|array<string, mixed> $item        RSVP comment data containing various properties like comment_ID.
+	 * @param string                      $column_name The name of the column being rendered.
 	 *
 	 * @return string Formatted content for the specified column.
 	 */
@@ -521,7 +522,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @param array $item Row data (a comment cast to an array).
+	 * @param array<string, mixed> $item Row data (a comment cast to an array).
 	 *
 	 * @return Provider|null The inferred provider, or null when none applies.
 	 */
@@ -551,7 +552,7 @@ final class List_Table extends WP_List_Table {
 	 * @since 0.34.0
 	 * @since 0.35.0 Row checkboxes carry a visually hidden label naming the attendee.
 	 *
-	 * @param array|object $item RSVP comment data containing the comment_ID.
+	 * @param array<string, mixed>|object $item RSVP comment data containing the comment_ID.
 	 *
 	 * @return string HTML markup for the labeled checkbox input element.
 	 */
@@ -585,7 +586,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @param array $item RSVP comment data.
+	 * @param array<string, mixed> $item RSVP comment data.
 	 *
 	 * @return string The attendee's display name.
 	 */
@@ -617,7 +618,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $item RSVP comment data for the RSVP entry.
+	 * @param array<string, mixed> $item RSVP comment data for the RSVP entry.
 	 *
 	 * @return string HTML content for the attendee column, including attendee information and action links.
 	 */
@@ -722,7 +723,7 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array An associative array of bulk action identifiers and their labels.
+	 * @return array<string, string> An associative array of bulk action identifiers and their labels.
 	 */
 	public function get_bulk_actions(): array {
 		if ( ! current_user_can( Rsvp::CAPABILITY ) ) {
@@ -747,8 +748,8 @@ final class List_Table extends WP_List_Table {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param object|array $item RSVP comment data, either as an object or an associative array.
-	 *                           Contains properties/keys like 'comment_ID' and 'comment_approved'.
+	 * @param object|array<string, mixed> $item RSVP comment data, either as an object or an associative array.
+	 *                                          Contains properties/keys like 'comment_ID' and 'comment_approved'.
 	 *
 	 * @return void The method outputs HTML directly and doesn't return a value.
 	 */
@@ -891,7 +892,7 @@ final class List_Table extends WP_List_Table {
 	 * @since 0.34.0
 	 *
 	 * @global string $post_type
-	 * @return array An array of HTML links for different views.
+	 * @return array<string, string> An array of HTML links for different views, keyed by view slug.
 	 */
 	public function get_views(): array {
 		$rsvp_query   = Query::get_instance();

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -87,10 +87,10 @@ final class Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array            $clauses       The clauses for the query.
-	 * @param WP_Comment_Query $comment_query Current instance of WP_Comment_Query (passed by reference).
+	 * @param array<string, string> $clauses       The clauses for the query.
+	 * @param WP_Comment_Query      $comment_query Current instance of WP_Comment_Query (passed by reference).
 	 *
-	 * @return array Modified query clauses.
+	 * @return array<string, string> Modified query clauses.
 	 */
 	public function taxonomy_query( array $clauses, WP_Comment_Query $comment_query ): array {
 		global $wpdb;
@@ -114,7 +114,7 @@ final class Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $args Arguments for retrieving RSVPs.
+	 * @param array<string, mixed> $args Arguments for retrieving RSVPs.
 	 *
 	 * @return mixed Array of RSVP comments or integer count when count parameter is true.
 	 */
@@ -150,7 +150,7 @@ final class Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $args Arguments for retrieving the RSVP.
+	 * @param array<string, mixed> $args Arguments for retrieving the RSVP.
 	 *
 	 * @return WP_Comment|null The RSVP comment or null if not found.
 	 */
@@ -175,7 +175,7 @@ final class Query {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array Array of all comment types in the database.
+	 * @return string[] Array of all comment types in the database.
 	 */
 	protected function get_all_comment_types(): array {
 		$default_types = array( 'comment', 'pingback', 'trackback' );

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -36,6 +36,35 @@ use WP_Post;
  * Manages RSVP functionality for events, including response status tracking and limits.
  *
  * @since 0.34.0
+ *
+ * @phpstan-type RsvpRecord array{
+ *     name: string,
+ *     photo: string|null,
+ *     profile: string|null,
+ *     status: string,
+ *     guests: int,
+ *     anonymous: bool,
+ *     timestamp: string,
+ *     provider: string,
+ *     identifier: int|string,
+ *     role: string,
+ *     comment_id: int,
+ *     post_id: int,
+ *     user_id: int,
+ *     commentId: int,
+ *     postId: int,
+ *     userId: int
+ * }
+ * @phpstan-type RsvpSaveDefault array{
+ *     comment_id: int,
+ *     post_id: int,
+ *     user_id: int,
+ *     timestamp: string,
+ *     status: string,
+ *     guests: int,
+ *     anonymous: int
+ * }
+ * @phpstan-type RsvpResponseGroup array{records: array<int, RsvpRecord>, count: int}
  */
 final class Rsvp {
 
@@ -67,7 +96,7 @@ final class Rsvp {
 	 * Default response for calling the save function.
 	 *
 	 * @since 0.35.0
-	 * @var array
+	 * @var RsvpSaveDefault
 	 */
 	private const DEFAULT_SAVE_RESPONSE = array(
 		'comment_id' => 0,
@@ -145,7 +174,7 @@ final class Rsvp {
 	 *
 	 * @param mixed $identifier The identifier of the RSVP.
 	 *
-	 * @return array|null An array containing RSVP information.
+	 * @return RsvpRecord|null An array containing RSVP information.
 	 */
 	public function get( $identifier ): array|null {
 		$identity = $this->resolve_identity( $identifier );
@@ -234,13 +263,15 @@ final class Rsvp {
 	 *                                    Accepts 1 for true (anonymous) and 0 for false (not anonymous). Default 0.
 	 * @param int        $guests          Optional. The number of guests the user plans to bring along. Default 0.
 	 *
-	 * @return array Associative array containing the event ID ('post_id'), user ID ('user_id'),
-	 *               RSVP timestamp ('timestamp'), RSVP status ('status'), number of guests ('guests'),
-	 *               and anonymity flag ('anonymous'). Returns a default array with 'post_id' and 'user_id'
-	 *               set to 0, 'timestamp' to '0000-00-00 00:00:00', 'status' to 'no_status', 'guests' to 0,
-	 *               and 'anonymous' to 0 if the post ID or user identifier is not valid, or if the status
-	 *               is not one of the acceptable values. If the attending limit is reached, 'status' may be
-	 *               automatically set to 'waiting_list', and 'guests' to 0, depending on the context.
+	 * @return RsvpRecord|RsvpSaveDefault Associative array containing the event ID ('post_id'),
+	 *                                    user ID ('user_id'), RSVP timestamp ('timestamp'), RSVP status ('status'),
+	 *                                    number of guests ('guests'), and anonymity flag ('anonymous'). Returns a
+	 *                                    default array with 'post_id' and 'user_id' set to 0, 'timestamp' to
+	 *                                    '0000-00-00 00:00:00', 'status' to 'no_status', 'guests' to 0, and
+	 *                                    'anonymous' to 0 if the post ID or user identifier is not valid, or if the
+	 *                                    status is not one of the acceptable values. If the attending limit is
+	 *                                    reached, 'status' may be automatically set to 'waiting_list', and 'guests'
+	 *                                    to 0, depending on the context.
 	 */
 	public function save(
 		mixed $identifier,
@@ -487,7 +518,7 @@ final class Rsvp {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array An array containing response information grouped by RSVP status.
+	 * @return array<string, RsvpResponseGroup> Response records and counts keyed by 'all' and each RSVP status.
 	 */
 	public function responses(): array {
 		// Serialized records vary by capability but the cache key does not, so
@@ -566,8 +597,10 @@ final class Rsvp {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $first  The first response to compare in the sort.
-	 * @param array $second The second response to compare in the sort.
+	 * @param array<string, mixed> $first  The first response to compare in the sort.
+	 * @param array<string, mixed> $second The second response to compare in the sort.
+	 * @phpstan-param RsvpRecord $first
+	 * @phpstan-param RsvpRecord $second
 	 *
 	 * @return int An integer indicating the sorting order:
 	 *             -1 if $first should come before $second,
@@ -598,8 +631,10 @@ final class Rsvp {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $first  First response to compare in the sort.
-	 * @param array $second Second response to compare in the sort.
+	 * @param array<string, mixed> $first  First response to compare in the sort.
+	 * @param array<string, mixed> $second Second response to compare in the sort.
+	 * @phpstan-param RsvpRecord $first
+	 * @phpstan-param RsvpRecord $second
 	 *
 	 * @return int Returns a negative number if the first response's timestamp is earlier,
 	 *             a positive number if the second response's timestamp is earlier,

--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -597,10 +597,10 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array  $emails     Array of email addresses to notify.
-	 * @param string $comment_id The comment ID.
+	 * @param string[] $emails     Array of email addresses to notify.
+	 * @param string   $comment_id The comment ID.
 	 *
-	 * @return array Empty array for RSVP comments, original array otherwise.
+	 * @return string[] Empty array for RSVP comments, original array otherwise.
 	 */
 	public function remove_rsvp_notification_emails( array $emails, string $comment_id ): array {
 		if ( get_comment_type( (int) $comment_id ) !== Rsvp::COMMENT_TYPE ) {

--- a/includes/core/classes/rsvp/class-storage.php
+++ b/includes/core/classes/rsvp/class-storage.php
@@ -49,7 +49,7 @@ final class Storage {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	private const DEFAULT_SAVE_ARGS = array(
 		'comment_author'       => '',
@@ -433,8 +433,8 @@ final class Storage {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @param array    $args     The current comment data args.
-	 * @param Identity $identity The identity.
+	 * @param array<array<int|string>|int|string> $args     The current comment data args.
+	 * @param Identity                            $identity The identity.
 	 *
 	 * @return array<array<int|string>|int|string> The comment data args including the identity.
 	 */

--- a/includes/core/classes/rsvp/class-token.php
+++ b/includes/core/classes/rsvp/class-token.php
@@ -351,7 +351,8 @@ final class Token {
 	 *
 	 * @param string|null $token_string Raw token string in format "commentId_token".
 	 *
-	 * @return array Array with 'comment_id' and 'token' keys, or empty array if invalid.
+	 * @return array{comment_id: int, token: string}|array{} Array with 'comment_id' and 'token' keys, or empty
+	 *                                                        array if invalid.
 	 */
 	public static function parse_token_string( ?string $token_string ): array {
 		if ( empty( $token_string ) ) {
@@ -477,7 +478,7 @@ final class Token {
 	 *
 	 * @param WP_Post|null $post The event post object.
 	 *
-	 * @return array Email data with subject, body, and headers.
+	 * @return array{subject: string, body: string, headers: string[]} Email data with subject, body, and headers.
 	 */
 	private function prepare_email_data( ?WP_Post $post ): array {
 		$title = $post ? get_the_title( $post ) : __( 'this event', 'gatherpress' );

--- a/includes/core/classes/rsvp/response/class-provider-registry.php
+++ b/includes/core/classes/rsvp/response/class-provider-registry.php
@@ -41,7 +41,7 @@ final class Provider_Registry {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @var array
+	 * @var array<string, Provider> Registered provider instances, keyed by slug.
 	 */
 	private array $providers = array();
 

--- a/includes/core/classes/rsvp/response/class-serializer.php
+++ b/includes/core/classes/rsvp/response/class-serializer.php
@@ -20,6 +20,8 @@ use GatherPress\Core\Utility;
  * Class with methods to serialize RSVP Response objects.
  *
  * @since 0.35.0
+ *
+ * @phpstan-import-type RsvpRecord from Rsvp
  */
 final class Serializer {
 
@@ -30,7 +32,7 @@ final class Serializer {
 	 *
 	 * @param State $state RSVP state.
 	 *
-	 * @return array The RSVP response state as an associative array.
+	 * @return RsvpRecord The RSVP response state as an associative array.
 	 */
 	public static function to_array( State $state ): array {
 		$identity = $state->data->identity;

--- a/includes/core/classes/rsvp/response/class-status.php
+++ b/includes/core/classes/rsvp/response/class-status.php
@@ -62,7 +62,7 @@ enum Status: string {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @return array List of all valid status values.
+	 * @return string[] List of all valid status values.
 	 */
 	public static function values(): array {
 		$values = array();

--- a/includes/core/classes/settings/class-base.php
+++ b/includes/core/classes/settings/class-base.php
@@ -15,12 +15,17 @@ namespace GatherPress\Core\Settings;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Settings;
+
 /**
  * Class Base.
  *
  * This class provides a foundation for creating settings pages in GatherPress.
  *
  * @since 0.27.0
+ *
+ * @phpstan-import-type SettingsSection from Settings
+ * @phpstan-import-type SettingsSubPage from Settings
  */
 abstract class Base {
 
@@ -51,7 +56,7 @@ abstract class Base {
 	/**
 	 * An array of sections to be displayed on the settings page.
 	 *
-	 * @var array
+	 * @var array<string, SettingsSection>
 	 * @since 0.27.0
 	 */
 	protected array $sections;
@@ -106,7 +111,7 @@ abstract class Base {
 	 *
 	 * @since 0.27.0
 	 *
-	 * @return array
+	 * @return array<string, SettingsSection>
 	 */
 	protected function get_sections(): array {
 		return array();
@@ -149,9 +154,9 @@ abstract class Base {
 	 *
 	 * @since 0.27.0
 	 *
-	 * @param array $sub_pages An array of sub-pages for GatherPress.
+	 * @param array<string, SettingsSubPage> $sub_pages An array of sub-pages for GatherPress.
 	 *
-	 * @return array Modified array with the sub-page added.
+	 * @return array<string, SettingsSubPage> Modified array with the sub-page added.
 	 */
 	public function set_sub_page( array $sub_pages ): array {
 		$sub_pages[ $this->slug ] = $this->page();
@@ -182,7 +187,7 @@ abstract class Base {
 	 *
 	 * @since 0.27.0
 	 *
-	 * @return array An array representing the settings page.
+	 * @return SettingsSubPage An array representing the settings page.
 	 */
 	public function page(): array {
 		return array(

--- a/includes/core/classes/settings/class-events.php
+++ b/includes/core/classes/settings/class-events.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Event;
 use GatherPress\Core\Event\Setup;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Topic;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
@@ -26,6 +27,8 @@ use GatherPress\Core\Utility;
  * Handles the "Events" settings page for GatherPress.
  *
  * @since 0.34.0
+ *
+ * @phpstan-import-type SettingsSection from Settings
  */
 final class Events extends Base {
 
@@ -75,7 +78,7 @@ final class Events extends Base {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array An array of sections and options for the Events settings page.
+	 * @return array<string, SettingsSection> An array of sections and options for the Events settings page.
 	 */
 	protected function get_sections(): array {
 		return array(

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -27,6 +27,9 @@ use GatherPress\Core\Utility;
  * Class Network.
  *
  * @since 0.34.0
+ *
+ * @phpstan-import-type SettingsSubPage from Settings
+ * @phpstan-type NetworkConfig array{enabled: bool, inherited: string[]}
  */
 final class Network {
 
@@ -88,6 +91,7 @@ final class Network {
 	 * @since 0.34.0
 	 *
 	 * @var array|null
+	 * @phpstan-var NetworkConfig|null
 	 */
 	protected static ?array $config_cache = null;
 
@@ -172,7 +176,7 @@ final class Network {
 		$config   = self::get_config();
 		$settings = Settings::get_instance();
 		$locked   = array_filter(
-			(array) ( $config['inherited'] ?? array() ),
+			$config['inherited'],
 			static function ( $option_key ) use ( $settings ): bool {
 				return $settings->is_option_inherited( (string) $option_key );
 			}
@@ -338,7 +342,7 @@ final class Network {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array
+	 * @return array<string, SettingsSubPage>
 	 */
 	protected function get_network_sub_pages(): array {
 		$sub_pages = Settings::get_instance()->get_sub_pages();
@@ -360,7 +364,7 @@ final class Network {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $sub_pages Available sub-pages keyed by slug.
+	 * @param array<string, SettingsSubPage> $sub_pages Available sub-pages keyed by slug.
 	 *
 	 * @return string
 	 */
@@ -470,7 +474,7 @@ final class Network {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $sub_pages Sub-pages from Settings::get_sub_pages().
+	 * @param array<string, SettingsSubPage> $sub_pages Sub-pages from Settings::get_sub_pages().
 	 *
 	 * @return array<string, string>
 	 */
@@ -532,6 +536,7 @@ final class Network {
 	 * @param mixed $input Raw input array.
 	 *
 	 * @return array
+	 * @phpstan-return NetworkConfig
 	 */
 	public function sanitize( $input ): array {
 		$input     = is_array( $input ) ? $input : array();
@@ -560,6 +565,7 @@ final class Network {
 	 * @since 0.34.0
 	 *
 	 * @return array Config with 'enabled' (bool) and 'inherited' (string[]).
+	 * @phpstan-return NetworkConfig
 	 */
 	public static function get_config(): array {
 		// Called twice per field render (via Settings::render_field → get() →
@@ -600,6 +606,7 @@ final class Network {
 	 * @since 0.34.0
 	 *
 	 * @return array
+	 * @phpstan-return NetworkConfig
 	 */
 	public static function get_default_config(): array {
 		return array(

--- a/includes/core/classes/settings/class-roles.php
+++ b/includes/core/classes/settings/class-roles.php
@@ -23,6 +23,9 @@ use GatherPress\Core\Traits\Singleton;
  * Handles the "Roles" settings page for GatherPress.
  *
  * @since 0.34.0
+ *
+ * @phpstan-import-type SettingsOption from Settings
+ * @phpstan-import-type SettingsSection from Settings
  */
 final class Roles extends Base {
 
@@ -58,7 +61,7 @@ final class Roles extends Base {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array An array of sections and their settings.
+	 * @return array<string, SettingsSection> An array of sections and their settings.
 	 */
 	protected function get_sections(): array {
 		$roles = array(
@@ -107,7 +110,7 @@ final class Roles extends Base {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array An array containing user roles and their corresponding settings.
+	 * @return array<string, SettingsOption> An array containing user roles and their corresponding settings.
 	 */
 	public function get_user_roles(): array {
 		$sub_pages = Settings::get_instance()->get_sub_pages();

--- a/includes/core/classes/settings/class-rsvp.php
+++ b/includes/core/classes/settings/class-rsvp.php
@@ -15,6 +15,7 @@ namespace GatherPress\Core\Settings;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Event;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 
@@ -24,6 +25,8 @@ use GatherPress\Core\Utility;
  * Handles the "RSVP" settings page for GatherPress.
  *
  * @since 0.34.0
+ *
+ * @phpstan-import-type SettingsSection from Settings
  */
 final class Rsvp extends Base {
 
@@ -70,7 +73,7 @@ final class Rsvp extends Base {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array An array of sections and options for the RSVP settings page.
+	 * @return array<string, SettingsSection> An array of sections and options for the RSVP settings page.
 	 */
 	protected function get_sections(): array {
 		return array(

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -15,6 +15,7 @@ namespace GatherPress\Core\Settings;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Venue;
@@ -27,6 +28,8 @@ use GatherPress\Core\Venue\Setup;
  * Handles the "Venues" settings page for GatherPress.
  *
  * @since 0.34.0
+ *
+ * @phpstan-import-type SettingsSection from Settings
  */
 final class Venues extends Base {
 
@@ -80,7 +83,7 @@ final class Venues extends Base {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return array An array of sections and options for the Venues settings page.
+	 * @return array<string, SettingsSection> An array of sections and options for the Venues settings page.
 	 */
 	protected function get_sections(): array {
 		return array(

--- a/includes/core/classes/venue/class-meta.php
+++ b/includes/core/classes/venue/class-meta.php
@@ -350,6 +350,7 @@ final class Meta {
 	 *
 	 * @param stdClass        $prepared_post An object representing a single post prepared for inserting or updating.
 	 * @param WP_REST_Request $request       Request object.
+	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @return stdClass The prepared post object.
 	 */

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -150,9 +150,9 @@ final class Setup {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $settings The block editor settings array.
+	 * @param array<string, mixed> $settings The block editor settings array.
 	 *
-	 * @return array The modified block editor settings array.
+	 * @return array<string, mixed> The modified block editor settings array.
 	 */
 	public function add_editor_settings( array $settings ): array {
 		if ( ! isset( $settings['gatherpress'] ) ) {
@@ -456,7 +456,24 @@ final class Setup {
 	 * @param int    $post_id   The post ID for which to retrieve venue information.
 	 * @param string $post_type The post type of the provided post ID.
 	 *
-	 * @return array An array containing venue-related information.
+	 * @return array{
+	 *     isOnlineEventTerm: bool,
+	 *     onlineEventLink: string,
+	 *     name?: string,
+	 *     address?: string,
+	 *     city?: string,
+	 *     country?: string,
+	 *     country_code?: string,
+	 *     county?: string,
+	 *     house_number?: string,
+	 *     latitude?: string,
+	 *     longitude?: string,
+	 *     phone?: string,
+	 *     postcode?: string,
+	 *     state?: string,
+	 *     street?: string,
+	 *     website?: string
+	 * } Venue-related information; the venue fields are present only when a venue resolves.
 	 */
 	public function get_venue_meta( int $post_id, string $post_type ): array {
 		$venue_meta = array(

--- a/includes/core/classes/venue/map/class-dimensions.php
+++ b/includes/core/classes/venue/map/class-dimensions.php
@@ -39,8 +39,8 @@ final class Dimensions {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @param array  $attributes Block attributes.
-	 * @param string $dimension  Either `width` or `height`.
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @param string               $dimension  Either `width` or `height`.
 	 *
 	 * @return string|null The dimension value, or null when unset.
 	 */

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -49,6 +49,13 @@ use WP_Post;
  * @phpstan-type Descriptor array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}
  * @phpstan-type DescriptorMap array<string, Descriptor>
  * @phpstan-type ProviderDescriptorMap array<string, DescriptorMap>
+ * @phpstan-type ComboRequest array{
+ *     zoom?: int|null,
+ *     width?: int|null,
+ *     height?: int|null,
+ *     aspect_ratio?: string,
+ *     map_type?: string
+ * }
  */
 final class Map {
 
@@ -350,9 +357,9 @@ final class Map {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array $metadata Parsed `block.json` metadata for the block being registered.
+	 * @param array<string, mixed> $metadata Parsed `block.json` metadata for the block being registered.
 	 *
-	 * @return array The metadata array, potentially with updated attribute defaults.
+	 * @return array<string, mixed> The metadata array, potentially with updated attribute defaults.
 	 */
 	public function apply_block_attribute_defaults( array $metadata ): array {
 		if ( 'gatherpress/venue-map' !== ( $metadata['name'] ?? '' ) ) {
@@ -558,11 +565,11 @@ final class Map {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param int        $post_id     The venue post ID.
-	 * @param array|null $extra_combo Optional extra combo to include, in the
-	 *                                {@see Rest_Api::parse_request()} shape:
-	 *                                `zoom`, `width` (0 = auto), `height`
-	 *                                (0 = auto), `aspect_ratio`, `map_type`.
+	 * @param int               $post_id     The venue post ID.
+	 * @param ComboRequest|null $extra_combo Optional extra combo to include, in the
+	 *                                       {@see Rest_Api::parse_request()} shape:
+	 *                                       `zoom`, `width` (0 = auto), `height`
+	 *                                       (0 = auto), `aspect_ratio`, `map_type`.
 	 *
 	 * @return ProviderDescriptorMap
 	 */
@@ -665,10 +672,11 @@ final class Map {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @param int   $post_id The venue post ID.
-	 * @param array $combo   Combo in the {@see Rest_Api::parse_request()}
-	 *                       shape: `zoom`, `width` (0 = auto), `height`
-	 *                       (0 = auto), `aspect_ratio`, `map_type`.
+	 * @param int                  $post_id The venue post ID.
+	 * @param array<string, mixed> $combo   Combo in the {@see Rest_Api::parse_request()}
+	 *                                      shape: `zoom`, `width` (0 = auto), `height`
+	 *                                      (0 = auto), `aspect_ratio`, `map_type`.
+	 * @phpstan-param ComboRequest $combo
 	 *
 	 * @return ProviderDescriptorMap
 	 */
@@ -1095,12 +1103,12 @@ final class Map {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param int    $post_id Venue post ID.
-	 * @param array  $info    Parsed venue information.
-	 * @param int    $zoom     Zoom level to render at.
-	 * @param int    $width    Pixel width of the PNG.
-	 * @param int    $height   Pixel height of the PNG.
-	 * @param string $map_type Map type slug for the render.
+	 * @param int                   $post_id  Venue post ID.
+	 * @param array<string, string> $info     Parsed venue information.
+	 * @param int                   $zoom     Zoom level to render at.
+	 * @param int                   $width    Pixel width of the PNG.
+	 * @param int                   $height   Pixel height of the PNG.
+	 * @param string                $map_type Map type slug for the render.
 	 *
 	 * @return array{url: string, url_2x: string, hash: string, zoom: int, width: int, height: int}|null
 	 */
@@ -1274,12 +1282,12 @@ final class Map {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param array  $info     Parsed venue information.
-	 * @param int    $zoom     Map zoom level.
-	 * @param int    $width    Output width.
-	 * @param int    $height   Output height.
-	 * @param string $provider Provider slug (e.g. `osm`).
-	 * @param string $map_type Map type slug.
+	 * @param array<string, string> $info     Parsed venue information.
+	 * @param int                   $zoom     Map zoom level.
+	 * @param int                   $width    Output width.
+	 * @param int                   $height   Output height.
+	 * @param string                $provider Provider slug (e.g. `osm`).
+	 * @param string                $map_type Map type slug.
 	 *
 	 * @return string MD5 hex digest.
 	 */

--- a/includes/core/classes/venue/map/class-rest-api.php
+++ b/includes/core/classes/venue/map/class-rest-api.php
@@ -30,7 +30,20 @@ use WP_REST_Server;
  * shape of `Event\Rest_Api` — one class per subsystem owning its whole
  * REST surface.
  *
+ * `aspect_ratio` and `map_type` stay `mixed` because {@see Rest_Api::parse_request()}
+ * guards them with `is_string()` for callers that bypass the route's validation.
+ *
  * @since 0.35.0
+ *
+ * @phpstan-type RegenerateRequestParams array{
+ *     id: int,
+ *     zoom?: int,
+ *     width?: int,
+ *     height?: int,
+ *     aspect_ratio?: mixed,
+ *     map_type?: mixed,
+ *     ensure_only?: bool
+ * }
  */
 final class Rest_Api {
 
@@ -207,6 +220,7 @@ final class Rest_Api {
 	 * @since 0.35.0
 	 *
 	 * @param WP_REST_Request $request The REST request.
+	 * @phpstan-param WP_REST_Request<RegenerateRequestParams> $request
 	 *
 	 * @return array{zoom: int|null, width: int|null, height: int|null, aspect_ratio: string, map_type: string}
 	 */
@@ -243,6 +257,7 @@ final class Rest_Api {
 	 * @since 0.35.0 Moved from `Map::rest_regenerate()`.
 	 *
 	 * @param WP_REST_Request $request The REST request.
+	 * @phpstan-param WP_REST_Request<RegenerateRequestParams> $request
 	 *
 	 * @return WP_REST_Response
 	 */

--- a/includes/templates/admin/settings/fields/checkbox.php
+++ b/includes/templates/admin/settings/fields/checkbox.php
@@ -26,6 +26,11 @@ $gatherpress_disabled = ! empty( $disabled ) ? ' disabled' : '';
 // from the POST, so the trailing hidden input's value is what lands in
 // `$_POST[$name]` — carry the current (possibly inherited) boolean so
 // the saved value matches what the UI displayed.
+/**
+ * Current checkbox value.
+ *
+ * @var bool|string|int $value Bool once sanitized; defaults and legacy options may carry a bool-like string or int.
+ */
 $gatherpress_fallback = ! empty( $disabled ) && rest_sanitize_boolean( $value ) ? '1' : '0';
 
 // IMPORTANT: keep the hidden input BEFORE the checkbox. PHP takes the

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,7 +20,7 @@ parameters:
 
     # the analysis level, from 0 (loose) to 9 (strict)
     # https://phpstan.org/user-guide/rule-levels
-    level: 5
+    level: 6
 
     paths:
         - includes/


### PR DESCRIPTION
First of two steps toward level 8. Level 6 is the largest and most mechanical jump — it requires every `array` in a docblock to declare what it contains — so it lands on its own before the nullability work.

## What changed

284 errors across 65 files, all in docblocks. Rather than blanket `array<string, mixed>`, the shapes are the real ones, read out of the method bodies and their callers:

- `@phpstan-type` aliases where a structure is stable and reused — `SettingsSection` / `SettingsSubPage` / `SettingsField` on `Settings`, `RsvpRecord` / `RsvpResponseGroup` on `Rsvp`, `RouteDefinition` / `Recipient` on `Event\Rest_Api`, `GeocodeResult` on `Geocoding`, `NetworkConfig` on `Settings\Network`, and others
- `array{...}` shapes where keys are fixed and known
- `array<string, mixed>` reserved for genuinely heterogeneous payloads: parsed blocks, WP hook arguments, `WP_Query` args, raw `get_option` storage, uploaded JSON

## Three runtime lines, each a defect the types exposed

- `Assets::get_block_variation_names()` passed `scandir()` directly into `array_diff()`. `scandir()` returns `false` on an unreadable directory, which the `file_exists()` check above it does not rule out.
- `Settings::is_option_inherited()` and `Settings\Network::render_page()` both guarded `$config[&apos;inherited&apos;]` with `??`, but `get_config()` merges `get_default_config()`, so the key always exists and the fallback was unreachable.

Everything else is comments.

## Verification

- PHPStan level 6: **`[OK] No errors`** across `includes/`
- PHPCS: clean on all 66 changed files (warnings included — they fail CI)
- PHPMD: exit 0
- PHPUnit: **1722 tests, 7093 assertions, OK**

## Note for reviewers

PHPCS `Squiz.Commenting.FunctionComment.IncorrectTypeHint` rejects a bare alias or an inline generic in `@param` when the parameter has a native `array` hint. Those places use `@param array<string, mixed> $x` paired with `@phpstan-param Alias $x` — PHPStan honors the latter, PHPCS reads the former. `@return` has no such restriction and uses aliases directly.

Level 7 and 8 follow in a second PR once this is in.