### PR TITLE
Narrow the map provider contract to GdImage

### DIFF
--- a/.github/changelog/gd-image-contract
+++ b/.github/changelog/gd-image-contract
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Narrow the venue map provider contract to GdImage, now that the PHP 7.4 floor that required accepting a resource is gone.

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -1422,19 +1422,19 @@ final class Map {
 	 *
 	 * @since 0.34.0
 	 *
-	 * @param GdImage|resource $image    Finished image from a provider's `render()`.
-	 * @param string           $address  Venue address (slugified for the filename).
-	 * @param int              $zoom     Map zoom level.
-	 * @param int              $width    Output width (at density 1).
-	 * @param int              $height   Output height (at density 1).
-	 * @param int              $density  Pixel-density multiplier. 1 = standard, 2 = retina.
-	 * @param string           $provider Provider slug.
-	 * @param string           $map_type Map type slug.
+	 * @param GdImage $image    Finished image from a provider's `render()`.
+	 * @param string  $address  Venue address (slugified for the filename).
+	 * @param int     $zoom     Map zoom level.
+	 * @param int     $width    Output width (at density 1).
+	 * @param int     $height   Output height (at density 1).
+	 * @param int     $density  Pixel-density multiplier. 1 = standard, 2 = retina.
+	 * @param string  $provider Provider slug.
+	 * @param string  $map_type Map type slug.
 	 *
 	 * @return string|null Public URL of the saved file, or null on failure.
 	 */
 	public function save_image(
-		$image,
+		GdImage $image,
 		string $address,
 		int $zoom,
 		int $width,

--- a/includes/core/classes/venue/map/provider/class-base.php
+++ b/includes/core/classes/venue/map/provider/class-base.php
@@ -66,11 +66,6 @@ abstract class Base {
 	 * combo, etc.). The caller treats null as "skip this combo" — it does
 	 * NOT fall back to another provider.
 	 *
-	 * Return type is intentionally untyped at the PHP signature level so the
-	 * abstract is loadable on PHP 7.4 (where the GD extension returns a
-	 * `resource`, not a `GdImage` — the latter class is 8.0+). PHPStan reads
-	 * the docblock instead.
-	 *
 	 * @since 0.34.0
 	 *
 	 * @param float  $latitude  Venue latitude in decimal degrees.
@@ -81,7 +76,7 @@ abstract class Base {
 	 * @param int    $density   Pixel-density multiplier. 1 = standard, 2 = retina.
 	 * @param string $map_type  Map type slug — one of `roadmap`, `satellite`, `hybrid`, `terrain`.
 	 *
-	 * @return GdImage|resource|null Finished image, or null on failure.
+	 * @return GdImage|null Finished image, or null on failure.
 	 */
 	abstract public function render(
 		float $latitude,
@@ -91,7 +86,7 @@ abstract class Base {
 		int $height,
 		int $density = 1,
 		string $map_type = 'roadmap'
-	);
+	): ?GdImage;
 
 	/**
 	 * Attribution markup the front end MUST display alongside the static

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-manager.php
@@ -15,6 +15,7 @@ use GatherPress\Core\Venue\Map\Provider\Google;
 use GatherPress\Core\Venue\Map\Provider\OSM;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
+use GdImage;
 
 /**
  * Class Test_Manager.
@@ -385,7 +386,7 @@ class Test_Manager extends Base {
 				int $height,
 				int $density = 1,
 				string $map_type = 'roadmap'
-			) {
+			): ?GdImage {
 				return null;
 			}
 		};

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-map.php
@@ -19,6 +19,7 @@ use GatherPress\Core\Venue\Setup;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
+use GdImage;
 
 /**
  * Class Test_Map.
@@ -3024,7 +3025,7 @@ class Test_Map extends Base {
 				int $height,
 				int $density = 1,
 				string $map_type = 'roadmap'
-			) {
+			): ?GdImage {
 				return null;
 			}
 		};

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-base.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-base.php
@@ -14,6 +14,7 @@ namespace GatherPress\Tests\Core\Venue\Map\Provider;
 
 use GatherPress\Core\Venue\Map\Provider\Base;
 use GatherPress\Tests\Base as GatherPress_Test_Base;
+use GdImage;
 
 /**
  * Class Test_Base.
@@ -119,7 +120,7 @@ class Test_Base extends GatherPress_Test_Base {
 				int $height,
 				int $density = 1,
 				string $map_type = 'roadmap'
-			) {
+			): ?GdImage {
 				return null;
 			}
 
@@ -184,7 +185,7 @@ class Test_Base extends GatherPress_Test_Base {
 				int $height,
 				int $density = 1,
 				string $map_type = 'roadmap'
-			) {
+			): ?GdImage {
 				return null;
 			}
 		};


### PR DESCRIPTION
Follows from a question on [#2178](https://github.com/GatherPress/gatherpress/pull/2178): why does `Map::save_image()` need an `instanceof GdImage` guard at all?

Because the contract still says it might get a `resource`:

```php
// provider/class-base.php
@return GdImage|resource|null Finished image, or null on failure.
```

with the reason written directly above it:

> Return type is intentionally untyped at the PHP signature level so the abstract is loadable on **PHP 7.4** (where the GD extension returns a `resource`, not a `GdImage` — the latter class is 8.0+).

That rationale expired. [#1929](https://github.com/GatherPress/gatherpress/pull/1929) raised the floor from 7.4 to 8.1 in 0.35.0, so GD only ever hands back `GdImage` and the `resource` arm is unreachable.

## Changes

- `Provider\Base::render()` — `: ?GdImage` return type, docblock narrowed, and the PHP 7.4 paragraph removed
- `Map::save_image()` — `GdImage $image` type hint and matching `@param`

Both shipped providers (`Osm`, `Google`) already declared `?GdImage`; only the abstract and `save_image()` were still loose. `save_image()`'s two call sites already null-check the provider result before calling, so the hint matches what they pass.

## Breaking for extenders, more than it first looks

A provider subclass whose `render()` has **no return type** now fatals:

```
Declaration of …::render(…) must be compatible with …Base::render(…): ?GdImage
```

An untyped return is `mixed`, which is wider than `?GdImage`, and return types must be covariant. So this is not only a problem for a subclass that returns a resource — any untyped one breaks. Four test doubles in this repo hit exactly that and are updated here.

Worth a line in the release notes for anyone shipping a custom map provider: add `: ?GdImage` to `render()`.

## Interaction with #2178

#2178 adds an `instanceof GdImage` guard to `save_image()` for level 8. Once this lands that guard is provably always-true, which PHPStan flags at level 4 — so whichever merges second needs the guard removed. Happy to do that on #2178 when the order is known.

## Testing

- PHPStan clean at the configured level, PHPCS clean, PHPMD clean
- Full PHP suite: 1739 tests, 7143 assertions