### PR TITLE
Remove Event::$rsvp in favor of direct Rsvp instantiation

### DIFF
--- a/.github/changelog/2156-remove-event-rsvp-property
+++ b/.github/changelog/2156-remove-event-rsvp-property
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove Event::$rsvp in favor of direct Rsvp instantiation, and gate Rsvp::is_enabled() on the gatherpress-rsvp post type support.

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -111,7 +111,9 @@ final class Rsvp {
 			return '';
 		}
 
-		if ( ! ( new Core_Rsvp( $post_id ) )->is_enabled() ) {
+		$rsvp = new Core_Rsvp( $post_id );
+
+		if ( ! $rsvp->is_enabled() ) {
 			return '';
 		}
 
@@ -146,13 +148,8 @@ final class Rsvp {
 			// Serialize the current inner blocks for the saved status.
 			$serialized_inner_blocks[ $saved_status ] = serialize_blocks( $inner_blocks );
 
-			$user_data = array();
-
-			if ( $event->rsvp ) {
-				$user_identifier = Rsvp_Setup::get_instance()->get_user_identifier();
-
-				$user_data = $event->rsvp->get( $user_identifier ) ?? array();
-			}
+			$user_identifier = Rsvp_Setup::get_instance()->get_user_identifier();
+			$user_data       = $rsvp->get( $user_identifier ) ?? array();
 
 			$filtered_data   = array_intersect_key(
 				$user_data,

--- a/includes/core/classes/commands/class-event-cli.php
+++ b/includes/core/classes/commands/class-event-cli.php
@@ -14,7 +14,7 @@ namespace GatherPress\Core\Commands;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-use GatherPress\Core\Event;
+use GatherPress\Core\Rsvp\Rsvp;
 use WP_CLI;
 
 /**
@@ -71,10 +71,9 @@ final class Event_Cli extends WP_CLI {
 		$guests    = ! empty( $assoc_args['guests'] ) ? (int) $assoc_args['guests'] : 0;
 		$anonymous = ! empty( $assoc_args['anonymous'] ) ? (int) $assoc_args['anonymous'] : 0;
 		$status    = ! empty( $assoc_args['status'] ) ? (string) $assoc_args['status'] : 'attending';
-		$event     = new Event( $event_id );
 
-		// Event::$rsvp stays null for a post that isn't an RSVP-capable event, so there is nothing to save.
-		if ( ! $event->rsvp ) {
+		// The error message names this support, so gate on it rather than on event dates.
+		if ( ! post_type_supports( (string) get_post_type( $event_id ), 'gatherpress-rsvp' ) ) {
 			self::error(
 				sprintf(
 					/* translators: %d: event ID. */
@@ -86,7 +85,7 @@ final class Event_Cli extends WP_CLI {
 			return; // @phpstan-ignore deadCode.unreachable
 		}
 
-		$response = $event->rsvp->save( $user_id, $status, $anonymous, $guests );
+		$response = ( new Rsvp( $event_id ) )->save( $user_id, $status, $anonymous, $guests );
 
 		self::success(
 			sprintf(

--- a/includes/core/classes/commands/class-event-cli.php
+++ b/includes/core/classes/commands/class-event-cli.php
@@ -14,7 +14,7 @@ namespace GatherPress\Core\Commands;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Rsvp;
 use WP_CLI;
 
 /**

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -165,14 +165,6 @@ class Event {
 	public ?WP_Post $post = null;
 
 	/**
-	 * RSVP instance.
-	 *
-	 * @since 0.34.0
-	 * @var Rsvp|null
-	 */
-	public ?Rsvp $rsvp = null;
-
-	/**
 	 * Cached datetime data.
 	 *
 	 * @since 0.34.0
@@ -193,7 +185,6 @@ class Event {
 	public function __construct( int $post_id ) {
 		if ( post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
 			$this->post = get_post( $post_id );
-			$this->rsvp = new Rsvp( $post_id );
 		}
 	}
 
@@ -910,12 +901,8 @@ class Event {
 		$force_online_event_link = apply_filters( 'gatherpress_force_online_event_link', false );
 
 		if ( ! $force_online_event_link && ! is_admin() ) {
-			if ( ! $this->rsvp ) {
-				return '';
-			}
-
 			$user_identifier = Rsvp_Setup::get_instance()->get_user_identifier();
-			$response        = $this->rsvp->get( $user_identifier );
+			$response        = ( new Rsvp( $this->post->ID ) )->get( $user_identifier );
 
 			if (
 				! isset( $response['status'] ) ||

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -761,10 +761,7 @@ final class Rest_Api {
 		$anonymous       = intval( $params['anonymous'] ?? 0 );
 		$unparsed_token  = sanitize_text_field( $params['rsvp_token'] ?? '' );
 		$event           = new Event( $post_id );
-
-		// Event only builds its Rsvp for a post type that carries event dates, which is what
-		// the route's post_id validation already requires.
-		$rsvp = $event->rsvp;
+		$rsvp            = new Rsvp( $post_id );
 
 		// If managing user is adding someone to an event.
 		$is_managing_other = false;
@@ -814,7 +811,6 @@ final class Rest_Api {
 		// A magic-link token supplies an email address; every other path supplies a user ID,
 		// so each identifier is checked against the one thing it can be.
 		if (
-			$rsvp &&
 			$user_identifier &&
 			(
 				is_string( $user_identifier )
@@ -842,7 +838,7 @@ final class Rest_Api {
 			'status'      => $status,
 			'guests'      => $guests,
 			'anonymous'   => $anonymous,
-			'responses'   => $rsvp ? $rsvp->responses() : array(),
+			'responses'   => $rsvp->responses(),
 			'online_link' => $event->maybe_get_online_event_link(),
 		);
 

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -414,12 +414,14 @@ final class Rsvp {
 	/**
 	 * Determines whether RSVP is enabled for this event.
 	 *
-	 * Returns false immediately when the sitewide mode is `disabled`.
-	 * Returns true when the mode is `enabled` (every event has RSVP).
-	 * In per-event modes (`per_event_enabled` or `per_event_disabled`), the
-	 * `gatherpress_enable_rsvp` post meta is consulted. An unset meta
-	 * (empty string) falls back to the mode default: `per_event_enabled`
-	 * defaults to enabled, `per_event_disabled` defaults to disabled.
+	 * A post type that does not declare `gatherpress-rsvp` never has RSVP
+	 * enabled, whatever the mode or the meta say. Beyond that: false when the
+	 * sitewide mode is `disabled`, true when the mode is `enabled` (every event
+	 * has RSVP). In per-event modes (`per_event_enabled` or
+	 * `per_event_disabled`), the `gatherpress_enable_rsvp` post meta is
+	 * consulted. An unset meta (empty string) falls back to the mode default:
+	 * `per_event_enabled` defaults to enabled, `per_event_disabled` defaults
+	 * to disabled.
 	 *
 	 * @since 0.35.0
 	 *
@@ -429,7 +431,10 @@ final class Rsvp {
 		$post_id   = $this->post->ID ?? 0;
 		$rsvp_mode = Settings::get_instance()->get( 'rsvp_mode' );
 
-		if ( 'disabled' === $rsvp_mode ) {
+		if (
+			'disabled' === $rsvp_mode
+			|| ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' )
+		) {
 			return false;
 		}
 

--- a/includes/templates/admin/emails/event-email.php
+++ b/includes/templates/admin/emails/event-email.php
@@ -15,6 +15,7 @@
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Event;
+use GatherPress\Core\Rsvp\Rsvp;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Venue;
 
@@ -89,7 +90,7 @@ $gatherpress_venue       = $gatherpress_event->get_venue_information()['name'];
 		<?php
 		if (
 			! $gatherpress_event->has_event_past()
-			&& $gatherpress_event->rsvp?->is_enabled()
+			&& ( new Rsvp( $event_id ) )->is_enabled()
 		) :
 			$gatherpress_rsvp_url = (string) get_the_permalink( $event_id );
 			?>

--- a/includes/templates/admin/emails/event-email.php
+++ b/includes/templates/admin/emails/event-email.php
@@ -15,7 +15,7 @@
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Event;
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Venue;
 

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-template.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-template.php
@@ -571,15 +571,15 @@ class Test_Rsvp_Template extends Base {
 		$post_id  = $post->ID;
 
 		// Get event and save an RSVP using the proper API.
-		$event   = new Event( $post_id );
+		$rsvp    = new Rsvp( $post_id );
 		$user_id = $this->factory->user->create();
 
 		// Save RSVP using the Event's RSVP system.
-		$event->rsvp->save( $user_id, 'attending', 0, 0 );
+		$rsvp->save( $user_id, 'attending', 0, 0 );
 
 		// Create one more RSVP.
 		$user_id_2 = $this->factory->user->create();
-		$event->rsvp->save( $user_id_2, 'attending', 0, 0 );
+		$rsvp->save( $user_id_2, 'attending', 0, 0 );
 
 		$wp_block = new WP_Block(
 			array(

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
@@ -10,7 +10,7 @@ namespace GatherPress\Tests\Core\Blocks;
 
 use GatherPress\Core\Blocks\Rsvp;
 use GatherPress\Core\Event;
-use GatherPress\Core\Rsvp\Rsvp as Core_Rsvp;
+use GatherPress\Core\Rsvp as Core_Rsvp;
 use GatherPress\Core\Event\Setup;
 use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
@@ -10,6 +10,7 @@ namespace GatherPress\Tests\Core\Blocks;
 
 use GatherPress\Core\Blocks\Rsvp;
 use GatherPress\Core\Event;
+use GatherPress\Core\Rsvp\Rsvp as Core_Rsvp;
 use GatherPress\Core\Event\Setup;
 use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
@@ -102,9 +103,9 @@ class Test_Rsvp extends Base {
 			)
 		);
 		$user     = $this->mock->user( true )->get();
-		$event    = new Event( $post_id );
+		$rsvp     = new Core_Rsvp( $post_id );
 
-		$save_result = $event->rsvp->save( $user->ID, 'attending' );
+		$save_result = $rsvp->save( $user->ID, 'attending' );
 
 		$block = array(
 			'blockName'   => 'gatherpress/rsvp-v2',

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -38,13 +38,11 @@ class Test_Event extends Base {
 		$event = new Event( $post->ID );
 
 		$this->assertNull( Utility::get_hidden_property( $event, 'post' ) );
-		$this->assertNull( Utility::get_hidden_property( $event, 'rsvp' ) );
 
 		$post  = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
 		$event = new Event( $post->ID );
 
 		$this->assertInstanceOf( WP_Post::class, Utility::get_hidden_property( $event, 'post' ) );
-		$this->assertInstanceOf( Rsvp::class, Utility::get_hidden_property( $event, 'rsvp' ) );
 	}
 
 	/**
@@ -996,7 +994,7 @@ class Test_Event extends Base {
 			'Failed to assert online event link is empty.'
 		);
 
-		$event->rsvp->save( $user_id, 'attending' );
+		( new Rsvp( $event_id ) )->save( $user_id, 'attending' );
 
 		$this->assertSame(
 			$link,
@@ -1020,13 +1018,6 @@ class Test_Event extends Base {
 		$this->assertEmpty(
 			$event->maybe_get_online_event_link(),
 			'Failed to assert online event link is empty.'
-		);
-
-		Utility::set_and_get_hidden_property( $event, 'rsvp', null );
-
-		$this->assertEmpty(
-			$event->maybe_get_online_event_link(),
-			'Failed to assert empty string due to RSVP being set to null.'
 		);
 	}
 
@@ -1369,7 +1360,6 @@ class Test_Event extends Base {
 		$event   = new Event( $post_id );
 
 		$this->assertNull( $event->post, 'Failed to assert post is null for non-event post.' );
-		$this->assertNull( $event->rsvp, 'Failed to assert rsvp is null for non-event post.' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -340,8 +340,8 @@ class Test_Rest_Api extends Base {
 			'not_attending' => false,
 		);
 
-		$event = new Event( $event_id );
-		$event->rsvp->save( $user_id, 'attending' );
+		$rsvp = new Rsvp( $event_id );
+		$rsvp->save( $user_id, 'attending' );
 
 		$this->assertFalse(
 			$instance->send_emails( $post_id, $send, $message ),
@@ -429,17 +429,17 @@ class Test_Rest_Api extends Base {
 		$event_id = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
-		$event    = new Event( $event_id );
+		$rsvp     = new Rsvp( $event_id );
 
 		// Create users and save RSVPs using the RSVP system.
 		$attending_user_id     = $this->factory->user->create();
 		$not_attending_user_id = $this->factory->user->create();
 
-		$event->rsvp->save( $attending_user_id, 'attending' );
-		$event->rsvp->save( $not_attending_user_id, 'not_attending' );
+		$rsvp->save( $attending_user_id, 'attending' );
+		$rsvp->save( $not_attending_user_id, 'not_attending' );
 
 		// Create anonymous attending RSVP.
-		$event->rsvp->save( 'attendee@example.com', 'attending', 1 );
+		$rsvp->save( 'attendee@example.com', 'attending', 1 );
 
 		$send = array(
 			'all'           => false,
@@ -496,10 +496,10 @@ class Test_Rest_Api extends Base {
 		$event_id = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
-		$event    = new Event( $event_id );
+		$rsvp     = new Rsvp( $event_id );
 
 		// Force no attendance so responses remain on waiting list.
-		Utility::set_and_get_hidden_property( $event->rsvp, 'max_attendance_limit', -1 );
+		Utility::set_and_get_hidden_property( $rsvp, 'max_attendance_limit', -1 );
 
 		// Create user RSVP.
 		$user_id = $this->factory->user->create(
@@ -508,7 +508,7 @@ class Test_Rest_Api extends Base {
 				'display_name' => 'User Name',
 			)
 		);
-		$event->rsvp->save( $user_id, 'waiting_list' );
+		$rsvp->save( $user_id, 'waiting_list' );
 
 		// Create anonymous RSVP using wp_insert_comment for better control.
 		$comment_id = wp_insert_comment(
@@ -522,7 +522,7 @@ class Test_Rest_Api extends Base {
 			)
 		);
 
-		$event->rsvp->save( 'anonymous@example.com', 'waiting_list' );
+		$rsvp->save( 'anonymous@example.com', 'waiting_list' );
 
 		$send = array(
 			'all'           => false,
@@ -755,8 +755,8 @@ class Test_Rest_Api extends Base {
 		// Approve the comment since rsvp->get() now only finds approved comments.
 		wp_set_comment_status( $data['comment_id'], 'approve' );
 
-		$event     = new Event( $post_id );
-		$rsvp_data = $event->rsvp->get( 'test@example.com' );
+		$rsvp      = new Rsvp( $post_id );
+		$rsvp_data = $rsvp->get( 'test@example.com' );
 
 		$this->assertNotEmpty( $rsvp_data['comment_id'] );
 
@@ -865,8 +865,8 @@ class Test_Rest_Api extends Base {
 		// Approve the comment since rsvp->get() now only finds approved comments.
 		wp_set_comment_status( $data['comment_id'], 'approve' );
 
-		$event     = new Event( $post_id );
-		$rsvp_data = $event->rsvp->get( $user_id );
+		$rsvp      = new Rsvp( $post_id );
+		$rsvp_data = $rsvp->get( $user_id );
 		$this->assertNotEmpty( $rsvp_data['comment_id'] );
 		$this->assertEquals( $user_id, $rsvp_data['user_id'] );
 	}
@@ -1095,8 +1095,8 @@ class Test_Rest_Api extends Base {
 
 		// Create an RSVP.
 		$user_id = $this->factory()->user->create();
-		$event   = new Event( $post_id );
-		$event->rsvp->save( $user_id, 'attending', 0, 1 );
+		$rsvp    = new Rsvp( $post_id );
+		$rsvp->save( $user_id, 'attending', 0, 1 );
 
 		$request = new WP_REST_Request( 'GET' );
 		$request->set_param( 'post_id', $post_id );
@@ -1147,8 +1147,8 @@ class Test_Rest_Api extends Base {
 
 		// Create an approved RSVP.
 		$user_id     = $this->factory()->user->create();
-		$event       = new Event( $post_id );
-		$user_record = $event->rsvp->save( $user_id, 'attending', 0, 1 );
+		$rsvp        = new Rsvp( $post_id );
+		$user_record = $rsvp->save( $user_id, 'attending', 0, 1 );
 
 		// Approve the comment.
 		wp_set_comment_status( $user_record['comment_id'], 'approve' );
@@ -1291,7 +1291,7 @@ class Test_Rest_Api extends Base {
 
 		// Create an RSVP with email.
 		$email       = 'test@example.com';
-		$user_record = $event->rsvp->save( $email, 'attending', 0, 0 );
+		$user_record = ( new Rsvp( $post_id ) )->save( $email, 'attending', 0, 0 );
 
 		// Generate token.
 		$rsvp_token = new Token( $user_record['comment_id'] );
@@ -1380,8 +1380,8 @@ class Test_Rest_Api extends Base {
 		// User opts out of event updates.
 		update_user_meta( $user_id, 'gatherpress_event_updates_opt_in', 0 );
 
-		$event = new Event( $event_id );
-		$event->rsvp->save( $user_id, 'attending' );
+		$rsvp = new Rsvp( $event_id );
+		$rsvp->save( $user_id, 'attending' );
 
 		$send = array(
 			'attending' => true,
@@ -1522,9 +1522,9 @@ class Test_Rest_Api extends Base {
 		$event_id = $this->mock->post(
 			array( 'post_type' => Event::POST_TYPE )
 		)->get()->ID;
-		$event    = new Event( $event_id );
+		$rsvp     = new Rsvp( $event_id );
 
-		$event->rsvp->save( 'attendee@example.com', 'attending', 1 );
+		$rsvp->save( 'attendee@example.com', 'attending', 1 );
 
 		// Append an unresolvable row to the RSVP lookup so a non-comment entry
 		// reaches the recipient loop.
@@ -1571,8 +1571,8 @@ class Test_Rest_Api extends Base {
 		// Opt in to updates.
 		update_user_meta( $user_id, 'gatherpress_event_updates_opt_in', 1 );
 
-		$event = new Event( $event_id );
-		$event->rsvp->save( $user_id, 'attending' );
+		$rsvp = new Rsvp( $event_id );
+		$rsvp->save( $user_id, 'attending' );
 
 		$send = array(
 			'attending' => true,
@@ -1717,8 +1717,8 @@ class Test_Rest_Api extends Base {
 
 		// Create a valid RSVP token.
 		$email       = 'test@example.com';
-		$event       = new Event( $post_id );
-		$user_record = $event->rsvp->save( $email, 'attending', 0, 0 );
+		$rsvp        = new Rsvp( $post_id );
+		$user_record = $rsvp->save( $email, 'attending', 0, 0 );
 
 		// Generate token.
 		$rsvp_token = new Token( $user_record['comment_id'] );
@@ -1758,7 +1758,7 @@ class Test_Rest_Api extends Base {
 			)
 		);
 
-		$user_record = ( new Event( $token_event ) )->rsvp->save( 'test@example.com', 'attending' );
+		$user_record = ( new Rsvp( $token_event ) )->save( 'test@example.com', 'attending' );
 		$rsvp_token  = new Token( $user_record['comment_id'] );
 		$rsvp_token->generate_token();
 		$token_str = sprintf( '%d_%s', $user_record['comment_id'], $rsvp_token->get_token() );
@@ -2199,11 +2199,11 @@ class Test_Rest_Api extends Base {
 			)
 		);
 
-		$event = new Event( $post_id );
+		$rsvp = new Rsvp( $post_id );
 
 		// Create non-user RSVP using email address.
 		$email   = 'nonuser@example.com';
-		$comment = $event->rsvp->save( $email, 'attending', 0, 0 );
+		$comment = $rsvp->save( $email, 'attending', 0, 0 );
 
 		// Set opt-in to '0' (opted out).
 		update_comment_meta( $comment['comment_id'], 'gatherpress_event_updates_opt_in', '0' );
@@ -2243,9 +2243,9 @@ class Test_Rest_Api extends Base {
 			)
 		);
 
-		$event = new Event( $post_id );
+		$rsvp  = new Rsvp( $post_id );
 		$email = 'recipient@example.test';
-		$event->rsvp->save( $email, 'attending', 0, 0 );
+		$rsvp->save( $email, 'attending', 0, 0 );
 
 		$captured = array();
 		add_filter(
@@ -2296,9 +2296,9 @@ class Test_Rest_Api extends Base {
 			)
 		);
 
-		$event = new Event( $post_id );
+		$rsvp  = new Rsvp( $post_id );
 		$email = 'recipient@example.test';
-		$event->rsvp->save( $email, 'attending', 0, 0 );
+		$rsvp->save( $email, 'attending', 0, 0 );
 
 		$captured = array();
 		add_filter(
@@ -2347,8 +2347,8 @@ class Test_Rest_Api extends Base {
 			)
 		);
 
-		$event = new Event( $post_id );
-		$event->rsvp->save( 'recipient@example.test', 'attending', 0, 0 );
+		$rsvp = new Rsvp( $post_id );
+		$rsvp->save( 'recipient@example.test', 'attending', 0, 0 );
 
 		add_filter(
 			'gatherpress_email_subject',
@@ -2403,8 +2403,8 @@ class Test_Rest_Api extends Base {
 			)
 		);
 
-		$event = new Event( $post_id );
-		$event->rsvp->save( 'recipient@example.test', 'attending', 0, 0 );
+		$rsvp = new Rsvp( $post_id );
+		$rsvp->save( 'recipient@example.test', 'attending', 0, 0 );
 
 		add_filter(
 			'gatherpress_email_subject',
@@ -2467,10 +2467,10 @@ class Test_Rest_Api extends Base {
 			)
 		);
 
-		$event = new Event( $post_id );
+		$rsvp = new Rsvp( $post_id );
 
 		// Create RSVP for the user.
-		$event->rsvp->save( $user_id, 'attending' );
+		$rsvp->save( $user_id, 'attending' );
 
 		$send = array( 'attending' => true );
 
@@ -2507,11 +2507,11 @@ class Test_Rest_Api extends Base {
 			)
 		);
 
-		$event = new Event( $post_id );
+		$rsvp = new Rsvp( $post_id );
 
 		// Create RSVP with valid email first.
 		$email   = 'test@example.com';
-		$comment = $event->rsvp->save( $email, 'attending', 0, 0 );
+		$comment = $rsvp->save( $email, 'attending', 0, 0 );
 
 		// Now remove the email to test the skip logic.
 		wp_update_comment(

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
@@ -88,7 +88,7 @@ class Test_Query extends Base {
 		);
 		$event    = new Event( $post->ID );
 
-		$event->rsvp->save( $user_id, 'attending' );
+		( new Rsvp( $post->ID ) )->save( $user_id, 'attending' );
 
 		$comment_query = new WP_Comment_Query(
 			array(

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
@@ -754,6 +754,26 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
+	 * Coverage for is_enabled method on a post type without RSVP support.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::is_enabled
+	 *
+	 * @return void
+	 */
+	public function test_is_enabled_without_rsvp_support(): void {
+		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+
+		Settings::get_instance()->set( 'rsvp_mode', 'enabled' );
+
+		$this->assertFalse(
+			( new Rsvp( $post_id ) )->is_enabled(),
+			'Should return false for a post type that does not support gatherpress-rsvp.'
+		);
+	}
+
+	/**
 	 * Test save method with email identifier.
 	 *
 	 * @covers ::save


### PR DESCRIPTION
Fixes #2156

## The support gate moved

`Event::__construct` built the RSVP object behind `gatherpress-event-date`, while the rest of the subsystem gates on `gatherpress-rsvp`. Two independently declarable supports, so it was wrong in both directions — dates-without-RSVP got a live `$event->rsvp` it had no use for, and RSVP-without-dates got `null`, where `! null` is `true` and every `$event->rsvp?->allows_open_rsvp()` took the "doesn't allow it" branch.

The gate now lives in `Rsvp::is_enabled()`:

```php
if (
    'disabled' === $rsvp_mode
    || ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' )
) {
    return false;
}
```

That is where the 15 sites already instantiating `Rsvp` directly were asking the question — and getting no support check at all, since only `initialize_enabled()` carried one. All sites now get the same answer from one place.

## Two guards were doing more than they looked

**`Event::maybe_get_online_event_link()`** — the issue flagged its `if ( ! $this->rsvp ) { return ''; }` as doubling for an "is this even an event" check. It turned out to be unreachable: both properties were assigned on the same constructor branch, so the `! $this->post` guard at the top of the method already covered it. Removed rather than replaced, along with the test that existed only to reach it.

**The WP-CLI command** — errored with *"does not exist or does not support RSVPs"* while actually testing for event dates. It now tests the support its message names, which also drops the `Event` object it only held to reach `->rsvp`.

## Remaining sites

`blocks/class-rsvp.php` already built a `Core_Rsvp` two lines above for its `is_enabled()` check, so the instance is hoisted and reused instead of the block constructing an `Event` to reach a second copy. `event/class-rest-api.php` takes `new Rsvp( $post_id )` and drops the two null guards that instance no longer needs. The email template swaps `$gatherpress_event->rsvp?->is_enabled()` for `( new Rsvp( $event_id ) )->is_enabled()` — same answer, and now with the support check behind it.

## Breaking change

`Event::$rsvp` was `public`. Anything outside the plugin reading `$event->rsvp` now gets an undefined-property warning and `null`. `$rsvp` shipped in 0.34.0 and never displaced direct instantiation internally, so the exposure is small, but it is real.

## Testing

- Full PHP suite green: 1768 tests, 7191 assertions
- Multisite suite green: 323 tests, 859 assertions
- PHPStan and PHPCS clean

New test covers the branch the gate adds: `is_enabled()` returns false on a post type without `gatherpress-rsvp`.