### PR TITLE
Remove the GdImage guard the narrowed contract made redundant

### DIFF
--- a/.github/changelog/redundant-gdimage-guard
+++ b/.github/changelog/redundant-gdimage-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove a static analysis guard that became redundant when the map provider contract was narrowed to GdImage.

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -1452,11 +1452,6 @@ final class Map {
 		string $provider,
 		string $map_type = self::DEFAULT_MAP_TYPE
 	): ?string {
-		// GD returns GdImage since PHP 8.0, so the contract's `resource` arm is dead on the 8.1 floor.
-		if ( ! $image instanceof GdImage ) {
-			return null; // @codeCoverageIgnore
-		}
-
 		$dirs = wp_get_upload_dir();
 
 		if ( ! empty( $dirs['error'] ) ) {


### PR DESCRIPTION
develop currently fails its own PHPStan gate:

```
includes/core/classes/venue/map/class-map.php:1456
  Instanceof between GdImage and GdImage will always evaluate to true.
```

[#2178](https://github.com/GatherPress/gatherpress/pull/2178) added `if ( ! $image instanceof GdImage )` to `save_image()` so PHPStan could narrow the then-untyped `$image`. [#2184](https://github.com/GatherPress/gatherpress/pull/2184) then type-hinted that parameter as `GdImage`, which makes the check provably always true — and level 4 flags always-true `instanceof`.

Neither PR was wrong; they only collide in this merge order, and #2184 flagged that whichever landed second would need the guard dropped. #2178 merged second.

This removes the guard and its `@codeCoverageIgnore`, which also retires one uncoverable line.

## Testing

- PHPStan clean at the configured level, PHPCS clean
- Full PHP suite green