### PR TITLE
Include noteworthy in the credits-sync roster

### DIFF
--- a/.github/scripts/release/credits/unreleased.json
+++ b/.github/scripts/release/credits/unreleased.json
@@ -1,7 +1,4 @@
 {
-    "contributors": [
-        "matthewneilcowan",
-        "motylanogha"
-    ],
+    "contributors": [],
     "noteworthy": []
 }

--- a/.github/workflows/credits-sync.yml
+++ b/.github/workflows/credits-sync.yml
@@ -112,7 +112,9 @@ jobs:
           # re-proposed from the stale branch copy.
           newest=$(ls .github/scripts/release/credits/*.json | grep -v unreleased | sort -V | tail -1)
           echo "Roster source: ${newest}"
-          jq -r '[(.leads // [])[], (.team // [])[], (.contributors // [])[]] | .[]' "${newest}" > /tmp/roster.txt
+          # `team` was renamed `noteworthy` in the 0.35.1 credits files; read
+          # both so old- and new-format files each contribute a full roster.
+          jq -r '[(.leads // [])[], (.team // [])[], (.noteworthy // [])[], (.contributors // [])[]] | .[]' "${newest}" > /tmp/roster.txt
           jq -r '(.contributors // [])[]' /tmp/unreleased.json >> /tmp/roster.txt
           sort -u /tmp/roster.txt -o /tmp/roster.txt
 

--- a/.github/workflows/credits-sync.yml
+++ b/.github/workflows/credits-sync.yml
@@ -115,7 +115,10 @@ jobs:
           # `team` was renamed `noteworthy` in the 0.35.1 credits files; read
           # both so old- and new-format files each contribute a full roster.
           jq -r '[(.leads // [])[], (.team // [])[], (.noteworthy // [])[], (.contributors // [])[]] | .[]' "${newest}" > /tmp/roster.txt
-          jq -r '(.contributors // [])[]' /tmp/unreleased.json >> /tmp/roster.txt
+          # The noteworthy queue (#2136) counts too: a queued promotion is
+          # already being tracked, so the sync must not re-propose the same
+          # person as a plain contributor.
+          jq -r '[(.contributors // [])[], (.noteworthy // [])[]] | .[]' /tmp/unreleased.json >> /tmp/roster.txt
           sort -u /tmp/roster.txt -o /tmp/roster.txt
 
           pending=$(comm -23 /tmp/pending.txt /tmp/roster.txt || true)


### PR DESCRIPTION
Answers the "why did this trigger?" on [#2206](https://github.com/GatherPress/gatherpress/pull/2206), which re-credited matthewneilcowan and motylanogha even though both are noteworthy in `credits/0.36.0-alpha.0.json`.

The sync dedupes against the newest version file's roster:

```sh
jq -r '[(.leads // [])[], (.team // [])[], (.contributors // [])[]] | .[]' "${newest}"
```

No `noteworthy`. The credits files renamed `team` to `noteworthy` at 0.35.1, so since then everyone in that group has looked uncredited to the sync. Same root cause behind the stale entries that sat in `unreleased.json` before the alpha.0 bump — the bump's fold deduped them silently because `fold_unreleased_credits()` checks noteworthy correctly; only the sync workflow missed the rename.

Two changes:

- The roster jq reads both `team` and `noteworthy`, so old- and new-format files each yield a full roster.
- `unreleased.json` is reset: its two current entries are both re-credits from this bug.

No urgency on merge order with anything else; the next sync run just stops proposing already-credited people.

## Second gap, from #2136

The sync builds its roster from two sources, and the develop-side read had the same blind spot: it only takes `unreleased.json`'s `contributors` array, never the `noteworthy` queue that [#2136](https://github.com/GatherPress/gatherpress/pull/2136) added. A queued promotion whose PR merges before the next bump would be re-proposed as a plain contributor, double-listing the person across the two arrays of the same file. Now both arrays count.

Timeline for the record: the version files renamed `team` to `noteworthy` with the 0.35.1 credits file (Aug 13), and #2136 (Aug 17) formalized the key in the bump tooling. Neither change taught the sync workflow, which still read the old shape from both sources.
