### PR TITLE
Add 0.36.0-alpha.0 credits, and port 0.35.2's to develop

### DIFF
--- a/.github/scripts/release/credits/0.35.2.json
+++ b/.github/scripts/release/credits/0.35.2.json
@@ -1,0 +1,24 @@
+{
+    "leads": [
+        "mauteri",
+        "patricia70"
+    ],
+    "noteworthy": [
+        "hrmervin",
+        "jmarx75",
+        "carstenbach",
+        "supernovia",
+        "matthewneilcowan",
+        "motylanogha"
+    ],
+    "contributors": [
+        "andremenrath",
+        "bor0",
+        "linewebdigital",
+        "w3lld1",
+        "fahimmurshed",
+        "lheroorg",
+        "puvaanraaj2001",
+        "vanyukov"
+    ]
+}

--- a/.github/scripts/release/credits/0.36.0-alpha.0.json
+++ b/.github/scripts/release/credits/0.36.0-alpha.0.json
@@ -1,0 +1,24 @@
+{
+    "leads": [
+        "mauteri",
+        "patricia70"
+    ],
+    "noteworthy": [
+        "hrmervin",
+        "jmarx75",
+        "carstenbach",
+        "supernovia",
+        "matthewneilcowan",
+        "motylanogha"
+    ],
+    "contributors": [
+        "andremenrath",
+        "bor0",
+        "linewebdigital",
+        "w3lld1",
+        "fahimmurshed",
+        "lheroorg",
+        "puvaanraaj2001",
+        "vanyukov"
+    ]
+}


### PR DESCRIPTION
Prerequisite for bumping develop to `0.36.0-alpha.0` (#2166). The Version Bump workflow refuses a version with no credits file.

Two files:

**`0.35.2.json`** — landed on `main` only, the way patch-release credits files do, so develop never got it. This is the same loose end we closed for 0.35.1 after that release.

**`0.36.0-alpha.0.json`** — seeded from 0.35.2, since that is the most recent roster. It carries Mariusz Szatkowski's promotion to noteworthy and Anton Vanyukov's credit, both of which happened after 0.35.1.

## The fold this sets up

`credits/unreleased.json` still queues `motylanogha` for promotion, which 0.35.2 already performed. Seeding from 0.35.2 rather than 0.35.1 means that queued entry deduplicates away instead of double-listing him. Dry-run of what the bump will fold:

```
promote to noteworthy: (none - already promoted in 0.35.2)
add as contributors:   faisalahammad, raicem
```

`carstenbach`, `matthewneilcowan` and `vanyukov` are in the pending list but already credited, so they dedupe out.

No code change.