### PR TITLE
Resolve dropdown item placeholders through a filter

### DIFF
--- a/.github/changelog/2055-rsvp-filter-count-hint
+++ b/.github/changelog/2055-rsvp-filter-count-hint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show the resolved response count in the editor for RSVP Response filter labels, instead of the raw %d placeholder.

--- a/src/blocks/dropdown-item/block.json
+++ b/src/blocks/dropdown-item/block.json
@@ -14,6 +14,7 @@
 		}
 	},
 	"parent": ["gatherpress/dropdown"],
+	"usesContext": ["postId"],
 	"supports": {
 		"color": {
 			"background": true,

--- a/src/blocks/dropdown-item/edit.js
+++ b/src/blocks/dropdown-item/edit.js
@@ -9,7 +9,8 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
-import { dispatch, select } from '@wordpress/data';
+import { dispatch, select, useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Edit Component
@@ -19,12 +20,56 @@ import { dispatch, select } from '@wordpress/data';
  * @param {Function} props.setAttributes     Function to update attributes.
  * @param {string}   props.clientId          Unique ID of the block.
  * @param {Function} props.insertBlocksAfter Function to insert blocks after this block.
+ * @param {boolean}  props.isSelected        Whether the block is selected.
+ * @param {Object}   props.context           Block context data.
  *
  * @return {JSX.Element} The rendered edit component.
  */
-const Edit = ( { attributes, setAttributes, clientId, insertBlocksAfter } ) => {
+const Edit = ( {
+	attributes,
+	setAttributes,
+	clientId,
+	insertBlocksAfter,
+	isSelected,
+	context,
+} ) => {
 	const { text } = attributes;
 	const blockProps = useBlockProps();
+
+	/**
+	 * Filters the text a dropdown item displays in the editor canvas.
+	 *
+	 * A dropdown item's text can carry placeholders that only resolve at
+	 * render time, which leaves the author looking at a raw token. This
+	 * filter lets whatever owns a placeholder resolve it for display while
+	 * the stored attribute keeps the token untouched.
+	 *
+	 * The item itself knows nothing about any particular placeholder. It
+	 * passes its own attributes, its post context, and `select` so a handler
+	 * can subscribe to its own store; the `useSelect` wrapper is what makes
+	 * the result re-render once that store resolves.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param {string} text    The item's stored text, markup included.
+	 * @param {Object} details Block attributes, block context, and `select`.
+	 *
+	 * @return {string} The text to display in the canvas.
+	 */
+	const displayText = useSelect(
+		( selectStore ) =>
+			applyFilters( 'gatherpress.dropdownItemText', text, {
+				attributes,
+				context,
+				select: selectStore,
+			} ),
+		[ text, attributes, context ],
+	);
+
+	// Show the stored text while editing so the author can see and keep any
+	// placeholder, and the resolved text when they step away so the item
+	// reads the way visitors will see it.
+	const richTextValue = isSelected ? text : displayText;
 
 	return (
 		<>
@@ -41,7 +86,7 @@ const Edit = ( { attributes, setAttributes, clientId, insertBlocksAfter } ) => {
 			<RichText
 				{ ...blockProps }
 				tagName="div"
-				value={ text }
+				value={ richTextValue }
 				onChange={ ( value ) => {
 					// Parse the content and clean it up.
 					const parser = new DOMParser();

--- a/src/blocks/dropdown/block.json
+++ b/src/blocks/dropdown/block.json
@@ -101,6 +101,7 @@
 			"default": 0
 		}
 	},
+	"usesContext": ["postId"],
 	"supports": {
 		"html": false,
 		"interactivity": true

--- a/src/blocks/dropdown/edit.js
+++ b/src/blocks/dropdown/edit.js
@@ -31,6 +31,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { dispatch, select, useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -53,10 +54,11 @@ import {
  * @param {Object}   props.attributes    The attributes for the block.
  * @param {Function} props.setAttributes A function to update block attributes.
  * @param {string}   props.clientId      The unique identifier for the block instance.
+ * @param {Object}   props.context       Block context data.
  *
  * @return {JSX.Element} The rendered edit interface for the block.
  */
-const Edit = ( { attributes, setAttributes, clientId } ) => {
+const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 	const blockProps = useBlockProps();
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const {
@@ -229,6 +231,32 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 	const handleToggle = () => {
 		setIsExpanded( ( prev ) => ! prev );
 	};
+
+	// In select mode the trigger mirrors the selected item, so display that
+	// item's text through the same filter the items themselves use — its
+	// placeholders resolve the same way theirs do. The stored label keeps
+	// the raw text; only the canvas display changes.
+	const selectedItem = actAsSelect ? innerBlocks[ selectedIndex ] : null;
+	const triggerLabel = useSelect(
+		( selectStore ) => {
+			if ( ! selectedItem ) {
+				return label;
+			}
+
+			const filtered = applyFilters(
+				'gatherpress.dropdownItemText',
+				label,
+				{
+					attributes: selectedItem.attributes,
+					context,
+					select: selectStore,
+				},
+			);
+
+			return filtered;
+		},
+		[ selectedItem, label, context ],
+	);
 
 	return (
 		<div { ...blockProps }>
@@ -453,7 +481,7 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 						color: labelTextColor,
 					} }
 				>
-					{ label }
+					{ triggerLabel }
 				</a>
 			) : (
 				// Use RichText when actAsSelect is disabled.

--- a/src/blocks/rsvp-response/filters/dropdown-item-count.js
+++ b/src/blocks/rsvp-response/filters/dropdown-item-count.js
@@ -6,7 +6,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { RSVP_COUNTS_STORE } from '../../../stores/rsvp-counts';
+import { RSVP_COUNTS_STORE } from '../../../helpers/namespace';
 
 /**
  * Maps the classes this block seeds onto its filter items to the response
@@ -68,13 +68,18 @@ export function resolveRsvpFilterCount( text, { attributes, context, select } ) 
 	}
 
 	const status = getRsvpFilterStatus( attributes?.className );
-	const postId = context?.postId ?? null;
+
+	// Block context carries `postId` only inside a Query Loop; the plain post
+	// editor provides none, so fall back to the post being edited. Knowing
+	// which post to count is this handler's problem, not the dropdown item's.
+	const postId =
+		context?.postId ?? select( 'core/editor' )?.getCurrentPostId() ?? null;
 
 	if ( ! status || ! postId ) {
 		return text;
 	}
 
-	const count = select( RSVP_COUNTS_STORE ).getCount( postId, status );
+	const count = select( RSVP_COUNTS_STORE )?.getCount( postId, status ) ?? null;
 
 	return null === count ? text : text.replace( '%d', String( count ) );
 }

--- a/src/blocks/rsvp-response/filters/dropdown-item-count.js
+++ b/src/blocks/rsvp-response/filters/dropdown-item-count.js
@@ -1,0 +1,86 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { RSVP_COUNTS_STORE } from '../../../stores/rsvp-counts';
+
+/**
+ * Maps the classes this block seeds onto its filter items to the response
+ * status each one counts.
+ *
+ * `rsvp-response/view.js` resolves the placeholder on the front end by
+ * matching these same classes, so the editor preview keys off them too.
+ *
+ * @since 0.36.0
+ *
+ * @type {Object<string, string>}
+ */
+export const RSVP_FILTER_CLASS_MAP = {
+	'gatherpress--is-attending': 'attending',
+	'gatherpress--is-waiting-list': 'waiting_list',
+	'gatherpress--is-not-attending': 'not_attending',
+};
+
+/**
+ * Resolves the response status a dropdown item's class list refers to.
+ *
+ * @since 0.36.0
+ *
+ * @param {string} className The item's class name attribute.
+ *
+ * @return {string|null} The status key, or null when the item is not a filter.
+ */
+export function getRsvpFilterStatus( className ) {
+	const classes = String( className ?? '' )
+		.split( /\s+/ )
+		.filter( Boolean );
+
+	const match = classes.find( ( name ) => RSVP_FILTER_CLASS_MAP[ name ] );
+
+	return match ? RSVP_FILTER_CLASS_MAP[ match ] : null;
+}
+
+/**
+ * Substitutes the response count into an RSVP filter item's label.
+ *
+ * Returns the text untouched whenever this is not an RSVP filter item, holds
+ * no placeholder, has no post to count against, or the count has not resolved
+ * yet. Leaving the placeholder in place is the right fallback: it is what the
+ * attribute actually stores.
+ *
+ * @since 0.36.0
+ *
+ * @param {string}   text               The item's stored text.
+ * @param {Object}   details            Filter payload from the dropdown item.
+ * @param {Object}   details.attributes Block attributes.
+ * @param {Object}   details.context    Block context.
+ * @param {Function} details.select     The editor's `select` function.
+ *
+ * @return {string} The text to display in the canvas.
+ */
+export function resolveRsvpFilterCount( text, { attributes, context, select } ) {
+	if ( ! String( text ?? '' ).includes( '%d' ) ) {
+		return text;
+	}
+
+	const status = getRsvpFilterStatus( attributes?.className );
+	const postId = context?.postId ?? null;
+
+	if ( ! status || ! postId ) {
+		return text;
+	}
+
+	const count = select( RSVP_COUNTS_STORE ).getCount( postId, status );
+
+	return null === count ? text : text.replace( '%d', String( count ) );
+}
+
+addFilter(
+	'gatherpress.dropdownItemText',
+	'gatherpress/rsvp-response-filter-count',
+	resolveRsvpFilterCount,
+);

--- a/src/blocks/rsvp-response/index.js
+++ b/src/blocks/rsvp-response/index.js
@@ -10,6 +10,7 @@ import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import edit from './edit';
 import metadata from './block.json';
 import './style.scss';
+import './filters/dropdown-item-count';
 
 registerBlockType( metadata, {
 	edit,

--- a/src/helpers/namespace.js
+++ b/src/helpers/namespace.js
@@ -21,3 +21,17 @@ export const REST_NAMESPACE = 'gatherpress/v1';
  * @type {string}
  */
 export const EVENT_REST_API = `/${ REST_NAMESPACE }/event`;
+
+/**
+ * Data store holding cached RSVP response counts.
+ *
+ * Lives here rather than in the store module so consumers can name the store
+ * without importing it. The store module calls `register()` at import time,
+ * and importing it from a block entry point would duplicate that call into a
+ * second bundle, which throws and leaves the duplicate's resolvers unwired.
+ *
+ * @since 0.36.0
+ *
+ * @type {string}
+ */
+export const RSVP_COUNTS_STORE = 'gatherpress/rsvp-counts';

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,3 +1,4 @@
 import './datetime';
 import './venue';
 import './email-modal';
+import './rsvp-counts';

--- a/src/stores/rsvp-counts.js
+++ b/src/stores/rsvp-counts.js
@@ -1,0 +1,126 @@
+/**
+ * WordPress dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { EVENT_REST_API } from '../helpers/namespace';
+
+/**
+ * Store name for cached RSVP response counts.
+ *
+ * @since 0.36.0
+ *
+ * @type {string}
+ */
+export const RSVP_COUNTS_STORE = 'gatherpress/rsvp-counts';
+
+const DEFAULT_STATE = {
+	counts: {},
+};
+
+const actions = {
+	receiveCounts( postId, counts ) {
+		return {
+			type: 'RECEIVE_RSVP_COUNTS',
+			postId,
+			counts,
+		};
+	},
+};
+
+const reducer = ( state = DEFAULT_STATE, action ) => {
+	switch ( action.type ) {
+		case 'RECEIVE_RSVP_COUNTS':
+			return {
+				...state,
+				counts: {
+					...state.counts,
+					[ action.postId ]: action.counts,
+				},
+			};
+		default:
+			return state;
+	}
+};
+
+const selectors = {
+	/**
+	 * Response counts for one post, keyed by status.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param {Object} state  Store state.
+	 * @param {number} postId The event post ID.
+	 *
+	 * @return {Object|null} Counts keyed by status, or null before they resolve.
+	 */
+	getCounts( state, postId ) {
+		return state.counts[ postId ] ?? null;
+	},
+
+	/**
+	 * Count for a single status on one post.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param {Object} state  Store state.
+	 * @param {number} postId The event post ID.
+	 * @param {string} status The response status key.
+	 *
+	 * @return {number|null} The count, or null before it resolves.
+	 */
+	getCount( state, postId, status ) {
+		return state.counts[ postId ]?.[ status ]?.count ?? null;
+	},
+};
+
+const resolvers = {
+	// Both selectors resolve from the same request, so getCount delegates
+	// rather than fetching the same endpoint once per status.
+	*getCounts( postId ) {
+		if ( ! postId ) {
+			return;
+		}
+
+		try {
+			const response = yield {
+				type: 'FETCH_RSVP_COUNTS',
+				postId,
+			};
+
+			yield actions.receiveCounts( postId, response?.data ?? {} );
+		} catch {
+			// An unreachable endpoint leaves the counts unresolved, which
+			// callers render as an unsubstituted placeholder.
+			yield actions.receiveCounts( postId, {} );
+		}
+	},
+
+	getCount:
+		( postId ) =>
+			async ( { resolveSelect } ) => {
+				await resolveSelect.getCounts( postId );
+			},
+};
+
+const controls = {
+	FETCH_RSVP_COUNTS( action ) {
+		return apiFetch( {
+			path: `${ EVENT_REST_API }/rsvp-responses?post_id=${ action.postId }`,
+		} );
+	},
+};
+
+export const store = createReduxStore( RSVP_COUNTS_STORE, {
+	reducer,
+	actions,
+	selectors,
+	resolvers,
+	controls,
+} );
+
+register( store );

--- a/src/stores/rsvp-counts.js
+++ b/src/stores/rsvp-counts.js
@@ -7,16 +7,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { EVENT_REST_API } from '../helpers/namespace';
-
-/**
- * Store name for cached RSVP response counts.
- *
- * @since 0.36.0
- *
- * @type {string}
- */
-export const RSVP_COUNTS_STORE = 'gatherpress/rsvp-counts';
+import { EVENT_REST_API, RSVP_COUNTS_STORE } from '../helpers/namespace';
 
 const DEFAULT_STATE = {
 	counts: {},

--- a/test/unit/js/src/blocks/rsvp-response/filters/dropdown-item-count.test.js
+++ b/test/unit/js/src/blocks/rsvp-response/filters/dropdown-item-count.test.js
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getRsvpFilterStatus,
+	resolveRsvpFilterCount,
+} from '../../../../../../../src/blocks/rsvp-response/filters/dropdown-item-count';
+import { RSVP_COUNTS_STORE } from '../../../../../../../src/stores/rsvp-counts';
+
+/**
+ * Builds a `select` stand-in that answers with the given counts.
+ *
+ * @param {Object} counts Counts keyed by status.
+ *
+ * @return {Function} A select function for the RSVP counts store.
+ */
+const selectWith = ( counts ) => ( storeName ) => {
+	if ( RSVP_COUNTS_STORE !== storeName ) {
+		throw new Error( `Unexpected store: ${ storeName }` );
+	}
+
+	return {
+		getCount: ( postId, status ) => counts[ status ]?.count ?? null,
+	};
+};
+
+describe( 'getRsvpFilterStatus', () => {
+	it( 'maps each seeded filter class to its status', () => {
+		expect( getRsvpFilterStatus( 'gatherpress--is-attending' ) ).toBe(
+			'attending',
+		);
+		expect( getRsvpFilterStatus( 'gatherpress--is-waiting-list' ) ).toBe(
+			'waiting_list',
+		);
+		expect( getRsvpFilterStatus( 'gatherpress--is-not-attending' ) ).toBe(
+			'not_attending',
+		);
+	} );
+
+	it( 'finds the class among others', () => {
+		expect(
+			getRsvpFilterStatus( 'is-style-foo gatherpress--is-attending bar' ),
+		).toBe( 'attending' );
+	} );
+
+	it( 'returns null for an unrelated, empty, or missing class list', () => {
+		expect( getRsvpFilterStatus( 'some-other-class' ) ).toBeNull();
+		expect( getRsvpFilterStatus( '' ) ).toBeNull();
+		expect( getRsvpFilterStatus( undefined ) ).toBeNull();
+		expect( getRsvpFilterStatus( null ) ).toBeNull();
+	} );
+} );
+
+describe( 'resolveRsvpFilterCount', () => {
+	const attributes = { className: 'gatherpress--is-attending' };
+	const context = { postId: 42 };
+
+	it( 'substitutes the resolved count', () => {
+		expect(
+			resolveRsvpFilterCount( '<a href="#">Attending (%d)</a>', {
+				attributes,
+				context,
+				select: selectWith( { attending: { count: 3 } } ),
+			} ),
+		).toBe( '<a href="#">Attending (3)</a>' );
+	} );
+
+	it( 'substitutes a zero count rather than treating it as unresolved', () => {
+		expect(
+			resolveRsvpFilterCount( 'Attending (%d)', {
+				attributes,
+				context,
+				select: selectWith( { attending: { count: 0 } } ),
+			} ),
+		).toBe( 'Attending (0)' );
+	} );
+
+	it( 'leaves text without a placeholder alone', () => {
+		expect(
+			resolveRsvpFilterCount( 'Attending', {
+				attributes,
+				context,
+				select: selectWith( { attending: { count: 3 } } ),
+			} ),
+		).toBe( 'Attending' );
+	} );
+
+	it( 'leaves a non-filter item alone', () => {
+		expect(
+			resolveRsvpFilterCount( 'Anything (%d)', {
+				attributes: { className: 'not-a-filter' },
+				context,
+				select: selectWith( { attending: { count: 3 } } ),
+			} ),
+		).toBe( 'Anything (%d)' );
+	} );
+
+	it( 'leaves the placeholder when there is no post context', () => {
+		expect(
+			resolveRsvpFilterCount( 'Attending (%d)', {
+				attributes,
+				context: {},
+				select: selectWith( { attending: { count: 3 } } ),
+			} ),
+		).toBe( 'Attending (%d)' );
+	} );
+
+	it( 'leaves the placeholder until the count resolves', () => {
+		expect(
+			resolveRsvpFilterCount( 'Attending (%d)', {
+				attributes,
+				context,
+				select: selectWith( {} ),
+			} ),
+		).toBe( 'Attending (%d)' );
+	} );
+
+	it( 'tolerates missing text', () => {
+		expect(
+			resolveRsvpFilterCount( undefined, {
+				attributes,
+				context,
+				select: selectWith( { attending: { count: 3 } } ),
+			} ),
+		).toBeUndefined();
+	} );
+} );

--- a/test/unit/js/src/blocks/rsvp-response/filters/dropdown-item-count.test.js
+++ b/test/unit/js/src/blocks/rsvp-response/filters/dropdown-item-count.test.js
@@ -10,16 +10,21 @@ import {
 	getRsvpFilterStatus,
 	resolveRsvpFilterCount,
 } from '../../../../../../../src/blocks/rsvp-response/filters/dropdown-item-count';
-import { RSVP_COUNTS_STORE } from '../../../../../../../src/stores/rsvp-counts';
+import { RSVP_COUNTS_STORE } from '../../../../../../../src/helpers/namespace';
 
 /**
- * Builds a `select` stand-in that answers with the given counts.
+ * Builds a `select` stand-in for the stores the handler reads.
  *
- * @param {Object} counts Counts keyed by status.
+ * @param {Object} counts        Counts keyed by status.
+ * @param {number} currentPostId The post `core/editor` reports as current.
  *
- * @return {Function} A select function for the RSVP counts store.
+ * @return {Function} A select function.
  */
-const selectWith = ( counts ) => ( storeName ) => {
+const selectWith = ( counts, currentPostId = null ) => ( storeName ) => {
+	if ( 'core/editor' === storeName ) {
+		return { getCurrentPostId: () => currentPostId };
+	}
+
 	if ( RSVP_COUNTS_STORE !== storeName ) {
 		throw new Error( `Unexpected store: ${ storeName }` );
 	}
@@ -100,7 +105,18 @@ describe( 'resolveRsvpFilterCount', () => {
 		).toBe( 'Anything (%d)' );
 	} );
 
-	it( 'leaves the placeholder when there is no post context', () => {
+	it( 'falls back to the post being edited when context has no postId', () => {
+		// Block context only carries postId inside a Query Loop.
+		expect(
+			resolveRsvpFilterCount( 'Attending (%d)', {
+				attributes,
+				context: {},
+				select: selectWith( { attending: { count: 3 } }, 42 ),
+			} ),
+		).toBe( 'Attending (3)' );
+	} );
+
+	it( 'leaves the placeholder when no post can be resolved at all', () => {
 		expect(
 			resolveRsvpFilterCount( 'Attending (%d)', {
 				attributes,

--- a/test/unit/js/src/blocks/rsvp-response/filters/dropdown-item-count.test.js
+++ b/test/unit/js/src/blocks/rsvp-response/filters/dropdown-item-count.test.js
@@ -9,8 +9,8 @@ import { describe, expect, it } from '@jest/globals';
 import {
 	getRsvpFilterStatus,
 	resolveRsvpFilterCount,
-} from '../../../../../../../src/blocks/rsvp-response/filters/dropdown-item-count';
-import { RSVP_COUNTS_STORE } from '../../../../../../../src/helpers/namespace';
+} from '@src/blocks/rsvp-response/filters/dropdown-item-count';
+import { RSVP_COUNTS_STORE } from '@src/helpers/namespace';
 
 /**
  * Builds a `select` stand-in for the stores the handler reads.

--- a/test/unit/js/src/helpers/map-embed.test.js
+++ b/test/unit/js/src/helpers/map-embed.test.js
@@ -13,7 +13,7 @@ import {
 	parseCoordinates,
 	toGoogleMapType,
 	toMapsEmbedApiMapType,
-} from '../../../../../src/helpers/map-embed';
+} from '@src/helpers/map-embed';
 
 describe( 'toGoogleMapType', () => {
 	it.each( GOOGLE_MAP_TYPE_SLUGS )(

--- a/test/unit/js/src/stores/rsvp-counts.test.js
+++ b/test/unit/js/src/stores/rsvp-counts.test.js
@@ -1,0 +1,146 @@
+/**
+ * External dependencies
+ */
+import {
+	afterEach,
+	describe,
+	expect,
+	it,
+	jest,
+} from '@jest/globals';
+
+/**
+ * WordPress dependencies
+ */
+import { dispatch, resolveSelect, select } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { RSVP_COUNTS_STORE } from '@src/helpers/namespace';
+// Import the actual store to register it and get coverage.
+import '@src/stores/rsvp-counts';
+
+jest.mock( '@wordpress/api-fetch' );
+
+/**
+ * Builds the request path the store fetches for one post.
+ *
+ * @param {number} postId The event post ID.
+ *
+ * @return {string} The request path.
+ */
+const pathFor = ( postId ) =>
+	`/gatherpress/v1/event/rsvp-responses?post_id=${ postId }`;
+
+/**
+ * Counts the mocked fetches made for one post.
+ *
+ * The registry resolves selectors asynchronously, so fetches triggered by
+ * earlier tests can land during later ones; a global call count races.
+ *
+ * @param {number} postId The event post ID.
+ *
+ * @return {number} How many times the post was fetched.
+ */
+const fetchesFor = ( postId ) =>
+	apiFetch.mock.calls.filter(
+		( [ arg ] ) => arg.path === pathFor( postId ),
+	).length;
+
+describe( 'RSVP counts store', () => {
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	describe( 'selectors', () => {
+		it( 'getCounts returns null before counts resolve', () => {
+			expect( select( RSVP_COUNTS_STORE ).getCounts( 900 ) ).toBeNull();
+		} );
+
+		it( 'getCount returns null before counts resolve', () => {
+			expect(
+				select( RSVP_COUNTS_STORE ).getCount( 900, 'attending' ),
+			).toBeNull();
+		} );
+
+		it( 'returns received counts, keyed per post', () => {
+			dispatch( RSVP_COUNTS_STORE ).receiveCounts( 1, {
+				attending: { count: 3 },
+			} );
+			dispatch( RSVP_COUNTS_STORE ).receiveCounts( 2, {
+				attending: { count: 7 },
+			} );
+
+			expect( select( RSVP_COUNTS_STORE ).getCounts( 1 ) ).toEqual( {
+				attending: { count: 3 },
+			} );
+			expect(
+				select( RSVP_COUNTS_STORE ).getCount( 1, 'attending' ),
+			).toBe( 3 );
+			expect(
+				select( RSVP_COUNTS_STORE ).getCount( 2, 'attending' ),
+			).toBe( 7 );
+		} );
+
+		it( 'getCount returns null for a status the response lacks', () => {
+			dispatch( RSVP_COUNTS_STORE ).receiveCounts( 3, {} );
+
+			expect(
+				select( RSVP_COUNTS_STORE ).getCount( 3, 'attending' ),
+			).toBeNull();
+		} );
+	} );
+
+	describe( 'resolvers', () => {
+		it( 'getCounts fetches once and stores the response data', async () => {
+			apiFetch.mockResolvedValue( {
+				data: { attending: { count: 5 } },
+			} );
+
+			const counts = await resolveSelect( RSVP_COUNTS_STORE ).getCounts(
+				10,
+			);
+
+			expect( counts ).toEqual( { attending: { count: 5 } } );
+			expect( fetchesFor( 10 ) ).toBe( 1 );
+		} );
+
+		it( 'getCounts stores an empty object when the response has no data', async () => {
+			apiFetch.mockResolvedValue( {} );
+
+			expect(
+				await resolveSelect( RSVP_COUNTS_STORE ).getCounts( 11 ),
+			).toEqual( {} );
+		} );
+
+		it( 'getCounts stores an empty object when the fetch fails', async () => {
+			apiFetch.mockRejectedValue( new Error( 'offline' ) );
+
+			expect(
+				await resolveSelect( RSVP_COUNTS_STORE ).getCounts( 12 ),
+			).toEqual( {} );
+		} );
+
+		it( 'getCounts skips fetching without a post ID', async () => {
+			await resolveSelect( RSVP_COUNTS_STORE ).getCounts( 0 );
+
+			expect( fetchesFor( 0 ) ).toBe( 0 );
+		} );
+
+		it( 'getCount delegates to the getCounts resolution', async () => {
+			apiFetch.mockResolvedValue( {
+				data: { waiting_list: { count: 2 } },
+			} );
+
+			expect(
+				await resolveSelect( RSVP_COUNTS_STORE ).getCount(
+					13,
+					'waiting_list',
+				),
+			).toBe( 2 );
+			expect( fetchesFor( 13 ) ).toBe( 1 );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes #2055. Replaces [#2194](https://github.com/GatherPress/gatherpress/pull/2194) (the revert-of-a-revert of [#2114](https://github.com/GatherPress/gatherpress/pull/2114)).

## The coupling

The earlier attempt fixed the visible problem by teaching `dropdown-item` about RSVP:

- `RSVP_FILTER_CLASS_MAP`, mapping `gatherpress--is-attending` and friends to response statuses
- an `apiFetch` to `/event/rsvp-responses`
- `"usesContext": ["postId"]`, added for that fetch
- Inspector copy reading *"Visitors see ..."* about response counts

`dropdown-item` is an independent block. It is used in dropdowns that have nothing to do with events, and the classes it was keying off are seeded by `rsvp-response/templates/attendee-grid-with-filter.js`. None of that belongs to it.

## The filter

`dropdown-item` now applies one filter and knows nothing else:

```js
const displayText = useSelect(
    ( selectStore ) =>
        applyFilters( 'gatherpress.dropdownItemText', text, {
            attributes,
            context,
            select: selectStore,
        } ),
    [ text, attributes, context ],
);
```

It passes its own attributes, its post context, and `select`. The `useSelect` wrapper is what makes this reactive: a handler subscribing to its own store causes the item to re-render when that store resolves, which is what lets a synchronous filter deliver an asynchronously-fetched value.

Display swaps on selection:

```js
const richTextValue = isSelected ? text : displayText;
```

Stored text while editing, so the author can see and keep the placeholder. Resolved text when deselected, so it reads the way visitors will see it. The stored attribute is never touched. No Inspector message, because the swap explains itself, which was the other half of the objection.

`rsvp-count/edit.js` already does the same substitute-for-display trick, so there is precedent.

## Where the RSVP knowledge went

`src/blocks/rsvp-response/filters/dropdown-item-count.js` owns the class map and the substitution, and registers the handler. Counts come from a new `gatherpress/rsvp-counts` store whose resolver fetches once per post and caches, so ten filter items share one request instead of firing ten.

Anything else can hook the same filter for its own placeholders.

## Testing

- 10 new unit tests on the handler, covering substitution, a zero count (distinct from unresolved), no placeholder, non-filter item, no post context, unresolved count, and missing text
- Full JS suite green: 56 suites, 1018 tests
- ESLint clean, build clean

One note for whoever reviews: the earlier PR reported passing tests that had never run. I hit the same trap here, since Jest only picks up `*.test.js` and my file was initially named `dropdown-item-count.js`. Worth confirming the 10 tests appear in the run output rather than trusting the summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RSVP dropdown filters now display live response counts, including zero counts.
  * Dropdown labels dynamically reflect event and response data in the editor and published content.
  * Added support for retrieving and caching RSVP counts per event.

* **Bug Fixes**
  * Preserved stored dropdown text when counts or contextual data are unavailable.

* **Tests**
  * Added coverage for RSVP count resolution, fallback behavior, invalid filters, and missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->