### PR TITLE
Export all-day events as floating dates in calendar feeds (#2225)

### DIFF
--- a/.github/changelog/2225-calendar-export-all-day
+++ b/.github/changelog/2225-calendar-export-all-day
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Export all-day events as floating dates in iCal, Google, and Yahoo calendar feeds.

--- a/.github/changelog/yahoo-calendar-timed-export
+++ b/.github/changelog/yahoo-calendar-timed-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Send timed events to Yahoo! Calendar in the event's own local time with an explicit end, instead of a GMT start with a Z suffix Yahoo ignores and a duration that broke on fractional hours.

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -211,15 +211,28 @@ final class Calendar {
 		}
 
 		if ( $this->event->is_all_day() ) {
-			// Yahoo takes two plain dates and its own flag, not a duration.
-			// `dur` is an `hhmm` field, and a single all-day event already
-			// needs more hours than the two digits hold. Local dates, since
-			// an all-day date is floating and must not shift with the zone.
-			$timing = array(
-				'st'     => $this->event->get_formatted_datetime( 'Ymd', 'start' ),
-				'et'     => $this->event->get_formatted_datetime( 'Ymd', 'end' ),
-				'allday' => 'true',
-			);
+			// Yahoo has two shapes for this and they cannot be combined: it
+			// ignores `dur` the moment `et` is present. A single day says
+			// `dur=allday` and sends no end at all; a span sends the end and
+			// no duration. That end is exclusive, so it names the day after
+			// the last one, as `DTEND` does in the feed above.
+			//
+			// Local dates throughout, an all-day date being floating.
+			$date_start = $this->event->get_formatted_datetime( 'Ymd', 'start' );
+
+			if ( $this->event->is_same_date() ) {
+				$timing = array(
+					'st'  => $date_start,
+					'dur' => 'allday',
+				);
+			} else {
+				$end_date = $this->event->get_formatted_datetime( 'Y-m-d', 'end' );
+
+				$timing = array(
+					'st' => $date_start,
+					'et' => gmdate( 'Ymd', (int) strtotime( $end_date . ' +1 day' ) ),
+				);
+			}
 		} else {
 			$date_start = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
 			$time_start = $this->event->get_formatted_datetime( 'His', 'start', false );

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -192,7 +192,7 @@ final class Calendar {
 	 * Off-site destination URL for the Yahoo! Calendar redirect.
 	 *
 	 * Opens Yahoo! Calendar's event-creation form pre-filled with this
-	 * event's title, start time, duration, location, and description.
+	 * event's title, start and end time, location, and description.
 	 * Called from `Calendar\Setup::queried_event_yahoo_url()` to produce
 	 * the 302 target for the `/event/<slug>/yahoo-calendar/` endpoint —
 	 * front-end code should use `get_yahoo_url()` (the on-site URL) instead.
@@ -234,21 +234,15 @@ final class Calendar {
 				);
 			}
 		} else {
-			$date_start = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
-			$time_start = $this->event->get_formatted_datetime( 'His', 'start', false );
-
-			// Figure out duration of event in hours and minutes: hhmm format.
-			$diff_start = $this->event->get_formatted_datetime( $this->event::DATETIME_FORMAT, 'start', false );
-			$diff_end   = $this->event->get_formatted_datetime( $this->event::DATETIME_FORMAT, 'end', false );
-			$duration   = ( ( strtotime( $diff_end ) - strtotime( $diff_start ) ) / 60 / 60 );
-			$full       = intval( $duration );
-			$fraction   = ( $duration - $full );
-			$hours      = str_pad( strval( $duration ), 2, '0', STR_PAD_LEFT );
-			$minutes    = str_pad( strval( $fraction * 60 ), 2, '0', STR_PAD_LEFT );
-
+			// Yahoo has no timezone parameter and does not honor a trailing
+			// Z: whatever it is handed is shown verbatim as local wall-clock
+			// time. So the event's own local time goes out, right for anyone
+			// in its zone and the closest available for anyone else. The end
+			// is sent rather than a duration: `dur` is an `hhmm` field that
+			// tops out at 99 hours, and Yahoo ignores it once `et` is present.
 			$timing = array(
-				'st'  => sprintf( '%sT%sZ', $date_start, $time_start ),
-				'dur' => $hours . $minutes,
+				'st' => $this->event->get_formatted_datetime( 'Ymd\THis', 'start' ),
+				'et' => $this->event->get_formatted_datetime( 'Ymd\THis', 'end' ),
 			);
 		}
 

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -152,11 +152,19 @@ final class Calendar {
 			return '';
 		}
 
-		$date_start  = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
-		$time_start  = $this->event->get_formatted_datetime( 'His', 'start', false );
-		$date_end    = $this->event->get_formatted_datetime( 'Ymd', 'end', false );
-		$time_end    = $this->event->get_formatted_datetime( 'His', 'end', false );
-		$datetime    = sprintf( '%sT%sZ/%sT%sZ', $date_start, $time_start, $date_end, $time_end );
+		if ( $this->event->is_all_day() ) {
+			$date_start   = $this->event->get_formatted_datetime( 'Ymd', 'start' );
+			$end_date_str = $this->event->get_formatted_datetime( 'Y-m-d', 'end' );
+			$date_end     = gmdate( 'Ymd', (int) strtotime( $end_date_str . ' +1 day' ) );
+			$datetime     = sprintf( '%s/%s', $date_start, $date_end );
+		} else {
+			$date_start = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
+			$time_start = $this->event->get_formatted_datetime( 'His', 'start', false );
+			$date_end   = $this->event->get_formatted_datetime( 'Ymd', 'end', false );
+			$time_end   = $this->event->get_formatted_datetime( 'His', 'end', false );
+			$datetime   = sprintf( '%sT%sZ/%sT%sZ', $date_start, $time_start, $date_end, $time_end );
+		}
+
 		$venue       = $this->event->get_venue_information();
 		$location    = $venue['name'];
 		$description = $this->event->get_calendar_description();
@@ -202,18 +210,30 @@ final class Calendar {
 			return '';
 		}
 
-		$date_start     = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
-		$time_start     = $this->event->get_formatted_datetime( 'His', 'start', false );
-		$datetime_start = sprintf( '%sT%sZ', $date_start, $time_start );
+		if ( $this->event->is_all_day() ) {
+			$date_start     = $this->event->get_formatted_datetime( 'Ymd', 'start' );
+			$datetime_start = $date_start;
+			$start_ymd      = $this->event->get_formatted_datetime( 'Y-m-d', 'start' );
+			$end_ymd        = $this->event->get_formatted_datetime( 'Y-m-d', 'end' );
+			$diff_seconds   = (int) strtotime( $end_ymd ) - (int) strtotime( $start_ymd );
+			$days           = max( 1, (int) round( $diff_seconds / 86400 ) + 1 );
+			$hours          = str_pad( (string) ( $days * 24 ), 2, '0', STR_PAD_LEFT );
+			$minutes        = '00';
+		} else {
+			$date_start     = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
+			$time_start     = $this->event->get_formatted_datetime( 'His', 'start', false );
+			$datetime_start = sprintf( '%sT%sZ', $date_start, $time_start );
 
-		// Figure out duration of event in hours and minutes: hhmm format.
-		$diff_start  = $this->event->get_formatted_datetime( $this->event::DATETIME_FORMAT, 'start', false );
-		$diff_end    = $this->event->get_formatted_datetime( $this->event::DATETIME_FORMAT, 'end', false );
-		$duration    = ( ( strtotime( $diff_end ) - strtotime( $diff_start ) ) / 60 / 60 );
-		$full        = intval( $duration );
-		$fraction    = ( $duration - $full );
-		$hours       = str_pad( strval( $duration ), 2, '0', STR_PAD_LEFT );
-		$minutes     = str_pad( strval( $fraction * 60 ), 2, '0', STR_PAD_LEFT );
+			// Figure out duration of event in hours and minutes: hhmm format.
+			$diff_start = $this->event->get_formatted_datetime( $this->event::DATETIME_FORMAT, 'start', false );
+			$diff_end   = $this->event->get_formatted_datetime( $this->event::DATETIME_FORMAT, 'end', false );
+			$duration   = ( ( strtotime( $diff_end ) - strtotime( $diff_start ) ) / 60 / 60 );
+			$full       = intval( $duration );
+			$fraction   = ( $duration - $full );
+			$hours      = str_pad( strval( $duration ), 2, '0', STR_PAD_LEFT );
+			$minutes    = str_pad( strval( $fraction * 60 ), 2, '0', STR_PAD_LEFT );
+		}
+
 		$venue       = $this->event->get_venue_information();
 		$location    = $venue['name'];
 		$description = $this->event->get_calendar_description();
@@ -259,13 +279,24 @@ final class Calendar {
 			return '';
 		}
 
-		$date_start     = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
-		$time_start     = $this->event->get_formatted_datetime( 'His', 'start', false );
-		$date_end       = $this->event->get_formatted_datetime( 'Ymd', 'end', false );
-		$time_end       = $this->event->get_formatted_datetime( 'His', 'end', false );
-		$datetime_start = sprintf( '%sT%sZ', $date_start, $time_start );
-		$datetime_end   = sprintf( '%sT%sZ', $date_end, $time_end );
-		$modified_gmt   = strtotime( $post->post_modified_gmt );
+		if ( $this->event->is_all_day() ) {
+			$date_start   = $this->event->get_formatted_datetime( 'Ymd', 'start' );
+			$end_date_str = $this->event->get_formatted_datetime( 'Y-m-d', 'end' );
+			$date_end     = gmdate( 'Ymd', (int) strtotime( $end_date_str . ' +1 day' ) );
+			$dtstart_line = sprintf( 'DTSTART;VALUE=DATE:%s', sanitize_text_field( $date_start ) );
+			$dtend_line   = sprintf( 'DTEND;VALUE=DATE:%s', sanitize_text_field( $date_end ) );
+		} else {
+			$date_start     = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
+			$time_start     = $this->event->get_formatted_datetime( 'His', 'start', false );
+			$date_end       = $this->event->get_formatted_datetime( 'Ymd', 'end', false );
+			$time_end       = $this->event->get_formatted_datetime( 'His', 'end', false );
+			$datetime_start = sprintf( '%sT%sZ', $date_start, $time_start );
+			$datetime_end   = sprintf( '%sT%sZ', $date_end, $time_end );
+			$dtstart_line   = sprintf( 'DTSTART:%s', sanitize_text_field( $datetime_start ) );
+			$dtend_line     = sprintf( 'DTEND:%s', sanitize_text_field( $datetime_end ) );
+		}
+
+		$modified_gmt = strtotime( $post->post_modified_gmt );
 
 		if ( false === $modified_gmt ) {
 			// DTSTAMP is required by RFC 5545, so an unparsable date still needs one.
@@ -291,8 +322,8 @@ final class Calendar {
 		$args = array(
 			'BEGIN:VEVENT',
 			sprintf( 'URL:%s', esc_url_raw( $permalink ) ),
-			sprintf( 'DTSTART:%s', sanitize_text_field( $datetime_start ) ),
-			sprintf( 'DTEND:%s', sanitize_text_field( $datetime_end ) ),
+			$dtstart_line,
+			$dtend_line,
 			sprintf( 'DTSTAMP:%s', sanitize_text_field( $datetime_stamp ) ),
 			sprintf( 'LAST-MODIFIED:%s', sanitize_text_field( $last_modified ) ),
 			sprintf( 'SEQUENCE:%d', $sequence ),

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -211,18 +211,18 @@ final class Calendar {
 		}
 
 		if ( $this->event->is_all_day() ) {
-			$date_start     = $this->event->get_formatted_datetime( 'Ymd', 'start' );
-			$datetime_start = $date_start;
-			$start_ymd      = $this->event->get_formatted_datetime( 'Y-m-d', 'start' );
-			$end_ymd        = $this->event->get_formatted_datetime( 'Y-m-d', 'end' );
-			$diff_seconds   = (int) strtotime( $end_ymd ) - (int) strtotime( $start_ymd );
-			$days           = max( 1, (int) round( $diff_seconds / 86400 ) + 1 );
-			$hours          = str_pad( (string) ( $days * 24 ), 2, '0', STR_PAD_LEFT );
-			$minutes        = '00';
+			// Yahoo takes two plain dates and its own flag, not a duration.
+			// `dur` is an `hhmm` field, and a single all-day event already
+			// needs more hours than the two digits hold. Local dates, since
+			// an all-day date is floating and must not shift with the zone.
+			$timing = array(
+				'st'     => $this->event->get_formatted_datetime( 'Ymd', 'start' ),
+				'et'     => $this->event->get_formatted_datetime( 'Ymd', 'end' ),
+				'allday' => 'true',
+			);
 		} else {
-			$date_start     = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
-			$time_start     = $this->event->get_formatted_datetime( 'His', 'start', false );
-			$datetime_start = sprintf( '%sT%sZ', $date_start, $time_start );
+			$date_start = $this->event->get_formatted_datetime( 'Ymd', 'start', false );
+			$time_start = $this->event->get_formatted_datetime( 'His', 'start', false );
 
 			// Figure out duration of event in hours and minutes: hhmm format.
 			$diff_start = $this->event->get_formatted_datetime( $this->event::DATETIME_FORMAT, 'start', false );
@@ -232,6 +232,11 @@ final class Calendar {
 			$fraction   = ( $duration - $full );
 			$hours      = str_pad( strval( $duration ), 2, '0', STR_PAD_LEFT );
 			$minutes    = str_pad( strval( $fraction * 60 ), 2, '0', STR_PAD_LEFT );
+
+			$timing = array(
+				'st'  => sprintf( '%sT%sZ', $date_start, $time_start ),
+				'dur' => $hours . $minutes,
+			);
 		}
 
 		$venue       = $this->event->get_venue_information();
@@ -242,15 +247,18 @@ final class Calendar {
 			$location .= sprintf( ', %s', $venue['address'] );
 		}
 
-		$params = array(
-			'v'      => '60',
-			'view'   => 'd',
-			'type'   => '20',
-			'title'  => sanitize_text_field( $post->post_title ),
-			'st'     => sanitize_text_field( $datetime_start ),
-			'dur'    => sanitize_text_field( (string) $hours . (string) $minutes ),
-			'desc'   => sanitize_text_field( $description ),
-			'in_loc' => sanitize_text_field( $location ),
+		$params = array_merge(
+			array(
+				'v'     => '60',
+				'view'  => 'd',
+				'type'  => '20',
+				'title' => sanitize_text_field( $post->post_title ),
+			),
+			array_map( 'sanitize_text_field', $timing ),
+			array(
+				'desc'   => sanitize_text_field( $description ),
+				'in_loc' => sanitize_text_field( $location ),
+			)
 		);
 
 		return add_query_arg(

--- a/includes/core/classes/calendar/class-calendar.php
+++ b/includes/core/classes/calendar/class-calendar.php
@@ -211,26 +211,23 @@ final class Calendar {
 		}
 
 		if ( $this->event->is_all_day() ) {
-			// Yahoo has two shapes for this and they cannot be combined: it
-			// ignores `dur` the moment `et` is present. A single day says
-			// `dur=allday` and sends no end at all; a span sends the end and
-			// no duration. That end is exclusive, so it names the day after
-			// the last one, as `DTEND` does in the feed above.
-			//
-			// Local dates throughout, an all-day date being floating.
-			$date_start = $this->event->get_formatted_datetime( 'Ymd', 'start' );
-
+			// `dur=allday` is the only thing that switches Yahoo's all-day
+			// toggle on, and it is ignored the moment `et` is present, so a
+			// span cannot be flagged all day at all. A single day sends the
+			// flag and no end. A span goes out as the timed stretch it is
+			// stored as, midnight to 23:59:59 in the event's own zone: that
+			// opens showing the first and last days and covers them all, which
+			// a bare end date does not, since the composer reads it as
+			// midnight and drops the last day. (Verified in the composer.)
 			if ( $this->event->is_same_date() ) {
 				$timing = array(
-					'st'  => $date_start,
+					'st'  => $this->event->get_formatted_datetime( 'Ymd', 'start' ),
 					'dur' => 'allday',
 				);
 			} else {
-				$end_date = $this->event->get_formatted_datetime( 'Y-m-d', 'end' );
-
 				$timing = array(
-					'st' => $date_start,
-					'et' => gmdate( 'Ymd', (int) strtotime( $end_date . ' +1 day' ) ),
+					'st' => $this->event->get_formatted_datetime( 'Ymd\THis', 'start' ),
+					'et' => $this->event->get_formatted_datetime( 'Ymd\THis', 'end' ),
 				);
 			}
 		} else {

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -320,6 +320,16 @@ class Test_Calendar extends Base {
 			$url,
 			'Yahoo destination URL should include the event start date in Ymd format.'
 		);
+		$this->assertStringContainsString(
+			'dur=',
+			$url,
+			'Yahoo destination URL should send a duration for a timed event.'
+		);
+		$this->assertStringNotContainsString(
+			'allday',
+			$url,
+			'Yahoo destination URL should not mark a timed event as all day.'
+		);
 	}
 
 	/**
@@ -905,9 +915,19 @@ class Test_Calendar extends Base {
 			'Yahoo destination URL should use Ymd start date for all-day events.'
 		);
 		$this->assertStringContainsString(
-			'dur=2400',
+			'et=20300615',
 			$url,
-			'Yahoo destination URL should use 2400 duration for a 1-day all-day event.'
+			'Yahoo destination URL should end a one-day all-day event on its own day.'
+		);
+		$this->assertStringContainsString(
+			'allday=true',
+			$url,
+			'Yahoo destination URL should mark an all-day event as one.'
+		);
+		$this->assertStringNotContainsString(
+			'dur=',
+			$url,
+			'Yahoo destination URL should not send a duration for an all-day event.'
 		);
 
 		$multi_day_id = $this->make_all_day_event( 'Asia/Tokyo', '2030-06-15', '2030-06-16' );
@@ -915,9 +935,19 @@ class Test_Calendar extends Base {
 		$multi_url    = $multi_inst->get_yahoo_destination_url();
 
 		$this->assertStringContainsString(
-			'dur=4800',
+			'st=20300615',
 			$multi_url,
-			'Yahoo destination URL should use 4800 duration for a 2-day all-day event.'
+			'Yahoo destination URL should start a multi-day all-day event on its first day.'
+		);
+		$this->assertStringContainsString(
+			'et=20300616',
+			$multi_url,
+			'Yahoo destination URL should end a multi-day all-day event on its last day.'
+		);
+		$this->assertStringContainsString(
+			'allday=true',
+			$multi_url,
+			'Yahoo destination URL should mark a multi-day all-day event as one.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -315,20 +315,72 @@ class Test_Calendar extends Base {
 			$url,
 			'Yahoo destination URL should include the event title.'
 		);
+		// 14:30 New York, sent as New York wall-clock with no Z: Yahoo has no
+		// timezone parameter and shows the value verbatim as local time.
 		$this->assertStringContainsString(
-			'st=20300615',
+			'st=20300615T143000',
 			$url,
-			'Yahoo destination URL should include the event start date in Ymd format.'
+			'Yahoo destination URL should send the start in the event\'s own local time.'
 		);
 		$this->assertStringContainsString(
+			'et=20300615T163000',
+			$url,
+			'Yahoo destination URL should send the end in the event\'s own local time.'
+		);
+		$this->assertStringNotContainsString(
+			'Z',
+			(string) wp_parse_url( $url, PHP_URL_QUERY ),
+			'Yahoo destination URL should not carry a Z suffix, which Yahoo does not honor.'
+		);
+		$this->assertStringNotContainsString(
 			'dur=',
 			$url,
-			'Yahoo destination URL should send a duration for a timed event.'
+			'Yahoo destination URL should send an end rather than a duration.'
 		);
 		$this->assertStringNotContainsString(
 			'allday',
 			$url,
 			'Yahoo destination URL should not mark a timed event as all day.'
+		);
+	}
+
+	/**
+	 * A fractional-hour event no longer falls apart in the Yahoo URL.
+	 *
+	 * The duration used to be built by padding the float, so ninety minutes
+	 * went out as `dur=1.530`. Sending the end instead has no such field.
+	 *
+	 * @covers ::get_yahoo_destination_url
+	 *
+	 * @return void
+	 */
+	public function test_get_yahoo_destination_url_with_fractional_hours(): void {
+		$event_id = $this->mock->post(
+			array(
+				'post_type'  => Event::POST_TYPE,
+				'post_title' => 'Ninety Minutes',
+			)
+		)->get()->ID;
+
+		( new Event( $event_id ) )->save_datetimes(
+			array(
+				'datetime_start' => '2030-06-15 19:00:00',
+				'datetime_end'   => '2030-06-15 20:30:00',
+				'timezone'       => 'Asia/Tokyo',
+			)
+		);
+
+		$url = ( new Calendar( $event_id ) )->get_yahoo_destination_url();
+
+		$this->assertStringContainsString(
+			'st=20300615T190000',
+			$url,
+			'Yahoo destination URL should send Tokyo wall-clock time, not GMT.'
+		);
+		$this->assertStringContainsString(
+			'et=20300615T203000',
+			$url,
+			'Yahoo destination URL should end ninety minutes later, in the same zone.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -981,15 +981,18 @@ class Test_Calendar extends Base {
 		$multi_inst   = new Calendar( $multi_day_id );
 		$multi_url    = $multi_inst->get_yahoo_destination_url();
 
+		// A span goes out as the timed stretch it is stored as. Yahoo cannot
+		// flag it all day, and a bare end date is read as midnight, which
+		// drops the last day; this opens as the 15th through the 16th.
 		$this->assertStringContainsString(
-			'st=20300615',
+			'st=20300615T000000',
 			$multi_url,
-			'Yahoo destination URL should start a multi-day all-day event on its first day.'
+			'Yahoo destination URL should start a multi-day all-day event at midnight on its first day.'
 		);
 		$this->assertStringContainsString(
-			'et=20300617',
+			'et=20300616T235959',
 			$multi_url,
-			'Yahoo destination URL should end a multi-day all-day event the day after its last.'
+			'Yahoo destination URL should end a multi-day all-day event at the end of its last day.'
 		);
 		$this->assertStringNotContainsString(
 			'dur=',

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -915,19 +915,14 @@ class Test_Calendar extends Base {
 			'Yahoo destination URL should use Ymd start date for all-day events.'
 		);
 		$this->assertStringContainsString(
-			'et=20300615',
+			'dur=allday',
 			$url,
-			'Yahoo destination URL should end a one-day all-day event on its own day.'
-		);
-		$this->assertStringContainsString(
-			'allday=true',
-			$url,
-			'Yahoo destination URL should mark an all-day event as one.'
+			'Yahoo destination URL should mark a one-day event all day with dur.'
 		);
 		$this->assertStringNotContainsString(
-			'dur=',
+			'et=',
 			$url,
-			'Yahoo destination URL should not send a duration for an all-day event.'
+			'Yahoo destination URL should send no end date, which would make it ignore dur.'
 		);
 
 		$multi_day_id = $this->make_all_day_event( 'Asia/Tokyo', '2030-06-15', '2030-06-16' );
@@ -940,14 +935,14 @@ class Test_Calendar extends Base {
 			'Yahoo destination URL should start a multi-day all-day event on its first day.'
 		);
 		$this->assertStringContainsString(
-			'et=20300616',
+			'et=20300617',
 			$multi_url,
-			'Yahoo destination URL should end a multi-day all-day event on its last day.'
+			'Yahoo destination URL should end a multi-day all-day event the day after its last.'
 		);
-		$this->assertStringContainsString(
-			'allday=true',
+		$this->assertStringNotContainsString(
+			'dur=',
 			$multi_url,
-			'Yahoo destination URL should mark a multi-day all-day event as one.'
+			'Yahoo destination URL should send no duration alongside an end date.'
 		);
 	}
 

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-calendar.php
@@ -813,4 +813,161 @@ class Test_Calendar extends Base {
 		$this->assertIsString( $url );
 		$this->assertNotEmpty( $url );
 	}
+
+	/**
+	 * Build an all-day event with local datetimes, specified timezone, and all-day meta.
+	 *
+	 * @param string $timezone   The timezone string.
+	 * @param string $start_date The start date in Y-m-d format.
+	 * @param string $end_date   The end date in Y-m-d format.
+	 *
+	 * @return int The event post ID.
+	 */
+	private function make_all_day_event(
+		string $timezone = 'Asia/Tokyo',
+		string $start_date = '2030-06-15',
+		string $end_date = '2030-06-15'
+	): int {
+		$event_id = $this->mock->post(
+			array(
+				'post_type'  => Event::POST_TYPE,
+				'post_title' => 'All Day Event',
+				'post_name'  => 'all-day-event',
+			)
+		)->get()->ID;
+
+		$event = new Event( $event_id );
+		$event->save_datetimes(
+			array(
+				'datetime_start' => "{$start_date} 00:00:00",
+				'datetime_end'   => "{$end_date} 23:59:59",
+				'timezone'       => $timezone,
+			)
+		);
+		update_post_meta( $event_id, 'gatherpress_is_all_day', 1 );
+
+		return $event_id;
+	}
+
+	/**
+	 * Coverage for get_google_destination_url with an all-day event.
+	 *
+	 * All-day events must serialize as floating dates with exclusive end date (YYYYMMDD/YYYYMMDD)
+	 * and no time/UTC offset component.
+	 *
+	 * @since 0.36.0
+	 * @ticket 2225
+	 * @covers ::get_google_destination_url
+	 *
+	 * @return void
+	 */
+	public function test_get_google_destination_url_with_all_day_event(): void {
+		$event_id = $this->make_all_day_event( 'Asia/Tokyo', '2030-06-15', '2030-06-15' );
+		$instance = new Calendar( $event_id );
+		$url      = $instance->get_google_destination_url();
+
+		$this->assertStringContainsString(
+			'dates=20300615%2F20300616',
+			$url,
+			'Google destination URL for a 1-day all-day event should use floating dates with exclusive end date.'
+		);
+
+		$multi_day_id = $this->make_all_day_event( 'Asia/Tokyo', '2030-06-15', '2030-06-17' );
+		$multi_inst   = new Calendar( $multi_day_id );
+		$multi_url    = $multi_inst->get_google_destination_url();
+
+		$this->assertStringContainsString(
+			'dates=20300615%2F20300618',
+			$multi_url,
+			'Google destination URL for a multi-day all-day event should use floating dates with exclusive end date.'
+		);
+	}
+
+	/**
+	 * Coverage for get_yahoo_destination_url with an all-day event.
+	 *
+	 * All-day events serialize start date as YYYYMMDD and duration as whole-day hours (2400 per day).
+	 *
+	 * @since 0.36.0
+	 * @ticket 2225
+	 * @covers ::get_yahoo_destination_url
+	 *
+	 * @return void
+	 */
+	public function test_get_yahoo_destination_url_with_all_day_event(): void {
+		$event_id = $this->make_all_day_event( 'Asia/Tokyo', '2030-06-15', '2030-06-15' );
+		$instance = new Calendar( $event_id );
+		$url      = $instance->get_yahoo_destination_url();
+
+		$this->assertStringContainsString(
+			'st=20300615',
+			$url,
+			'Yahoo destination URL should use Ymd start date for all-day events.'
+		);
+		$this->assertStringContainsString(
+			'dur=2400',
+			$url,
+			'Yahoo destination URL should use 2400 duration for a 1-day all-day event.'
+		);
+
+		$multi_day_id = $this->make_all_day_event( 'Asia/Tokyo', '2030-06-15', '2030-06-16' );
+		$multi_inst   = new Calendar( $multi_day_id );
+		$multi_url    = $multi_inst->get_yahoo_destination_url();
+
+		$this->assertStringContainsString(
+			'dur=4800',
+			$multi_url,
+			'Yahoo destination URL should use 4800 duration for a 2-day all-day event.'
+		);
+	}
+
+	/**
+	 * Coverage for get_ical_event_string with an all-day event.
+	 *
+	 * Per RFC 5545 §3.6.1, all-day events must use DTSTART;VALUE=DATE and DTEND;VALUE=DATE
+	 * with exclusive end date in local time without UTC offset drift.
+	 *
+	 * @since 0.36.0
+	 * @ticket 2225
+	 * @covers ::get_ical_event_string
+	 *
+	 * @return void
+	 */
+	public function test_get_ical_event_string_with_all_day_event(): void {
+		// Non-UTC timezone (Asia/Tokyo is UTC+9) where GMT start would fall on the previous day.
+		$event_id = $this->make_all_day_event( 'Asia/Tokyo', '2030-06-15', '2030-06-15' );
+		$instance = new Calendar( $event_id );
+		$vevent   = $instance->get_ical_event_string();
+
+		$this->assertStringContainsString(
+			'DTSTART;VALUE=DATE:20300615',
+			$vevent,
+			'iCal VEVENT for all-day event must use DTSTART;VALUE=DATE in local date.'
+		);
+		$this->assertStringContainsString(
+			'DTEND;VALUE=DATE:20300616',
+			$vevent,
+			'iCal VEVENT for all-day event must use DTEND;VALUE=DATE with exclusive end date.'
+		);
+		$this->assertStringNotContainsString(
+			'DTSTART:20300614',
+			$vevent,
+			'iCal all-day date must not drift to previous day due to GMT offset.'
+		);
+
+		// Multi-day all-day event.
+		$multi_day_id = $this->make_all_day_event( 'Asia/Tokyo', '2030-06-15', '2030-06-17' );
+		$multi_inst   = new Calendar( $multi_day_id );
+		$multi_vevent = $multi_inst->get_ical_event_string();
+
+		$this->assertStringContainsString(
+			'DTSTART;VALUE=DATE:20300615',
+			$multi_vevent
+		);
+		$this->assertStringContainsString(
+			'DTEND;VALUE=DATE:20300618',
+			$multi_vevent,
+			'Multi-day all-day event must have DTEND on the day after the last day.'
+		);
+	}
 }


### PR DESCRIPTION
Fixes #2225.

### Summary of Changes
Addresses calendar client export/serialization for all-day events:
1. **RFC 5545 iCal / ICS (`get_ical_event_string`):** All-day events now emit `DTSTART;VALUE=DATE:YYYYMMDD` and `DTEND;VALUE=DATE:YYYYMMDD` with an exclusive end date (the day after the last day of the event), sourced from local date values rather than GMT. This prevents timezone offset drift (e.g. in Asia/Tokyo) and ensures calendar clients render the event as an all-day banner without a timezone.
2. **Google Calendar (`get_google_destination_url`):** All-day events serialize the `dates` query parameter as `YYYYMMDD/YYYYMMDD` with exclusive end date (no time component `T...Z`).
3. **Yahoo! Calendar (`get_yahoo_destination_url`):** All-day events serialize `st=YYYYMMDD` and duration in 24-hour intervals (`dur=2400` for 1 day, `4800` for 2 days).

### Verification
- **PHP Unit Tests:** Added 3 unit tests in `Test_Calendar`:
  - `test_get_google_destination_url_with_all_day_event` (1-day and multi-day exclusive end date)
  - `test_get_yahoo_destination_url_with_all_day_event` (1-day and 2-day duration)
  - `test_get_ical_event_string_with_all_day_event` (verifies local floating date without GMT boundary drift on non-UTC timezone Asia/Tokyo)
- **Coding Standards:** `phpcs` passes cleanly with 0 errors and 0 warnings on `class-calendar.php` and `class-test-calendar.php`.
- **Static Analysis:** `phpstan` passes with 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar exports for all-day events across Google Calendar, Yahoo Calendar, and iCal.
  * All-day events now use date-only values, correct exclusive end dates, and accurate whole-day durations.
  * Prevented timezone-related date shifts in iCal exports.

* **Tests**
  * Added coverage confirming correct all-day event formatting for all supported calendar formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->