### PR TITLE
Refuse to release a cycle-marker tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,20 @@ jobs:
       version: ${{ steps.context.outputs.version }}
       is_prerelease: ${{ steps.context.outputs.is_prerelease }}
     steps:
+      - name: Reject the cycle marker
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          # `-alpha.0` is the marker set on develop right after a release so
+          # the branch stops advertising the version that just shipped. It is
+          # not a build: nothing should reach the Releases tab or wp.org under
+          # it. Pre-release numbering starts at .1, so no suffix ending in .0
+          # is ever a real build.
+          if [[ "${VERSION}" =~ -(alpha|beta|rc)\.0$ ]]; then
+            echo "::error::'${VERSION}' is a cycle marker, not a release. Delete the tag; pre-releases start at .1."
+            exit 1
+          fi
+
       - name: Classify tag
         id: context
         run: |


### PR DESCRIPTION
The `-alpha.0` marker exists to *reduce* confusion about which line develop is on. It should never reach the Releases tab or wp.org.

Until now that was convention, not enforcement. The tag filter matches it:

```yaml
tags:
  - '[0-9]+.[0-9]+.[0-9]+'
  - '[0-9]+.[0-9]+.[0-9]+-*'
```

`0.36.0-alpha.0` matches the second pattern, so a stray `git push origin 0.36.0-alpha.0` would have built a zip and created a GitHub pre-release. wp.org was never at risk, since that step is already gated on `is_prerelease == 'false'`, but a Releases-tab entry for a version that only exists as a marker is exactly the wrong outcome.

A new first step in `prepare` fails the run before anything is built:

```
::error::'0.36.0-alpha.0' is a cycle marker, not a release. Delete the tag; pre-releases start at .1.
```

Covers `-beta.0` and `-rc.0` as well. Pre-release numbering starts at `.1` for every suffix, so nothing ending in `.0` is ever a real build.

| tag | result |
| --- | --- |
| `0.36.0-alpha.0` | blocked |
| `0.36.0-beta.0` | blocked |
| `0.36.0-alpha.1` | releases |
| `0.36.0` | releases |

Related: [#2166](https://github.com/GatherPress/gatherpress/issues/2166), [#2197](https://github.com/GatherPress/gatherpress/pull/2197).