### PR TITLE
Add i18n src-to-build translation mapping

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -66,6 +66,9 @@ docs
 wp-cron.sh
 patches
 
+# Generated translations (npm run i18n); only the pot ships.
+languages/map.json
+
 # Miscellaneous and SQL Archives
 behat.yml
 bitbucket-pipelines.yml

--- a/.github/changelog/2011-i18n-src-to-build-map
+++ b/.github/changelog/2011-i18n-src-to-build-map
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Ship a src-referenced translation template and correctly named JSON translation files with each release zip, so translators see readable source lines instead of minified build paths.

--- a/.github/scripts/i18n/build-map.js
+++ b/.github/scripts/i18n/build-map.js
@@ -1,0 +1,291 @@
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+// The project webpack config spreads the default config's entries, and the
+// default only exports the two-config array when the modules flag is set
+// (the same flag `npm run build` passes). Setting it here lets this script
+// require the real config instead of duplicating its entry list.
+process.env.WP_EXPERIMENTAL_MODULES = '1';
+
+/**
+ * WordPress dependencies
+ */
+const projectConfig = require( path.resolve( process.cwd(), 'webpack.config.js' ) );
+
+/**
+ * Generates the src-to-build file map used by `wp i18n make-json --use-map`.
+ *
+ * The translation POT is extracted from `src/` so its references stay readable,
+ * but WordPress loads translations for `build/` script paths at runtime. This
+ * script bridges the two by deriving the mapping from the same webpack entry
+ * points the build uses, then following static imports to find every bundled
+ * source file, so it never has to be maintained by hand.
+ *
+ * Output goes to stdout as a JSON object keyed by source path. Values are
+ * arrays because webpack bundles shared modules into every entry that imports
+ * them, and `wp i18n make-json` emits one Jed JSON per build path:
+ * { "src/blocks/rsvp/edit.js": [ "build/blocks/rsvp/index.js" ] }.
+ *
+ * @since 0.36.0
+ */
+
+/**
+ * Collects the entry points of the classic webpack config.
+ *
+ * Mirrors how `npm run build` resolves entries: the project's webpack.config.js
+ * spreads the default `script` config's entries and adds its own.
+ *
+ * @since 0.36.0
+ *
+ * @return {Object<string, string>} Entry names mapped to absolute source paths.
+ */
+function getEntries() {
+	const configs = Array.isArray( projectConfig )
+		? projectConfig
+		: [ projectConfig ];
+
+	const scriptConfig =
+		configs.find(
+			( config ) => ! config.experiments?.outputModule
+		) ?? configs[ 0 ];
+
+	return typeof scriptConfig.entry === 'function'
+		? scriptConfig.entry()
+		: scriptConfig.entry;
+}
+
+/**
+ * Collects PHP render files copied verbatim from src to build.
+ *
+ * The block build copies `render.php` next to each block's build output without
+ * touching the code inside, so a translation reference in `src/.../render.php`
+ * resolves to the identical file under `build/`.
+ *
+ * @since 0.36.0
+ *
+ * @return {string[]} Source paths of render files that exist in both trees.
+ */
+function getRenderFiles() {
+	const srcBlocks = path.resolve( process.cwd(), 'src', 'blocks' );
+	const buildBlocks = path.resolve( process.cwd(), 'build', 'blocks' );
+
+	if ( ! fs.existsSync( srcBlocks ) || ! fs.existsSync( buildBlocks ) ) {
+		return [];
+	}
+
+	return fs
+		.readdirSync( srcBlocks )
+		.flatMap( ( block ) => {
+			const srcFile = path.join( srcBlocks, block, 'render.php' );
+			const buildFile = path.join( buildBlocks, block, 'render.php' );
+
+			if ( ! fs.existsSync( srcFile ) || ! fs.existsSync( buildFile ) ) {
+				return [];
+			}
+
+			return [ srcFile ];
+		} );
+}
+
+/**
+ * Resolves a static import specifier against the importing file.
+ *
+ * Handles the shapes this codebase uses: extension-less relative paths,
+ * explicit .js extensions, and directory imports resolving to index.js.
+ * Package imports and stylesheets return null; they contain no plugin
+ * translatable strings worth mapping.
+ *
+ * @param {string} specifier Raw import path as written in the source.
+ * @param {string} importer  Absolute path of the file doing the importing.
+ * @since 0.36.0
+ *
+ * @return {string|null} Absolute resolved path, or null when unresolvable.
+ */
+function resolveImport( specifier, importer ) {
+	if ( ! specifier.startsWith( '.' ) && ! specifier.startsWith( '/' ) ) {
+		return null;
+	}
+
+	const base = path.resolve( path.dirname( importer ), specifier );
+	const candidates = [
+		base,
+		`${ base }.js`,
+		path.join( base, 'index.js' ),
+	];
+
+	return candidates.find( ( candidate ) => fs.existsSync( candidate ) && fs.statSync( candidate ).isFile() ) ?? null;
+}
+
+/**
+ * Extracts relative import specifiers from a module's source text.
+ *
+ * Matches static imports and re-exports (`import x from '...'`,
+ * `import '...'`, `export { y } from '...'`). Dynamic `import()` calls are out
+ * of scope: they become separate async chunks under --experimental-modules,
+ * which carry no statically extractable strings.
+ *
+ * @param {string} filePath Path of the module to scan.
+ * @since 0.36.0
+ *
+ * @return {string[]} Import specifiers found in the file.
+ */
+function getImportSpecifiers( filePath ) {
+	const contents = fs.readFileSync( filePath, 'utf8' );
+	const pattern = /(?:import|export)[^;'"]*?from\s*['"]([^'"]+)['"]|import\s*['"]([^'"]+)['"]/g;
+	const specifiers = [];
+
+	let match = pattern.exec( contents );
+
+	while ( match ) {
+		specifiers.push( match[ 1 ] || match[ 2 ] );
+		match = pattern.exec( contents );
+	}
+
+	return specifiers;
+}
+
+/**
+ * Walks an entry's static import graph and returns every reachable src file.
+ *
+ * @param {string} entryPath Absolute path of the entry module.
+ * @since 0.36.0
+ *
+ * @return {Set<string>} Absolute paths of all modules reachable via static imports, including the entry itself.
+ */
+function collectBundledModules( entryPath ) {
+	const visited = new Set();
+	const queue = [ entryPath ];
+
+	while ( queue.length > 0 ) {
+		const current = queue.pop();
+
+		if ( visited.has( current ) ) {
+			continue;
+		}
+		visited.add( current );
+
+		for ( const specifier of getImportSpecifiers( current ) ) {
+			const resolved = resolveImport( specifier, current );
+
+			// Stylesheets resolve but carry no JavaScript strings, and the
+			// extractor never references them, so the walk stops there.
+			if ( resolved && resolved.endsWith( '.js' ) ) {
+				queue.push( resolved );
+			}
+		}
+	}
+
+	return visited;
+}
+
+/**
+ * Converts an absolute path to a repo-relative POSIX path.
+ *
+ * @param {string} absolutePath Absolute filesystem path.
+ * @since 0.36.0
+ *
+ * @return {string} Path relative to the repo root with forward slashes.
+ */
+function toRelative( absolutePath ) {
+	return path.relative( process.cwd(), absolutePath ).split( path.sep ).join( '/' );
+}
+
+/**
+ * Lists JavaScript files under a directory.
+ *
+ * @param {string} dir Directory to scan recursively.
+ * @since 0.36.0
+ *
+ * @return {string[]} Absolute paths of .js files.
+ */
+function listJsFiles( dir ) {
+	const files = [];
+
+	for ( const entry of fs.readdirSync( dir, { withFileTypes: true } ) ) {
+		const fullPath = path.join( dir, entry.name );
+
+		if ( entry.isDirectory() ) {
+			files.push( ...listJsFiles( fullPath ) );
+		} else if ( entry.isFile() && entry.name.endsWith( '.js' ) ) {
+			files.push( fullPath );
+		}
+	}
+
+	return files;
+}
+
+/**
+ * Lists repo-relative script paths emitted by a previous webpack run.
+ *
+ * @param {string} dir Build directory to scan recursively.
+ * @since 0.36.0
+ *
+ * @return {Set<string>} Paths like "build/panels.js"; empty when no build exists yet.
+ */
+function listBuildScripts( dir ) {
+	if ( ! fs.existsSync( dir ) ) {
+		return new Set();
+	}
+
+	const scripts = [];
+
+	for ( const file of listJsFiles( dir ) ) {
+		const relativePath = toRelative( file );
+
+		// Asset manifests and module chunks aside, only plain .js outputs
+		// correspond one to one with entry names.
+		if ( relativePath.endsWith( '.js' ) && ! relativePath.endsWith( '.module.js' ) ) {
+			scripts.push( relativePath );
+		}
+	}
+
+	return new Set( scripts );
+}
+
+const entries = getEntries();
+const map = {};
+
+// Every module a JS entry pulls in ends up inside that entry's build output,
+// so each maps to `build/<name>.js`. Shared components appear under every
+// entry that imports them; make-json accepts the array and writes one JSON per
+// build path.
+//
+// Some declared entries emit no JavaScript at all: .scss entries produce only
+// CSS, and stylesheet-only anchors like the Leaflet one lose their empty JS
+// bundle to RemoveEmptyScriptsPlugin. When a previous build output exists, its
+// emitted scripts are the source of truth for which targets are real, so keys
+// pointing at nothing get dropped rather than producing dangling JSON names.
+const emittedScripts = new Set(
+	listBuildScripts( path.resolve( process.cwd(), 'build' ) )
+);
+
+for ( const [ name, srcPath ] of Object.entries( entries ) ) {
+	if ( ! srcPath.endsWith( '.js' ) ) {
+		continue;
+	}
+
+	const buildPath = `build/${ name }.js`;
+
+	if ( emittedScripts.size > 0 && ! emittedScripts.has( buildPath ) ) {
+		continue;
+	}
+
+	for ( const modulePath of collectBundledModules( srcPath ) ) {
+		const key = toRelative( modulePath );
+
+		map[ key ] = map[ key ] ?? [];
+		map[ key ].push( buildPath );
+	}
+}
+
+// render.php files are copied unchanged, so src and build paths mirror each other.
+for ( const srcFile of getRenderFiles() ) {
+	map[ toRelative( srcFile ) ] = [
+		toRelative( srcFile ).replace( /^src\//, 'build/' ),
+	];
+}
+
+process.stdout.write( JSON.stringify( map, null, 2 ) + '\n' );

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,14 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          # WP-CLI backs `npm run i18n` (make-pot / make-json); it is not on
+          # the ubuntu-latest image, so install it here alongside composer.
+          tools: composer, wp-cli
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -325,16 +333,22 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          node-version-file: .nvmrc
-          cache: npm
+          php-version: '8.1'
+          # WP-CLI backs `npm run i18n` (make-pot / make-json); it is not on
+          # the ubuntu-latest image, so install it here alongside composer.
+          tools: composer, wp-cli
 
       - name: Build production assets
+        # i18n generates languages/gatherpress.pot from src/ references; the
+        # 10up deploy action honors .distignore, which ships the pot but not
+        # the intermediate map.
         run: |
           npm ci
           npm run build
+          npm run i18n
 
       - name: WordPress.org Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
@@ -374,6 +388,14 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          # WP-CLI backs `npm run i18n` (make-pot / make-json); it is not on
+          # the ubuntu-latest image, so install it here.
+          tools: wp-cli
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -381,9 +403,12 @@ jobs:
           cache: npm
 
       - name: Build production assets
+        # Same rationale as the stable deploy: the pot must exist before
+        # rsync so trunk (and GlotPress, which scans deployed code) sees it.
         run: |
           npm ci
           npm run build
+          npm run i18n
 
       # The GitHub-hosted Ubuntu images no longer ship Subversion, so the
       # deploy step below dies with `svn: command not found` (exit 127)

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ coverage.xml
 .wp-env.override.json
 mu-plugins/
 
+# Generated translations (npm run i18n) #
+#########################################
+languages/
+
 # Playwright #
 ##########
 artifacts/

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -95,6 +95,8 @@ final class Setup {
 		register_activation_hook( GATHERPRESS_CORE_FILE, array( $this, 'activate_gatherpress_plugin' ) );
 		register_deactivation_hook( GATHERPRESS_CORE_FILE, array( $this, 'deactivate_gatherpress_plugin' ) );
 
+		add_action( 'init', array( $this, 'load_textdomain' ) );
+
 		add_action( 'admin_init', array( $this, 'check_plugin_version' ) );
 		add_action( 'admin_init', array( $this, 'add_privacy_policy_content' ) );
 		add_action( 'admin_notices', array( $this, 'check_gatherpress_alpha' ) );
@@ -148,6 +150,27 @@ final class Setup {
 					'">' . esc_html__( 'Settings', 'gatherpress' ) . '</a>',
 			),
 			$actions
+		);
+	}
+
+	/**
+	 * Load the plugin text domain.
+	 *
+	 * Registers `languages/` inside the plugin folder as an additional
+	 * translation source. On WordPress.org-hosted installs core already loads
+	 * translations automatically, but self-hosted distributions (the GitHub
+	 * release zip) and tools like Loco Translate rely on this call to find the
+	 * shipped pot and any locally generated mo files.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return void
+	 */
+	public function load_textdomain(): void {
+		load_plugin_textdomain(
+			'gatherpress',
+			false,
+			dirname( plugin_basename( GATHERPRESS_CORE_FILE ) ) . '/languages'
 		);
 	}
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
 	"files": [
 		"build",
 		"includes",
+		"languages",
+		"!languages/map.json",
 		"gatherpress.php",
 		"CHANGELOG.md",
 		"SECURITY.md"
@@ -105,6 +107,8 @@
 		"check-engines": "wp-scripts check-engines",
 		"check-licenses": "wp-scripts check-licenses",
 		"format": "wp-scripts format",
+		"i18n": "npm run i18n:pot && node .github/scripts/i18n/build-map.js > languages/map.json && wp i18n make-json languages --use-map=languages/map.json --no-purge",
+		"i18n:pot": "mkdir -p languages && wp i18n make-pot . languages/gatherpress.pot --exclude=node_modules,vendor,build,test,docs,patches,.github,languages --domain=gatherpress",
 		"lint:css": "wp-scripts lint-style",
 		"lint:css:fix": "wp-scripts lint-style --fix",
 		"lint:js": "wp-scripts lint-js",
@@ -117,7 +121,7 @@
 		"lint:phpstan": "vendor/bin/phpstan analyze -vv --memory-limit=2G",
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
 		"packages-update": "wp-scripts packages-update",
-		"plugin-zip": "npm run build && wp-scripts plugin-zip",
+		"plugin-zip": "npm run build && npm run i18n && wp-scripts plugin-zip",
 		"start": "wp-scripts start --experimental-modules",
 		"version:bump": "php .github/scripts/release/generate-version.php",
 		"screenshots:docs": "WP_BASE_URL='http://127.0.0.1:9400/' wp-scripts test-playwright --config .github/scripts/docs-screenshots/playwright.config.ts",

--- a/test/unit/php/includes/tests/core/classes/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-setup.php
@@ -38,6 +38,12 @@ class Test_Setup extends Base {
 		$hooks    = array(
 			array(
 				'type'     => 'action',
+				'name'     => 'init',
+				'priority' => 10,
+				'callback' => array( $instance, 'load_textdomain' ),
+			),
+			array(
+				'type'     => 'action',
 				'name'     => 'admin_init',
 				'priority' => 10,
 				'callback' => array( $instance, 'check_plugin_version' ),
@@ -541,6 +547,60 @@ class Test_Setup extends Base {
 		$this->assertTrue(
 			true,
 			'The smash_table method should execute without error.'
+		);
+	}
+
+	/**
+	 * Coverage for load_textdomain method.
+	 *
+	 * Verifies that calling the method registers the plugin's languages
+	 * directory in the text domain registry, so WordPress looks there for
+	 * the shipped pot and locally generated mo files on self-hosted installs.
+	 *
+	 * @covers ::load_textdomain
+	 *
+	 * @return void
+	 */
+	public function test_load_textdomain_registers_domain(): void {
+		global $wp_textdomain_registry;
+
+		$instance = Setup::get_instance();
+
+		$instance->load_textdomain();
+
+		$expected_path = WP_PLUGIN_DIR . '/' . dirname( plugin_basename( GATHERPRESS_CORE_FILE ) ) . '/languages/';
+
+		$this->assertSame(
+			$expected_path,
+			$wp_textdomain_registry->get( 'gatherpress', determine_locale() ),
+			'The gatherpress text domain should point at the plugin languages directory.'
+		);
+	}
+
+	/**
+	 * Coverage for the init wiring of load_textdomain.
+	 *
+	 * Firing init end to end proves the hook registered by setup_hooks is
+	 * what populates the registry, not just that the method works in
+	 * isolation.
+	 *
+	 * @covers ::setup_hooks
+	 * @covers ::load_textdomain
+	 *
+	 * @return void
+	 */
+	public function test_load_textdomain_fires_on_init(): void {
+		global $wp_textdomain_registry;
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Testing WordPress core hook.
+		do_action( 'init' );
+
+		$expected_path = WP_PLUGIN_DIR . '/' . dirname( plugin_basename( GATHERPRESS_CORE_FILE ) ) . '/languages/';
+
+		$this->assertSame(
+			$expected_path,
+			$wp_textdomain_registry->get( 'gatherpress', determine_locale() ),
+			'Firing init should register the gatherpress languages directory.'
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #2011

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Adds i18n tooling so every release zip ships a translation template with readable source references and correctly named JSON translation files.

- New `npm run i18n` script generates `languages/gatherpress.pot` with references pointing at `src/` files (build output is excluded from extraction), so translators see real source lines instead of minified build paths.
- New `.github/scripts/i18n/build-map.js` derives a src-to-build path map automatically from `webpack.config.js` entries plus a static import walk. Nothing is maintained by hand; adding a block or component updates the map on the next run.
- `wp i18n make-json --use-map` then splits translations into per-script JSON files whose names hash-match the actual `build/` script paths WordPress looks up at runtime in `load_script_translation_file()`.
- `npm run plugin-zip` runs the i18n step, and the wp.org deploy jobs in `release.yml` generate the pot before rsync so SVN trunk (and GlotPress) sees it. WP-CLI is installed in those jobs since `wp` is not on the runner image.
- New `Setup::load_textdomain()` hooked on `init` registers the plugin's own `languages/` directory, so self-hosted installs (GitHub zip) and tools like Loco Translate can find the shipped template and locally generated translations.
- The intermediate `languages/map.json` is excluded from both distribution paths (`package.json` files field, `.distignore`), and `languages/` is gitignored like `build/`.

One honest limit: this cannot change what translate.wordpress.org itself indexes from the deployed SVN code. What it does fix is every self-hosted and local translator path, and it ships a correct src-referenced POT with each zip.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

New tests in `class-test-setup.php` cover the `init` hook registration and the textdomain registry path.

## Testing instructions:
<!-- If you were reviewing this PR, how would like the instructions to be presented? -->

1. Run `npm run i18n`.
2. Result: no errors. `Success:` from make-json may say `Created 0 files.` while only the `.pot` template exists; that is expected. JSON files appear per locale once translated `.po` files are present.
3. Run `grep -c "src/" languages/gatherpress.pot` and `grep -c "build/" languages/gatherpress.pot`.
4. Result: hundreds of src references, zero build references.
5. Run `node .github/scripts/i18n/build-map.js | jq 'keys | length'`.
6. Result: 187 keys, shared components list every bundle that includes them.
7. Optional, proves the hash naming: copy the pot to a `de_DE.po`, add a msgstr, run `wp i18n make-json /tmp/gatherpress-de_DE.po /tmp/jsonout --use-map=languages/map.json --no-purge`, then compare `php -r "echo md5('build/panels.js');"` against the generated filename.
8. Run `npm run plugin-zip` and `unzip -l gatherpress.zip | grep languages`.
9. Result: `gatherpress/languages/gatherpress.pot` present, no `src/`, no `.github/scripts/i18n/`, no `map.json`.
10. On a test site, switch the site language and load an admin page.
11. Result: no fatals, strings fall back to English since no translations exist yet.

### Credit (for release notes)

My WordPress.org username: faisalahammad

### Changelog entry

Changelog entry added manually with `composer changelog:add` at `.github/changelog/2011-i18n-src-to-build-map` (Significance: minor, Type: added), since the workflow job fails for fork PRs.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Minor

#### Type

-   [x] Added - for new features

#### Message

Ship a src-referenced translation template and correctly named JSON translation files with each release zip, so translators see readable source lines instead of minified build paths.

</details>