### PR TITLE
Import the aliased core classes by their short names

### DIFF
--- a/.github/changelog/import-aliased-class-short-names
+++ b/.github/changelog/import-aliased-class-short-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Import the five aliased core classes by their short GatherPress\Core names, and register the missing Calendar alias with PHPStan.

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -16,7 +16,7 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Event;
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_HTML_Tag_Processor;

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -13,7 +13,7 @@ namespace GatherPress\Core\Blocks;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Event;
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use WP_Comment;

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 use GatherPress\Core\Blocks\Form_Field;
 use GatherPress\Core\Blocks\General_Block;
 use GatherPress\Core\Event;
-use GatherPress\Core\Rsvp\Rsvp as Core_Rsvp;
+use GatherPress\Core\Rsvp as Core_Rsvp;
 use GatherPress\Core\Rsvp\Setup as Rsvp_Setup;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -14,7 +14,7 @@ namespace GatherPress\Core;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-use GatherPress\Core\Event\Event;
+use GatherPress\Core\Event;
 use GatherPress\Core\Traits\Singleton;
 
 /**

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -16,14 +16,14 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use DateTimeZone;
 use Exception;
-use GatherPress\Core\Calendar\Calendar;
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Calendar;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp\Setup as Rsvp_Setup;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Validate;
 use GatherPress\Core\Venue\Setup;
-use GatherPress\Core\Venue\Venue;
+use GatherPress\Core\Venue;
 use WP_Post;
 use WP_Term;
 

--- a/includes/core/classes/rsvp/response/class-serializer.php
+++ b/includes/core/classes/rsvp/response/class-serializer.php
@@ -12,7 +12,7 @@ namespace GatherPress\Core\Rsvp\Response;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Rsvp\Response\Identity_Type;
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Settings\Roles;
 use GatherPress\Core\Utility;
 

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -19,7 +19,7 @@ namespace GatherPress\Core\Venue;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-use GatherPress\Core\Event\Event;
+use GatherPress\Core\Event;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Shadow_Source;
 use GatherPress\Core\Starter_Pattern_Loader;

--- a/includes/core/classes/venue/map/class-rest-api.php
+++ b/includes/core/classes/venue/map/class-rest-api.php
@@ -18,7 +18,7 @@ namespace GatherPress\Core\Venue\Map;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
-use GatherPress\Core\Venue\Venue;
+use GatherPress\Core\Venue;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;

--- a/phpstan.stubs
+++ b/phpstan.stubs
@@ -49,6 +49,11 @@ namespace {
         class_alias( 'GatherPress\\Core\\Event\\Event', 'GatherPress\\Core\\Event' );
     }
 
+    if ( ! class_exists( 'GatherPress\\Core\\Calendar', false ) ) {
+        require_once __DIR__ . '/includes/core/classes/calendar/class-calendar.php';
+        class_alias( 'GatherPress\\Core\\Calendar\\Calendar', 'GatherPress\\Core\\Calendar' );
+    }
+
     if ( ! class_exists( 'GatherPress\\Core\\Rsvp', false ) ) {
         require_once __DIR__ . '/includes/core/classes/rsvp/class-rsvp.php';
         class_alias( 'GatherPress\\Core\\Rsvp\\Rsvp', 'GatherPress\\Core\\Rsvp' );

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-general-block.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-general-block.php
@@ -9,7 +9,7 @@
 namespace GatherPress\Tests\Core\Blocks;
 
 use GatherPress\Core\Blocks\General_Block;
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Utility;
 use GatherPress\Tests\Base;

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-response.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp-response.php
@@ -10,7 +10,7 @@ namespace GatherPress\Tests\Core\Blocks;
 
 use GatherPress\Core\Blocks\Rsvp_Response;
 use GatherPress\Core\Event;
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
 

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-cache.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-cache.php
@@ -9,7 +9,7 @@
 namespace GatherPress\Tests\Core\Calendar;
 
 use GatherPress\Core\Calendar\Cache;
-use GatherPress\Core\Event\Event;
+use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp\Response\Status;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -8,9 +8,9 @@
 
 namespace GatherPress\Tests\Core\Calendar;
 
-use GatherPress\Core\Calendar\Calendar;
+use GatherPress\Core\Calendar;
 use GatherPress\Core\Calendar\Setup;
-use GatherPress\Core\Event\Event;
+use GatherPress\Core\Event;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -9,7 +9,7 @@
 namespace GatherPress\Tests\Core\Calendar;
 
 use GatherPress\Core\Calendar\Setup;
-use GatherPress\Core\Event\Event;
+use GatherPress\Core\Event;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -11,7 +11,7 @@ namespace GatherPress\Tests\Core;
 use GatherPress\Core\Geocoding;
 use GatherPress\Core\Utility as GP_Utility;
 use GatherPress\Core\Venue\Meta as Venue_Meta;
-use GatherPress\Core\Venue\Venue;
+use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Mocks\Http;
 use PMC\Unit_Test\Utility;

--- a/test/unit/php/includes/tests/core/classes/class-test-shadow-source.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-shadow-source.php
@@ -9,7 +9,7 @@
 namespace GatherPress\Tests\Core;
 
 use GatherPress\Core\Shadow_Source;
-use GatherPress\Core\Venue\Venue;
+use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use WP_Post;
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -10,9 +10,11 @@ namespace GatherPress\Tests\Core\Event;
 
 use DateTime;
 use DateTimeZone;
+// Deep import on purpose: test_prior_fqn_resolves_to_current_class asserts
+// Event::class equals the real FQN, which the BC alias intentionally is not.
 use GatherPress\Core\Event\Event;
 use GatherPress\Core\Event\Setup as Event_Setup;
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-storage.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-storage.php
@@ -17,7 +17,7 @@ use GatherPress\Core\Rsvp\Response\Provider\Email;
 use GatherPress\Core\Rsvp\Response\Provider\User;
 use GatherPress\Core\Rsvp\Response\State;
 use GatherPress\Core\Rsvp\Response\Status;
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp\Storage;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;

--- a/test/unit/php/includes/tests/core/classes/rsvp/response/class-test-serializer.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/response/class-test-serializer.php
@@ -16,7 +16,7 @@ use GatherPress\Core\Rsvp\Response\Provider\User;
 use GatherPress\Core\Rsvp\Response\Serializer;
 use GatherPress\Core\Rsvp\Response\State;
 use GatherPress\Core\Rsvp\Response\Status;
-use GatherPress\Core\Rsvp\Rsvp;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Settings\Roles;
 use GatherPress\Tests\Base;
 

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-meta.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-meta.php
@@ -9,7 +9,7 @@
 namespace GatherPress\Tests\Core\Venue;
 
 use GatherPress\Core\Venue\Meta;
-use GatherPress\Core\Venue\Venue;
+use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-venue.php
@@ -13,6 +13,8 @@
 namespace GatherPress\Tests\Core\Venue;
 
 use GatherPress\Core\Venue\Meta;
+// Deep import on purpose: test_prior_fqn_resolves_to_current_class asserts
+// Venue::class equals the real FQN, which the BC alias intentionally is not.
 use GatherPress\Core\Venue\Venue;
 use GatherPress\Tests\Base;
 use ReflectionClass;

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-map-dimensions.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-map-dimensions.php
@@ -18,7 +18,7 @@ namespace GatherPress\Tests\Core\Venue\Map;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Dimensions;
-use GatherPress\Core\Venue\Venue;
+use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 
 /**

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-prewarm.php
@@ -11,7 +11,7 @@ namespace GatherPress\Tests\Core\Venue\Map;
 use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Prewarm;
 use GatherPress\Core\Venue\Setup;
-use GatherPress\Core\Venue\Venue;
+use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 

--- a/test/unit/php/includes/tests/core/classes/venue/map/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/class-test-rest-api.php
@@ -13,9 +13,9 @@
 
 namespace GatherPress\Tests\Core\Venue\Map;
 
-use GatherPress\Core\Venue\Map\Map;
+use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Rest_Api;
-use GatherPress\Core\Venue\Venue;
+use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 
 /**


### PR DESCRIPTION
Follow-up to the import discussion on [#2191](https://github.com/GatherPress/gatherpress/pull/2191).

`Event`, `Rsvp`, `Venue`, `Calendar` and `Venue\Map` each resolve under two names — the subnamespace FQN, and the shorter `GatherPress\Core\X` that [register-class-aliases.php](includes/core/register-class-aliases.php) provides. The tree used both, roughly eight files on the short form against five on the deep one, with no rule separating them. This settles on the short form everywhere.

26 imports across 24 files.

## Three deep imports stay

`test_prior_fqn_resolves_to_current_class` (Event, Rsvp, Venue) asserts that `X::class` is the real FQN and specifically *not* the alias:

```php
$reflection = new ReflectionClass( 'GatherPress\Core\Rsvp' );
$this->assertSame( Rsvp::class, $reflection->getName() );
```

`ReflectionClass` resolves the alias, so `getName()` returns the canonical name. Converting the import would make `Rsvp::class` the alias and flip a real assertion into a failing comparison against the one value it exists to distinguish. The Rsvp test already carried a note explaining this; Event and Venue now do too.

Everything else converts safely — `instanceof` and `assertInstanceOf` treat an alias and its target as the same class, so only identity comparisons on the name string were at risk, and those are the three above.

## A gap this surfaced

`phpstan.stubs` mirrors the runtime alias map so PHPStan can resolve the short names. It had four of the five entries — `Calendar` was missing. Nothing noticed while no file in `includes/` imported `GatherPress\Core\Calendar`; the first one to do so failed with:

```
class-event.php:725  Instantiated class GatherPress\Core\Calendar not found.
```

Added, which puts the stub back in step with `register-class-aliases.php`.

## Testing

- Full PHP suite green: 1767 tests, 7194 assertions
- Multisite green: 323 tests, 859 assertions
- PHPStan and PHPCS clean

Pure import churn otherwise — no behavior change.