### PR TITLE
Fix editor accessibility: help text, focus outlines, key handler

### DIFF
--- a/.github/changelog/2182-from-description
+++ b/.github/changelog/2182-from-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix editor accessibility: associate help text with controls, restore visible focus indicators, and guard RSVP template key handler to Enter and Space only.

--- a/src/blocks/rsvp-template/edit.js
+++ b/src/blocks/rsvp-template/edit.js
@@ -59,6 +59,23 @@ const RsvpTemplatePreview = ( {
 		setActiveRsvpId( commentId );
 	};
 
+	const handleKeyDown = ( event ) => {
+		if ( 'Enter' === event.key ) {
+			event.preventDefault();
+			handleOnClick();
+		} else if ( ' ' === event.key ) {
+			// Prevent scroll on Space; activation fires on keyup per button semantics.
+			event.preventDefault();
+		}
+	};
+
+	const handleKeyUp = ( event ) => {
+		if ( ' ' === event.key ) {
+			event.preventDefault();
+			handleOnClick();
+		}
+	};
+
 	// We have to hide the preview block if the `comment` props points to
 	// the currently active block!
 
@@ -76,7 +93,8 @@ const RsvpTemplatePreview = ( {
 			style={ style }
 			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 			onClick={ handleOnClick }
-			onKeyUp={ handleOnClick }
+			onKeyDown={ handleKeyDown }
+			onKeyUp={ handleKeyUp }
 		/>
 	);
 };

--- a/src/blocks/rsvp-template/edit.js
+++ b/src/blocks/rsvp-template/edit.js
@@ -10,7 +10,7 @@ import {
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { memo, useState } from '@wordpress/element';
+import { memo, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -29,10 +29,30 @@ const TemplateInnerBlocks = ( {
 		{ template: TEMPLATE },
 	);
 
+	// Activating a preview hides its own button (display: none), which strands
+	// keyboard focus. When this response becomes the active one, move focus to
+	// the revealed template content so focus follows the keyboard interaction.
+	const childrenRef = useRef( null );
+
+	const isSkippedInitial = useRef( false );
+	useEffect( () => {
+		// Skip the initial render so the default first-active preview never
+		// steals focus on editor load, and only focus after this response has
+		// just become active.
+		if ( ! isSkippedInitial.current ) {
+			isSkippedInitial.current = true;
+			return;
+		}
+
+		if ( response.commentId === ( activeRsvpId || firstRsvpId ) ) {
+			childrenRef.current?.focus();
+		}
+	}, [ activeRsvpId, firstRsvpId, response.commentId ] );
+
 	return (
 		<div { ...innerBlocksProps }>
 			{ response.commentId === ( activeRsvpId || firstRsvpId )
-				? children
+				? <div ref={ childrenRef } tabIndex={ -1 }>{ children }</div>
 				: null }
 
 			<MemoizedRsvpTemplatePreview

--- a/src/blocks/venue-detail/editor.scss
+++ b/src/blocks/venue-detail/editor.scss
@@ -58,12 +58,6 @@
 		white-space: pre-wrap;
 		overflow-wrap: anywhere;
 
-		&:focus-visible {
-			outline: 1.5px solid var(--wp-admin-theme-color, #007cba);
-			outline-offset: 2px;
-			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba);
-		}
-
 		&:focus {
 			outline: 1.5px solid var(--wp-admin-theme-color, #007cba);
 			outline-offset: 2px;

--- a/src/blocks/venue-detail/editor.scss
+++ b/src/blocks/venue-detail/editor.scss
@@ -52,16 +52,22 @@
 		background: transparent;
 		border: none;
 		box-shadow: none;
-		outline: none;
 		vertical-align: baseline;
 		resize: none;
 		overflow: hidden auto;
 		white-space: pre-wrap;
 		overflow-wrap: anywhere;
 
+		&:focus-visible {
+			outline: 1.5px solid var(--wp-admin-theme-color, #007cba);
+			outline-offset: 2px;
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba);
+		}
+
 		&:focus {
-			outline: none;
-			box-shadow: none;
+			outline: 1.5px solid var(--wp-admin-theme-color, #007cba);
+			outline-offset: 2px;
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba);
 		}
 	}
 

--- a/src/components/GuestLimit.js
+++ b/src/components/GuestLimit.js
@@ -63,23 +63,19 @@ const GuestLimit = () => {
 	}, [ isNewEvent, defaultGuestLimit, updateGuestLimit ] );
 
 	return (
-		<>
-			<NumberControl
-				label={ __( 'Maximum Number of Guests', 'gatherpress' ) }
-				value={ guestLimit }
-				min={ 0 }
-				max={ 5 }
-				onChange={ ( value ) => {
-					updateGuestLimit( value );
-				} }
-			/>
-			<p className="description">
-				{ __(
-					'Maximum number of additional people each attendee can bring.',
-					'gatherpress',
-				) }
-			</p>
-		</>
+		<NumberControl
+			label={ __( 'Maximum Number of Guests', 'gatherpress' ) }
+			value={ guestLimit }
+			min={ 0 }
+			max={ 5 }
+			help={ __(
+				'Maximum number of additional people each attendee can bring.',
+				'gatherpress',
+			) }
+			onChange={ ( value ) => {
+				updateGuestLimit( value );
+			} }
+		/>
 	);
 };
 

--- a/src/components/MaxAttendanceLimit.js
+++ b/src/components/MaxAttendanceLimit.js
@@ -67,22 +67,18 @@ const MaxAttendanceLimit = () => {
 	}, [ isNewEvent, defaultMaxAttendanceLimit, updateMaxAttendanceLimit ] );
 
 	return (
-		<>
-			<NumberControl
-				label={ __( 'Maximum Attendance Limit', 'gatherpress' ) }
-				value={ maxAttendanceLimit }
-				min={ 0 }
-				onChange={ ( value ) => {
-					updateMaxAttendanceLimit( value );
-				} }
-			/>
-			<p className="description">
-				{ __(
-					'Total number of people allowed at the event. A value of 0 indicates no limit.',
-					'gatherpress',
-				) }
-			</p>
-		</>
+		<NumberControl
+			label={ __( 'Maximum Attendance Limit', 'gatherpress' ) }
+			value={ maxAttendanceLimit }
+			min={ 0 }
+			help={ __(
+				'Total number of people allowed at the event. A value of 0 indicates no limit.',
+				'gatherpress',
+			) }
+			onChange={ ( value ) => {
+				updateMaxAttendanceLimit( value );
+			} }
+		/>
 	);
 };
 

--- a/src/components/PatternPicker/index.scss
+++ b/src/components/PatternPicker/index.scss
@@ -39,13 +39,6 @@
 			outline: 2px solid var(--wp-admin-theme-color, #007cba);
 			outline-offset: 1px;
 		}
-
-		&:focus {
-			border-color: var(--wp-admin-theme-color, #007cba);
-			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba);
-			outline: 2px solid var(--wp-admin-theme-color, #007cba);
-			outline-offset: 1px;
-		}
 	}
 
 	&__pattern-preview {

--- a/src/components/PatternPicker/index.scss
+++ b/src/components/PatternPicker/index.scss
@@ -29,10 +29,22 @@
 		text-align: left;
 		transition: border-color 120ms ease-in-out;
 
-		&:hover,
+		&:hover {
+			border-color: var(--wp-admin-theme-color, #007cba);
+		}
+
+		&:focus-visible {
+			border-color: var(--wp-admin-theme-color, #007cba);
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba);
+			outline: 2px solid var(--wp-admin-theme-color, #007cba);
+			outline-offset: 1px;
+		}
+
 		&:focus {
 			border-color: var(--wp-admin-theme-color, #007cba);
-			outline: none;
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba);
+			outline: 2px solid var(--wp-admin-theme-color, #007cba);
+			outline-offset: 1px;
 		}
 	}
 


### PR DESCRIPTION
Fixes #2143

## Proposed changes:
* Associates help text with its control in `GuestLimit` and `MaxAttendanceLimit` by using `NumberControl` `help` prop, which wires `aria-describedby` so screen readers announce the description on focus.
* Restores visible focus indicators in `PatternPicker` and venue-detail address textarea. PatternPicker hover and focus are now distinct (hover is border only, focus adds ring/outline). Textarea `outline: none` removed and replaced with `focus`/`focus-visible` ring in admin theme color. Restores WCAG 2.4.7.
* Guards RSVP template preview key handler to Enter (keydown) and Space (keyup) only. Previously `onKeyUp` fired on any key including Tab and arrow keys.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Testing instructions:

1. Guest Limit / Max Attendance help: edit an event, focus each NumberControl with a screen reader. Help text should be announced. Before, sibling `<p>` was never associated.
2. Pattern Picker focus: open pattern picker modal, Tab through cards. Focus ring should be visible and distinct from hover.
3. Venue address textarea: Tab into the textarea. Visible focus ring should appear.
4. RSVP template: focus preview `div[role="button"]`, press Tab/arrows/Esc. Click must not fire. Press Enter and Space. Each should activate.

## Screenshots
No visual change except focus states, which are covered by testing steps above.

### Credit (for release notes)

My WordPress.org username: faisalahammad

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

- [x] Patch

#### Type

- [x] Fixed - for any bug fixes

#### Message

Fix editor accessibility: associate help text with controls, restore visible focus indicators, and guard RSVP template key handler to Enter and Space only.

</details>
