### PR TITLE
Raise PHPStan to level 8

### DIFF
--- a/.github/changelog/phpstan-level-8
+++ b/.github/changelog/phpstan-level-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Raise static analysis to PHPStan level 8 and fix the nullability defects it surfaced, including calendar feed links for deleted venue terms, RSVP admin rows for deleted events, and several paths that could fatal on an unresolvable event.

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -208,7 +208,6 @@ final class General_Block {
 				$processor->remove_attribute( 'role' );
 
 				$content = $processor->get_updated_html();
-
 				$content = (string) preg_replace( '/<a\b/', '<button', $content );
 				$content = str_replace( '</a>', '</button>', $content );
 				break;

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -209,7 +209,6 @@ final class General_Block {
 
 				$content = $processor->get_updated_html();
 
-				// A literal pattern cannot fail to compile, so preg_replace() never returns null here.
 				$content = (string) preg_replace( '/<a\b/', '<button', $content );
 				$content = str_replace( '</a>', '</button>', $content );
 				break;

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -208,7 +208,9 @@ final class General_Block {
 				$processor->remove_attribute( 'role' );
 
 				$content = $processor->get_updated_html();
-				$content = preg_replace( '/<a\b/', '<button', $content );
+
+				// A literal pattern cannot fail to compile, so preg_replace() never returns null here.
+				$content = (string) preg_replace( '/<a\b/', '<button', $content );
 				$content = str_replace( '</a>', '</button>', $content );
 				break;
 			}

--- a/includes/core/classes/blocks/class-modal.php
+++ b/includes/core/classes/blocks/class-modal.php
@@ -123,7 +123,7 @@ final class Modal {
 		if ( $tag->next_tag() ) {
 			$z_index = $block['attrs']['zIndex'] ?? 1000;
 
-			// A missing or valueless `style` attribute carries no declarations to preserve.
+			// A valueless attribute reads back as true.
 			$existing_styles       = $tag->get_attribute( 'style' );
 			$existing_styles       = is_string( $existing_styles ) ? $existing_styles : '';
 			$existing_styles_array = explode( ';', rtrim( $existing_styles, ';' ) );

--- a/includes/core/classes/blocks/class-modal.php
+++ b/includes/core/classes/blocks/class-modal.php
@@ -121,8 +121,11 @@ final class Modal {
 		$tag = new WP_HTML_Tag_Processor( $block_content );
 
 		if ( $tag->next_tag() ) {
-			$z_index               = $block['attrs']['zIndex'] ?? 1000;
-			$existing_styles       = $tag->get_attribute( 'style' ) ?? '';
+			$z_index = $block['attrs']['zIndex'] ?? 1000;
+
+			// A missing or valueless `style` attribute carries no declarations to preserve.
+			$existing_styles       = $tag->get_attribute( 'style' );
+			$existing_styles       = is_string( $existing_styles ) ? $existing_styles : '';
 			$existing_styles_array = explode( ';', rtrim( $existing_styles, ';' ) );
 			$existing_styles_clean = implode( ';', array_filter( $existing_styles_array ) ) . ';';
 			$updated_styles        = trim(

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -87,8 +87,7 @@ final class Online_Event {
 		// Check if block has a postId override attribute.
 		$post_id = isset( $block['attrs']['postId'] ) ? intval( $block['attrs']['postId'] ) : get_the_ID();
 
-		// Don't render without a post in context — `get_the_ID()` is false outside the loop — or if the
-		// event doesn't have the online-event term.
+		// get_the_ID() is false outside the loop.
 		if ( false === $post_id || ! $this->has_online_event_term( $post_id ) ) {
 			return '';
 		}

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -87,8 +87,9 @@ final class Online_Event {
 		// Check if block has a postId override attribute.
 		$post_id = isset( $block['attrs']['postId'] ) ? intval( $block['attrs']['postId'] ) : get_the_ID();
 
-		// Don't render if the event doesn't have the online-event term.
-		if ( ! $this->has_online_event_term( $post_id ) ) {
+		// Don't render without a post in context — `get_the_ID()` is false outside the loop — or if the
+		// event doesn't have the online-event term.
+		if ( false === $post_id || ! $this->has_online_event_term( $post_id ) ) {
 			return '';
 		}
 

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -144,8 +144,10 @@ final class Rsvp_Form {
 		$schema_form_id = $this->get_form_schema_id( $post_id, $block );
 
 		$block_content = trim( $block_content );
-		$block_content = preg_replace( '/^<div\b/', '<form', $block_content );
-		$block_content = preg_replace(
+
+		// Both patterns are literals anchored to one end, so preg_replace() never returns null.
+		$block_content = (string) preg_replace( '/^<div\b/', '<form', $block_content );
+		$block_content = (string) preg_replace(
 			'/(<\/div>)$/',
 			'<input type="hidden" name="comment_post_ID" value="' . intval( $post_id ) . '">' .
 			'<input type="hidden" name="' . esc_attr( Rsvp::COMMENT_TYPE ) . '" value="1">' .
@@ -220,15 +222,19 @@ final class Rsvp_Form {
 		// Check if this is a success redirect (form was just submitted).
 		$is_success = 'true' === Utility::get_http_input( INPUT_GET, 'gatherpress_rsvp_success' );
 
+		// Block attributes were produced by json_decode() during parsing, so re-encoding
+		// them cannot fail.
+		$visibility_json = (string) wp_json_encode( $visibility );
+
 		// Determine if block should be visible using centralized logic.
-		$should_show = $this->determine_visibility( wp_json_encode( $visibility ), $is_success, $is_past );
+		$should_show = $this->determine_visibility( $visibility_json, $is_success, $is_past );
 
 		// Add the visibility data attribute(s) to the rendered block.
 		$tag = new WP_HTML_Tag_Processor( $block_content );
 
 		if ( $tag->next_tag() ) {
 			// Store visibility as JSON.
-			$tag->set_attribute( 'data-gatherpress-rsvp-form-visibility', wp_json_encode( $visibility ) );
+			$tag->set_attribute( 'data-gatherpress-rsvp-form-visibility', $visibility_json );
 
 			// Add event state for frontend JavaScript.
 			if ( $is_past ) {
@@ -311,7 +317,8 @@ final class Rsvp_Form {
 		while ( $tag->next_tag() ) {
 			$visibility_attr = $tag->get_attribute( 'data-gatherpress-rsvp-form-visibility' );
 
-			if ( $visibility_attr ) {
+			// A valueless boolean attribute reads back as true and carries no rule to apply.
+			if ( is_string( $visibility_attr ) && '' !== $visibility_attr ) {
 				$this->apply_visibility_rule( $tag, $visibility_attr, $is_success, $is_past );
 			}
 		}
@@ -433,8 +440,9 @@ final class Rsvp_Form {
 			return;
 		}
 
-		// Parse blocks and extract schemas for each RSVP Form.
-		$blocks  = parse_blocks( $post->post_content );
+		// Parse blocks and extract schemas for each RSVP Form. parse_blocks() returns a list,
+		// and array_values() pins that so the index-based schema IDs stay integers.
+		$blocks  = array_values( parse_blocks( $post->post_content ) );
 		$schemas = $this->extract_form_schemas_from_blocks( $blocks );
 
 		if ( ! empty( $schemas ) ) {
@@ -469,7 +477,8 @@ final class Rsvp_Form {
 				if ( ! empty( $fields ) ) {
 					$schemas[ $form_id ] = array(
 						'fields' => $fields,
-						'hash'   => wp_hash( wp_json_encode( $fields ) ),
+						// Every field value went through sanitize_*(), so encoding cannot fail.
+						'hash'   => wp_hash( (string) wp_json_encode( $fields ) ),
 					);
 				}
 			}
@@ -566,7 +575,8 @@ final class Rsvp_Form {
 			return 'form_0'; // Fallback.
 		}
 
-		$blocks     = parse_blocks( $post->post_content );
+		// parse_blocks() returns a list; array_values() pins that for the index math below.
+		$blocks     = array_values( parse_blocks( $post->post_content ) );
 		$form_index = $this->find_form_index_in_blocks( $blocks, $block );
 
 		return 'form_' . $form_index;

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -145,7 +145,6 @@ final class Rsvp_Form {
 
 		$block_content = trim( $block_content );
 
-		// Both patterns are literals anchored to one end, so preg_replace() never returns null.
 		$block_content = (string) preg_replace( '/^<div\b/', '<form', $block_content );
 		$block_content = (string) preg_replace(
 			'/(<\/div>)$/',
@@ -222,8 +221,6 @@ final class Rsvp_Form {
 		// Check if this is a success redirect (form was just submitted).
 		$is_success = 'true' === Utility::get_http_input( INPUT_GET, 'gatherpress_rsvp_success' );
 
-		// Block attributes were produced by json_decode() during parsing, so re-encoding
-		// them cannot fail.
 		$visibility_json = (string) wp_json_encode( $visibility );
 
 		// Determine if block should be visible using centralized logic.
@@ -317,7 +314,7 @@ final class Rsvp_Form {
 		while ( $tag->next_tag() ) {
 			$visibility_attr = $tag->get_attribute( 'data-gatherpress-rsvp-form-visibility' );
 
-			// A valueless boolean attribute reads back as true and carries no rule to apply.
+			// A valueless attribute reads back as true.
 			if ( is_string( $visibility_attr ) && '' !== $visibility_attr ) {
 				$this->apply_visibility_rule( $tag, $visibility_attr, $is_success, $is_past );
 			}
@@ -440,8 +437,7 @@ final class Rsvp_Form {
 			return;
 		}
 
-		// Parse blocks and extract schemas for each RSVP Form. parse_blocks() returns a list,
-		// and array_values() pins that so the index-based schema IDs stay integers.
+		// Schema IDs are the list index, so the keys have to stay integers.
 		$blocks  = array_values( parse_blocks( $post->post_content ) );
 		$schemas = $this->extract_form_schemas_from_blocks( $blocks );
 
@@ -477,7 +473,6 @@ final class Rsvp_Form {
 				if ( ! empty( $fields ) ) {
 					$schemas[ $form_id ] = array(
 						'fields' => $fields,
-						// Every field value went through sanitize_*(), so encoding cannot fail.
 						'hash'   => wp_hash( (string) wp_json_encode( $fields ) ),
 					);
 				}
@@ -575,7 +570,6 @@ final class Rsvp_Form {
 			return 'form_0'; // Fallback.
 		}
 
-		// parse_blocks() returns a list; array_values() pins that for the index math below.
 		$blocks     = array_values( parse_blocks( $post->post_content ) );
 		$form_index = $this->find_form_index_in_blocks( $blocks, $block );
 

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -144,7 +144,6 @@ final class Rsvp_Form {
 		$schema_form_id = $this->get_form_schema_id( $post_id, $block );
 
 		$block_content = trim( $block_content );
-
 		$block_content = (string) preg_replace( '/^<div\b/', '<form', $block_content );
 		$block_content = (string) preg_replace(
 			'/(<\/div>)$/',

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -142,6 +142,9 @@ final class Rsvp_Response {
 			do {
 				$class_attr = $tag->get_attribute( 'class' );
 
+				// A missing or valueless `class` attribute carries no classes, so both normalize to an empty string.
+				$class_attr = is_string( $class_attr ) ? $class_attr : '';
+
 				if ( Utility::has_css_class( $class_attr, 'gatherpress-rsvp-response--no-responses' ) ) {
 					if ( $has_responses ) {
 						$updated_class  = str_replace(
@@ -206,8 +209,11 @@ final class Rsvp_Response {
 	public function attach_dropdown_interactivity( string $block_content ): string {
 		$tag = new WP_HTML_Tag_Processor( $block_content );
 		$tag->next_tag();
-		$counts = ! empty( $tag->get_attribute( 'data-counts' ) ) ?
-			json_decode( $tag->get_attribute( 'data-counts' ), true ) :
+		$counts_attr = $tag->get_attribute( 'data-counts' );
+
+		// A valueless `data-counts` attribute comes back as `true` and holds no JSON to decode.
+		$counts = ! empty( $counts_attr ) && is_string( $counts_attr ) ?
+			json_decode( $counts_attr, true ) :
 			array();
 
 		if ( $tag->next_tag(
@@ -241,7 +247,8 @@ final class Rsvp_Response {
 				$current_class = $tag->get_attribute( 'class' );
 
 				if (
-					$current_class &&
+					// A valueless `class` attribute comes back as `true` and carries no classes to match.
+					is_string( $current_class ) &&
 					preg_match(
 						'/gatherpress--is-(attending|waiting-list|not-attending)/',
 						$current_class,

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -142,7 +142,7 @@ final class Rsvp_Response {
 			do {
 				$class_attr = $tag->get_attribute( 'class' );
 
-				// A missing or valueless `class` attribute carries no classes, so both normalize to an empty string.
+				// A valueless attribute reads back as true.
 				$class_attr = is_string( $class_attr ) ? $class_attr : '';
 
 				if ( Utility::has_css_class( $class_attr, 'gatherpress-rsvp-response--no-responses' ) ) {
@@ -211,7 +211,6 @@ final class Rsvp_Response {
 		$tag->next_tag();
 		$counts_attr = $tag->get_attribute( 'data-counts' );
 
-		// A valueless `data-counts` attribute comes back as `true` and holds no JSON to decode.
 		$counts = ! empty( $counts_attr ) && is_string( $counts_attr ) ?
 			json_decode( $counts_attr, true ) :
 			array();
@@ -247,7 +246,6 @@ final class Rsvp_Response {
 				$current_class = $tag->get_attribute( 'class' );
 
 				if (
-					// A valueless `class` attribute comes back as `true` and carries no classes to match.
 					is_string( $current_class ) &&
 					preg_match(
 						'/gatherpress--is-(attending|waiting-list|not-attending)/',

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -89,7 +89,7 @@ final class Rsvp_Template {
 
 		$blocks_attr = $tag->next_tag() ? $tag->get_attribute( 'data-blocks' ) : null;
 
-		// A valueless `data-blocks` attribute comes back as `true` and holds no JSON to decode.
+		// A valueless attribute reads back as true.
 		if ( ! empty( $blocks_attr ) && is_string( $blocks_attr ) ) {
 			$inner_blocks = (array) json_decode( $blocks_attr, true );
 			$inner_blocks = Utility::get_block_names( $inner_blocks );
@@ -165,8 +165,7 @@ final class Rsvp_Template {
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
 		);
 
-		// Encoding only fails on block data JSON cannot represent; without it there is no template to hand
-		// the front end, so the rendered responses go out on their own.
+		// Without a template there is nothing to hand the front end, so send the responses alone.
 		if ( false === $blocks ) {
 			return $block_content;
 		}

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -87,8 +87,11 @@ final class Rsvp_Template {
 	public function ensure_block_styles_loaded( string $block_content ): string {
 		$tag = new WP_HTML_Tag_Processor( $block_content );
 
-		if ( $tag->next_tag() && ! empty( $tag->get_attribute( 'data-blocks' ) ) ) {
-			$inner_blocks = (array) json_decode( $tag->get_attribute( 'data-blocks' ), true );
+		$blocks_attr = $tag->next_tag() ? $tag->get_attribute( 'data-blocks' ) : null;
+
+		// A valueless `data-blocks` attribute comes back as `true` and holds no JSON to decode.
+		if ( ! empty( $blocks_attr ) && is_string( $blocks_attr ) ) {
+			$inner_blocks = (array) json_decode( $blocks_attr, true );
 			$inner_blocks = Utility::get_block_names( $inner_blocks );
 
 			foreach ( $inner_blocks as $inner_block ) {
@@ -122,7 +125,6 @@ final class Rsvp_Template {
 	 */
 	public function generate_rsvp_template_block( string $block_content, array $block, WP_Block $instance ): string {
 		$post_id = (int) $instance->context['postId'];
-		$event   = new Event( $post_id );
 
 		// Only process if the post type supports RSVP. An unpublished event
 		// keeps its responses to viewers allowed to read it, so organizers see
@@ -134,11 +136,13 @@ final class Rsvp_Template {
 			return $block_content;
 		}
 
-		if ( ! ( new Rsvp( $post_id ) )->is_enabled() ) {
+		$rsvp = new Rsvp( $post_id );
+
+		if ( ! $rsvp->is_enabled() ) {
 			return '';
 		}
 
-		$responses     = $event->rsvp->responses()['attending']['records'];
+		$responses     = $rsvp->responses()['attending']['records'];
 		$block_content = '';
 		$args          = array(
 			'limit_enabled' => isset( $instance->context['gatherpress/rsvpLimitEnabled'] )
@@ -156,10 +160,17 @@ final class Rsvp_Template {
 		}
 
 		// Used for generating a parsed block for calls to API on the front end.
-		$blocks                 = wp_json_encode(
+		$blocks = wp_json_encode(
 			$block,
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
 		);
+
+		// Encoding only fails on block data JSON cannot represent; without it there is no template to hand
+		// the front end, so the rendered responses go out on their own.
+		if ( false === $blocks ) {
+			return $block_content;
+		}
+
 		$rsvp_response_template = sprintf(
 			'<div hidden data-wp-interactive="gatherpress"'
 				. ' data-wp-watch="callbacks.renderBlocks"'

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -230,8 +230,15 @@ final class Rsvp {
 
 			// str_contains is used here to match BEM modifiers that extend the base class.
 			// For example, 'gatherpress-rsvp--trigger-update__attending' includes the base class as a prefix.
-			if ( $class_attr && str_contains( $class_attr, $rsvp_class ) ) {
-				$classes        = preg_split( '/\s+/', trim( $class_attr ) );
+			// A valueless class attribute reads back as true and carries no classes.
+			if ( is_string( $class_attr ) && str_contains( $class_attr, $rsvp_class ) ) {
+				/**
+				 * Class names split on whitespace.
+				 *
+				 * @var list<string> $classes A literal pattern cannot fail, so preg_split() never returns false.
+				 */
+				$classes = preg_split( '/\s+/', trim( $class_attr ) );
+
 				$statuses       = array( 'attending', 'waiting-list', 'not-attending' );
 				$matched_status = null;
 
@@ -296,8 +303,11 @@ final class Rsvp {
 
 		$tag->next_tag();
 
-		$user_details = ! empty( $tag->get_attribute( 'data-user-details' ) ) ?
-			json_decode( $tag->get_attribute( 'data-user-details' ), true ) :
+		$user_details_attr = $tag->get_attribute( 'data-user-details' );
+
+		// A valueless attribute reads back as true and carries no JSON to decode.
+		$user_details = ( is_string( $user_details_attr ) && ! empty( $user_details_attr ) ) ?
+			json_decode( $user_details_attr, true ) :
 			array();
 
 		while ( $tag->next_tag() ) {

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -230,7 +230,7 @@ final class Rsvp {
 
 			// str_contains is used here to match BEM modifiers that extend the base class.
 			// For example, 'gatherpress-rsvp--trigger-update__attending' includes the base class as a prefix.
-			// A valueless class attribute reads back as true and carries no classes.
+			// A valueless attribute reads back as true.
 			if ( is_string( $class_attr ) && str_contains( $class_attr, $rsvp_class ) ) {
 				/**
 				 * Class names split on whitespace.
@@ -305,7 +305,6 @@ final class Rsvp {
 
 		$user_details_attr = $tag->get_attribute( 'data-user-details' );
 
-		// A valueless attribute reads back as true and carries no JSON to decode.
 		$user_details = ( is_string( $user_details_attr ) && ! empty( $user_details_attr ) ) ?
 			json_decode( $user_details_attr, true ) :
 			array();

--- a/includes/core/classes/blocks/class-setup.php
+++ b/includes/core/classes/blocks/class-setup.php
@@ -77,9 +77,7 @@ final class Setup {
 		$blocks_directory = sprintf( '%1$s/build/blocks/', GATHERPRESS_CORE_PATH );
 		$blocks           = is_dir( $blocks_directory ) ? scandir( $blocks_directory ) : false;
 
-		// The build directory is absent when the plugin is run straight from
-		// source. Untestable: the test bootstrap mounts a built plugin, so the
-		// directory always exists and the path is unreachable from a test.
+		// Absent when run from source. Untestable: the test bootstrap mounts a built plugin.
 		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
 		// @codeCoverageIgnoreStart
 		if ( false === $blocks ) {
@@ -323,7 +321,6 @@ final class Setup {
 			return $post_id;
 		}
 
-		// get_the_ID() returns false outside the loop, where 0 signals "no post" to callers.
 		$current_post_id = get_the_ID();
 
 		return false !== $current_post_id ? $current_post_id : 0;

--- a/includes/core/classes/blocks/class-setup.php
+++ b/includes/core/classes/blocks/class-setup.php
@@ -77,10 +77,16 @@ final class Setup {
 		$blocks_directory = sprintf( '%1$s/build/blocks/', GATHERPRESS_CORE_PATH );
 		$blocks           = is_dir( $blocks_directory ) ? scandir( $blocks_directory ) : false;
 
-		// The build directory is absent when the plugin is run straight from source.
+		// The build directory is absent when the plugin is run straight from
+		// source. Untestable: the test bootstrap mounts a built plugin, so the
+		// directory always exists and the path is unreachable from a test.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreStart
 		if ( false === $blocks ) {
 			return;
 		}
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreEnd
 
 		foreach ( array_diff( $blocks, array( '..', '.' ) ) as $block ) {
 			$block_metadata_path = sprintf( '%1$s/build/blocks/%2$s', GATHERPRESS_CORE_PATH, $block );

--- a/includes/core/classes/blocks/class-setup.php
+++ b/includes/core/classes/blocks/class-setup.php
@@ -75,9 +75,14 @@ final class Setup {
 	 */
 	public function register_blocks(): void {
 		$blocks_directory = sprintf( '%1$s/build/blocks/', GATHERPRESS_CORE_PATH );
-		$blocks           = array_diff( scandir( $blocks_directory ), array( '..', '.' ) );
+		$blocks           = is_dir( $blocks_directory ) ? scandir( $blocks_directory ) : false;
 
-		foreach ( $blocks as $block ) {
+		// The build directory is absent when the plugin is run straight from source.
+		if ( false === $blocks ) {
+			return;
+		}
+
+		foreach ( array_diff( $blocks, array( '..', '.' ) ) as $block ) {
 			$block_metadata_path = sprintf( '%1$s/build/blocks/%2$s', GATHERPRESS_CORE_PATH, $block );
 
 			if ( is_dir( $block_metadata_path ) ) {
@@ -308,7 +313,14 @@ final class Setup {
 	public function get_post_id( array $block ): int {
 		$post_id = isset( $block['attrs']['postId'] ) ? intval( $block['attrs']['postId'] ) : 0;
 
-		return $post_id > 0 ? $post_id : get_the_ID();
+		if ( $post_id > 0 ) {
+			return $post_id;
+		}
+
+		// get_the_ID() returns false outside the loop, where 0 signals "no post" to callers.
+		$current_post_id = get_the_ID();
+
+		return false !== $current_post_id ? $current_post_id : 0;
 	}
 
 	/**

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -268,7 +268,7 @@ final class Calendar {
 		$modified_gmt   = strtotime( $post->post_modified_gmt );
 
 		if ( false === $modified_gmt ) {
-			// A post whose modified date won't parse still needs the RFC-required DTSTAMP, so stamp it now.
+			// DTSTAMP is required by RFC 5545, so an unparsable date still needs one.
 			$modified_gmt = time();
 		}
 
@@ -283,7 +283,6 @@ final class Calendar {
 			$location .= sprintf( ', %s', $venue['address'] );
 		}
 
-		// The post object was resolved above, so get_permalink() cannot return false here.
 		$permalink   = (string) get_permalink( $post );
 		$summary     = $this->fold_ical_text( $this->escape_ical_text( $post->post_title ) );
 		$description = $this->fold_ical_text( $this->escape_ical_text( $description ) );

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -141,11 +141,17 @@ final class Calendar {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return string The Google Calendar add-event URL.
+	 * @return string The Google Calendar add-event URL, or an empty string when the event post can't be resolved.
 	 *
 	 * @throws Exception If reading event datetime/venue data fails.
 	 */
 	public function get_google_destination_url(): string {
+		$post = $this->event->event;
+
+		if ( ! $post ) {
+			return '';
+		}
+
 		$date_start  = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
 		$time_start  = $this->event->get_formatted_datetime( 'His', 'start', false );
 		$date_end    = $this->event->get_formatted_datetime( 'Ymd', 'end', false );
@@ -161,7 +167,7 @@ final class Calendar {
 
 		$params = array(
 			'action'   => 'TEMPLATE',
-			'text'     => sanitize_text_field( $this->event->event->post_title ),
+			'text'     => sanitize_text_field( $post->post_title ),
 			'dates'    => sanitize_text_field( $datetime ),
 			'details'  => sanitize_text_field( $description ),
 			'location' => sanitize_text_field( $location ),
@@ -185,11 +191,17 @@ final class Calendar {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return string The Yahoo! Calendar add-event URL.
+	 * @return string The Yahoo! Calendar add-event URL, or an empty string when the event post can't be resolved.
 	 *
 	 * @throws Exception If reading event datetime/venue data fails.
 	 */
 	public function get_yahoo_destination_url(): string {
+		$post = $this->event->event;
+
+		if ( ! $post ) {
+			return '';
+		}
+
 		$date_start     = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
 		$time_start     = $this->event->get_formatted_datetime( 'His', 'start', false );
 		$datetime_start = sprintf( '%sT%sZ', $date_start, $time_start );
@@ -214,7 +226,7 @@ final class Calendar {
 			'v'      => '60',
 			'view'   => 'd',
 			'type'   => '20',
-			'title'  => sanitize_text_field( $this->event->event->post_title ),
+			'title'  => sanitize_text_field( $post->post_title ),
 			'st'     => sanitize_text_field( $datetime_start ),
 			'dur'    => sanitize_text_field( (string) $hours . (string) $minutes ),
 			'desc'   => sanitize_text_field( $description ),
@@ -236,18 +248,30 @@ final class Calendar {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @return string The VEVENT block.
+	 * @return string The VEVENT block, or an empty string when the event post can't be resolved.
 	 *
 	 * @throws Exception If reading event data fails.
 	 */
 	public function get_ical_event_string(): string {
+		$post = $this->event->event;
+
+		if ( ! $post ) {
+			return '';
+		}
+
 		$date_start     = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
 		$time_start     = $this->event->get_formatted_datetime( 'His', 'start', false );
 		$date_end       = $this->event->get_formatted_datetime( 'Ymd', 'end', false );
 		$time_end       = $this->event->get_formatted_datetime( 'His', 'end', false );
 		$datetime_start = sprintf( '%sT%sZ', $date_start, $time_start );
 		$datetime_end   = sprintf( '%sT%sZ', $date_end, $time_end );
-		$modified_gmt   = strtotime( $this->event->event->post_modified_gmt );
+		$modified_gmt   = strtotime( $post->post_modified_gmt );
+
+		if ( false === $modified_gmt ) {
+			// A post whose modified date won't parse still needs the RFC-required DTSTAMP, so stamp it now.
+			$modified_gmt = time();
+		}
+
 		$datetime_stamp = sprintf( '%sT%sZ', gmdate( 'Ymd', $modified_gmt ), gmdate( 'His', $modified_gmt ) );
 		$last_modified  = $datetime_stamp;
 		$sequence       = $this->get_sequence();
@@ -259,13 +283,15 @@ final class Calendar {
 			$location .= sprintf( ', %s', $venue['address'] );
 		}
 
-		$summary     = $this->fold_ical_text( $this->escape_ical_text( $this->event->event->post_title ) );
+		// The post object was resolved above, so get_permalink() cannot return false here.
+		$permalink   = (string) get_permalink( $post );
+		$summary     = $this->fold_ical_text( $this->escape_ical_text( $post->post_title ) );
 		$description = $this->fold_ical_text( $this->escape_ical_text( $description ) );
 		$location    = $this->fold_ical_text( $this->escape_ical_text( $location ) );
 
 		$args = array(
 			'BEGIN:VEVENT',
-			sprintf( 'URL:%s', esc_url_raw( get_permalink( $this->event->event->ID ) ) ),
+			sprintf( 'URL:%s', esc_url_raw( $permalink ) ),
 			sprintf( 'DTSTART:%s', sanitize_text_field( $datetime_start ) ),
 			sprintf( 'DTEND:%s', sanitize_text_field( $datetime_end ) ),
 			sprintf( 'DTSTAMP:%s', sanitize_text_field( $datetime_stamp ) ),
@@ -274,7 +300,7 @@ final class Calendar {
 			sprintf( 'SUMMARY:%s', $summary ),
 			sprintf( 'DESCRIPTION:%s', $description ),
 			sprintf( 'LOCATION:%s', $location ),
-			'UID:gatherpress_' . intval( $this->event->event->ID ),
+			'UID:gatherpress_' . intval( $post->ID ),
 			'END:VEVENT',
 		);
 
@@ -312,7 +338,13 @@ final class Calendar {
 	 * @return int Non-negative revision number for this event.
 	 */
 	private function get_sequence(): int {
-		$modified = strtotime( (string) $this->event->event->post_modified_gmt );
+		$post = $this->event->event;
+
+		if ( ! $post ) {
+			return 0;
+		}
+
+		$modified = strtotime( $post->post_modified_gmt );
 
 		if ( false === $modified ) {
 			return 0;

--- a/includes/core/classes/calendar/class-endpoint.php
+++ b/includes/core/classes/calendar/class-endpoint.php
@@ -52,9 +52,13 @@ class Endpoint {
 	 * a `WP_Post_Type` object for a post type or a `WP_Taxonomy` object for a taxonomy.
 	 * This is used to generate the correct rewrite rules and handle URL matching.
 	 *
+	 * An unregistered object leaves the failed lookup in place — `null` from
+	 * `get_post_type_object()`, `false` from `get_taxonomy()` — and registration
+	 * bails, so the endpoint is never initialized.
+	 *
 	 * @since 0.34.0
 	 *
-	 * @var WP_Post_Type|WP_Taxonomy|null
+	 * @var WP_Post_Type|WP_Taxonomy|false|null
 	 */
 	public $type_object;
 
@@ -192,7 +196,23 @@ class Endpoint {
 	 * @return string The compiled regex pattern.
 	 */
 	protected function get_regex_pattern(): string {
-		$rewrite_base = $this->type_object->rewrite['slug'];
+		/**
+		 * The registered post type or taxonomy object.
+		 *
+		 * @var WP_Post_Type|WP_Taxonomy $type_object Registration resolved the object before the
+		 *                                           endpoint could initialize, and the object-less
+		 *                                           sitewide endpoint overrides this method.
+		 */
+		$type_object = $this->type_object;
+
+		/**
+		 * Rewrite settings of the registered object.
+		 *
+		 * @var array<string, mixed> $rewrite Registration bails on objects with rewrites disabled.
+		 */
+		$rewrite = $type_object->rewrite;
+
+		$rewrite_base = $rewrite['slug'];
 		$slugs        = join( '|', $this->get_slugs() );
 		return sprintf(
 			$this->reg_ex,
@@ -212,9 +232,18 @@ class Endpoint {
 	 * @return array<string, string> The rewrite replacement attributes for add_rewrite_rule().
 	 */
 	public function get_rewrite_atts(): array {
+		/**
+		 * The registered post type or taxonomy object.
+		 *
+		 * @var WP_Post_Type|WP_Taxonomy $type_object Registration resolved the object before the
+		 *                                           endpoint could initialize, and the object-less
+		 *                                           sitewide endpoint overrides this method.
+		 */
+		$type_object = $this->type_object;
+
 		return array(
-			$this->type_object->name => '$matches[1]',
-			$this->query_var         => '$matches[2]',
+			$type_object->name => '$matches[1]',
+			$this->query_var   => '$matches[2]',
 		);
 	}
 

--- a/includes/core/classes/calendar/class-post-type-feed.php
+++ b/includes/core/classes/calendar/class-post-type-feed.php
@@ -16,6 +16,8 @@ namespace GatherPress\Core\Calendar;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use WP_Post_Type;
+
 /**
  * Manages custom feed endpoints for post types in GatherPress.
  *
@@ -73,7 +75,15 @@ final class Post_Type_Feed extends Endpoint {
 	 * @return bool True if the current request is a valid feed request for the post type archive.
 	 */
 	public function is_valid(): bool {
-		return is_post_type_archive( $this->type_object->name ) && is_feed();
+		/**
+		 * The registered post type object.
+		 *
+		 * @var WP_Post_Type $type_object Registration resolved the object before the
+		 *                                endpoint could initialize.
+		 */
+		$type_object = $this->type_object;
+
+		return is_post_type_archive( $type_object->name ) && is_feed();
 	}
 
 	/**
@@ -87,8 +97,16 @@ final class Post_Type_Feed extends Endpoint {
 	 * @return array<string, string> The rewrite replacement attributes for add_rewrite_rule().
 	 */
 	public function get_rewrite_atts(): array {
+		/**
+		 * The registered post type object.
+		 *
+		 * @var WP_Post_Type $type_object Registration resolved the object before the
+		 *                                endpoint could initialize.
+		 */
+		$type_object = $this->type_object;
+
 		return array(
-			$this->object_type => $this->type_object->name,
+			$this->object_type => $type_object->name,
 			'feed'             => '$matches[1]',
 			$this->query_var   => '$matches[1]',
 		);

--- a/includes/core/classes/calendar/class-post-type-single-feed.php
+++ b/includes/core/classes/calendar/class-post-type-single-feed.php
@@ -15,6 +15,8 @@ namespace GatherPress\Core\Calendar;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use WP_Post_Type;
+
 /**
  * Manages custom feed endpoints for post types in GatherPress.
  *
@@ -70,7 +72,15 @@ final class Post_Type_Single_Feed extends Endpoint {
 	 * @return bool True if the current request is a valid feed request for the post type singular.
 	 */
 	public function is_valid(): bool {
-		return is_singular( $this->type_object->name ) && is_feed();
+		/**
+		 * The registered post type object.
+		 *
+		 * @var WP_Post_Type $type_object Registration resolved the object before the
+		 *                                endpoint could initialize.
+		 */
+		$type_object = $this->type_object;
+
+		return is_singular( $type_object->name ) && is_feed();
 	}
 
 	/**
@@ -84,11 +94,19 @@ final class Post_Type_Single_Feed extends Endpoint {
 	 * @return array<string, string> The rewrite replacement attributes for add_rewrite_rule().
 	 */
 	public function get_rewrite_atts(): array {
+		/**
+		 * The registered post type object.
+		 *
+		 * @var WP_Post_Type $type_object Registration resolved the object before the
+		 *                                endpoint could initialize.
+		 */
+		$type_object = $this->type_object;
+
 		return array(
-			$this->object_type       => $this->type_object->name,
-			$this->type_object->name => '$matches[1]',
-			'feed'                   => '$matches[2]',
-			$this->query_var         => '$matches[2]',
+			$this->object_type => $type_object->name,
+			$type_object->name => '$matches[1]',
+			'feed'             => '$matches[2]',
+			$this->query_var   => '$matches[2]',
 		);
 	}
 }

--- a/includes/core/classes/calendar/class-post-type-single.php
+++ b/includes/core/classes/calendar/class-post-type-single.php
@@ -16,6 +16,8 @@ namespace GatherPress\Core\Calendar;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use WP_Post_Type;
+
 /**
  * Endpoint for Singular Post Types in GatherPress.
  *
@@ -73,6 +75,17 @@ final class Post_Type_Single extends Endpoint {
 	 * @return bool True if the current query is for a singular post of the post type, false otherwise.
 	 */
 	public function is_valid(): bool {
-		return is_singular( $this->type_object->name );
+		/**
+		 * Post type object this endpoint was registered for.
+		 *
+		 * `Endpoint` only finishes registration once the post type resolved,
+		 * so the base class' nullable union cannot be null by the time the
+		 * validation callback runs.
+		 *
+		 * @var WP_Post_Type $type_object
+		 */
+		$type_object = $this->type_object;
+
+		return is_singular( $type_object->name );
 	}
 }

--- a/includes/core/classes/calendar/class-redirect.php
+++ b/includes/core/classes/calendar/class-redirect.php
@@ -88,11 +88,13 @@ final class Redirect extends Endpoint_Type {
 	 * @return string[]       The updated array of allowed host names, including the redirect target.
 	 */
 	public function allowed_redirect_hosts( array $hosts ): array {
-		return array_merge(
-			$hosts,
-			array(
-				wp_parse_url( $this->url, PHP_URL_HOST ),
-			)
-		);
+		$host = wp_parse_url( $this->url, PHP_URL_HOST );
+
+		// A relative or malformed target has no host to allow, so the list is left untouched.
+		if ( ! is_string( $host ) || '' === $host ) {
+			return $hosts;
+		}
+
+		return array_merge( $hosts, array( $host ) );
 	}
 }

--- a/includes/core/classes/calendar/class-redirect.php
+++ b/includes/core/classes/calendar/class-redirect.php
@@ -90,7 +90,7 @@ final class Redirect extends Endpoint_Type {
 	public function allowed_redirect_hosts( array $hosts ): array {
 		$host = wp_parse_url( $this->url, PHP_URL_HOST );
 
-		// A relative or malformed target has no host to allow, so the list is left untouched.
+		// A relative or malformed target has no host to allow.
 		if ( ! is_string( $host ) || '' === $host ) {
 			return $hosts;
 		}

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -195,12 +195,16 @@ final class Setup {
 	 * @return void
 	 */
 	public function init_taxonomies( string $taxonomy ): void {
+		$taxonomy_object = get_taxonomy( $taxonomy );
+
 		// Stop if the currently registered taxonomy does not validate.
-		if ( // Stop, if taxonomy is not registered for any event-date supporting post type.
+		if ( // Stop, if the taxonomy is not registered.
+			! $taxonomy_object ||
+			// Stop, if taxonomy is not registered for any event-date supporting post type.
 			! $this->has_post_type_for_taxonomy( $taxonomy ) ||
 			// Stop, if taxonomy is not public.
-			! is_taxonomy_viewable( $taxonomy ) ||
-			false === get_taxonomy( $taxonomy )->rewrite
+			! is_taxonomy_viewable( $taxonomy_object ) ||
+			false === $taxonomy_object->rewrite
 		) {
 			return;
 		}
@@ -400,6 +404,13 @@ final class Setup {
 		$links = array();
 
 		foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $post_type ) {
+			$feed_link = get_post_type_archive_feed_link( $post_type, self::ICAL_SLUG );
+
+			// A post type registered without an archive has no archive feed to advertise.
+			if ( false === $feed_link ) {
+				continue;
+			}
+
 			$post_type_object = get_post_type_object( $post_type );
 			// The fallback to the bare slug only fires when `get_post_type_object()`
 			// returns null — structurally unreachable here because the loop
@@ -409,10 +420,7 @@ final class Setup {
 				? $post_type_object->labels->name
 				: $post_type; // @codeCoverageIgnore
 			$links[]       = array(
-				'url'  => get_post_type_archive_feed_link(
-					$post_type,
-					self::ICAL_SLUG
-				),
+				'url'  => $feed_link,
 				'attr' => sprintf(
 					$args['posttypetitle'],
 					$args['blogtitle'],
@@ -443,15 +451,17 @@ final class Setup {
 	protected function collect_contextual_alternate_links( array $args ): array {
 		$queried = get_queried_object();
 
-		if ( is_singular() && post_type_supports( $queried->post_type, 'gatherpress-event-date' ) ) {
-			return $this->collect_singular_event_alternate_links( $queried, $args );
+		if ( is_singular() && $queried instanceof WP_Post ) {
+			if ( post_type_supports( $queried->post_type, 'gatherpress-event-date' ) ) {
+				return $this->collect_singular_event_alternate_links( $queried, $args );
+			}
+
+			if ( $this->is_tax_like_type_for_event_supporting_types( $queried->post_type ) ) {
+				return $this->collect_singular_tax_like_alternate_links( $queried, $args );
+			}
 		}
 
-		if ( is_singular() && $this->is_tax_like_type_for_event_supporting_types( $queried->post_type ) ) {
-			return $this->collect_singular_tax_like_alternate_links( $queried, $args );
-		}
-
-		if ( is_tax() && $this->has_post_type_for_taxonomy( $queried->taxonomy ) ) {
+		if ( is_tax() && $queried instanceof WP_Term && $this->has_post_type_for_taxonomy( $queried->taxonomy ) ) {
 			return $this->collect_tax_archive_alternate_links( $queried, $args );
 		}
 
@@ -473,18 +483,26 @@ final class Setup {
 	 * @return array<int,array{url:string,attr:string}>
 	 */
 	protected function collect_singular_event_alternate_links( WP_Post $event, array $args ): array {
+		// `the_title_attribute()` returns nothing for an empty title, so fall back to an empty string.
+		$title = the_title_attribute( array( 'echo' => false ) );
+		$title = is_string( $title ) ? $title : '';
+
 		$calendar = new Calendar( $event->ID );
-		$links    = array(
-			array(
-				'url'  => $calendar->get_ical_url(),
+		$ical_url = $calendar->get_ical_url();
+		$links    = array();
+
+		// `get_ical_url()` is false when the event post can no longer be resolved; skip the download entry then.
+		if ( false !== $ical_url ) {
+			$links[] = array(
+				'url'  => $ical_url,
 				'attr' => sprintf(
 					$args['singletitle'],
 					$args['blogtitle'],
 					$args['separator'],
-					the_title_attribute( array( 'echo' => false ) )
+					$title
 				),
-			),
-		);
+			);
+		}
 
 		return array_merge( $links, $this->collect_event_term_alternate_links( $event, $args ) );
 	}
@@ -504,6 +522,10 @@ final class Setup {
 	 * @return array<int,array{url:string,attr:string}>
 	 */
 	protected function collect_singular_tax_like_alternate_links( WP_Post $post, array $args ): array {
+		// `the_title_attribute()` returns nothing for an empty title, so fall back to an empty string.
+		$title = the_title_attribute( array( 'echo' => false ) );
+		$title = is_string( $title ) ? $title : '';
+
 		return array(
 			array(
 				'url'  => get_post_comments_feed_link( $post->ID, self::ICAL_SLUG ),
@@ -511,7 +533,7 @@ final class Setup {
 					$args['singletitle'],
 					$args['blogtitle'],
 					$args['separator'],
-					the_title_attribute( array( 'echo' => false ) )
+					$title
 				),
 			),
 		);
@@ -529,17 +551,22 @@ final class Setup {
 	 * @return array<int,array{url:string,attr:string}>
 	 */
 	protected function collect_tax_archive_alternate_links( WP_Term $term, array $args ): array {
-		$tax = get_taxonomy( $term->taxonomy );
+		$href = get_term_feed_link( $term->term_id, $term->taxonomy, self::ICAL_SLUG );
+
+		// `get_term_feed_link()` is false when the term can no longer be resolved; nothing to link to then.
+		if ( false === $href ) {
+			return array();
+		}
 
 		return array(
 			array(
-				'url'  => get_term_feed_link( $term->term_id, $term->taxonomy, self::ICAL_SLUG ),
+				'url'  => $href,
 				'attr' => sprintf(
 					$args['taxtitle'],
 					$args['blogtitle'],
 					$args['separator'],
 					$term->name,
-					$tax->labels->singular_name
+					Utility::taxonomy_label( 'singular_name', $term->taxonomy )
 				),
 			),
 		);
@@ -563,6 +590,11 @@ final class Setup {
 				'object_ids' => $event->ID,
 			)
 		);
+
+		// `get_terms()` errors out when the event's post type has no taxonomies at all.
+		if ( is_wp_error( $terms ) ) {
+			return array();
+		}
 
 		$links = array();
 
@@ -603,9 +635,14 @@ final class Setup {
 					$term->slug,
 					ltrim( $term->taxonomy, '_' )
 				);
-				// Feels weird to use a *_comments_* function here, but it delivers clean results
-				// in the form of "domain.tld/event/my-sample-event/feed/ical/".
-				$href = get_post_comments_feed_link( $post->ID, self::ICAL_SLUG );
+
+				// A term whose backing post was deleted resolves to null and keeps `$href` empty,
+				// so the entry is skipped below instead of falling back to the global post.
+				if ( $post instanceof WP_Post ) {
+					// Feels weird to use a *_comments_* function here, but it delivers clean results
+					// in the form of "domain.tld/event/my-sample-event/feed/ical/".
+					$href = get_post_comments_feed_link( $post->ID, self::ICAL_SLUG );
+				}
 			}
 		} else {
 			$href = get_term_feed_link( $term->term_id, $term->taxonomy, self::ICAL_SLUG );
@@ -615,8 +652,6 @@ final class Setup {
 			return array();
 		}
 
-		$tax = get_taxonomy( $term->taxonomy );
-
 		return array(
 			array(
 				'url'  => $href,
@@ -625,7 +660,7 @@ final class Setup {
 					$args['blogtitle'],
 					$args['separator'],
 					$term->name,
-					$tax->labels->singular_name
+					Utility::taxonomy_label( 'singular_name', $term->taxonomy )
 				),
 			),
 		);
@@ -706,21 +741,31 @@ final class Setup {
 		$topics          = array();
 		$venues          = array();
 		$output          = array();
+		$queried_object  = get_queried_object();
 
-		if ( is_singular() && $this->is_tax_like_type_for_event_supporting_types( get_queried_object()->post_type ) ) {
+		if (
+			is_singular() &&
+			$queried_object instanceof WP_Post &&
+			$this->is_tax_like_type_for_event_supporting_types( $queried_object->post_type )
+		) {
 			if ( is_singular( 'gatherpress_venue' ) ) {
-				$venues = array( '_' . get_queried_object()->post_name );
+				$venues = array( '_' . $queried_object->post_name );
 			}
-		} elseif ( is_tax() && $this->has_post_type_for_taxonomy( get_queried_object()->taxonomy ) ) {
+		} elseif (
+			is_tax() &&
+			$queried_object instanceof WP_Term &&
+			$this->has_post_type_for_taxonomy( $queried_object->taxonomy )
+		) {
 			if ( is_tax( 'gatherpress_topic' ) ) {
-				$topics = array( get_queried_object()->slug );
+				$topics = array( $queried_object->slug );
 			}
 		}
 
 		$query = Query::get_instance()->get_events_list( $event_list_type, $number, $topics, $venues );
 		while ( $query->have_posts() ) {
 			$query->the_post();
-			$calendar = new Calendar( get_the_ID() );
+			// `the_post()` set the global post directly above, so `get_the_ID()` always returns its ID.
+			$calendar = new Calendar( (int) get_the_ID() );
 			$output[] = $calendar->get_ical_event_string();
 		}
 
@@ -769,26 +814,31 @@ final class Setup {
 		$queried_object = get_queried_object();
 		$filename       = 'calendar';
 
-		if ( is_singular() && post_type_supports( $queried_object->post_type, 'gatherpress-event-date' ) ) {
-			$calendar  = new Calendar( $queried_object->ID );
-			$date      = $calendar->event->get_datetime_start( 'Y-m-d' );
-			$post_name = $queried_object->post_name;
-			$filename  = $date . '_' . $post_name;
-		} elseif ( is_singular() && $this->is_tax_like_type_for_event_supporting_types( $queried_object->post_type ) ) {
-			$filename = $queried_object->post_name;
-		} elseif ( is_tax() && $this->has_post_type_for_taxonomy( $queried_object->taxonomy ) ) {
+		if ( is_singular() && $queried_object instanceof WP_Post ) {
+			if ( post_type_supports( $queried_object->post_type, 'gatherpress-event-date' ) ) {
+				$calendar  = new Calendar( $queried_object->ID );
+				$date      = $calendar->event->get_datetime_start( 'Y-m-d' );
+				$post_name = $queried_object->post_name;
+				$filename  = $date . '_' . $post_name;
+			} elseif ( $this->is_tax_like_type_for_event_supporting_types( $queried_object->post_type ) ) {
+				$filename = $queried_object->post_name;
+			}
+		} elseif (
+			is_tax() &&
+			$queried_object instanceof WP_Term &&
+			$this->has_post_type_for_taxonomy( $queried_object->taxonomy )
+		) {
 			$filename = $queried_object->slug;
-		} elseif ( is_post_type_archive() ) {
-			// `$queried_object` is the WP_Post_Type here. `rewrite` is `false`
-			// when the post type opted out of rewrite rules — fall back to the
-			// default filename in that case rather than `false['slug']`-ing.
+		} elseif ( is_post_type_archive() && $queried_object instanceof WP_Post_Type ) {
+			// `rewrite` is `false` when the post type opted out of rewrite
+			// rules — fall back to the default filename in that case rather
+			// than `false['slug']`-ing.
 			$filename = is_array( $queried_object->rewrite ) ? $queried_object->rewrite['slug'] : $filename;
 		} elseif ( is_feed() && ! is_singular() && ! is_tax() ) {
-			$filename = str_replace(
-				'.',
-				'-',
-				wp_parse_url( home_url(), PHP_URL_HOST )
-			);
+			$host = wp_parse_url( home_url(), PHP_URL_HOST );
+
+			// A site URL without a parsable host keeps the default filename.
+			$filename = is_string( $host ) ? str_replace( '.', '-', $host ) : $filename;
 		}
 
 		return $filename . '.ics';

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -591,7 +591,9 @@ final class Setup {
 			)
 		);
 
-		// `get_terms()` errors out when the event's post type has no taxonomies at all.
+		// get_object_taxonomies() only yields registered names, so no natural
+		// input reaches this. A `get_terms` filter can still hand back an error,
+		// and iterating one would fatal on the WP_Term-typed helper below.
 		if ( is_wp_error( $terms ) ) {
 			return array();
 		}

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -483,7 +483,7 @@ final class Setup {
 	 * @return array<int,array{url:string,attr:string}>
 	 */
 	protected function collect_singular_event_alternate_links( WP_Post $event, array $args ): array {
-		// `the_title_attribute()` returns nothing for an empty title, so fall back to an empty string.
+		// the_title_attribute() returns nothing for an empty title.
 		$title = the_title_attribute( array( 'echo' => false ) );
 		$title = is_string( $title ) ? $title : '';
 
@@ -491,7 +491,7 @@ final class Setup {
 		$ical_url = $calendar->get_ical_url();
 		$links    = array();
 
-		// `get_ical_url()` is false when the event post can no longer be resolved; skip the download entry then.
+		// False when the event post no longer resolves.
 		if ( false !== $ical_url ) {
 			$links[] = array(
 				'url'  => $ical_url,
@@ -522,7 +522,7 @@ final class Setup {
 	 * @return array<int,array{url:string,attr:string}>
 	 */
 	protected function collect_singular_tax_like_alternate_links( WP_Post $post, array $args ): array {
-		// `the_title_attribute()` returns nothing for an empty title, so fall back to an empty string.
+		// the_title_attribute() returns nothing for an empty title.
 		$title = the_title_attribute( array( 'echo' => false ) );
 		$title = is_string( $title ) ? $title : '';
 
@@ -553,7 +553,7 @@ final class Setup {
 	protected function collect_tax_archive_alternate_links( WP_Term $term, array $args ): array {
 		$href = get_term_feed_link( $term->term_id, $term->taxonomy, self::ICAL_SLUG );
 
-		// `get_term_feed_link()` is false when the term can no longer be resolved; nothing to link to then.
+		// False when the term no longer resolves.
 		if ( false === $href ) {
 			return array();
 		}
@@ -591,9 +591,7 @@ final class Setup {
 			)
 		);
 
-		// get_object_taxonomies() only yields registered names, so no natural
-		// input reaches this. A `get_terms` filter can still hand back an error,
-		// and iterating one would fatal on the WP_Term-typed helper below.
+		// Only a `get_terms` filter can produce this; iterating it would fatal below.
 		if ( is_wp_error( $terms ) ) {
 			return array();
 		}
@@ -638,8 +636,7 @@ final class Setup {
 					ltrim( $term->taxonomy, '_' )
 				);
 
-				// A term whose backing post was deleted resolves to null and keeps `$href` empty,
-				// so the entry is skipped below instead of falling back to the global post.
+				// Without this, get_post_comments_feed_link( null ) falls back to the global post.
 				if ( $post instanceof WP_Post ) {
 					// Feels weird to use a *_comments_* function here, but it delivers clean results
 					// in the form of "domain.tld/event/my-sample-event/feed/ical/".
@@ -766,7 +763,6 @@ final class Setup {
 		$query = Query::get_instance()->get_events_list( $event_list_type, $number, $topics, $venues );
 		while ( $query->have_posts() ) {
 			$query->the_post();
-			// `the_post()` set the global post directly above, so `get_the_ID()` always returns its ID.
 			$calendar = new Calendar( (int) get_the_ID() );
 			$output[] = $calendar->get_ical_event_string();
 		}
@@ -832,9 +828,7 @@ final class Setup {
 		) {
 			$filename = $queried_object->slug;
 		} elseif ( is_post_type_archive() && $queried_object instanceof WP_Post_Type ) {
-			// `rewrite` is `false` when the post type opted out of rewrite
-			// rules — fall back to the default filename in that case rather
-			// than `false['slug']`-ing.
+			// `rewrite` is false when the post type opted out of rewrite rules.
 			$filename = is_array( $queried_object->rewrite ) ? $queried_object->rewrite['slug'] : $filename;
 		} elseif ( is_feed() && ! is_singular() && ! is_tax() ) {
 			$host = wp_parse_url( home_url(), PHP_URL_HOST );

--- a/includes/core/classes/calendar/class-taxonomy-feed.php
+++ b/includes/core/classes/calendar/class-taxonomy-feed.php
@@ -16,6 +16,8 @@ namespace GatherPress\Core\Calendar;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use WP_Taxonomy;
+
 /**
  * Manages custom feed endpoints for taxonomies in GatherPress.
  *
@@ -73,7 +75,15 @@ final class Taxonomy_Feed extends Endpoint {
 	 * @return bool True if the current request is a valid feed request for the taxonomy archive.
 	 */
 	public function is_valid(): bool {
-		return is_tax( $this->type_object->name ) && is_feed();
+		/**
+		 * The registered taxonomy object.
+		 *
+		 * @var WP_Taxonomy $type_object Registration resolved the object before the
+		 *                               endpoint could initialize.
+		 */
+		$type_object = $this->type_object;
+
+		return is_tax( $type_object->name ) && is_feed();
 	}
 
 	/**
@@ -87,11 +97,19 @@ final class Taxonomy_Feed extends Endpoint {
 	 * @return array<string, string> The rewrite replacement attributes for add_rewrite_rule().
 	 */
 	public function get_rewrite_atts(): array {
+		/**
+		 * The registered taxonomy object.
+		 *
+		 * @var WP_Taxonomy $type_object Registration resolved the object before the
+		 *                               endpoint could initialize.
+		 */
+		$type_object = $this->type_object;
+
 		return array(
-			$this->object_type       => $this->type_object->name,
-			$this->type_object->name => '$matches[1]',
-			'feed'                   => '$matches[2]',
-			$this->query_var         => '$matches[2]',
+			$this->object_type => $type_object->name,
+			$type_object->name => '$matches[1]',
+			'feed'             => '$matches[2]',
+			$this->query_var   => '$matches[2]',
 		);
 	}
 }

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -35,7 +35,7 @@ final class Assets {
 	 * This property stores data assets in an array for efficient access and management.
 	 *
 	 * @since 0.27.0
-	 * @var array<string, array{dependencies?: string[], version?: string}>
+	 * @var array<string, array{dependencies: string[], version: string}>
 	 */
 	protected array $asset_data = array();
 
@@ -174,7 +174,18 @@ final class Assets {
 		// @codeCoverageIgnoreEnd
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a plugin-local static file.
-		wp_add_inline_script( 'wp-date', file_get_contents( $script_path ), 'after' );
+		$script = file_get_contents( $script_path );
+
+		// file_exists() above does not rule out an unreadable file.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreStart
+		if ( false === $script ) {
+			return;
+		}
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation must match exactly.
+		// @codeCoverageIgnoreEnd
+
+		wp_add_inline_script( 'wp-date', $script, 'after' );
 	}
 
 	/**
@@ -533,16 +544,27 @@ final class Assets {
 	 * @param string  $asset The file name of the asset.
 	 * @param ?string $path  (Optional) The absolute path to the asset file
 	 *                       or null to use the path based on the default naming scheme.
-	 * @return array{dependencies?: string[], version?: string} An array containing asset-related data.
+	 * @return array{dependencies: string[], version: string} An array containing asset-related data.
 	 */
 	public function get_asset_data( string $asset, ?string $path = null ): array {
 		$path = $path ?? $this->path . sprintf( '%s.asset.php', $asset );
 		if ( empty( $this->asset_data[ $asset ] ) ) {
 			// Loading a WordPress asset metadata file that returns an array, not importing a class.
-			$this->asset_data[ $asset ] = file_exists( $path ) ? require $path : array(); // NOSONAR — see #1768.
+			$data = file_exists( $path ) ? require $path : array(); // NOSONAR — see #1768.
+
+			// Callers read both keys unguarded, so a missing or partial
+			// metadata file resolves to defaults rather than to a warning.
+			$data         = is_array( $data ) ? $data : array();
+			$dependencies = $data['dependencies'] ?? null;
+			$version      = $data['version'] ?? null;
+
+			$this->asset_data[ $asset ] = array(
+				'dependencies' => is_array( $dependencies ) ? $dependencies : array(),
+				'version'      => is_string( $version ) ? $version : GATHERPRESS_VERSION,
+			);
 		}
 
-		return (array) $this->asset_data[ $asset ];
+		return $this->asset_data[ $asset ];
 	}
 
 	/**

--- a/includes/core/classes/class-export.php
+++ b/includes/core/classes/class-export.php
@@ -121,16 +121,26 @@ final class Export extends Migrate {
 	 * @param  bool   $skip     Whether to skip the current post meta. Default false.
 	 * @param  string $meta_key Current meta key.
 	 * @param  object $meta     Current meta object.
+	 * @phpstan-param object{post_id: int|string} $meta
 	 *
 	 * @return bool             Whether to skip the current post meta. Default false.
 	 */
 	public function extend( bool $skip, string $meta_key, object $meta ): bool {
 		if ( self::POST_META === $meta_key ) {
+			$post_id = (int) $meta->post_id;
+
+			/**
+			 * The post the temporary marker belongs to.
+			 *
+			 * @var WP_Post $post The marker is only ever read while its own post is being exported.
+			 */
+			$post = get_post( $post_id );
+
 			// Echos out xml with pseudo-postmeta.
-			$this->run( get_post( $meta->post_id ) );
+			$this->run( $post );
 
 			// Deletes temporary marker.
-			delete_post_meta( $meta->post_id, self::POST_META );
+			delete_post_meta( $post_id, self::POST_META );
 
 			// Prevent 'normal' export processing for that particular postmeta field,
 			// because it doesn't exist in real and will trigger an error.

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -160,7 +160,8 @@ final class Feed {
 			return $excerpt;
 		}
 
-		$event = new Event( get_the_ID() );
+		// The support check above already returned when no post is in context, so get_the_ID() is an ID here.
+		$event = new Event( (int) get_the_ID() );
 		$venue = $event->get_venue_information();
 
 		$event_info = $this->get_event_datetime_info( $event );
@@ -185,7 +186,8 @@ final class Feed {
 		// Add the original excerpt if it exists and is different from the content.
 		if ( ! empty( $excerpt ) && get_the_content() !== $excerpt ) {
 			$clean_excerpt = wp_strip_all_tags( $excerpt );
-			$clean_excerpt = preg_replace( '/\s+/', ' ', $clean_excerpt ); // Normalize whitespace.
+			// Normalize whitespace. A literal pattern cannot fail to compile, so preg_replace() never returns null.
+			$clean_excerpt = (string) preg_replace( '/\s+/', ' ', $clean_excerpt );
 			$clean_excerpt = trim( $clean_excerpt );
 
 			if ( ! empty( $clean_excerpt ) ) {
@@ -211,7 +213,8 @@ final class Feed {
 			return $content;
 		}
 
-		$event = new Event( get_the_ID() );
+		// The support check above already returned when no post is in context, so get_the_ID() is an ID here.
+		$event = new Event( (int) get_the_ID() );
 		$venue = $event->get_venue_information();
 
 		$event_info = $this->get_event_datetime_info( $event );
@@ -236,7 +239,8 @@ final class Feed {
 		// For RSS feeds, provide a cleaner version of the content.
 		// Strip out complex HTML and keep only essential information.
 		$clean_content = wp_strip_all_tags( $content );
-		$clean_content = preg_replace( '/\s+/', ' ', $clean_content ); // Normalize whitespace.
+		// Normalize whitespace. A literal pattern cannot fail to compile, so preg_replace() never returns null.
+		$clean_content = (string) preg_replace( '/\s+/', ' ', $clean_content );
 		$clean_content = trim( $clean_content );
 
 		if ( ! empty( $clean_content ) ) {

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -31,6 +31,16 @@ use WP_REST_Server;
  *
  * @since 0.34.0
  *
+ * @phpstan-type StructuredAddress array{
+ *     house_number: string,
+ *     street: string,
+ *     city: string,
+ *     county: string,
+ *     state: string,
+ *     postcode: string,
+ *     country: string,
+ *     country_code: string
+ * }
  * @phpstan-type GeocodeResult array{
  *     latitude: string,
  *     longitude: string,
@@ -669,6 +679,12 @@ final class Geocoding {
 		// `house_number` slot. Treat as miss and refetch so the cache
 		// self-heals after the upgrade.
 		if ( is_array( $cached ) && array_key_exists( 'house_number', $cached ) ) {
+			/**
+			 * Cached payload.
+			 *
+			 * @var GeocodeResult $cached This method is the only writer of the cache key, and entries
+			 *                            predating the structured pieces were ruled out above.
+			 */
 			return $cached;
 		}
 
@@ -970,16 +986,7 @@ final class Geocoding {
 	 *
 	 * @param array<string, mixed> $properties Photon `properties` object.
 	 *
-	 * @return array{
-	 *     house_number: string,
-	 *     street: string,
-	 *     city: string,
-	 *     county: string,
-	 *     state: string,
-	 *     postcode: string,
-	 *     country: string,
-	 *     country_code: string
-	 * }
+	 * @return StructuredAddress
 	 */
 	private function extract_structured_address( array $properties ): array {
 		$pluck = static function ( string $key ) use ( $properties ): string {
@@ -1005,6 +1012,12 @@ final class Geocoding {
 			$structured[ $field ] = $pluck( str_replace( '_', '', $field ) );
 		}
 
+		/**
+		 * Structured-address pieces.
+		 *
+		 * @var StructuredAddress $structured The loop fills one slot per `STRUCTURED_ADDRESS_FIELDS`
+		 *                                    entry, so every key of the shape is present.
+		 */
 		return $structured;
 	}
 

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -771,8 +771,8 @@ class Settings {
 			$sanitized[] = $clean_item;
 		}
 
-		// Re-encode.
-		return wp_json_encode( $sanitized );
+		// Re-encode. Every value ran through a sanitizer that guarantees valid UTF-8, so encoding cannot fail.
+		return (string) wp_json_encode( $sanitized );
 	}
 
 	/**

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -368,15 +368,9 @@ final class Setup {
 			$taxonomy = Venue\Setup::get_instance()->get_taxonomy( $venue_post_type );
 			$term     = term_exists( $term_slug, $taxonomy );
 
-			if ( ! $term ) {
-				wp_insert_term(
-					$term_name,
-					$taxonomy,
-					array(
-						'slug' => $term_slug,
-					)
-				);
-			} else {
+			// Only a taxonomy-scoped hit comes back as the `term_id` array; anything else means there is
+			// nothing to update in this taxonomy yet.
+			if ( is_array( $term ) ) {
 				wp_update_term(
 					intval( $term['term_id'] ),
 					$taxonomy,
@@ -384,6 +378,14 @@ final class Setup {
 						'name' => $term_name,
 						'slug' => $term_slug,
 					),
+				);
+			} else {
+				wp_insert_term(
+					$term_name,
+					$taxonomy,
+					array(
+						'slug' => $term_slug,
+					)
 				);
 			}
 		}
@@ -515,13 +517,16 @@ final class Setup {
 		 * @param bool $is_alpha_active Whether GatherPress Alpha is active.
 		 */
 		$is_alpha_active = apply_filters( 'gatherpress_is_alpha_active', defined( 'GATHERPRESS_ALPHA_VERSION' ) );
+		$screen          = get_current_screen();
 
 		if (
 			$is_alpha_active ||
+			// Without a screen there is no admin page to attach the notice to.
+			null === $screen ||
 			filter_var( ! current_user_can( 'install_plugins' ), FILTER_VALIDATE_BOOLEAN ) || (
-				! str_contains( get_current_screen()->id, 'plugins' ) &&
-				! str_contains( get_current_screen()->id, 'plugin-install' ) &&
-				! str_contains( get_current_screen()->id, 'gatherpress' )
+				! str_contains( $screen->id, 'plugins' ) &&
+				! str_contains( $screen->id, 'plugin-install' ) &&
+				! str_contains( $screen->id, 'gatherpress' )
 			)
 		) {
 			return;

--- a/includes/core/classes/class-shadow-source.php
+++ b/includes/core/classes/class-shadow-source.php
@@ -339,7 +339,8 @@ final class Shadow_Source {
 
 		$term = term_exists( $old_term_slug, $taxonomy );
 
-		if ( empty( $term ) ) {
+		// Only a taxonomy-scoped hit comes back as the `term_id` array; anything else means the term is missing.
+		if ( ! is_array( $term ) ) {
 			wp_insert_term(
 				$title,
 				$taxonomy,

--- a/includes/core/classes/class-utility.php
+++ b/includes/core/classes/class-utility.php
@@ -57,7 +57,9 @@ final class Utility {
 		ob_start();
 		// Loading PHP template file, not importing a class.
 		require $path; // NOSONAR.
-		return ob_get_clean();
+
+		// The buffer was opened directly above, so ob_get_clean() always returns its contents.
+		return (string) ob_get_clean();
 	}
 
 	/**
@@ -189,7 +191,8 @@ final class Utility {
 	 * @return string The key with the 'gatherpress_' prefix removed.
 	 */
 	public static function unprefix_key( string $key ): string {
-		return preg_replace( '/^gatherpress_/', '', $key );
+		// A literal pattern cannot fail to compile, so preg_replace() never returns null here.
+		return (string) preg_replace( '/^gatherpress_/', '', $key );
 	}
 
 	/**
@@ -466,9 +469,7 @@ final class Utility {
 	 */
 	public static function maybe_convert_utc_offset( string $timezone ): string {
 		// Regex: https://regex101.com/r/wxhjIu/1.
-		preg_match( '/^UTC([+-])(\d+)(.\d+)?$/', $timezone, $matches );
-
-		if ( ! count( $matches ) ) {
+		if ( ! preg_match( '/^UTC([+-])(\d+)(.\d+)?$/', $timezone, $matches ) ) {
 			return $timezone;
 		}
 
@@ -602,7 +603,8 @@ final class Utility {
 	 * @return string The login URL for the event.
 	 */
 	public static function get_login_url( int $post_id = 0 ): string {
-		$permalink = get_the_permalink( $post_id );
+		// A post ID with no permalink (no such post, or no post in context) logs in without a redirect.
+		$permalink = (string) get_the_permalink( $post_id );
 
 		return wp_login_url( $permalink );
 	}
@@ -666,16 +668,23 @@ final class Utility {
 	 *
 	 * @since 0.33.0
 	 *
-	 * @param string|null $class_string The CSS class string to search in.
-	 * @param string      $target_class The specific class to search for.
+	 * @param string|bool|null $class_string The CSS class string to search in. `WP_HTML_Tag_Processor`
+	 *                                       hands back `true` for a valueless `class` attribute, which
+	 *                                       carries no classes.
+	 * @param string           $target_class The specific class to search for.
 	 *
 	 * @return bool True if the target class is found, false otherwise.
 	 */
-	public static function has_css_class( ?string $class_string, string $target_class ): bool {
-		if ( empty( $class_string ) || empty( $target_class ) ) {
+	public static function has_css_class( string|bool|null $class_string, string $target_class ): bool {
+		if ( ! is_string( $class_string ) || empty( $class_string ) || empty( $target_class ) ) {
 			return false;
 		}
 
+		/**
+		 * Class names split on whitespace.
+		 *
+		 * @var list<string> $classes A literal pattern cannot fail, so preg_split() never returns false.
+		 */
 		$classes = preg_split( '/\s+/', trim( $class_string ) );
 
 		return in_array( $target_class, $classes, true );

--- a/includes/core/classes/class-validate.php
+++ b/includes/core/classes/class-validate.php
@@ -62,9 +62,10 @@ final class Validate {
 	 * @return bool True if the parameter is a valid Event Post ID, false otherwise.
 	 */
 	public static function event_post_id( $param ): bool {
+		// positive_number() short-circuits first, so the cast only ever runs on a numeric ID.
 		return (
 			self::positive_number( $param ) &&
-			post_type_supports( (string) get_post_type( $param ), 'gatherpress-event-date' )
+			post_type_supports( (string) get_post_type( (int) $param ), 'gatherpress-event-date' )
 		);
 	}
 

--- a/includes/core/classes/commands/class-event-cli.php
+++ b/includes/core/classes/commands/class-event-cli.php
@@ -82,6 +82,8 @@ final class Event_Cli extends WP_CLI {
 					$event_id
 				)
 			);
+
+			return; // @phpstan-ignore deadCode.unreachable
 		}
 
 		$response = $event->rsvp->save( $user_id, $status, $anonymous, $guests );

--- a/includes/core/classes/commands/class-event-cli.php
+++ b/includes/core/classes/commands/class-event-cli.php
@@ -72,7 +72,19 @@ final class Event_Cli extends WP_CLI {
 		$anonymous = ! empty( $assoc_args['anonymous'] ) ? (int) $assoc_args['anonymous'] : 0;
 		$status    = ! empty( $assoc_args['status'] ) ? (string) $assoc_args['status'] : 'attending';
 		$event     = new Event( $event_id );
-		$response  = $event->rsvp->save( $user_id, $status, $anonymous, $guests );
+
+		// Event::$rsvp stays null for a post that isn't an RSVP-capable event, so there is nothing to save.
+		if ( ! $event->rsvp ) {
+			self::error(
+				sprintf(
+					/* translators: %d: event ID. */
+					__( 'Event ID "%d" does not exist or does not support RSVPs.', 'gatherpress' ),
+					$event_id
+				)
+			);
+		}
+
+		$response = $event->rsvp->save( $user_id, $status, $anonymous, $guests );
 
 		self::success(
 			sprintf(

--- a/includes/core/classes/commands/class-settings-cli.php
+++ b/includes/core/classes/commands/class-settings-cli.php
@@ -58,6 +58,13 @@ final class Settings_Cli extends WP_CLI {
 		if ( ! empty( $assoc_args['file'] ) ) {
 			$file = $assoc_args['file'];
 
+			// WP-CLI hands back `true` for a bare `--file` with no value, which is not a path to write to.
+			if ( ! is_string( $file ) ) {
+				self::error( __( 'The --file option requires a file path.', 'gatherpress' ) );
+
+				return; // @phpstan-ignore deadCode.unreachable
+			}
+
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 			if ( false === file_put_contents( $file, $json ) ) {
 				self::error(
@@ -141,6 +148,20 @@ final class Settings_Cli extends WP_CLI {
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$json = file_get_contents( $file );
+
+		// The file exists but can still be unreadable — a directory, or owned by another user.
+		if ( false === $json ) {
+			self::error(
+				sprintf(
+					/* translators: %s: File path. */
+					__( 'Failed to read file: %s', 'gatherpress' ),
+					$file
+				)
+			);
+
+			return; // @phpstan-ignore deadCode.unreachable
+		}
+
 		$data = json_decode( $json, true );
 
 		if ( ! is_array( $data ) ) {
@@ -188,7 +209,10 @@ final class Settings_Cli extends WP_CLI {
 			return;
 		}
 
-		$mode   = $assoc_args['mode'] ?? 'merge';
+		$mode = $assoc_args['mode'] ?? 'merge';
+
+		// A bare `--mode` with no value arrives as `true`; fall back to the documented default.
+		$mode   = is_string( $mode ) ? $mode : 'merge';
 		$result = $settings->import_settings( $data, $mode );
 
 		if ( ! $result['success'] ) {

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -25,6 +25,7 @@ use GatherPress\Core\Validate;
 use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue\Venue;
 use WP_Post;
+use WP_Term;
 
 /**
  * Class Event.
@@ -513,15 +514,24 @@ class Event {
 		}
 
 		if ( ! empty( $date ) ) {
-			$ts   = strtotime( $date );
-			$date = wp_date(
+			$ts = strtotime( $date );
+
+			// A stored value that validates but will not parse (a legacy all-zero datetime,
+			// for one) has no timestamp to format, so report no datetime at all rather
+			// than falling back to the epoch.
+			if ( false === $ts ) {
+				return '';
+			}
+
+			// wp_date() only returns false for a non-numeric timestamp, which $ts is not.
+			$date = (string) wp_date(
 				apply_filters( 'gatherpress_datetime_format', $format, $which, $local ),
 				$ts,
 				$tz
 			);
 		}
 
-		return (string) trim( $date );
+		return trim( $date );
 	}
 
 	/**
@@ -637,10 +647,20 @@ class Event {
 			'website'   => '',
 		);
 
+		if ( ! $this->event ) {
+			return $venue_information;
+		}
+
 		$event_post_type = (string) get_post_type( $this->event );
 		$venue_setup     = Setup::get_instance();
 		$taxonomy        = $venue_setup->taxonomy_for_event_post_type( $event_post_type );
-		$venue_terms     = (array) get_the_terms( $this->event, $taxonomy );
+		$venue_terms     = get_the_terms( $this->event, $taxonomy );
+
+		// get_the_terms() hands back false when nothing is assigned and a WP_Error for an
+		// unregistered taxonomy; neither carries venue terms to inspect.
+		if ( ! is_array( $venue_terms ) ) {
+			return $venue_information;
+		}
 
 		// Prefer a real venue term (leading-underscore prefix) so a hybrid
 		// event with both a physical venue and the `online-event` sentinel
@@ -653,10 +673,6 @@ class Event {
 		$fallback = null;
 
 		foreach ( $venue_terms as $candidate ) {
-			if ( ! is_a( $candidate, 'WP_Term' ) ) {
-				continue;
-			}
-
 			if ( $venue_setup->is_venue_term_slug( $candidate->slug ) ) {
 				$term = $candidate;
 				break;
@@ -668,12 +684,12 @@ class Event {
 		$term  = $term ?? $fallback;
 		$venue = null;
 
-		if ( is_a( $term, 'WP_Term' ) ) {
+		if ( $term instanceof WP_Term ) {
 			$venue_information['name'] = $term->name;
 			$venue                     = $venue_setup->get_venue_post_from_term_slug( $term->slug );
 		}
 
-		if ( is_a( $venue, 'WP_Post' ) ) {
+		if ( $venue instanceof WP_Post ) {
 			$venue_information = array_merge( $venue_information, ( new Venue( $venue->ID ) )->get_information() );
 
 			$venue_information['permalink'] = (string) get_permalink( $venue->ID );
@@ -707,22 +723,24 @@ class Event {
 
 		$calendar = new Calendar( $this->event->ID );
 
+		// Each URL getter only reports false when its event post cannot be resolved, and the
+		// calendar was built from the post resolved directly above.
 		return array(
 			'google'  => array(
 				'name' => __( 'Google Calendar', 'gatherpress' ),
-				'link' => $calendar->get_google_url(),
+				'link' => (string) $calendar->get_google_url(),
 			),
 			'ical'    => array(
 				'name'     => __( 'iCal', 'gatherpress' ),
-				'download' => $calendar->get_ical_url(),
+				'download' => (string) $calendar->get_ical_url(),
 			),
 			'outlook' => array(
 				'name'     => __( 'Outlook', 'gatherpress' ),
-				'download' => $calendar->get_outlook_url(),
+				'download' => (string) $calendar->get_outlook_url(),
 			),
 			'yahoo'   => array(
 				'name' => __( 'Yahoo Calendar', 'gatherpress' ),
-				'link' => $calendar->get_yahoo_url(),
+				'link' => (string) $calendar->get_yahoo_url(),
 			),
 		);
 	}
@@ -738,6 +756,10 @@ class Event {
 	 * @return string The calendar event description with the event details link.
 	 */
 	public function get_calendar_description(): string {
+		if ( ! $this->event ) {
+			return '';
+		}
+
 		/* translators: %s: event link. */
 		return sprintf( __( 'For details go to %s', 'gatherpress' ), get_the_permalink( $this->event ) );
 	}
@@ -765,6 +787,12 @@ class Event {
 	 */
 	public function save_datetimes( array $params ): bool {
 		global $wpdb;
+
+		// Nothing to attach the datetimes to when the post ID handed to the constructor
+		// did not resolve to an event.
+		if ( ! $this->event ) {
+			return false;
+		}
 
 		$params = array_merge(
 			array(
@@ -841,7 +869,8 @@ class Event {
 			update_post_meta(
 				$fields['post_id'],
 				$meta_key,
-				sanitize_text_field( $field )
+				// Only the string-valued fields reach here; post_id is skipped above.
+				sanitize_text_field( (string) $field )
 			);
 		}
 
@@ -858,6 +887,10 @@ class Event {
 	 * @return string The online event link if all conditions are met; otherwise, an empty string.
 	 */
 	public function maybe_get_online_event_link(): string {
+		if ( ! $this->event ) {
+			return '';
+		}
+
 		$event_link = (string) get_post_meta( $this->event->ID, 'gatherpress_online_event_link', true );
 
 		/**

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -516,9 +516,10 @@ class Event {
 		if ( ! empty( $date ) ) {
 			$ts = strtotime( $date );
 
-			// A stored value that validates but will not parse (a legacy all-zero datetime,
-			// for one) has no timestamp to format, so report no datetime at all rather
-			// than falling back to the epoch.
+			// Validate::datetime() accepts what DateTime::createFromFormat() accepts,
+			// which is wider than strtotime(): an overflowing value like
+			// '2030-06-31 25:00:00' passes validation and still has no timestamp to
+			// format, so report no datetime rather than falling back to the epoch.
 			if ( false === $ts ) {
 				return '';
 			}

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -456,9 +456,24 @@ final class Query {
 		);
 		$pieces   = array_merge( $defaults, $pieces );
 
-		$table           = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
-		$pieces['join'] .= ' LEFT JOIN ' . esc_sql( $table ) . ' ON ' . esc_sql( $wpdb->posts ) . '.ID='
-						. esc_sql( $table ) . '.post_id';
+		$table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+
+		/**
+		 * Escaped events table name.
+		 *
+		 * @var string $events_table esc_sql() only returns an array when it is handed one.
+		 */
+		$events_table = esc_sql( $table );
+
+		/**
+		 * Escaped posts table name.
+		 *
+		 * @var string $posts_table esc_sql() only returns an array when it is handed one.
+		 */
+		$posts_table = esc_sql( $wpdb->posts );
+
+		$pieces['join'] .= ' LEFT JOIN ' . $events_table . ' ON ' . $posts_table . '.ID='
+						. $events_table . '.post_id';
 		$order           = strtoupper( $order );
 
 		if ( in_array( $order, array( 'DESC', 'ASC' ), true ) ) {
@@ -468,14 +483,14 @@ final class Query {
 
 			switch ( strtolower( $order_by ) ) {
 				case 'id':
-					$pieces['orderby'] = sprintf( esc_sql( $wpdb->posts ) . '.ID %s', esc_sql( $order ) );
+					$pieces['orderby'] = sprintf( $posts_table . '.ID %s', esc_sql( $order ) );
 					break;
 				case 'title':
-					$pieces['orderby'] = sprintf( esc_sql( $wpdb->posts ) . '.post_name %s', esc_sql( $order ) );
+					$pieces['orderby'] = sprintf( $posts_table . '.post_name %s', esc_sql( $order ) );
 					break;
 				case 'modified':
 					$pieces['orderby'] = sprintf(
-						esc_sql( $wpdb->posts ) . '.post_modified_gmt %s',
+						$posts_table . '.post_modified_gmt %s',
 						esc_sql( $order )
 					);
 					break;
@@ -483,7 +498,7 @@ final class Query {
 					$pieces['orderby'] = esc_sql( 'RAND()' );
 					break;
 				case 'datetime':
-					$pieces['orderby'] = sprintf( esc_sql( $table ) . '.datetime_start_gmt %s', esc_sql( $order ) );
+					$pieces['orderby'] = sprintf( $events_table . '.datetime_start_gmt %s', esc_sql( $order ) );
 					break;
 				default:
 					// Custom column sorting (e.g., rsvps, venue) is handled
@@ -522,8 +537,9 @@ final class Query {
 	 *
 	 * @param string[] $venues Array of venue slugs to filter by.
 	 *
-	 * @return array{relation: string, ...<int, array{taxonomy: string, field: string, terms: string[]}>}
-	 *               WP_Query compatible tax_query array.
+	 * @return array<int|string, string|array{taxonomy: string, field: string, terms: string[]}>
+	 *               WP_Query compatible tax_query array: an `OR` relation under the `relation` key,
+	 *               plus one clause per registered venue taxonomy under integer keys.
 	 */
 	private function build_venue_tax_query( array $venues ): array {
 		$venue_tax_query = array( 'relation' => 'OR' );

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -27,6 +27,7 @@ use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\User;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Validate;
+use WP_Comment;
 use WP_Post;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -45,7 +46,7 @@ use WP_User;
  *
  * @phpstan-type RouteDefinition array{route: string, args: array<string, mixed>}
  * @phpstan-type SendOptions array{all: bool, attending: bool, waiting_list: bool, not_attending: bool}
- * @phpstan-type Recipient array{is_user: bool, user_id: int, comment_id: int|string, email: string, name: string}
+ * @phpstan-type Recipient array{is_user: bool, user_id: int, comment_id: int, email: string, name: string}
  */
 final class Rest_Api {
 
@@ -673,6 +674,12 @@ final class Rest_Api {
 		);
 
 		foreach ( $comments as $comment ) {
+			// get_rsvps() is typed loosely enough to return counts, so only comment rows
+			// are turned into recipients.
+			if ( ! $comment instanceof WP_Comment ) {
+				continue;
+			}
+
 			$recipient = $this->build_comment_recipient( $comment );
 
 			if ( null !== $recipient ) {
@@ -694,7 +701,7 @@ final class Rest_Api {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param object $comment RSVP comment row from `Rsvp_Query::get_rsvps()`.
+	 * @param WP_Comment $comment RSVP comment row from `Rsvp_Query::get_rsvps()`.
 	 *
 	 * @return Recipient|null Recipient row, or null when no email is on file.
 	 */
@@ -719,7 +726,7 @@ final class Rest_Api {
 		return array(
 			'is_user'    => (bool) $user_id,
 			'user_id'    => $user_id,
-			'comment_id' => $comment->comment_ID,
+			'comment_id' => (int) $comment->comment_ID,
 			'email'      => $email,
 			'name'       => $name,
 		);
@@ -754,6 +761,10 @@ final class Rest_Api {
 		$anonymous       = intval( $params['anonymous'] ?? 0 );
 		$unparsed_token  = sanitize_text_field( $params['rsvp_token'] ?? '' );
 		$event           = new Event( $post_id );
+
+		// Event only builds its Rsvp for a post type that carries event dates, which is what
+		// the route's post_id validation already requires.
+		$rsvp = $event->rsvp;
 
 		// If managing user is adding someone to an event.
 		$is_managing_other = false;
@@ -800,16 +811,23 @@ final class Rest_Api {
 			}
 		}
 
+		// A magic-link token supplies an email address; every other path supplies a user ID,
+		// so each identifier is checked against the one thing it can be.
 		if (
+			$rsvp &&
 			$user_identifier &&
-			( is_user_member_of_blog( $user_identifier ) || is_email( $user_identifier ) ) &&
+			(
+				is_string( $user_identifier )
+					? is_email( $user_identifier )
+					: is_user_member_of_blog( $user_identifier )
+			) &&
 			! $event->has_event_past()
 		) {
 			if ( 'attending' !== $status ) {
 				$guests = 0;
 			}
 
-			$user_record = $event->rsvp->save( $user_identifier, $status, $anonymous, $guests );
+			$user_record = $rsvp->save( $user_identifier, $status, $anonymous, $guests );
 			$status      = $user_record['status'];
 			$guests      = $user_record['guests'];
 
@@ -824,7 +842,7 @@ final class Rest_Api {
 			'status'      => $status,
 			'guests'      => $guests,
 			'anonymous'   => $anonymous,
-			'responses'   => $event->rsvp->responses(),
+			'responses'   => $rsvp ? $rsvp->responses() : array(),
 			'online_link' => $event->maybe_get_online_event_link(),
 		);
 
@@ -984,7 +1002,7 @@ final class Rest_Api {
 				'success'    => true,
 				'message'    => $result['message'],
 				'comment_id' => $result['comment_id'],
-				'responses'  => $this->rsvp_response_counts( $event->rsvp->responses() ),
+				'responses'  => $this->rsvp_response_counts( $rsvp->responses() ),
 			);
 			$status   = 200;
 		} else {

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -639,8 +639,10 @@ final class Setup {
 		$post_type = $post instanceof WP_Post ? $post->post_type : get_post_type();
 		$post_id   = $post instanceof WP_Post ? $post->ID : get_the_ID();
 
+		// get_the_ID() returns false when there is no post in the loop to date.
 		if (
-			! post_type_supports( (string) $post_type, 'gatherpress-event-date' )
+			false === $post_id
+			|| ! post_type_supports( (string) $post_type, 'gatherpress-event-date' )
 			|| 1 !== intval( $use_event_date )
 		) {
 			return $the_date;
@@ -696,18 +698,24 @@ final class Setup {
 		}
 
 		// Replace the datetime attribute and the displayed date text in the block output.
-		$iso_date      = $event->get_datetime_start( 'c' );
-		$block_content = preg_replace(
+		$iso_date = $event->get_datetime_start( 'c' );
+
+		// A literal pattern cannot fail to compile, so preg_replace() never returns null here.
+		$block_content = (string) preg_replace(
 			'/datetime="[^"]*"/',
 			'datetime="' . esc_attr( $iso_date ) . '"',
 			$block_content
 		);
 
-		return preg_replace(
+		$replaced = preg_replace(
 			'|(<time[^>]*>).*?(</time>)|s',
 			'$1' . esc_html( $display_date ) . '$2',
 			$block_content
 		);
+
+		// A null return means PCRE gave up (e.g. the backtrack limit on very large
+		// markup), so the unmodified block content is served instead.
+		return $replaced ?? $block_content;
 	}
 
 	/**

--- a/includes/core/classes/rsvp/class-cleanup.php
+++ b/includes/core/classes/rsvp/class-cleanup.php
@@ -93,7 +93,8 @@ final class Cleanup {
 			$meta_keys = array_keys( get_comment_meta( $rsvp->comment_ID ) );
 
 			foreach ( $meta_keys as $meta_key ) {
-				delete_comment_meta( $rsvp->comment_ID, $meta_key );
+				// A numeric meta key comes back from `array_keys()` as an int.
+				delete_comment_meta( $rsvp->comment_ID, (string) $meta_key );
 			}
 
 			wp_delete_comment( $rsvp->comment_ID, true );

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -81,14 +81,19 @@ final class List_Table extends WP_List_Table {
 	public function __construct( $args = array() ) {
 		$this->post_type = ! empty( $args['post_type'] ) ? (string) $args['post_type'] : Event::POST_TYPE;
 
-		parent::__construct(
-			array(
-				'plural'   => __( 'RSVPs', 'gatherpress' ),
-				'singular' => __( 'RSVP', 'gatherpress' ),
-				'ajax'     => false,
-				'screen'   => isset( $args['screen'] ) ? $args['screen'] : null,
-			)
+		$table_args = array(
+			'plural'   => __( 'RSVPs', 'gatherpress' ),
+			'singular' => __( 'RSVP', 'gatherpress' ),
+			'ajax'     => false,
 		);
+
+		// WP_List_Table defaults 'screen' to null, so leaving the key out is the same
+		// as the old explicit null and keeps the array to the shape the parent declares.
+		if ( ! empty( $args['screen'] ) ) {
+			$table_args['screen'] = (string) $args['screen'];
+		}
+
+		parent::__construct( $table_args );
 	}
 
 	/**
@@ -251,8 +256,11 @@ final class List_Table extends WP_List_Table {
 		$user     = get_current_user_id();
 		$option   = sprintf( '%s_per_page', Rsvp::COMMENT_TYPE );
 		$per_page = get_user_meta( $user, $option, true );
+		$per_page = is_numeric( $per_page ) ? (int) $per_page : 0;
 
-		if ( empty( $per_page ) || ! is_numeric( $per_page ) ) {
+		// A stored preference of zero or less would divide the total by a non-positive
+		// number when the page count is calculated below.
+		if ( 1 > $per_page ) {
 			$per_page = self::DEFAULT_PER_PAGE;
 		}
 
@@ -453,14 +461,22 @@ final class List_Table extends WP_List_Table {
 	 * @return string Formatted content for the specified column.
 	 */
 	public function column_default( $item, $column_name ): string {
+		// Rows are comments cast to arrays by get_rsvps(); normalize anything else
+		// the parent hands over, the same way column_cb() does.
+		$item       = (array) $item;
+		$comment_id = (int) ( $item['comment_ID'] ?? 0 );
+
 		// Default fall-through (matches the original switch's `default` arm).
-		$output = isset( $item[ $column_name ] ) ? $item[ $column_name ] : '-';
+		$output = isset( $item[ $column_name ] ) && is_scalar( $item[ $column_name ] )
+			? (string) $item[ $column_name ]
+			: '-';
 
 		switch ( $column_name ) {
 			case 'response':
-				$terms = wp_get_object_terms( $item['comment_ID'], Status::TAXONOMY );
+				$terms = wp_get_object_terms( $comment_id, Status::TAXONOMY );
 
-				if ( empty( $terms ) ) {
+				// An unregistered taxonomy yields WP_Error rather than a term list.
+				if ( is_wp_error( $terms ) || empty( $terms ) ) {
 					return '-';
 				}
 
@@ -473,8 +489,17 @@ final class List_Table extends WP_List_Table {
 
 				break;
 			case 'event':
-				$output = '<a href="' . esc_url( get_permalink( $item['comment_post_ID'] ) ) . '">' .
-					wp_kses_post( $item['event_title'] ) . '</a>';
+				$event_title = is_scalar( $item['event_title'] ?? null ) ? (string) $item['event_title'] : '';
+				$event_link  = get_permalink( (int) ( $item['comment_post_ID'] ?? 0 ) );
+
+				// An RSVP row outlives the post it points at, so a deleted event has
+				// neither a permalink nor a title. Show whatever is left of it.
+				if ( false === $event_link ) {
+					$output = '' !== $event_title ? wp_kses_post( $event_title ) : '-';
+					break;
+				}
+
+				$output = '<a href="' . esc_url( $event_link ) . '">' . wp_kses_post( $event_title ) . '</a>';
 				break;
 			case 'approved':
 				$statuses = array(
@@ -482,19 +507,26 @@ final class List_Table extends WP_List_Table {
 					'0'    => __( 'Pending', 'gatherpress' ),
 					'spam' => __( 'Spam', 'gatherpress' ),
 				);
-				$output   = $statuses[ $item['comment_approved'] ];
+				$approved = is_scalar( $item['comment_approved'] ?? null )
+					? (string) $item['comment_approved']
+					: '';
+
+				// Core stores other values here too ('trash', 'post-trashed'), which
+				// this table has no label for.
+				$output = $statuses[ $approved ] ?? '-';
 				break;
 			case 'date':
-				return get_comment_date( 'Y/m/d \a\t g:i a', $item['comment_ID'] );
+				return get_comment_date( 'Y/m/d \a\t g:i a', $comment_id );
 			case 'type':
-				$terms = wp_get_object_terms( $item['comment_ID'], Provider::TAXONOMY );
+				$terms = wp_get_object_terms( $comment_id, Provider::TAXONOMY );
 
 				// Prefer the authoritative provider term when present, but
 				// fall back to inferring the provider from the comment so
 				// the column is correct for rows that never carried the
 				// term — the open/email front-end form doesn't stamp it,
 				// and RSVPs saved before the term existed predate it.
-				if ( empty( $terms ) ) {
+				// An unregistered taxonomy yields WP_Error rather than a term list.
+				if ( is_wp_error( $terms ) || empty( $terms ) ) {
 					$provider = $this->infer_provider_from_item( $item );
 
 					return $provider ? $provider::get_label() : '';
@@ -757,6 +789,10 @@ final class List_Table extends WP_List_Table {
 		if ( ! current_user_can( Rsvp::CAPABILITY ) ) {
 			return;
 		}
+
+		// Rows are comments cast to arrays by get_rsvps(); normalize anything else
+		// the parent hands over, the same way column_cb() does.
+		$item = (array) $item;
 
 		if ( '1' === $item['comment_approved'] ) {
 			$status = 'approved';

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -286,16 +286,23 @@ final class Rsvp {
 		}
 
 		$provider = $this->resolve_provider( $identity );
-		$status   = Status::try_from( $status );
-		$data     = new Data( $identity, $status, $guests, (bool) $anonymous );
-		$intent   = new Intent( $data, $provider );
-		$state    = $this->process( $intent );
 
-		if ( null === $state ) {
+		// No provider handles this identity type, so there is no response to record.
+		if ( null === $provider ) {
 			return self::DEFAULT_SAVE_RESPONSE;
 		}
 
-		Cache::delete( $this->event->ID );
+		$status = Status::try_from( $status );
+		$data   = new Data( $identity, $status, $guests, (bool) $anonymous );
+		$intent = new Intent( $data, $provider );
+		$state  = $this->process( $intent );
+		$event  = $this->event;
+
+		if ( null === $state || null === $event ) {
+			return self::DEFAULT_SAVE_RESPONSE;
+		}
+
+		Cache::delete( $event->ID );
 
 		return Serializer::to_array( $state );
 	}
@@ -521,12 +528,15 @@ final class Rsvp {
 	 * @return array<string, RsvpResponseGroup> Response records and counts keyed by 'all' and each RSVP status.
 	 */
 	public function responses(): array {
+		$post_id = $this->event->ID ?? 0;
+
 		// Serialized records vary by capability but the cache key does not, so
 		// only the public variant is cached; privileged viewers compute fresh.
-		$can_use_cache = ! current_user_can( self::CAPABILITY );
+		// An unresolved event has no cache key of its own, so it computes fresh too.
+		$can_use_cache = 0 < $post_id && ! current_user_can( self::CAPABILITY );
 
 		if ( $can_use_cache ) {
-			$cached = Cache::get( $this->event->ID );
+			$cached = Cache::get( $post_id );
 
 			if ( is_array( $cached ) ) {
 				return $cached;
@@ -583,7 +593,7 @@ final class Rsvp {
 		}
 
 		if ( $can_use_cache ) {
-			Cache::set( $this->event->ID, $retval );
+			Cache::set( $post_id, $retval );
 		}
 
 		return $retval;
@@ -653,7 +663,8 @@ final class Rsvp {
 	 * @return Intent
 	 */
 	private function constrain_rsvp_intent( Intent $intent, ?State $current_response ): Intent {
-		$max_guest_limit = intval( get_post_meta( $this->event->ID, 'gatherpress_max_guest_limit', true ) );
+		$post_id         = $this->event->ID ?? 0;
+		$max_guest_limit = intval( get_post_meta( $post_id, 'gatherpress_max_guest_limit', true ) );
 
 		$guests    = $intent->data->guests;
 		$anonymous = $intent->data->anonymous;
@@ -664,7 +675,7 @@ final class Rsvp {
 		}
 
 		// Check if anonymous RSVP is enabled for this event.
-		$enable_anonymous_rsvp = get_post_meta( $this->event->ID, 'gatherpress_enable_anonymous_rsvp', true );
+		$enable_anonymous_rsvp = get_post_meta( $post_id, 'gatherpress_enable_anonymous_rsvp', true );
 		if ( ! $enable_anonymous_rsvp ) {
 			$anonymous = false;
 		}
@@ -719,7 +730,7 @@ final class Rsvp {
 	 * @return Identity|null
 	 */
 	private function resolve_identity( int|string $identifier ): ?Identity {
-		if ( is_email( $identifier ) ) {
+		if ( is_string( $identifier ) && is_email( $identifier ) ) {
 			return new Identity( Identity_Type::EMAIL, $identifier );
 		}
 

--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -414,7 +414,10 @@ final class Setup {
 			)
 		);
 
-		$this->list_table->register_column_options();
+		// The list table only exists when `prepare_rsvp_admin_page()` created it for this screen.
+		if ( $this->list_table instanceof List_Table ) {
+			$this->list_table->register_column_options();
+		}
 	}
 
 	/**

--- a/includes/core/classes/rsvp/class-storage.php
+++ b/includes/core/classes/rsvp/class-storage.php
@@ -133,8 +133,7 @@ final class Storage {
 		if ( $comment_id ) {
 			$existing = get_comment( $comment_id );
 
-			// The row can be deleted between the lookup that produced $comment_id and this
-			// save, leaving nothing to update.
+			// The row can be deleted between the lookup and this save.
 			if ( ! $existing instanceof WP_Comment ) {
 				return false;
 			}
@@ -196,8 +195,7 @@ final class Storage {
 
 		$comment = get_comment( $comment_id );
 
-		// A comment that no longer resolves, or that does not hydrate into a state, is
-		// reported as a failed save rather than a successful one.
+		// Report a failed save rather than a successful one.
 		if ( ! $comment instanceof WP_Comment ) {
 			return false;
 		}

--- a/includes/core/classes/rsvp/class-storage.php
+++ b/includes/core/classes/rsvp/class-storage.php
@@ -131,7 +131,15 @@ final class Storage {
 		$success = true;
 
 		if ( $comment_id ) {
-			$args = get_comment( $comment_id )->to_array();
+			$existing = get_comment( $comment_id );
+
+			// The row can be deleted between the lookup that produced $comment_id and this
+			// save, leaving nothing to update.
+			if ( ! $existing instanceof WP_Comment ) {
+				return false;
+			}
+
+			$args = $existing->to_array();
 
 			if ( $args['comment_author'] ) {
 				$intent->data->identity->display_name = $args['comment_author'];
@@ -188,7 +196,13 @@ final class Storage {
 
 		$comment = get_comment( $comment_id );
 
-		return $this->hydrate( $comment, $intent->data->identity, $intent->provider );
+		// A comment that no longer resolves, or that does not hydrate into a state, is
+		// reported as a failed save rather than a successful one.
+		if ( ! $comment instanceof WP_Comment ) {
+			return false;
+		}
+
+		return $this->hydrate( $comment, $intent->data->identity, $intent->provider ) ?? false;
 	}
 
 	/**
@@ -433,10 +447,10 @@ final class Storage {
 	 *
 	 * @since 0.35.0
 	 *
-	 * @param array<array<int|string>|int|string> $args     The current comment data args.
-	 * @param Identity                            $identity The identity.
+	 * @param array<string, mixed> $args     The current comment data args.
+	 * @param Identity             $identity The identity.
 	 *
-	 * @return array<array<int|string>|int|string> The comment data args including the identity.
+	 * @return array<string, mixed> The comment data args including the identity.
 	 */
 	private function add_identity_comment_data( array $args, Identity $identity ): array {
 		switch ( $identity->type ) {

--- a/includes/core/classes/rsvp/class-token.php
+++ b/includes/core/classes/rsvp/class-token.php
@@ -243,6 +243,11 @@ final class Token {
 	 * @return void
 	 */
 	private function save_token_to_meta(): void {
+		// Without a comment there is no meta row to write the token to.
+		if ( ! $this->comment ) {
+			return;
+		}
+
 		update_comment_meta(
 			(int) $this->comment->comment_ID,
 			$this->get_meta_key(),
@@ -422,6 +427,9 @@ final class Token {
 	 * @param WP_Post|null    $post The post object.
 	 * @param WP_Comment|null $comment The comment object.
 	 * @param string          $token The token string.
+	 *
+	 * @phpstan-assert-if-true !null $post
+	 * @phpstan-assert-if-true !null $comment
 	 *
 	 * @return bool True if all components are available, false otherwise.
 	 */

--- a/includes/core/classes/rsvp/response/class-serializer.php
+++ b/includes/core/classes/rsvp/response/class-serializer.php
@@ -97,6 +97,12 @@ final class Serializer {
 			$data[ Utility::snake_to_camel( $gatherpress_snake_key ) ] = $data[ $gatherpress_snake_key ];
 		}
 
+		/**
+		 * The completed record.
+		 *
+		 * @var RsvpRecord $data Writing the camelCase aliases in a loop loses the shape, but the
+		 *                       literal above plus those three aliases is the whole contract.
+		 */
 		return $data;
 	}
 

--- a/includes/core/classes/rsvp/response/provider/class-base.php
+++ b/includes/core/classes/rsvp/response/provider/class-base.php
@@ -104,8 +104,14 @@ abstract class Base {
 	 * @return string|null The avatar URL, or null if the identity has no avatar.
 	 */
 	public function get_avatar_url( Identity $identity ): ?string {
-		if ( Identity_Type::WP_USER_ID === $identity->type || is_email( $identity->value ) ) {
-			return get_avatar_url( $identity->value );
+		// An integer identity value is an ID, never an address, so only strings are worth checking.
+		$is_email = is_string( $identity->value ) && is_email( $identity->value );
+
+		if ( Identity_Type::WP_USER_ID === $identity->type || $is_email ) {
+			$avatar_url = get_avatar_url( $identity->value );
+
+			// `get_avatar_url()` is false when avatars are turned off or the identity resolves to none.
+			return false === $avatar_url ? null : $avatar_url;
 		}
 
 		return null;
@@ -121,7 +127,8 @@ abstract class Base {
 	 * @return string|null The profile URL, or null if the identity value is not a URL.
 	 */
 	public function get_url( Identity $identity ): ?string {
-		if ( false !== filter_var( $identity->value, FILTER_VALIDATE_URL ) ) {
+		// An integer identity value is an ID, never a URL, so only strings can validate here.
+		if ( is_string( $identity->value ) && false !== filter_var( $identity->value, FILTER_VALIDATE_URL ) ) {
 			return $identity->value;
 		}
 

--- a/includes/core/classes/rsvp/response/provider/class-base.php
+++ b/includes/core/classes/rsvp/response/provider/class-base.php
@@ -104,7 +104,7 @@ abstract class Base {
 	 * @return string|null The avatar URL, or null if the identity has no avatar.
 	 */
 	public function get_avatar_url( Identity $identity ): ?string {
-		// An integer identity value is an ID, never an address, so only strings are worth checking.
+		// An integer identity is an ID, never an address.
 		$is_email = is_string( $identity->value ) && is_email( $identity->value );
 
 		if ( Identity_Type::WP_USER_ID === $identity->type || $is_email ) {
@@ -127,7 +127,6 @@ abstract class Base {
 	 * @return string|null The profile URL, or null if the identity value is not a URL.
 	 */
 	public function get_url( Identity $identity ): ?string {
-		// An integer identity value is an ID, never a URL, so only strings can validate here.
 		if ( is_string( $identity->value ) && false !== filter_var( $identity->value, FILTER_VALIDATE_URL ) ) {
 			return $identity->value;
 		}

--- a/includes/core/classes/rsvp/response/provider/class-user.php
+++ b/includes/core/classes/rsvp/response/provider/class-user.php
@@ -88,6 +88,7 @@ final class User extends Base {
 	 * @return string The author posts URL.
 	 */
 	public function get_url( Identity $identity ): string {
-		return get_author_posts_url( $identity->value );
+		// Identity values are typed `string|int`; this provider's is always a WP user ID.
+		return get_author_posts_url( intval( $identity->value ) );
 	}
 }

--- a/includes/core/classes/rsvp/response/provider/class-user.php
+++ b/includes/core/classes/rsvp/response/provider/class-user.php
@@ -88,7 +88,6 @@ final class User extends Base {
 	 * @return string The author posts URL.
 	 */
 	public function get_url( Identity $identity ): string {
-		// Identity values are typed `string|int`; this provider's is always a WP user ID.
 		return get_author_posts_url( intval( $identity->value ) );
 	}
 }

--- a/includes/core/classes/settings/class-network.php
+++ b/includes/core/classes/settings/class-network.php
@@ -581,9 +581,17 @@ final class Network {
 
 		// Single-site (no $stored) and multisite-with-corrupt-stored-value
 		// (non-array) both fall back to defaults.
-		self::$config_cache = is_array( $stored )
+		$config = is_array( $stored )
 			? array_merge( $defaults, $stored )
 			: $defaults;
+
+		// A stored array can still hold junk under either key, so coerce both back to shape.
+		self::$config_cache = array(
+			'enabled'   => ! empty( $config['enabled'] ),
+			'inherited' => is_array( $config['inherited'] ?? null )
+				? array_values( array_filter( $config['inherited'], 'is_string' ) )
+				: array(),
+		);
 
 		return self::$config_cache;
 	}

--- a/includes/core/classes/settings/class-roles.php
+++ b/includes/core/classes/settings/class-roles.php
@@ -115,7 +115,8 @@ final class Roles extends Base {
 	public function get_user_roles(): array {
 		$sub_pages = Settings::get_instance()->get_sub_pages();
 
-		return (array) $sub_pages['roles_settings']['sections']['roles']['options'];
+		// The sub-pages array is filterable, so a site can drop the roles section entirely.
+		return $sub_pages['roles_settings']['sections']['roles']['options'] ?? array();
 	}
 
 	/**

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -1452,8 +1452,7 @@ final class Map {
 		string $provider,
 		string $map_type = self::DEFAULT_MAP_TYPE
 	): ?string {
-		// GD has handed back GdImage objects since PHP 8.0, so the `resource` arm of the
-		// provider contract can't occur on the 8.1 floor. Anything else is a failed render.
+		// GD returns GdImage since PHP 8.0, so the contract's `resource` arm is dead on the 8.1 floor.
 		if ( ! $image instanceof GdImage ) {
 			return null; // @codeCoverageIgnore
 		}

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -1005,7 +1005,16 @@ final class Map {
 		 * @param array<string, array<string, array<string, mixed>>> $descriptors Provider-keyed descriptor map.
 		 * @param int                                                $post_id     Venue post ID.
 		 */
-		return (array) apply_filters( 'gatherpress_static_map_descriptors', $descriptors, $post_id );
+		$filtered = (array) apply_filters( 'gatherpress_static_map_descriptors', $descriptors, $post_id );
+
+		/**
+		 * The filtered descriptor map.
+		 *
+		 * @var ProviderDescriptorMap $filtered Integrators are documented to hand back the descriptor
+		 *                                      shape they were given; anything malformed is dropped
+		 *                                      the next time a descriptor is saved.
+		 */
+		return $filtered;
 	}
 
 	/**
@@ -1443,6 +1452,12 @@ final class Map {
 		string $provider,
 		string $map_type = self::DEFAULT_MAP_TYPE
 	): ?string {
+		// GD has handed back GdImage objects since PHP 8.0, so the `resource` arm of the
+		// provider contract can't occur on the 8.1 floor. Anything else is a failed render.
+		if ( ! $image instanceof GdImage ) {
+			return null; // @codeCoverageIgnore
+		}
+
 		$dirs = wp_get_upload_dir();
 
 		if ( ! empty( $dirs['error'] ) ) {

--- a/includes/core/classes/venue/map/class-prewarm.php
+++ b/includes/core/classes/venue/map/class-prewarm.php
@@ -552,7 +552,6 @@ final class Prewarm {
 			return array();
 		}
 
-		// parse_blocks() returns a list; array_values() pins that for the int-keyed walk.
 		$blocks = array_values( parse_blocks( $content ) );
 
 		return $this->walk_blocks_for_combos( $blocks );

--- a/includes/core/classes/venue/map/class-prewarm.php
+++ b/includes/core/classes/venue/map/class-prewarm.php
@@ -552,7 +552,8 @@ final class Prewarm {
 			return array();
 		}
 
-		$blocks = parse_blocks( $content );
+		// parse_blocks() returns a list; array_values() pins that for the int-keyed walk.
+		$blocks = array_values( parse_blocks( $content ) );
 
 		return $this->walk_blocks_for_combos( $blocks );
 	}

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -88,8 +88,8 @@ final class OSM extends Base {
 	/**
 	 * Composite OSM tiles around the venue, stamp a marker at the canvas
 	 * center, and return the finished GD image. Returns null when GD is
-	 * unavailable, when the requested density is unsupported, or when the
-	 * retina variant would require a tile zoom past `Map::ZOOM_MAX`.
+	 * unavailable, when the requested dimensions are not positive, or when
+	 * the retina variant would require a tile zoom past `Map::ZOOM_MAX`.
 	 *
 	 * @since 0.34.0
 	 *
@@ -116,6 +116,11 @@ final class OSM extends Base {
 		// PHP built without the GD extension. Can't simulate in a unit test without making the runtime itself broken.
 		if ( ! function_exists( 'imagecreatetruecolor' ) ) { // @codeCoverageIgnore
 			return null; // @codeCoverageIgnore
+		}
+
+		// A canvas needs at least one pixel on each axis, so anything smaller is unrenderable.
+		if ( $width < 1 || $height < 1 ) {
+			return null;
 		}
 
 		// Coerce unsupported densities back to 1. Allowing, say, density=3
@@ -152,7 +157,8 @@ final class OSM extends Base {
 		$canvas = imagecreatetruecolor( $canvas_width, $canvas_height );
 
 		// Background: neutral gray so missing tiles blend rather than glaring black.
-		$bg = imagecolorallocate( $canvas, 238, 238, 238 );
+		// The canvas above is truecolor, where color allocation has no palette to exhaust.
+		$bg = (int) imagecolorallocate( $canvas, 238, 238, 238 );
 		imagefilledrectangle( $canvas, 0, 0, $canvas_width - 1, $canvas_height - 1, $bg );
 
 		$tiles = $this->get_tile_url_template();
@@ -349,9 +355,11 @@ final class OSM extends Base {
 	 * @return void
 	 */
 	public function stamp_marker( $canvas, int $x, int $y, float $scale = 1.0 ): void {
-		$white = imagecolorallocate( $canvas, 255, 255, 255 );
-		$red   = imagecolorallocate( $canvas, 220, 53, 69 );
-		$dark  = imagecolorallocate( $canvas, 30, 30, 30 );
+		// Callers hand over the truecolor canvas from render(), where allocation has no
+		// palette to exhaust and so cannot fail.
+		$white = (int) imagecolorallocate( $canvas, 255, 255, 255 );
+		$red   = (int) imagecolorallocate( $canvas, 220, 53, 69 );
+		$dark  = (int) imagecolorallocate( $canvas, 30, 30, 30 );
 
 		$outer = max( 1, (int) round( 20 * $scale ) );
 		$inner = max( 1, (int) round( 16 * $scale ) );

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -118,7 +118,6 @@ final class OSM extends Base {
 			return null; // @codeCoverageIgnore
 		}
 
-		// A canvas needs at least one pixel on each axis, so anything smaller is unrenderable.
 		if ( $width < 1 || $height < 1 ) {
 			return null;
 		}
@@ -157,7 +156,6 @@ final class OSM extends Base {
 		$canvas = imagecreatetruecolor( $canvas_width, $canvas_height );
 
 		// Background: neutral gray so missing tiles blend rather than glaring black.
-		// The canvas above is truecolor, where color allocation has no palette to exhaust.
 		$bg = (int) imagecolorallocate( $canvas, 238, 238, 238 );
 		imagefilledrectangle( $canvas, 0, 0, $canvas_width - 1, $canvas_height - 1, $bg );
 
@@ -355,8 +353,6 @@ final class OSM extends Base {
 	 * @return void
 	 */
 	public function stamp_marker( $canvas, int $x, int $y, float $scale = 1.0 ): void {
-		// Callers hand over the truecolor canvas from render(), where allocation has no
-		// palette to exhaust and so cannot fail.
 		$white = (int) imagecolorallocate( $canvas, 255, 255, 255 );
 		$red   = (int) imagecolorallocate( $canvas, 220, 53, 69 );
 		$dark  = (int) imagecolorallocate( $canvas, 30, 30, 30 );

--- a/includes/templates/admin/emails/event-email.php
+++ b/includes/templates/admin/emails/event-email.php
@@ -91,7 +91,6 @@ $gatherpress_venue       = $gatherpress_event->get_venue_information()['name'];
 			! $gatherpress_event->has_event_past()
 			&& $gatherpress_event->rsvp?->is_enabled()
 		) :
-			// An enabled RSVP proves the event post exists, so the permalink is always a string here.
 			$gatherpress_rsvp_url = (string) get_the_permalink( $event_id );
 			?>
 			<div style="text-align: center; margin-top: 20px;">

--- a/includes/templates/admin/emails/event-email.php
+++ b/includes/templates/admin/emails/event-email.php
@@ -91,9 +91,11 @@ $gatherpress_venue       = $gatherpress_event->get_venue_information()['name'];
 			! $gatherpress_event->has_event_past()
 			&& $gatherpress_event->rsvp?->is_enabled()
 		) :
+			// An enabled RSVP proves the event post exists, so the permalink is always a string here.
+			$gatherpress_rsvp_url = (string) get_the_permalink( $event_id );
 			?>
 			<div style="text-align: center; margin-top: 20px;">
-				<a href="<?php echo esc_url( get_the_permalink( $event_id ) ); ?>" style="background-color: #007bff; color: #ffffff; padding: 12px 20px; text-decoration: none; border-radius: 4px; font-weight: bold;">
+				<a href="<?php echo esc_url( $gatherpress_rsvp_url ); ?>" style="background-color: #007bff; color: #ffffff; padding: 12px 20px; text-decoration: none; border-radius: 4px; font-weight: bold;">
 					<?php esc_html_e( 'RSVP Now', 'gatherpress' ); ?>
 				</a>
 			</div>

--- a/includes/templates/admin/rsvp/list-table.php
+++ b/includes/templates/admin/rsvp/list-table.php
@@ -41,10 +41,13 @@ $rsvp_table->prepare_items();
 	</h1>
 
 	<?php
-	if ( $gatherpress_post_id ) {
+	// A request can name a post that no longer exists, in which case there is no link to render.
+	$gatherpress_event_link = $gatherpress_post_id ? get_permalink( $gatherpress_post_id ) : false;
+
+	if ( $gatherpress_event_link ) {
 		printf(
 			'<a href="%1$s" class="comments-view-item-link">%2$s</a>',
-			esc_url( get_permalink( $gatherpress_post_id ) ),
+			esc_url( $gatherpress_event_link ),
 			esc_html(
 				sprintf(
 					/* translators: %s: Singular post type label, e.g. "Event". */

--- a/includes/templates/admin/settings/fields/autocomplete.php
+++ b/includes/templates/admin/settings/fields/autocomplete.php
@@ -28,8 +28,15 @@ $gatherpress_component_attrs = array(
 	'fieldOptions' => $field_options,
 	'disabled'     => ! empty( $disabled ),
 );
+
+$gatherpress_component_json = wp_json_encode( $gatherpress_component_attrs );
+
+// Without encodable attributes there is nothing to mount the component with.
+if ( false === $gatherpress_component_json ) {
+	return;
+}
 ?>
-<div class="regular-text" data-gatherpress_component_name="autocomplete" data-gatherpress_component_attrs="<?php echo esc_attr( htmlspecialchars( wp_json_encode( $gatherpress_component_attrs ), ENT_QUOTES, 'UTF-8' ) ); ?>"></div>
+<div class="regular-text" data-gatherpress_component_name="autocomplete" data-gatherpress_component_attrs="<?php echo esc_attr( htmlspecialchars( $gatherpress_component_json, ENT_QUOTES, 'UTF-8' ) ); ?>"></div>
 <?php
 if ( ! empty( $description ) ) {
 	?>

--- a/includes/templates/admin/settings/partials/datetime-preview.php
+++ b/includes/templates/admin/settings/partials/datetime-preview.php
@@ -21,7 +21,6 @@ $gatherpress_component_attrs = array(
 	'value' => ! empty( $value ) ? $value : '',
 );
 
-// Both members are plain strings, so wp_json_encode() cannot fail on this array.
 $gatherpress_component_json = (string) wp_json_encode( $gatherpress_component_attrs );
 ?>
 <p>

--- a/includes/templates/admin/settings/partials/datetime-preview.php
+++ b/includes/templates/admin/settings/partials/datetime-preview.php
@@ -20,8 +20,11 @@ $gatherpress_component_attrs = array(
 	'name'  => $name,
 	'value' => ! empty( $value ) ? $value : '',
 );
+
+// Both members are plain strings, so wp_json_encode() cannot fail on this array.
+$gatherpress_component_json = (string) wp_json_encode( $gatherpress_component_attrs );
 ?>
 <p>
 	<strong><?php esc_html_e( 'Preview:', 'gatherpress' ); ?></strong>
-	<span data-gatherpress_component_name="datetime-preview" data-gatherpress_component_attrs="<?php echo esc_attr( htmlspecialchars( wp_json_encode( $gatherpress_component_attrs ), ENT_QUOTES, 'UTF-8' ) ); ?>"></span>
+	<span data-gatherpress_component_name="datetime-preview" data-gatherpress_component_attrs="<?php echo esc_attr( htmlspecialchars( $gatherpress_component_json, ENT_QUOTES, 'UTF-8' ) ); ?>"></span>
 </p>

--- a/includes/templates/admin/settings/partials/url-rewrite-preview.php
+++ b/includes/templates/admin/settings/partials/url-rewrite-preview.php
@@ -23,7 +23,6 @@ $gatherpress_component_attrs = array(
 	'homeUrl' => home_url(),
 );
 
-// Every value in the array is a string, so JSON encoding cannot fail.
 $gatherpress_component_json = (string) wp_json_encode( $gatherpress_component_attrs );
 ?>
 <p>

--- a/includes/templates/admin/settings/partials/url-rewrite-preview.php
+++ b/includes/templates/admin/settings/partials/url-rewrite-preview.php
@@ -22,8 +22,11 @@ $gatherpress_component_attrs = array(
 	'suffix'  => $suffix,
 	'homeUrl' => home_url(),
 );
+
+// Every value in the array is a string, so JSON encoding cannot fail.
+$gatherpress_component_json = (string) wp_json_encode( $gatherpress_component_attrs );
 ?>
 <p>
 	<strong><?php esc_html_e( 'Preview:', 'gatherpress' ); ?></strong>
-	<span data-gatherpress_component_name="urlrewrite-preview" data-gatherpress_component_attrs="<?php echo esc_attr( htmlspecialchars( wp_json_encode( $gatherpress_component_attrs ), ENT_QUOTES, 'UTF-8' ) ); ?>"></span>
+	<span data-gatherpress_component_name="urlrewrite-preview" data-gatherpress_component_attrs="<?php echo esc_attr( htmlspecialchars( $gatherpress_component_json, ENT_QUOTES, 'UTF-8' ) ); ?>"></span>
 </p>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,7 +20,7 @@ parameters:
 
     # the analysis level, from 0 (loose) to 9 (strict)
     # https://phpstan.org/user-guide/rule-levels
-    level: 6
+    level: 8
 
     paths:
         - includes/

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-template.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-template.php
@@ -709,6 +709,7 @@ class Test_Rsvp_Template extends Base {
 	/**
 	 * Tests generate_rsvp_template_block with block data JSON cannot represent.
 	 *
+	 * @since 0.36.0
 	 * @covers ::generate_rsvp_template_block
 	 * @return void
 	 */

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-template.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-template.php
@@ -705,4 +705,42 @@ class Test_Rsvp_Template extends Base {
 			'No record degrades to the zero ID a missing commentId key produces.'
 		);
 	}
+
+	/**
+	 * Tests generate_rsvp_template_block with block data JSON cannot represent.
+	 *
+	 * @covers ::generate_rsvp_template_block
+	 * @return void
+	 */
+	public function test_generate_rsvp_template_block_unencodable_block(): void {
+		$instance = Rsvp_Template::get_instance();
+		$post     = $this->mock->post(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		)->get();
+
+		$wp_block = new WP_Block(
+			array(),
+			array( 'postId' => $post->ID )
+		);
+
+		// INF has no JSON representation, so encoding the block comes back false.
+		$block  = array(
+			'innerBlocks' => array(),
+			'attrs'       => array( 'gatherpressUnencodable' => INF ),
+		);
+		$result = $instance->generate_rsvp_template_block( '', $block, $wp_block );
+
+		$this->assertSame(
+			'',
+			$result,
+			'Failed to assert an unencodable block renders the responses alone.'
+		);
+		$this->assertStringNotContainsString(
+			'data-block-template=',
+			$result,
+			'Failed to assert an unencodable block is not handed to the front end.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -278,6 +278,7 @@ class Test_Calendar extends Base {
 	 * underlying Event has no post — a Calendar built from a post type that
 	 * does not support `gatherpress-event-date` never resolves one.
 	 *
+	 * @since 0.36.0
 	 * @covers ::get_google_destination_url
 	 *
 	 * @return void
@@ -343,6 +344,7 @@ class Test_Calendar extends Base {
 	 * Returns an empty string from get_yahoo_destination_url when the
 	 * underlying Event has no post.
 	 *
+	 * @since 0.36.0
 	 * @covers ::get_yahoo_destination_url
 	 *
 	 * @return void
@@ -520,6 +522,7 @@ class Test_Calendar extends Base {
 	 * Coverage for the get_sequence guard when the underlying Event has no
 	 * post: there is no post_modified_gmt to derive a revision from.
 	 *
+	 * @since 0.36.0
 	 * @covers ::get_sequence
 	 *
 	 * @return void
@@ -576,6 +579,7 @@ class Test_Calendar extends Base {
 	 * Returns an empty string from get_ical_event_string when the underlying
 	 * Event has no post, so nothing malformed lands inside a VCALENDAR wrap.
 	 *
+	 * @since 0.36.0
 	 * @covers ::get_ical_event_string
 	 *
 	 * @return void
@@ -596,6 +600,7 @@ class Test_Calendar extends Base {
 	 * RFC-required DTSTAMP, stamped at generation time rather than at the
 	 * Unix epoch.
 	 *
+	 * @since 0.36.0
 	 * @covers ::get_ical_event_string
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -274,6 +274,26 @@ class Test_Calendar extends Base {
 	}
 
 	/**
+	 * Returns an empty string from get_google_destination_url when the
+	 * underlying Event has no post — a Calendar built from a post type that
+	 * does not support `gatherpress-event-date` never resolves one.
+	 *
+	 * @covers ::get_google_destination_url
+	 *
+	 * @return void
+	 */
+	public function test_get_google_destination_url_returns_empty_without_post(): void {
+		$post     = $this->mock->post( array( 'post_type' => 'post' ) )->get();
+		$instance = new Calendar( $post->ID );
+
+		$this->assertSame(
+			'',
+			$instance->get_google_destination_url(),
+			'Google destination URL should be empty when the underlying post cannot be resolved as an event.'
+		);
+	}
+
+	/**
 	 * Coverage for get_yahoo_destination_url with no venue address.
 	 *
 	 * @covers ::get_yahoo_destination_url
@@ -316,6 +336,25 @@ class Test_Calendar extends Base {
 			'in_loc=' . rawurlencode( 'Brooklyn Office, 123 Main; Street, Brooklyn' ),
 			$url,
 			'Yahoo destination URL in_loc should concat venue name and address.'
+		);
+	}
+
+	/**
+	 * Returns an empty string from get_yahoo_destination_url when the
+	 * underlying Event has no post.
+	 *
+	 * @covers ::get_yahoo_destination_url
+	 *
+	 * @return void
+	 */
+	public function test_get_yahoo_destination_url_returns_empty_without_post(): void {
+		$post     = $this->mock->post( array( 'post_type' => 'post' ) )->get();
+		$instance = new Calendar( $post->ID );
+
+		$this->assertSame(
+			'',
+			$instance->get_yahoo_destination_url(),
+			'Yahoo destination URL should be empty when the underlying post cannot be resolved as an event.'
 		);
 	}
 
@@ -478,6 +517,25 @@ class Test_Calendar extends Base {
 	}
 
 	/**
+	 * Coverage for the get_sequence guard when the underlying Event has no
+	 * post: there is no post_modified_gmt to derive a revision from.
+	 *
+	 * @covers ::get_sequence
+	 *
+	 * @return void
+	 */
+	public function test_get_sequence_returns_zero_without_post(): void {
+		$post     = $this->mock->post( array( 'post_type' => 'post' ) )->get();
+		$instance = new Calendar( $post->ID );
+
+		$this->assertSame(
+			0,
+			Utility::invoke_hidden_method( $instance, 'get_sequence' ),
+			'Sequence should be zero when the underlying post cannot be resolved as an event.'
+		);
+	}
+
+	/**
 	 * Coverage for get_sequence clamping: a span wider than the RFC 5545
 	 * integer ceiling saturates instead of overflowing.
 	 *
@@ -512,6 +570,68 @@ class Test_Calendar extends Base {
 
 		$this->assertStringContainsString( 'SUMMARY:Sample Event', $vevent );
 		$this->assertStringContainsString( 'LOCATION:', $vevent );
+	}
+
+	/**
+	 * Returns an empty string from get_ical_event_string when the underlying
+	 * Event has no post, so nothing malformed lands inside a VCALENDAR wrap.
+	 *
+	 * @covers ::get_ical_event_string
+	 *
+	 * @return void
+	 */
+	public function test_get_ical_event_string_returns_empty_without_post(): void {
+		$post     = $this->mock->post( array( 'post_type' => 'post' ) )->get();
+		$instance = new Calendar( $post->ID );
+
+		$this->assertSame(
+			'',
+			$instance->get_ical_event_string(),
+			'VEVENT should be empty when the underlying post cannot be resolved as an event.'
+		);
+	}
+
+	/**
+	 * A post whose post_modified_gmt will not parse still gets the
+	 * RFC-required DTSTAMP, stamped at generation time rather than at the
+	 * Unix epoch.
+	 *
+	 * @covers ::get_ical_event_string
+	 *
+	 * @return void
+	 */
+	public function test_get_ical_event_string_stamps_now_for_unparsable_modified_date(): void {
+		$instance = new Calendar( $this->make_event() );
+
+		$instance->event->event->post_modified_gmt = '9999-99-99 99:99:99';
+
+		$before = time();
+		$vevent = $instance->get_ical_event_string();
+		$after  = time();
+
+		$this->assertSame(
+			1,
+			preg_match( '/DTSTAMP:(\d{8}T\d{6}Z)/', $vevent, $matches ),
+			'VEVENT should still carry a DTSTAMP when post_modified_gmt will not parse.'
+		);
+
+		$stamp = strtotime( $matches[1] );
+
+		$this->assertGreaterThanOrEqual(
+			$before,
+			$stamp,
+			'DTSTAMP should fall back to the generation time, not the Unix epoch.'
+		);
+		$this->assertLessThanOrEqual(
+			$after,
+			$stamp,
+			'DTSTAMP should fall back to the generation time, not a future date.'
+		);
+		$this->assertStringContainsString(
+			sprintf( 'LAST-MODIFIED:%s', $matches[1] ),
+			$vevent,
+			'LAST-MODIFIED should share the fallback stamp with DTSTAMP.'
+		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-redirect.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-redirect.php
@@ -124,4 +124,27 @@ class Test_Redirect extends Base {
 			'Failed to assert, that the redirect url got merged into allowed_redirect_hosts.'
 		);
 	}
+
+	/**
+	 * A relative or malformed target has no host for wp_parse_url() to report,
+	 * so allowed_redirect_hosts hands the list back untouched.
+	 *
+	 * @covers ::allowed_redirect_hosts
+	 *
+	 * @return void
+	 */
+	public function test_allowed_redirect_hosts_without_host_leaves_list_untouched(): void {
+		$callback = static function () {
+			return '/event/sample-event/google-calendar/';
+		};
+		$instance = new Redirect( 'endpoint-redirect', $callback );
+
+		Utility::set_and_get_hidden_property( $instance, 'url', ( $callback )() );
+
+		$this->assertSame(
+			array( 'apples', 'oranges' ),
+			$instance->allowed_redirect_hosts( array( 'apples', 'oranges' ) ),
+			'Failed to assert, that a hostless redirect url leaves allowed_redirect_hosts unchanged.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-redirect.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-redirect.php
@@ -129,6 +129,7 @@ class Test_Redirect extends Base {
 	 * A relative or malformed target has no host for wp_parse_url() to report,
 	 * so allowed_redirect_hosts hands the list back untouched.
 	 *
+	 * @since 0.36.0
 	 * @covers ::allowed_redirect_hosts
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -937,6 +937,7 @@ class Test_Setup extends Base {
 	 * archive feed to advertise, so it is skipped instead of emitting an entry
 	 * with a false url.
 	 *
+	 * @since 0.36.0
 	 * @covers ::collect_post_type_archive_alternate_links
 	 *
 	 * @return void
@@ -1200,6 +1201,7 @@ class Test_Setup extends Base {
 	 * A term that can no longer be resolved has no feed link, so the tax
 	 * archive collector emits nothing rather than an entry with a false url.
 	 *
+	 * @since 0.36.0
 	 * @covers ::collect_tax_archive_alternate_links
 	 *
 	 * @return void
@@ -1264,6 +1266,7 @@ class Test_Setup extends Base {
 	 * A `get_terms()` error carries no terms to walk, so the collector emits
 	 * nothing rather than iterating the WP_Error object.
 	 *
+	 * @since 0.36.0
 	 * @covers ::collect_event_term_alternate_links
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -13,6 +13,7 @@ use GatherPress\Core\Event\Event;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
+use WP_Error;
 
 /**
  * Class Test_Setup.
@@ -932,6 +933,56 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * An event-supporting post type registered without an archive has no
+	 * archive feed to advertise, so it is skipped instead of emitting an entry
+	 * with a false url.
+	 *
+	 * @covers ::collect_post_type_archive_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_post_type_archive_alternate_links_skips_post_type_without_archive(): void {
+		register_post_type(
+			'gatherpress_noarch',
+			array(
+				'public'      => true,
+				'has_archive' => false,
+				'supports'    => array( 'title', 'gatherpress-event-date' ),
+			)
+		);
+
+		$instance   = Setup::get_instance();
+		$args       = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$supporting = get_post_types_by_support( 'gatherpress-event-date' );
+		$links      = Utility::invoke_hidden_method(
+			$instance,
+			'collect_post_type_archive_alternate_links',
+			array( $args )
+		);
+
+		unregister_post_type( 'gatherpress_noarch' );
+
+		$this->assertContains(
+			'gatherpress_noarch',
+			$supporting,
+			'The archive-less post type should be among the event-supporting post types.'
+		);
+		$this->assertCount(
+			count( $supporting ) - 1,
+			$links,
+			'The archive-less post type should be skipped, leaving one entry per remaining post type.'
+		);
+
+		foreach ( $links as $link ) {
+			$this->assertStringNotContainsString(
+				'gatherpress_noarch',
+				$link['url'],
+				'No alternate link should point at the archive-less post type.'
+			);
+		}
+	}
+
+	/**
 	 * Coverage for collect_contextual_alternate_links — returns the singular-event
 	 * branch when on an event permalink.
 	 *
@@ -1146,6 +1197,37 @@ class Test_Setup extends Base {
 	}
 
 	/**
+	 * A term that can no longer be resolved has no feed link, so the tax
+	 * archive collector emits nothing rather than an entry with a false url.
+	 *
+	 * @covers ::collect_tax_archive_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_tax_archive_alternate_links_skips_unresolvable_term(): void {
+		$term_id = $this->factory->term->create(
+			array( 'taxonomy' => 'gatherpress_topic' )
+		);
+		$term    = get_term( $term_id, 'gatherpress_topic' );
+
+		wp_delete_term( $term_id, 'gatherpress_topic' );
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+		$links    = Utility::invoke_hidden_method(
+			$instance,
+			'collect_tax_archive_alternate_links',
+			array( $term, $args )
+		);
+
+		$this->assertSame(
+			array(),
+			$links,
+			'A deleted term should produce no alternate-link entries.'
+		);
+	}
+
+	/**
 	 * Coverage for collect_event_term_alternate_links — walks the event's
 	 * related terms and returns one entry per resolvable term.
 	 *
@@ -1175,6 +1257,47 @@ class Test_Setup extends Base {
 			'iCal Feed',
 			$links[0]['attr'],
 			'Term entry attr should be formatted with the taxtitle template.'
+		);
+	}
+
+	/**
+	 * A `get_terms()` error carries no terms to walk, so the collector emits
+	 * nothing rather than iterating the WP_Error object.
+	 *
+	 * @covers ::collect_event_term_alternate_links
+	 *
+	 * @return void
+	 */
+	public function test_collect_event_term_alternate_links_returns_empty_on_term_error(): void {
+		$event_id = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+		$topic_id = $this->factory->term->create(
+			array( 'taxonomy' => 'gatherpress_topic' )
+		);
+		wp_set_post_terms( $event_id, array( $topic_id ), 'gatherpress_topic' );
+
+		$error = static function () {
+			return new WP_Error( 'invalid_taxonomy', 'Invalid taxonomy.' );
+		};
+
+		$instance = Setup::get_instance();
+		$args     = Utility::invoke_hidden_method( $instance, 'alternate_link_label_args' );
+
+		add_filter( 'get_terms', $error );
+
+		$links = Utility::invoke_hidden_method(
+			$instance,
+			'collect_event_term_alternate_links',
+			array( get_post( $event_id ), $args )
+		);
+
+		remove_filter( 'get_terms', $error );
+
+		$this->assertSame(
+			array(),
+			$links,
+			'An errored term query should produce no alternate-link entries.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -487,6 +487,7 @@ class Test_Assets extends Base {
 	 * without checking, so a missing metadata file resolves to usable
 	 * defaults rather than to an undefined-key warning.
 	 *
+	 * @since 0.36.0
 	 * @covers ::get_asset_data
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/class-test-assets.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-assets.php
@@ -483,11 +483,15 @@ class Test_Assets extends Base {
 	/**
 	 * Coverage for get_asset_data when the asset file is missing.
 	 *
+	 * Callers pass both keys straight to wp_register_script() and friends
+	 * without checking, so a missing metadata file resolves to usable
+	 * defaults rather than to an undefined-key warning.
+	 *
 	 * @covers ::get_asset_data
 	 *
 	 * @return void
 	 */
-	public function test_get_asset_data_returns_empty_array_for_missing_file(): void {
+	public function test_get_asset_data_returns_defaults_for_missing_file(): void {
 		$instance = Assets::get_instance();
 
 		Utility::set_and_get_hidden_property( $instance, 'asset_data', array() );
@@ -497,9 +501,12 @@ class Test_Assets extends Base {
 		);
 
 		$this->assertSame(
-			array(),
+			array(
+				'dependencies' => array(),
+				'version'      => GATHERPRESS_VERSION,
+			),
 			$asset,
-			'get_asset_data should return an empty array when the asset file is missing.'
+			'A missing asset file should resolve to empty dependencies and the plugin version.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/commands/class-test-event-cli.php
+++ b/test/unit/php/includes/tests/core/classes/commands/class-test-event-cli.php
@@ -48,4 +48,40 @@ class Test_Event_Cli extends Base {
 
 		$this->assertSame( $expects, $output, 'Failed to assert output matches.' );
 	}
+
+	/**
+	 * Coverage for rsvp against a post type without RSVP support.
+	 *
+	 * @covers ::rsvp
+	 *
+	 * @return void
+	 */
+	public function test_rsvp_without_rsvp_support(): void {
+		$cli_event  = new Event_Cli();
+		$post       = $this->mock->post( array( 'post_type' => 'post' ) )->get();
+		$user       = $this->mock->user()->get();
+		$assoc_args = array(
+			'event_id' => $post->ID,
+			'user_id'  => $user->ID,
+		);
+
+		$output  = Utility::buffer_and_return(
+			array( $cli_event, 'rsvp' ),
+			array( array(), $assoc_args )
+		);
+		$expects = sprintf(
+			'Error: Event ID "%d" does not exist or does not support RSVPs.',
+			$post->ID
+		);
+
+		$this->assertSame(
+			$expects,
+			trim( $output ),
+			'Failed to assert RSVP support error output matches.'
+		);
+		$this->assertEmpty(
+			get_comments( array( 'post_id' => $post->ID ) ),
+			'Failed to assert no RSVP was saved.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/commands/class-test-event-cli.php
+++ b/test/unit/php/includes/tests/core/classes/commands/class-test-event-cli.php
@@ -52,6 +52,7 @@ class Test_Event_Cli extends Base {
 	/**
 	 * Coverage for rsvp against a post type without RSVP support.
 	 *
+	 * @since 0.36.0
 	 * @covers ::rsvp
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/commands/class-test-settings-cli.php
+++ b/test/unit/php/includes/tests/core/classes/commands/class-test-settings-cli.php
@@ -446,4 +446,71 @@ class Test_Settings_Cli extends Base {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
 		unlink( $file );
 	}
+
+	/**
+	 * Coverage for export with a valueless --file flag.
+	 *
+	 * @covers ::export
+	 *
+	 * @return void
+	 */
+	public function test_export_with_valueless_file_flag(): void {
+		$cli = new Settings_Cli();
+
+		// WP-CLI passes boolean true for `--file` with no value.
+		$output = Utility::buffer_and_return(
+			array( $cli, 'export' ),
+			array( array(), array( 'file' => true ) )
+		);
+
+		$this->assertStringContainsString(
+			'The --file option requires a file path.',
+			$output,
+			'Failed to assert valueless --file error.'
+		);
+		$this->assertStringNotContainsString(
+			'Settings exported to',
+			$output,
+			'Failed to assert export was aborted.'
+		);
+	}
+
+	/**
+	 * Coverage for import with an unreadable file.
+	 *
+	 * @covers ::import
+	 *
+	 * @return void
+	 */
+	public function test_import_unreadable_file(): void {
+		$cli  = new Settings_Cli();
+		$file = tempnam( sys_get_temp_dir(), 'gatherpress_test_' );
+
+		$data = array(
+			'version'  => GATHERPRESS_VERSION,
+			'settings' => array( 'map_platform' => 'google' ),
+		);
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $file, wp_json_encode( $data ) );
+
+		// Strip every permission bit so the file still exists but file_get_contents() returns false.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod
+		chmod( $file, 0000 );
+
+		$output = Utility::buffer_and_return(
+			array( $cli, 'import' ),
+			array( array( $file ), array( 'apply' => true ) )
+		);
+
+		$this->assertStringContainsString( 'Failed to read file', $output, 'Failed to assert unreadable file error.' );
+		$this->assertStringNotContainsString(
+			'imported successfully',
+			$output,
+			'Failed to assert import was aborted.'
+		);
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		unlink( $file );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/commands/class-test-settings-cli.php
+++ b/test/unit/php/includes/tests/core/classes/commands/class-test-settings-cli.php
@@ -450,6 +450,7 @@ class Test_Settings_Cli extends Base {
 	/**
 	 * Coverage for export with a valueless --file flag.
 	 *
+	 * @since 0.36.0
 	 * @covers ::export
 	 *
 	 * @return void
@@ -478,6 +479,7 @@ class Test_Settings_Cli extends Base {
 	/**
 	 * Coverage for import with an unreadable file.
 	 *
+	 * @since 0.36.0
 	 * @covers ::import
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -278,6 +278,7 @@ class Test_Event extends Base {
 	 * A post that is not an event has nothing to attach datetimes to, so the
 	 * save reports failure and writes no meta.
 	 *
+	 * @since 0.36.0
 	 * @covers ::save_datetimes
 	 *
 	 * @return void
@@ -627,6 +628,7 @@ class Test_Event extends Base {
 	 * A post that is not an event has no venue to report, and must not fall
 	 * through to the venue of whatever post is globally queried.
 	 *
+	 * @since 0.36.0
 	 * @covers ::get_venue_information
 	 *
 	 * @return void
@@ -1032,6 +1034,7 @@ class Test_Event extends Base {
 	 * A post that is not an event never surfaces an online event link, even
 	 * when the meta happens to be present on the post.
 	 *
+	 * @since 0.36.0
 	 * @covers ::maybe_get_online_event_link
 	 *
 	 * @return void
@@ -1241,6 +1244,7 @@ class Test_Event extends Base {
 	 * at all, bailing before the format filter rather than falling back to the
 	 * epoch.
 	 *
+	 * @since 0.36.0
 	 * @covers ::get_formatted_datetime
 	 *
 	 * @return void
@@ -1338,6 +1342,7 @@ class Test_Event extends Base {
 	 * client at, so the description is empty rather than pointing at whatever
 	 * post is globally queried.
 	 *
+	 * @since 0.36.0
 	 * @covers ::get_calendar_description
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -275,6 +275,35 @@ class Test_Event extends Base {
 	}
 
 	/**
+	 * A post that is not an event has nothing to attach datetimes to, so the
+	 * save reports failure and writes no meta.
+	 *
+	 * @covers ::save_datetimes
+	 *
+	 * @return void
+	 */
+	public function test_save_datetimes_returns_false_without_post(): void {
+		$post_id = $this->mock->post( array( 'post_type' => 'post' ) )->get()->ID;
+		$event   = new Event( $post_id );
+
+		$this->assertFalse(
+			$event->save_datetimes(
+				array(
+					'datetime_start' => '2020-05-11 15:00:00',
+					'datetime_end'   => '2020-05-11 17:00:00',
+					'timezone'       => 'America/New_York',
+				)
+			),
+			'Failed to assert false due to the post not resolving to an event.'
+		);
+		$this->assertSame(
+			'',
+			get_post_meta( $post_id, 'gatherpress_datetime_start', true ),
+			'Failed to assert no datetime meta was written for a non-event post.'
+		);
+	}
+
+	/**
 	 * Coverage for get_datetime method.
 	 *
 	 * @covers ::get_datetime
@@ -591,6 +620,50 @@ class Test_Event extends Base {
 			'500 Hybrid Way',
 			$response['address'],
 			'Hybrid event should surface the physical venue address.'
+		);
+	}
+
+	/**
+	 * A post that is not an event has no venue to report, and must not fall
+	 * through to the venue of whatever post is globally queried.
+	 *
+	 * @covers ::get_venue_information
+	 *
+	 * @return void
+	 */
+	public function test_get_venue_information_returns_empty_shape_without_post(): void {
+		$post_id  = $this->mock->post( array( 'post_type' => 'post' ) )->get()->ID;
+		$venue    = $this->mock->post(
+			array(
+				'post_type'  => Venue::POST_TYPE,
+				'post_title' => 'Queried Venue',
+				'post_name'  => 'queried-venue',
+			)
+		)->get();
+		$event_id = $this->mock->post(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		)->get()->ID;
+
+		update_post_meta( $venue->ID, 'gatherpress_address', '900 Queried Way' );
+		wp_set_post_terms( $event_id, array( '_queried-venue' ), Venue::TAXONOMY );
+
+		// Query the venue-bearing event so any fall-through would surface its venue.
+		$this->go_to( get_permalink( $event_id ) );
+
+		$response = ( new Event( $post_id ) )->get_venue_information();
+
+		$this->assertSame(
+			array(
+				'address'   => '',
+				'name'      => '',
+				'permalink' => '',
+				'phone'     => '',
+				'website'   => '',
+			),
+			$response,
+			'Failed to assert a non-event post reports the empty venue shape.'
 		);
 	}
 
@@ -956,6 +1029,26 @@ class Test_Event extends Base {
 	}
 
 	/**
+	 * A post that is not an event never surfaces an online event link, even
+	 * when the meta happens to be present on the post.
+	 *
+	 * @covers ::maybe_get_online_event_link
+	 *
+	 * @return void
+	 */
+	public function test_maybe_get_online_event_link_returns_empty_without_post(): void {
+		$post_id = $this->mock->post( array( 'post_type' => 'post' ) )->get()->ID;
+
+		update_post_meta( $post_id, 'gatherpress_online_event_link', 'https://unittest.com/video/' );
+
+		$this->assertSame(
+			'',
+			( new Event( $post_id ) )->maybe_get_online_event_link(),
+			'Failed to assert online event link is empty for a non-event post.'
+		);
+	}
+
+	/**
 	 * Coverage for is_same_date method.
 	 *
 	 * @covers ::is_same_date
@@ -1144,6 +1237,46 @@ class Test_Event extends Base {
 	}
 
 	/**
+	 * A stored datetime that validates but will not parse reports no datetime
+	 * at all, bailing before the format filter rather than falling back to the
+	 * epoch.
+	 *
+	 * @covers ::get_formatted_datetime
+	 *
+	 * @return void
+	 */
+	public function test_get_formatted_datetime_returns_empty_for_unparsable_value(): void {
+		$event_id = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+
+		// Validates as `Y-m-d H:i:s` but has an out-of-range day and hour, so strtotime() rejects it.
+		update_post_meta( $event_id, 'gatherpress_datetime_start_gmt', '2030-06-31 25:00:00' );
+
+		$formatted = 0;
+		$counter   = static function ( $format ) use ( &$formatted ) {
+			++$formatted;
+
+			return $format;
+		};
+
+		add_filter( 'gatherpress_datetime_format', $counter );
+
+		$result = ( new Event( $event_id ) )->get_formatted_datetime( 'Y-m-d', 'start', false );
+
+		remove_filter( 'gatherpress_datetime_format', $counter );
+
+		$this->assertSame(
+			'',
+			$result,
+			'Failed to assert an unparsable stored datetime reports no datetime at all.'
+		);
+		$this->assertSame(
+			0,
+			$formatted,
+			'Failed to assert an unparsable stored datetime bails before the datetime format filter runs.'
+		);
+	}
+
+	/**
 	 * Coverage for get_calendar_description method.
 	 *
 	 * @covers ::get_calendar_description
@@ -1198,6 +1331,25 @@ class Test_Event extends Base {
 		$result = $event->get_calendar_description();
 
 		$this->assertNotEmpty( $result, 'Failed to assert calendar description is not empty even without excerpt.' );
+	}
+
+	/**
+	 * A post that is not an event has no permalink worth pointing a calendar
+	 * client at, so the description is empty rather than pointing at whatever
+	 * post is globally queried.
+	 *
+	 * @covers ::get_calendar_description
+	 *
+	 * @return void
+	 */
+	public function test_get_calendar_description_returns_empty_without_post(): void {
+		$post_id = $this->mock->post( array( 'post_type' => 'post' ) )->get()->ID;
+
+		$this->assertSame(
+			'',
+			( new Event( $post_id ) )->get_calendar_description(),
+			'Failed to assert a non-event post has no calendar description.'
+		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -1400,6 +1400,7 @@ class Test_Rest_Api extends Base {
 	/**
 	 * Test get_recipients skips rows the RSVP query returns that are not comments.
 	 *
+	 * @since 0.36.0
 	 * @covers ::get_recipients
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -1398,6 +1398,50 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
+	 * Test get_recipients skips rows the RSVP query returns that are not comments.
+	 *
+	 * @covers ::get_recipients
+	 *
+	 * @return void
+	 */
+	public function test_get_recipients_skips_non_comment_rows(): void {
+		$instance = Rest_Api::get_instance();
+		$event_id = $this->mock->post(
+			array( 'post_type' => Event::POST_TYPE )
+		)->get()->ID;
+		$event    = new Event( $event_id );
+
+		$event->rsvp->save( 'attendee@example.com', 'attending', 1 );
+
+		// Append an unresolvable row to the RSVP lookup so a non-comment entry
+		// reaches the recipient loop.
+		$injector = static function ( $comments, $query ) {
+			if ( ! empty( $query->query_vars['comment__in'] ) ) {
+				$comments[] = PHP_INT_MAX;
+			}
+
+			return $comments;
+		};
+
+		add_filter( 'the_comments', $injector, 10, 2 );
+
+		$recipients = $instance->get_recipients( array( 'attending' => true ), $event_id );
+
+		remove_filter( 'the_comments', $injector, 10 );
+
+		$this->assertCount(
+			1,
+			$recipients,
+			'Failed to assert the non-comment row was skipped.'
+		);
+		$this->assertSame(
+			'attendee@example.com',
+			$recipients[0]['email'],
+			'Failed to assert the surviving recipient is the real RSVP.'
+		);
+	}
+
+	/**
 	 * Test send_emails with locale switching for user.
 	 *
 	 * @covers ::send_emails

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
@@ -2000,4 +2000,108 @@ class Test_List_Table extends Base {
 			'No term and nothing to infer from renders empty.'
 		);
 	}
+
+	/**
+	 * A screen passed to the constructor is the one the table binds its column
+	 * hooks to, instead of whatever screen the request is currently on.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_with_screen(): void {
+		$screen_id  = 'gatherpress_event_page_gatherpress_rsvp';
+		$list_table = new List_Table( array( 'screen' => $screen_id ) );
+
+		$this->assertSame(
+			$screen_id,
+			$list_table->screen->id,
+			'The table adopts the screen named in the constructor arguments.'
+		);
+		$this->assertSame(
+			0,
+			has_filter( sprintf( 'manage_%s_columns', $screen_id ), array( $list_table, 'get_columns' ) ),
+			'The column hooks bind to the screen named in the constructor arguments.'
+		);
+	}
+
+	/**
+	 * A stored per-page preference that is not a positive integer would divide
+	 * the total by a non-positive number, so it falls back to the default.
+	 *
+	 * @covers ::prepare_items
+	 *
+	 * @return void
+	 */
+	public function test_prepare_items_falls_back_to_default_per_page(): void {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $user_id );
+		update_user_meta( $user_id, sprintf( '%s_per_page', Rsvp::COMMENT_TYPE ), -5 );
+
+		$this->list_table->prepare_items();
+
+		$this->assertSame(
+			List_Table::DEFAULT_PER_PAGE,
+			$this->list_table->get_pagination_arg( 'per_page' ),
+			'A stored preference below one falls back to the default page size.'
+		);
+	}
+
+	/**
+	 * An RSVP row outlives the post it points at, so a deleted event renders the
+	 * stored title as text, or a dash when nothing is left of it.
+	 *
+	 * @covers ::column_default
+	 *
+	 * @return void
+	 */
+	public function test_column_default_event_deleted(): void {
+		$item = $this->rsvp;
+
+		wp_delete_post( $this->event_id, true );
+
+		$item['event_title'] = 'Deleted Event';
+
+		$this->assertSame(
+			'Deleted Event',
+			$this->list_table->column_default( $item, 'event' ),
+			'A deleted event renders the stored title without a link.'
+		);
+
+		$item['event_title'] = '';
+
+		$this->assertSame(
+			'-',
+			$this->list_table->column_default( $item, 'event' ),
+			'A deleted event with no stored title renders a dash.'
+		);
+	}
+
+	/**
+	 * Core stores comment statuses this table has no label for, and a row can
+	 * arrive without the field at all; both render a dash.
+	 *
+	 * @covers ::column_default
+	 *
+	 * @return void
+	 */
+	public function test_column_default_approved_unlabeled_status(): void {
+		$item                     = $this->rsvp;
+		$item['comment_approved'] = 'trash';
+
+		$this->assertSame(
+			'-',
+			$this->list_table->column_default( $item, 'approved' ),
+			'A status the table has no label for renders a dash.'
+		);
+
+		unset( $item['comment_approved'] );
+
+		$this->assertSame(
+			'-',
+			$this->list_table->column_default( $item, 'approved' ),
+			'A row carrying no status at all renders a dash.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-list-table.php
@@ -2005,6 +2005,7 @@ class Test_List_Table extends Base {
 	 * A screen passed to the constructor is the one the table binds its column
 	 * hooks to, instead of whatever screen the request is currently on.
 	 *
+	 * @since 0.36.0
 	 * @covers ::__construct
 	 *
 	 * @return void
@@ -2029,6 +2030,7 @@ class Test_List_Table extends Base {
 	 * A stored per-page preference that is not a positive integer would divide
 	 * the total by a non-positive number, so it falls back to the default.
 	 *
+	 * @since 0.36.0
 	 * @covers ::prepare_items
 	 *
 	 * @return void
@@ -2052,6 +2054,7 @@ class Test_List_Table extends Base {
 	 * An RSVP row outlives the post it points at, so a deleted event renders the
 	 * stored title as text, or a dash when nothing is left of it.
 	 *
+	 * @since 0.36.0
 	 * @covers ::column_default
 	 *
 	 * @return void
@@ -2082,6 +2085,7 @@ class Test_List_Table extends Base {
 	 * Core stores comment statuses this table has no label for, and a row can
 	 * arrive without the field at all; both render a dash.
 	 *
+	 * @since 0.36.0
 	 * @covers ::column_default
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
@@ -1395,4 +1395,48 @@ class Test_Rsvp extends Base {
 			'Only user and email identities resolve to core providers.'
 		);
 	}
+
+	/**
+	 * An identity that no registered provider handles records nothing and hands
+	 * back the default save response.
+	 *
+	 * @covers ::save
+	 *
+	 * @return void
+	 */
+	public function test_save_returns_default_when_no_provider_handles_identity(): void {
+		$event_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+		$user_id  = $this->factory->user->create();
+		$registry = Provider_Registry::get_instance();
+		$restore  = Utility::get_hidden_property( $registry, 'providers' );
+
+		// Rsvp snapshots the registry when it is constructed, so blanking the
+		// user provider first leaves an identity that resolves to no provider.
+		Utility::set_and_get_hidden_property(
+			$registry,
+			'providers',
+			array_merge( $restore, array( 'user' => null ) )
+		);
+
+		$rsvp = new Rsvp( $event_id );
+
+		Utility::set_and_get_hidden_property( $registry, 'providers', $restore );
+
+		$response = $rsvp->save( $user_id, 'attending' );
+
+		$this->assertSame(
+			'no_status',
+			$response['status'],
+			'An identity without a provider returns the default save response.'
+		);
+		$this->assertSame(
+			0,
+			$response['comment_id'],
+			'No response is recorded for an identity without a provider.'
+		);
+		$this->assertNull(
+			$rsvp->get( $user_id ),
+			'Nothing is stored for an identity without a provider.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
@@ -1400,6 +1400,7 @@ class Test_Rsvp extends Base {
 	 * An identity that no registered provider handles records nothing and hands
 	 * back the default save response.
 	 *
+	 * @since 0.36.0
 	 * @covers ::save
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-storage.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-storage.php
@@ -561,4 +561,57 @@ class Test_Storage extends Base {
 		);
 		$this->assertSame( $event_id, (int) $state->comment->comment_post_ID );
 	}
+
+	/**
+	 * A comment that was deleted between the lookup that produced its ID and
+	 * the save reports false instead of updating a row that is no longer there.
+	 *
+	 * @covers ::save
+	 *
+	 * @return void
+	 */
+	public function test_save_returns_false_when_the_row_to_update_is_gone(): void {
+		list( , $storage ) = $this->make_storage();
+
+		$user_id = $this->factory->user->create();
+		$result  = $storage->save( $this->user_intent( $user_id, Status::ATTENDING ), 999999 );
+
+		$this->assertFalse( $result, 'Updating a comment that no longer exists reports false.' );
+		$this->assertNull(
+			$storage->get( new Identity( Identity_Type::WP_USER_ID, $user_id ) ),
+			'The failed update does not fall through to an insert.'
+		);
+	}
+
+	/**
+	 * A comment that stops resolving after the write lands — deleted here from
+	 * the term hook that fires between the update and the read-back — reports a
+	 * failed save rather than a successful one.
+	 *
+	 * @covers ::save
+	 *
+	 * @return void
+	 */
+	public function test_save_returns_false_when_the_saved_comment_stops_resolving(): void {
+		list( , $storage ) = $this->make_storage();
+
+		$user_id    = $this->factory->user->create();
+		$state      = $storage->save( $this->user_intent( $user_id, Status::ATTENDING ), null );
+		$comment_id = (int) $state->comment->comment_ID;
+		$vanish     = static function () use ( $comment_id ) {
+			wp_delete_comment( $comment_id, true );
+		};
+
+		add_action( 'set_object_terms', $vanish );
+
+		$result = $storage->save( $this->user_intent( $user_id, Status::NOT_ATTENDING ), $comment_id );
+
+		remove_action( 'set_object_terms', $vanish );
+
+		$this->assertFalse( $result, 'A comment that no longer resolves reports a failed save.' );
+		$this->assertNull(
+			get_comment( $comment_id ),
+			'The comment really is gone by the time the save reads it back.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-storage.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-storage.php
@@ -566,6 +566,7 @@ class Test_Storage extends Base {
 	 * A comment that was deleted between the lookup that produced its ID and
 	 * the save reports false instead of updating a row that is no longer there.
 	 *
+	 * @since 0.36.0
 	 * @covers ::save
 	 *
 	 * @return void
@@ -588,6 +589,7 @@ class Test_Storage extends Base {
 	 * the term hook that fires between the update and the read-back — reports a
 	 * failed save rather than a successful one.
 	 *
+	 * @since 0.36.0
 	 * @covers ::save
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-token.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-token.php
@@ -1268,6 +1268,7 @@ class Test_Token extends Base {
 	/**
 	 * Coverage for save_token_to_meta with no comment.
 	 *
+	 * @since 0.36.0
 	 * @covers ::save_token_to_meta
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-token.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-token.php
@@ -1264,4 +1264,28 @@ class Test_Token extends Base {
 		// Clean up filters.
 		remove_all_filters( 'gatherpress_pre_get_http_input' );
 	}
+
+	/**
+	 * Coverage for save_token_to_meta with no comment.
+	 *
+	 * @covers ::save_token_to_meta
+	 *
+	 * @return void
+	 */
+	public function test_save_token_to_meta_without_comment(): void {
+		$token = new Token( 0 );
+
+		$this->assertNull(
+			$token->get_comment(),
+			'A token built from an invalid comment ID holds no comment.'
+		);
+
+		Utility::invoke_hidden_method( $token, 'save_token_to_meta' );
+
+		$this->assertSame(
+			'',
+			$token->get_token(),
+			'Without a comment there is no meta row to write the token to.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -675,6 +675,7 @@ class Test_OSM extends Base {
 	 * A canvas needs at least one pixel on each axis, so a zero or negative
 	 * dimension is unrenderable and comes back as null before GD is touched.
 	 *
+	 * @since 0.36.0
 	 * @covers ::render
 	 *
 	 * @return void

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -670,4 +670,26 @@ class Test_OSM extends Base {
 		$this->assertInstanceOf( GdImage::class, $canvas );
 		unset( $canvas );
 	}
+
+	/**
+	 * A canvas needs at least one pixel on each axis, so a zero or negative
+	 * dimension is unrenderable and comes back as null before GD is touched.
+	 *
+	 * @covers ::render
+	 *
+	 * @return void
+	 */
+	public function test_render_returns_null_for_non_positive_dimensions(): void {
+		$provider = new OSM();
+
+		$this->assertNull(
+			$provider->render( 40.7128, -74.0060, 12, 0, 240 ),
+			'A zero width is unrenderable.'
+		);
+
+		$this->assertNull(
+			$provider->render( 40.7128, -74.0060, 12, 320, -1 ),
+			'A negative height is unrenderable.'
+		);
+	}
 }


### PR DESCRIPTION
Follows the level-6 PR. Levels 7 and 8 check that values which can be `null` or `false` are narrowed before use, so unlike level 6 these are real code changes, not docblocks — and most of them turned out to be latent defects.

## Bugs this surfaced

- **Calendar feed links for a deleted venue.** `collect_term_alternate_link()` read `->ID` on `null` for a shadow term whose backing post was gone. The warning was the harmless part: `get_post_comments_feed_link( null )` then fell back to the *global* post, so the page advertised a feed for the event itself, labeled with the venue taxonomy. The existing test only asserted the venue slug was absent, so it passed either way.
- **RSVP admin rows for a deleted event** rendered `<a href="">`; they now show the stored title as text.
- **`comment_approved` values core stores but the lookup omitted** (`trash`, `post-trashed`) raised an undefined-index warning.
- **A negative stored per-page preference** fed `ceil( $total / $per_page )` and produced a negative page count.
- **Several `Event` methods dereferenced a null post**, and RSVP paths reached `save()` with a null provider — both fatal for an unresolvable event. `wp gatherpress event rsvp --event_id=<bogus>` fataled outright.
- **`Assets::get_asset_data()`** returned an empty array for a missing `.asset.php` while every caller reads `dependencies` and `version` unguarded on the way into `wp_register_script()`. It now fills both with defaults.
- **`update_rsvp()` identity check.** The guard was `is_user_member_of_blog( $id ) || is_email( $id )`. WordPress casts that first argument to `int` and **falls back to the current user when it is 0**, so a token-supplied email made `is_user_member_of_blog()` answer for the logged-in user and short-circuit the `||` — the address was never validated. Each identifier is now checked against the one thing it can be. Strictly tighter; no path loses access.

## Approach

Every finding was triaged for whether the null/false case is actually reachable. Reachable cases got real guards that do something correct; structurally impossible ones got a cast with a comment saying why it cannot fail. No blanket `?->` — it merges "no object" with "method returned false", which is the trap [#2156](https://github.com/GatherPress/gatherpress/issues/2156) documents.

Verified at **level 4 as well as 8**, so none of the new guards are dead code the analyzer would later flag as always-false.

## Behavior changes worth review

- **Two new translatable strings**: `wp gatherpress settings import --file` with no value now errors instead of writing to a path of `true`; `wp gatherpress event rsvp` with a bad event ID now errors instead of fataling.
- **One test updated**: `test_get_asset_data_returns_empty_array_for_missing_file` asserted the old empty-array contract and is now `..._returns_defaults_for_missing_file`.
- **`Calendar` URL/VEVENT getters return `''`** for an unresolvable event rather than fataling. `get_ical_list()` implodes the results, so such an event contributes a blank line to a feed.
- **Feed links are omitted** rather than emitted empty when a post type has no archive or a term link resolves `false`.

## Testing

- PHPStan level 8: 0 errors (was 221 before this branch, 471 before the level-6 PR)
- PHPStan level 4: 0 errors — no dead guards introduced
- PHPCS, PHPMD: clean
- PHPUnit: 1725 tests, 7099 assertions, all passing