### PR TITLE
Rename the WP_Post property on Event and Rsvp to $post

### DIFF
--- a/.github/changelog/2183-event-post-property
+++ b/.github/changelog/2183-event-post-property
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Rename the WP_Post property on Event and Rsvp from $event to $post, so a chained read says what it holds.

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -146,7 +146,7 @@ final class Calendar {
 	 * @throws Exception If reading event datetime/venue data fails.
 	 */
 	public function get_google_destination_url(): string {
-		$post = $this->event->event;
+		$post = $this->event->post;
 
 		if ( ! $post ) {
 			return '';
@@ -196,7 +196,7 @@ final class Calendar {
 	 * @throws Exception If reading event datetime/venue data fails.
 	 */
 	public function get_yahoo_destination_url(): string {
-		$post = $this->event->event;
+		$post = $this->event->post;
 
 		if ( ! $post ) {
 			return '';
@@ -253,7 +253,7 @@ final class Calendar {
 	 * @throws Exception If reading event data fails.
 	 */
 	public function get_ical_event_string(): string {
-		$post = $this->event->event;
+		$post = $this->event->post;
 
 		if ( ! $post ) {
 			return '';
@@ -337,7 +337,7 @@ final class Calendar {
 	 * @return int Non-negative revision number for this event.
 	 */
 	private function get_sequence(): int {
-		$post = $this->event->event;
+		$post = $this->event->post;
 
 		if ( ! $post ) {
 			return 0;
@@ -392,7 +392,7 @@ final class Calendar {
 	 * @return string|false              URL of the event's endpoint, or false when the post can't be resolved.
 	 */
 	protected function get_endpoint_url( string $endpoint_slug, ?string $query_var = null ): string|false {
-		$post = $this->event->event;
+		$post = $this->event->post;
 
 		if ( ! $post ) {
 			return false;

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -157,12 +157,12 @@ class Event {
 	);
 
 	/**
-	 * Event post object.
+	 * The event post.
 	 *
 	 * @since 0.34.0
 	 * @var WP_Post|null
 	 */
-	public ?WP_Post $event = null;
+	public ?WP_Post $post = null;
 
 	/**
 	 * RSVP instance.
@@ -192,8 +192,8 @@ class Event {
 	 */
 	public function __construct( int $post_id ) {
 		if ( post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
-			$this->event = get_post( $post_id );
-			$this->rsvp  = new Rsvp( $post_id );
+			$this->post = get_post( $post_id );
+			$this->rsvp = new Rsvp( $post_id );
 		}
 	}
 
@@ -561,7 +561,7 @@ class Event {
 			'timezone'           => sanitize_text_field( wp_timezone_string() ),
 		);
 
-		if ( ! $this->event ) {
+		if ( ! $this->post ) {
 			return $data;
 		}
 
@@ -570,7 +570,7 @@ class Event {
 		}
 
 		foreach ( array_keys( $data ) as $key ) {
-			$result = get_post_meta( $this->event->ID, Utility::prefix_key( $key ), true );
+			$result = get_post_meta( $this->post->ID, Utility::prefix_key( $key ), true );
 
 			if ( empty( $result ) ) {
 				continue;
@@ -648,14 +648,14 @@ class Event {
 			'website'   => '',
 		);
 
-		if ( ! $this->event ) {
+		if ( ! $this->post ) {
 			return $venue_information;
 		}
 
-		$event_post_type = (string) get_post_type( $this->event );
+		$event_post_type = (string) get_post_type( $this->post );
 		$venue_setup     = Setup::get_instance();
 		$taxonomy        = $venue_setup->taxonomy_for_event_post_type( $event_post_type );
-		$venue_terms     = get_the_terms( $this->event, $taxonomy );
+		$venue_terms     = get_the_terms( $this->post, $taxonomy );
 
 		// get_the_terms() hands back false when nothing is assigned and a WP_Error for an
 		// unregistered taxonomy; neither carries venue terms to inspect.
@@ -718,11 +718,11 @@ class Event {
 	 * @throws Exception If there is an issue while generating calendar links.
 	 */
 	public function get_calendar_links(): array {
-		if ( ! $this->event ) {
+		if ( ! $this->post ) {
 			return array();
 		}
 
-		$calendar = new Calendar( $this->event->ID );
+		$calendar = new Calendar( $this->post->ID );
 
 		// Each URL getter only reports false when its event post cannot be resolved, and the
 		// calendar was built from the post resolved directly above.
@@ -757,12 +757,12 @@ class Event {
 	 * @return string The calendar event description with the event details link.
 	 */
 	public function get_calendar_description(): string {
-		if ( ! $this->event ) {
+		if ( ! $this->post ) {
 			return '';
 		}
 
 		/* translators: %s: event link. */
-		return sprintf( __( 'For details go to %s', 'gatherpress' ), get_the_permalink( $this->event ) );
+		return sprintf( __( 'For details go to %s', 'gatherpress' ), get_the_permalink( $this->post ) );
 	}
 
 	/**
@@ -791,13 +791,13 @@ class Event {
 
 		// Nothing to attach the datetimes to when the post ID handed to the constructor
 		// did not resolve to an event.
-		if ( ! $this->event ) {
+		if ( ! $this->post ) {
 			return false;
 		}
 
 		$params = array_merge(
 			array(
-				'post_id'        => $this->event->ID,
+				'post_id'        => $this->post->ID,
 				'datetime_start' => '',
 				'datetime_end'   => '',
 				'timezone'       => '',
@@ -888,11 +888,11 @@ class Event {
 	 * @return string The online event link if all conditions are met; otherwise, an empty string.
 	 */
 	public function maybe_get_online_event_link(): string {
-		if ( ! $this->event ) {
+		if ( ! $this->post ) {
 			return '';
 		}
 
-		$event_link = (string) get_post_meta( $this->event->ID, 'gatherpress_online_event_link', true );
+		$event_link = (string) get_post_meta( $this->post->ID, 'gatherpress_online_event_link', true );
 
 		/**
 		 * Filters whether to force the display of the online event link.

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -122,7 +122,7 @@ final class Rsvp {
 	 * @since 0.34.0
 	 * @var WP_Post|null Null when the instance wraps an invalid post ID.
 	 */
-	protected readonly ?WP_Post $event;
+	protected readonly ?WP_Post $post;
 
 	/**
 	 * Storage for RSVP Responses for this event.
@@ -156,7 +156,7 @@ final class Rsvp {
 	 * @param int $post_id The event post ID.
 	 */
 	public function __construct( int $post_id ) {
-		$this->event                = get_post( $post_id );
+		$this->post                 = get_post( $post_id );
 		$this->storage              = new Storage( $post_id );
 		$this->max_attendance_limit = (int) get_post_meta( $post_id, 'gatherpress_max_attendance_limit', true );
 		$this->providers            = Provider_Registry::get_instance()->get_all();
@@ -226,7 +226,7 @@ final class Rsvp {
 	 * @return void
 	 */
 	public function initialize_enabled(): void {
-		$post_id   = $this->event->ID ?? 0;
+		$post_id   = $this->post->ID ?? 0;
 		$rsvp_mode = Settings::get_instance()->get( 'rsvp_mode' );
 
 		if ( 'disabled' === $rsvp_mode ) {
@@ -296,13 +296,13 @@ final class Rsvp {
 		$data   = new Data( $identity, $status, $guests, (bool) $anonymous );
 		$intent = new Intent( $data, $provider );
 		$state  = $this->process( $intent );
-		$event  = $this->event;
+		$post   = $this->post;
 
-		if ( null === $state || null === $event ) {
+		if ( null === $state || null === $post ) {
 			return self::DEFAULT_SAVE_RESPONSE;
 		}
 
-		Cache::delete( $event->ID );
+		Cache::delete( $post->ID );
 
 		return Serializer::to_array( $state );
 	}
@@ -318,7 +318,7 @@ final class Rsvp {
 	 */
 	public function process( Intent $intent ): State|null {
 		// If no valid event or RSVP is disabled for this event return empty default response.
-		if ( 1 > ( $this->event->ID ?? 0 ) || ! $this->is_enabled() ) {
+		if ( 1 > ( $this->post->ID ?? 0 ) || ! $this->is_enabled() ) {
 			return null;
 		}
 
@@ -426,7 +426,7 @@ final class Rsvp {
 	 * @return bool True if RSVP is enabled for this event, false otherwise.
 	 */
 	public function is_enabled(): bool {
-		$post_id   = $this->event->ID ?? 0;
+		$post_id   = $this->post->ID ?? 0;
 		$rsvp_mode = Settings::get_instance()->get( 'rsvp_mode' );
 
 		if ( 'disabled' === $rsvp_mode ) {
@@ -459,7 +459,7 @@ final class Rsvp {
 	 * @return bool True if Open RSVP is enabled for this event, false otherwise.
 	 */
 	public function allows_open_rsvp(): bool {
-		$post_id = $this->event->ID ?? 0;
+		$post_id = $this->post->ID ?? 0;
 
 		// Sitewide gate: if open RSVP is globally disabled, always return false.
 		if ( ! Settings::get_instance()->get( 'enable_open_rsvp' ) ) {
@@ -528,7 +528,7 @@ final class Rsvp {
 	 * @return array<string, RsvpResponseGroup> Response records and counts keyed by 'all' and each RSVP status.
 	 */
 	public function responses(): array {
-		$post_id = $this->event->ID ?? 0;
+		$post_id = $this->post->ID ?? 0;
 
 		// Serialized records vary by capability but the cache key does not, so
 		// only the public variant is cached; privileged viewers compute fresh.
@@ -663,7 +663,7 @@ final class Rsvp {
 	 * @return Intent
 	 */
 	private function constrain_rsvp_intent( Intent $intent, ?State $current_response ): Intent {
-		$post_id         = $this->event->ID ?? 0;
+		$post_id         = $this->post->ID ?? 0;
 		$max_guest_limit = intval( get_post_meta( $post_id, 'gatherpress_max_guest_limit', true ) );
 
 		$guests    = $intent->data->guests;

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -83,12 +83,12 @@ class Test_Calendar extends Base {
 		);
 		$this->assertInstanceOf(
 			WP_Post::class,
-			$instance->event->event,
+			$instance->event->post,
 			'Composed Event should resolve to a real WP_Post.'
 		);
 		$this->assertSame(
 			$event_id,
-			$instance->event->event->ID,
+			$instance->event->post->ID,
 			'Composed Event should wrap the requested post id.'
 		);
 	}
@@ -401,7 +401,7 @@ class Test_Calendar extends Base {
 	public function test_get_ical_event_string_sequence_and_last_modified(): void {
 		$instance = new Calendar( $this->make_event() );
 
-		$instance->event->event->post_modified_gmt = '2030-01-01 10:00:00';
+		$instance->event->post->post_modified_gmt = '2030-01-01 10:00:00';
 
 		$vevent = $instance->get_ical_event_string();
 
@@ -421,7 +421,7 @@ class Test_Calendar extends Base {
 			'DTSTAMP shares the post_modified_gmt derivation with LAST-MODIFIED.'
 		);
 
-		$instance->event->event->post_modified_gmt = '2030-01-01 11:00:00';
+		$instance->event->post->post_modified_gmt = '2030-01-01 11:00:00';
 
 		$this->assertStringContainsString(
 			sprintf( 'SEQUENCE:%d', strtotime( '2030-01-01 11:00:00' ) - 1577836800 ),
@@ -446,8 +446,8 @@ class Test_Calendar extends Base {
 		$instance = new Calendar( $this->make_event() );
 
 		// Site-local modification time and its GMT counterpart differ by the offset.
-		$instance->event->event->post_modified     = '2030-01-01 05:00:00';
-		$instance->event->event->post_modified_gmt = '2030-01-01 10:00:00';
+		$instance->event->post->post_modified     = '2030-01-01 05:00:00';
+		$instance->event->post->post_modified_gmt = '2030-01-01 10:00:00';
 
 		$vevent = $instance->get_ical_event_string();
 
@@ -481,7 +481,7 @@ class Test_Calendar extends Base {
 		$event_id = $this->make_event();
 		$instance = new Calendar( $event_id );
 
-		$instance->event->event->post_modified_gmt = '2030-01-01 11:00:00';
+		$instance->event->post->post_modified_gmt = '2030-01-01 11:00:00';
 
 		$this->assertSame(
 			strtotime( '2030-01-01 11:00:00' ) - 1577836800,
@@ -489,7 +489,7 @@ class Test_Calendar extends Base {
 			'Sequence should be seconds since the 2020 epoch, taken from post_modified_gmt.'
 		);
 
-		$instance->event->event->post_modified_gmt = '2030-01-01 12:00:00';
+		$instance->event->post->post_modified_gmt = '2030-01-01 12:00:00';
 
 		$this->assertSame(
 			strtotime( '2030-01-01 12:00:00' ) - 1577836800,
@@ -509,7 +509,7 @@ class Test_Calendar extends Base {
 	public function test_get_sequence_returns_zero_for_unparsable_date(): void {
 		$instance = new Calendar( $this->make_event() );
 
-		$instance->event->event->post_modified_gmt = 'not a date';
+		$instance->event->post->post_modified_gmt = 'not a date';
 
 		$this->assertSame(
 			0,
@@ -549,7 +549,7 @@ class Test_Calendar extends Base {
 	public function test_get_sequence_clamps_to_rfc_integer_ceiling(): void {
 		$instance = new Calendar( $this->make_event() );
 
-		$instance->event->event->post_modified_gmt = '2100-01-01 00:00:00';
+		$instance->event->post->post_modified_gmt = '2100-01-01 00:00:00';
 
 		$this->assertSame(
 			2147483647,
@@ -608,7 +608,7 @@ class Test_Calendar extends Base {
 	public function test_get_ical_event_string_stamps_now_for_unparsable_modified_date(): void {
 		$instance = new Calendar( $this->make_event() );
 
-		$instance->event->event->post_modified_gmt = '9999-99-99 99:99:99';
+		$instance->event->post->post_modified_gmt = '9999-99-99 99:99:99';
 
 		$before = time();
 		$vevent = $instance->get_ical_event_string();

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -37,13 +37,13 @@ class Test_Event extends Base {
 		$post  = $this->mock->post()->get();
 		$event = new Event( $post->ID );
 
-		$this->assertNull( Utility::get_hidden_property( $event, 'event' ) );
+		$this->assertNull( Utility::get_hidden_property( $event, 'post' ) );
 		$this->assertNull( Utility::get_hidden_property( $event, 'rsvp' ) );
 
 		$post  = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
 		$event = new Event( $post->ID );
 
-		$this->assertInstanceOf( WP_Post::class, Utility::get_hidden_property( $event, 'event' ) );
+		$this->assertInstanceOf( WP_Post::class, Utility::get_hidden_property( $event, 'post' ) );
 		$this->assertInstanceOf( Rsvp::class, Utility::get_hidden_property( $event, 'rsvp' ) );
 	}
 
@@ -266,7 +266,7 @@ class Test_Event extends Base {
 
 		$post->ID = 0;
 
-		Utility::set_and_get_hidden_property( $event, 'event', $post );
+		Utility::set_and_get_hidden_property( $event, 'post', $post );
 
 		$this->assertFalse(
 			$event->save_datetimes( $params ),
@@ -738,7 +738,7 @@ class Test_Event extends Base {
 
 		$this->assertSame( $expects, $output );
 
-		Utility::set_and_get_hidden_property( $event, 'event', null );
+		Utility::set_and_get_hidden_property( $event, 'post', null );
 
 		$this->assertEmpty(
 			$event->get_calendar_links(),
@@ -1368,7 +1368,7 @@ class Test_Event extends Base {
 		$post_id = $this->mock->post( array( 'post_type' => 'post' ) )->get()->ID;
 		$event   = new Event( $post_id );
 
-		$this->assertNull( $event->event, 'Failed to assert event is null for non-event post.' );
+		$this->assertNull( $event->post, 'Failed to assert post is null for non-event post.' );
 		$this->assertNull( $event->rsvp, 'Failed to assert rsvp is null for non-event post.' );
 	}
 

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
@@ -92,7 +92,7 @@ class Test_Query extends Base {
 
 		$comment_query = new WP_Comment_Query(
 			array(
-				'post_id'   => $event->event->ID,
+				'post_id'   => $event->post->ID,
 				'user_id'   => $user_id,
 				'tax_query' => array( //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 					array(


### PR DESCRIPTION
Fixes #2183

`Event::$event` and `Rsvp::$event` both hold a `WP_Post`. `Calendar::$event` holds an `Event`. Chaining them stuttered:

```php
$post = $this->event->event;   // Calendar's Event, then that Event's… event?
```

Each link now names what it holds:

```php
$post = $this->event->post;    // Calendar's Event, then that Event's post
```

`Calendar::$event` keeps its name. It genuinely holds an `Event`, and it reads correctly everywhere it is used.

## Both, not one

`Rsvp::$event` was `protected`, so renaming only `Event::$event` would have been the lower-risk half. But it would also have left a `WP_Post` called `$event` sitting in the codebase, which is the exact confusion this removes. Both got renamed.

## Breaking change

`Event::$event` is `public`. A companion plugin reading `$event->event` now gets an undefined-property warning and `null` rather than the post. `Rsvp::$event` was `protected`, so that half is internal only.

No deprecation shim — a `__get()` that warns would keep the old name working, but it also keeps the old name discoverable, and 0.x is where a rename like this is cheapest.

## Testing

- Full PHP suite green (1767 tests, 7194 assertions)
- PHPCS clean

Four test sites reached the property by string name through `Utility::get_hidden_property()` / `set_and_get_hidden_property()`, which reflection resolves at runtime — invisible to a grep for `->event`. Those are updated too.