### PR TITLE
Wait on the RSVP flow instead of a fixed sleep in the modal-switch tests

### DIFF
--- a/.github/changelog/flaky-rsvp-modal-switch-test
+++ b/.github/changelog/flaky-rsvp-modal-switch-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the RSVP modal-switch tests failing on a loaded machine. They waited a flat 30ms for a flow that has to finish two fetches and a 10ms timer, which leaves about 3ms of slack on an idle machine and none on a busy one. They now wait on the flow completing instead of on the clock.

--- a/test/unit/js/src/blocks/rsvp/view.test.js
+++ b/test/unit/js/src/blocks/rsvp/view.test.js
@@ -9,6 +9,7 @@ import {
 	beforeEach,
 	afterEach,
 } from '@jest/globals';
+import { waitFor } from '@testing-library/react';
 
 /**
  * Mock the Interactivity API with a namespace-merging store so every
@@ -58,18 +59,6 @@ import { getNonce } from '@src/helpers/interactivity';
 // Import the actual modules so their actions register on the shared store.
 import '@src/blocks/rsvp/view';
 import '@src/blocks/modal-manager/view';
-
-/**
- * Waits long enough for the fire-and-forget sendRsvpApiRequest promise
- * chain and the 10ms closeModal timeout inside updateRsvp to settle.
- *
- * @return {Promise<void>} Resolves after the RSVP flow settles.
- */
-function flushRsvpFlow() {
-	return new Promise( ( resolve ) => {
-		setTimeout( resolve, 30 );
-	} );
-}
 
 /**
  * Regression coverage for #1719 — after a successful RSVP from the
@@ -169,7 +158,10 @@ describe( 'rsvp updateRsvp post-success modal switch', () => {
 		const { trigger, attendingButton } = setupDom( true );
 
 		actions.updateRsvp( { preventDefault: jest.fn() } );
-		await flushRsvpFlow();
+
+		// closeModal is the last step of the flow, so waiting on it means the
+		// whole chain has settled without racing a fixed sleep against it.
+		await waitFor( () => expect( actions.closeModal ).toHaveBeenCalled() );
 
 		expect( actions.openModal ).toHaveBeenCalledWith(
 			null,
@@ -187,7 +179,10 @@ describe( 'rsvp updateRsvp post-success modal switch', () => {
 		const { trigger } = setupDom( false );
 
 		actions.updateRsvp( { preventDefault: jest.fn() } );
-		await flushRsvpFlow();
+
+		// openModal is decided synchronously before closeModal is scheduled,
+		// so once closeModal has fired the negative assertion below is settled.
+		await waitFor( () => expect( actions.closeModal ).toHaveBeenCalled() );
 
 		expect( actions.openModal ).not.toHaveBeenCalled();
 		expect( actions.closeModal ).toHaveBeenCalledWith(


### PR DESCRIPTION
Fixes #2180.

`flushRsvpFlow()` waits a flat 30ms. Inside that budget the flow has to finish a `GET /nonce` fetch, a `POST /rsvp` fetch, the promise chain through `sendRsvpApiRequest`, and a `setTimeout( …, 10 )` in `updateRsvp` before `closeModal` fires. On an idle machine that leaves about 3ms of slack. On a loaded one it leaves none, and both tests fail for reasons that have nothing to do with the code under test.

I hit it with a PHPUnit run going in the background, which is not a reproducible bug report, so here it is deterministically. Delaying the mocked nonce fetch by 25ms models the same pressure:

```diff
 			if ( url.endsWith( '/nonce' ) ) {
-				return Promise.resolve( {
-					json: () => Promise.resolve( { nonce: 'test-nonce' } ),
-				} );
+				return new Promise( ( r ) => setTimeout( () => r( {
+					json: () => Promise.resolve( { nonce: 'test-nonce' } ),
+				} ), 25 ) );
 			}
```

Against `develop` that turns both tests red:

```
✕ switches to the attending modal when its markup is present (62 ms)
✕ fully closes the modal instead of throwing when the attending markup is missing (#1719) (33 ms)
Tests: 2 failed, 2 total
```

With this branch and the same 25ms delay applied, both pass. The delay is not committed, it is only how I demonstrated the race.

## The change

`waitFor` from `@testing-library/react`, which this suite already uses in ten other files, waiting on the outcome instead of the clock:

```js
await waitFor( () => expect( actions.closeModal ).toHaveBeenCalled() );
```

`closeModal` is the last step of the flow in both branches of `updateRsvp`, and `openModal` is called synchronously before `closeModal` is scheduled. So once `closeModal` has fired, every existing assertion is settled, including the negative `expect( actions.openModal ).not.toHaveBeenCalled()` in the second test. No assertion was weakened or removed.

## Testing

- Both tests pass with and without the injected 25ms delay.
- Full suite: 55 suites, 1002 tests, all passing.
- Nothing in `src/` changes, so #1719 coverage is intact.
