### PR TITLE
Keep the email subject default per recipient, and sanitize the email text params

### DIFF
--- a/.github/changelog/email-subject-locale-and-arg-sanitization
+++ b/.github/changelog/email-subject-locale-and-arg-sanitization
@@ -1,0 +1,6 @@
+Significance: patch
+Type: fixed
+
+Fixed event update emails ignoring each recipient's language. The send modal pre-filled the subject with the sender's rendering of the default template and posted it on every send, so the server-side default, which is composed inside each recipient's locale, never ran. The field now starts empty and shows that default as a placeholder instead.
+
+Also fixed the `message` and `subject` parameters of the email endpoint declaring `sanitize_text_field` as a `validate_callback`. In that slot it never sanitizes, since the REST server only treats an exact `false` return as invalid. They now use `sanitize_callback`, with `sanitize_textarea_field` for the message so line breaks survive to the `nl2br()` in the email template.

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -152,11 +152,11 @@ final class Rest_Api {
 					),
 					'message' => array(
 						'required'          => false,
-						'validate_callback' => 'sanitize_text_field',
+						'sanitize_callback' => 'sanitize_textarea_field',
 					),
 					'subject' => array(
 						'required'          => false,
-						'validate_callback' => 'sanitize_text_field',
+						'sanitize_callback' => 'sanitize_text_field',
 					),
 					'send'    => array(
 						'required'          => true,

--- a/src/modals/email-communication/index.js
+++ b/src/modals/email-communication/index.js
@@ -38,6 +38,20 @@ const EventCommunicationModal = () => {
 		isSaving: wpSelect( 'gatherpress/email-modal' ).isSaving(),
 	} ), [] );
 	const { closeModal } = useDispatch( 'gatherpress/email-modal' );
+
+	// Shown as a placeholder only. Leaving the field empty lets the server
+	// compose the default subject once per recipient, inside that recipient's
+	// locale, which a pre-filled value would override with the sender's.
+	const postTitle = useSelect(
+		( wpSelect ) =>
+			wpSelect( 'core/editor' ).getEditedPostAttribute( 'title' ) || '',
+		[],
+	);
+	const defaultSubject = sprintf(
+		// translators: %s: event title.
+		_x( '📅 %s', 'Email notification subject with event title', 'gatherpress' ),
+		postTitle,
+	);
 	const [ isAllChecked, setAllChecked ] = useState( false );
 	const [ isAttendingChecked, setAttendingChecked ] = useState( false );
 	const [ isWaitingListChecked, setWaitingListChecked ] = useState( false );
@@ -104,21 +118,6 @@ const EventCommunicationModal = () => {
 		}
 	}, [ isOpen ] );
 
-	useEffect( () => {
-		if ( isOpen ) {
-			const title =
-				select( 'core/editor' ).getEditedPostAttribute( 'title' ) ||
-				'';
-			setSubject(
-				sprintf(
-					// translators: %s: event title.
-					_x( '📅 %s', 'Email notification subject with event title', 'gatherpress' ),
-					title,
-				),
-			);
-		}
-	}, [ isOpen ] );
-
 	return (
 		<>
 			{ isOpen && (
@@ -131,6 +130,7 @@ const EventCommunicationModal = () => {
 					<TextControl
 						label={ __( 'Subject', 'gatherpress' ) }
 						value={ subject }
+						placeholder={ defaultSubject }
 						onChange={ ( value ) => setSubject( value ) }
 						style={ { marginBottom: '1rem' } }
 					/>

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -203,6 +203,118 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
+	 * Coverage for email_route argument handling.
+	 *
+	 * A sanitizer in the validate_callback slot never sanitizes: the REST server
+	 * only treats an exact `false` return as invalid, so the raw value is used.
+	 *
+	 * @covers ::email_route
+	 *
+	 * @return void
+	 */
+	public function test_email_route_sanitizes_text_params(): void {
+		$instance = Rest_Api::get_instance();
+		$route    = Utility::invoke_hidden_method( $instance, 'email_route' );
+		$args     = $route['args']['args'];
+
+		$this->assertArrayNotHasKey(
+			'validate_callback',
+			$args['message'],
+			'Failed to assert message does not use a sanitizer as a validator.'
+		);
+		$this->assertSame(
+			'sanitize_textarea_field',
+			$args['message']['sanitize_callback'],
+			'Failed to assert message is sanitized with newlines preserved.'
+		);
+		$this->assertArrayNotHasKey(
+			'validate_callback',
+			$args['subject'],
+			'Failed to assert subject does not use a sanitizer as a validator.'
+		);
+		$this->assertSame(
+			'sanitize_text_field',
+			$args['subject']['sanitize_callback'],
+			'Failed to assert subject is sanitized.'
+		);
+	}
+
+	/**
+	 * Coverage for text params sanitized through a dispatched request.
+	 *
+	 * Sanitization only runs on dispatch, so this exercises the registered route
+	 * rather than calling the callback directly, and reads the values back off
+	 * the scheduled event the callback hands to cron.
+	 *
+	 * @covers ::email
+	 *
+	 * @return void
+	 */
+	public function test_email_route_sanitizes_on_dispatch(): void {
+		$captured = array();
+
+		add_filter(
+			'schedule_event',
+			static function ( $event ) use ( &$captured ) {
+				if ( $event && 'gatherpress_send_emails' === $event->hook ) {
+					$captured = $event->args;
+				}
+
+				return $event;
+			}
+		);
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$event_id = $this->mock->post(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_author' => $admin_id,
+			)
+		)->get()->ID;
+
+		wp_set_current_user( $admin_id );
+
+		Rest_Api::get_instance()->register_endpoints();
+
+		$request = new WP_REST_Request(
+			'POST',
+			sprintf( '/%s/event/email', GATHERPRESS_REST_NAMESPACE )
+		);
+
+		$request->set_body_params(
+			array(
+				'post_id' => $event_id,
+				'message' => "First line.\nSecond line.",
+				'subject' => '  Subject <b>with</b> markup  ',
+				'send'    => array(
+					'all'           => false,
+					'attending'     => true,
+					'waiting_list'  => false,
+					'not_attending' => false,
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame(
+			200,
+			$response->get_status(),
+			'Failed to assert the email request was accepted.'
+		);
+		$this->assertSame(
+			"First line.\nSecond line.",
+			$captured[2],
+			'Failed to assert the newline survived sanitization of the message.'
+		);
+		$this->assertSame(
+			'Subject with markup',
+			$captured[3],
+			'Failed to assert the subject was sanitized.'
+		);
+	}
+
+	/**
 	 * Coverage for send_emails method.
 	 *
 	 * @covers ::send_emails


### PR DESCRIPTION
Two follow-ups to #2042 (editable email subject, #827). I raised both as a PR into @faisalahammad's branch before that landed, but it merged first, so they are in `develop` now and this brings them upstream properly.

## 1. The pre-filled subject takes per-recipient locale away

`send_event_email_to_recipient()` composes the default subject *after* `switch_to_user_locale( $recipient['user_id'] )`:

```php
if ( '' === $subject ) {
	$subject = sprintf(
		// translators: %s: event title.
		_x( '📅 %s', 'Email notification subject with event title', 'gatherpress' ),
		get_the_title( $post_id )
	);
}
```

That branch is correct and it is the reason each member used to receive the subject rendered in their own language. It is now unreachable. The modal fills the field on open and posts the value on every send:

```js
useEffect( () => {
	if ( isOpen ) {
		const title = select( 'core/editor' ).getEditedPostAttribute( 'title' ) || '';
		setSubject( sprintf( _x( '📅 %s', ... ), title ) );
	}
}, [ isOpen ] );
```

so `$subject` is never `''`, and every recipient gets the sender's rendering.

This makes the default a `placeholder` instead of a value. The field starts empty, the editor still sees exactly what will go out, and typing anything still overrides it. Nothing else in the flow changes: the field was already reset to `''` after a successful send.

## 2. The text params declare a sanitizer where a validator goes

```php
'message' => array(
	'required'          => false,
	'validate_callback' => 'sanitize_text_field',
),
'subject' => array(
	'required'          => false,
	'validate_callback' => 'sanitize_text_field',
),
```

`WP_REST_Request::has_valid_params()` only rejects on an exact `false` return, so a sanitizer in that slot passes everything through and no sanitization ever runs. The values reach `email()` raw.

The obvious repair is wrong in a way worth naming: moving `sanitize_text_field` straight into `sanitize_callback` would silently flatten every multi-line message, because `_sanitize_text_fields()` collapses `[\r\n\t ]+` to a single space unless `$keep_newlines` is set, and the email template renders `wp_kses( nl2br( $message ), ... )`. So `message` gets `sanitize_textarea_field` and only `subject` gets `sanitize_text_field`.

The practical impact today is low rather than nil: the template escapes the message with `wp_kses()`, and PHPMailer strips CR/LF from the subject, so this is a correctness fix, not a security advisory.

## Testing

Two tests, both verified to fail against the current source:

- `test_email_route_sanitizes_text_params` locks the arg declaration: no sanitizer in the validator slot, `sanitize_textarea_field` for message, `sanitize_text_field` for subject.
- `test_email_route_sanitizes_on_dispatch` goes through the registered route, since sanitization only runs on dispatch, and reads the values back off the scheduled `gatherpress_send_emails` event. Asserts `"First line.\nSecond line."` survives intact and `'  Subject <b>with</b> markup  '` arrives as `'Subject with markup'`.

Reverting only `class-rest-api.php` turns both red:

```
Failed asserting that an array does not have the key 'validate_callback'.
Failed asserting that two strings are identical.
FAILURES! Tests: 2, Assertions: 4, Failures: 2.
```

With the fix in place: `OK (2 tests, 7 assertions)`. PHPCS clean on both changed PHP files.

Unrelated, so flagging rather than touching: `test/unit/js/src/blocks/rsvp/view.test.js` went red while I was running this branch. Correcting what I first wrote here, it is not a hard failure on `develop`. It is a flaky test that races a fixed 30ms sleep against the RSVP flow, so it fails on a loaded machine and passes on an idle one. Filed as #2180 with a deterministic reproduction, fixed in #2181.

