### PR TITLE
fix(a11y): raise email button and RSVP heading contrast

### DIFF
--- a/.github/changelog/2091-wcag-contrast-colors
+++ b/.github/changelog/2091-wcag-contrast-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Raise the color contrast of the RSVP buttons in event notification and token confirmation emails to pass WCAG AA, and let the success heading in the standard RSVP form inherit the theme's heading color instead of a hardcoded green that failed contrast on white backgrounds.

--- a/includes/templates/admin/emails/event-email.php
+++ b/includes/templates/admin/emails/event-email.php
@@ -95,7 +95,7 @@ $gatherpress_venue       = $gatherpress_event->get_venue_information()['name'];
 			$gatherpress_rsvp_url = (string) get_the_permalink( $event_id );
 			?>
 			<div style="text-align: center; margin-top: 20px;">
-				<a href="<?php echo esc_url( $gatherpress_rsvp_url ); ?>" style="background-color: #007bff; color: #ffffff; padding: 12px 20px; text-decoration: none; border-radius: 4px; font-weight: bold;">
+				<a href="<?php echo esc_url( $gatherpress_rsvp_url ); ?>" style="background-color: #0a58ca; color: #ffffff; padding: 12px 20px; text-decoration: none; border-radius: 4px; font-weight: bold; font-size: 16px;">
 					<?php esc_html_e( 'RSVP Now', 'gatherpress' ); ?>
 				</a>
 			</div>

--- a/includes/templates/admin/emails/rsvp-token-confirmation.php
+++ b/includes/templates/admin/emails/rsvp-token-confirmation.php
@@ -52,7 +52,7 @@ $gatherpress_venue       = $gatherpress_event->get_venue_information()['name'];
 
 			<div style="text-align: center; margin: 30px 0;">
 				<?php // phpcs:disable Generic.Files.LineLength.TooLong ?>
-				<a href="<?php echo esc_url( $token_url ); ?>" style="background-color: #3498db; color: white; padding: 12px 24px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">
+				<a href="<?php echo esc_url( $token_url ); ?>" style="background-color: #0a58ca; color: #ffffff; padding: 12px 24px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold; font-size: 16px;">
 				<?php // phpcs:enable Generic.Files.LineLength.TooLong ?>
 					<?php esc_html_e( 'Confirm My RSVP', 'gatherpress' ); ?>
 				</a>

--- a/src/blocks/rsvp-form/templates/standard-rsvp-form.js
+++ b/src/blocks/rsvp-form/templates/standard-rsvp-form.js
@@ -34,9 +34,6 @@ const STANDARD_RSVP_FORM_TEMPLATE = [
 						typography: {
 							fontWeight: '600',
 						},
-						color: {
-							text: '#16a085',
-						},
 					},
 				},
 			],


### PR DESCRIPTION
Fixes #2091

## Proposed changes:

Three hardcoded colors failed WCAG 2.2 SC 1.4.3 (4.5:1 for normal-size text):

- Event email "RSVP Now" button: white on `#007bff` (3.98:1)
- Token confirmation "Confirm My RSVP" button: white on `#3498db` (3.15:1)
- Standard RSVP form success heading: `#16a085` on white (3.28:1)

This PR darkens both email buttons to the same accessible blue, `#0a58ca` (white text now 6.44:1), and declares an explicit `font-size: 16px` on them so contrast no longer depends on client-default sizing. The success heading drops its hardcoded green entirely and inherits the theme heading color instead, which also makes it robust on dark-background themes.

The heading color removal only affects newly inserted RSVP form patterns; existing posts keep the old value baked into their saved content.

- [x] Have you written new tests for your changes, if applicable?

No new tests needed: no existing tests assert these colors (verified by search across PHP/JS/E2E suites) and templates are render-only markup; lint, PHPStan, build, and a CodeRabbit review all pass.

## Testing instructions:

* Go to an event with RSVP enabled and send yourself the event notification email.
* Confirm the "RSVP Now" button background is the darker blue `#0a58ca`.
* Enable anonymous RSVP, submit the RSVP form logged out, open the confirmation email.
* Confirm the "Confirm My RSVP" button background is `#0a58ca`.
* Insert the RSVP Form block into a fresh post, pick the standard pattern.
* Confirm the "Thank you for your RSVP!" heading has no inline color and follows the theme heading color.
* Optional: check `#ffffff` on `#0a58ca` in a contrast checker, expect 6.44:1.

### Credit (for release notes)

My WordPress.org username: faisal03

### Changelog entry

A changelog entry is included in this PR at `.github/changelog/2091-wcag-contrast-colors`, so the automatic workflow is not needed.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>