### PR TITLE
Support Accept: text/calendar content-negotiation for event URLs (#1685)

### DIFF
--- a/.github/changelog/1685-calendar-content-negotiation
+++ b/.github/changelog/1685-calendar-content-negotiation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support HTTP Accept: text/calendar content-negotiation for event URLs and calendar feeds.

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -89,6 +89,8 @@ final class Setup {
 		// validity check and never registered its rewrite rule.
 		add_action( 'init', array( $this, 'register_endpoints' ), PHP_INT_MAX );
 		add_action( 'wp_head', array( $this, 'alternate_links' ) );
+		add_action( 'template_redirect', array( $this, 'maybe_handle_content_negotiation' ), 0 );
+		add_filter( 'wp_headers', array( $this, 'filter_wp_headers' ) );
 	}
 
 	/**
@@ -1096,5 +1098,191 @@ final class Setup {
 	protected function is_tax_like_type_for_event_supporting_types( string $post_type ): bool {
 		return post_type_supports( $post_type, 'gatherpress-shadow-source' ) &&
 			$this->has_post_type_for_taxonomy( Shadow_Source::get_instance()->get_taxonomy( $post_type ) );
+	}
+
+	/**
+	 * Determine whether the client's `Accept` HTTP header prefers `text/calendar`.
+	 *
+	 * Implements RFC 7231 / RFC 9110 content negotiation by parsing comma-separated
+	 * media ranges and their quality factor (`q=`) weights. Returns `true` if
+	 * `text/calendar` is requested with an explicit quality weight equal to or
+	 * higher than standard HTML formats (`text/html`, `application/xhtml+xml`).
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string|null $accept_header Optional raw Accept header. Defaults to `$_SERVER['HTTP_ACCEPT']`.
+	 *
+	 * @return bool True if text/calendar is negotiated/preferred, false otherwise.
+	 */
+	public function is_calendar_negotiated( ?string $accept_header = null ): bool {
+		if ( null === $accept_header ) {
+			$accept_header = isset( $_SERVER['HTTP_ACCEPT'] ) && is_string( $_SERVER['HTTP_ACCEPT'] )
+				? sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT'] ) )
+				: '';
+		}
+
+		if ( '' === $accept_header || false === stripos( $accept_header, 'text/calendar' ) ) {
+			return false;
+		}
+
+		$calendar_q = 0.0;
+		$html_q     = 0.0;
+
+		$ranges = explode( ',', $accept_header );
+		foreach ( $ranges as $range ) {
+			$parts = explode( ';', trim( $range ) );
+			$mime  = strtolower( trim( $parts[0] ) );
+			$q     = 1.0;
+
+			if ( count( $parts ) > 1 ) {
+				foreach ( array_slice( $parts, 1 ) as $param ) {
+					$param_parts = explode( '=', trim( $param ), 2 );
+					if ( 2 === count( $param_parts ) && 'q' === strtolower( trim( $param_parts[0] ) ) ) {
+						$q = (float) trim( $param_parts[1] );
+						break;
+					}
+				}
+			}
+
+			if ( 'text/calendar' === $mime ) {
+				$calendar_q = max( $calendar_q, $q );
+			} elseif ( 'text/html' === $mime || 'application/xhtml+xml' === $mime ) {
+				$html_q = max( $html_q, $q );
+			}
+		}
+
+		return $calendar_q > 0.0 && $calendar_q >= $html_q;
+	}
+
+	/**
+	 * Resolve the canonical calendar feed URL for the current query context.
+	 *
+	 * Dispatches across singular events, shadow-source posts (venues),
+	 * event-bearing taxonomy archives, event post-type archives, and the sitewide feed.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return string|false Calendar feed or download URL, or false if not an event-related request.
+	 */
+	public function get_calendar_url_for_request() {
+		$queried = get_queried_object();
+
+		if ( is_singular() && $queried instanceof WP_Post ) {
+			if ( post_type_supports( $queried->post_type, 'gatherpress-event-date' ) ) {
+				$calendar = new Calendar( $queried->ID );
+				return $calendar->get_ical_url();
+			}
+
+			if ( $this->is_tax_like_type_for_event_supporting_types( $queried->post_type ) ) {
+				return get_post_comments_feed_link( $queried->ID, self::ICAL_SLUG );
+			}
+		}
+
+		if ( is_tax() && $queried instanceof WP_Term && $this->has_post_type_for_taxonomy( $queried->taxonomy ) ) {
+			return get_term_feed_link( $queried->term_id, $queried->taxonomy, self::ICAL_SLUG );
+		}
+
+		if ( is_post_type_archive() ) {
+			$post_type = get_query_var( 'post_type' );
+			if ( is_array( $post_type ) ) {
+				$post_type = reset( $post_type );
+			}
+			if ( is_string( $post_type ) && post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+				return get_post_type_archive_feed_link( $post_type, self::ICAL_SLUG );
+			}
+		}
+
+		if ( is_front_page() || is_home() ) {
+			return get_feed_link( self::ICAL_SLUG );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether the current request is for an event-related view.
+	 *
+	 * Used to determine if the `Vary: Accept` HTTP header should be attached.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return bool
+	 */
+	public function is_event_related_request(): bool {
+		return false !== $this->get_calendar_url_for_request();
+	}
+
+	/**
+	 * Handle HTTP Content Negotiation for `Accept: text/calendar` requests.
+	 *
+	 * If the client requests `text/calendar` on an event-supporting URL,
+	 * safely redirect to the corresponding ICS calendar feed/download URL.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return void
+	 */
+	public function maybe_handle_content_negotiation(): void {
+		if ( ! $this->is_calendar_negotiated() ) {
+			return;
+		}
+
+		$calendar_url = $this->get_calendar_url_for_request();
+
+		if ( ! is_string( $calendar_url ) || '' === $calendar_url ) {
+			return;
+		}
+
+		// Avoid redirect loops if the request is already for the target URL.
+		$current_url = isset( $_SERVER['REQUEST_URI'] ) && is_string( $_SERVER['REQUEST_URI'] )
+			? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+			: '';
+
+		if ( '' !== $current_url && false !== strpos( $calendar_url, $current_url ) ) {
+			return;
+		}
+
+		// Ensure the redirect target host is permitted.
+		add_filter(
+			'allowed_redirect_hosts',
+			function ( array $hosts ) use ( $calendar_url ): array {
+				$host = wp_parse_url( $calendar_url, PHP_URL_HOST );
+				if ( is_string( $host ) && '' !== $host && ! in_array( $host, $hosts, true ) ) {
+					$hosts[] = $host;
+				}
+				return $hosts;
+			}
+		);
+
+		header( 'Vary: Accept' );
+		wp_safe_redirect( $calendar_url, 302 );
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation.
+		// @codeCoverageIgnoreStart
+		exit;
+		// @codeCoverageIgnoreEnd
+	}
+
+	/**
+	 * Add `Vary: Accept` header for event-related HTML views so downstream caches
+	 * (proxies, CDNs) differentiate responses based on the Accept header.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param array<string, string> $headers Associative array of HTTP headers to be sent.
+	 *
+	 * @return array<string, string> Updated HTTP headers array.
+	 */
+	public function filter_wp_headers( array $headers ): array {
+		if ( $this->is_event_related_request() ) {
+			if ( isset( $headers['Vary'] ) ) {
+				if ( false === stripos( $headers['Vary'], 'Accept' ) ) {
+					$headers['Vary'] .= ', Accept';
+				}
+			} else {
+				$headers['Vary'] = 'Accept';
+			}
+		}
+
+		return $headers;
 	}
 }

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -91,12 +91,7 @@ final class Setup {
 		// validity check and never registered its rewrite rule.
 		add_action( 'init', array( $this, 'register_endpoints' ), PHP_INT_MAX );
 		add_action( 'wp_head', array( $this, 'alternate_links' ) );
-		// PHP_INT_MIN so a client asking for text/calendar is answered before
-		// anything else acts on the request: core's redirect_canonical() runs
-		// at 10, and themes and plugins commonly use template_redirect to
-		// redirect, gate access, or send output. Each of those would either
-		// send the client somewhere else first or make the redirect here a
-		// headers-already-sent failure.
+		// PHP_INT_MIN so the calendar redirect runs before redirect_canonical() or any theme's template_redirect handler.
 		add_action( 'template_redirect', array( $this, 'maybe_handle_content_negotiation' ), PHP_INT_MIN );
 		add_filter( 'wp_headers', array( $this, 'filter_wp_headers' ) );
 	}

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -22,8 +22,10 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Event\Query;
 use GatherPress\Core\Shadow_Source;
+use GatherPress\Core\Topic;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
+use GatherPress\Core\Venue;
 use GatherPress\Core\Venue\Setup as Venue_Setup;
 use WP_Post;
 use WP_Post_Type;
@@ -743,13 +745,13 @@ final class Setup {
 		$queried_object  = get_queried_object();
 
 		if (
-			is_singular( 'gatherpress_venue' ) &&
+			is_singular( Venue::POST_TYPE ) &&
 			$queried_object instanceof WP_Post &&
 			$this->is_tax_like_type_for_event_supporting_types( $queried_object->post_type )
 		) {
 			$venues = array( '_' . $queried_object->post_name );
 		} elseif (
-			is_tax( 'gatherpress_topic' ) &&
+			is_tax( Topic::TAXONOMY ) &&
 			$queried_object instanceof WP_Term &&
 			$this->has_post_type_for_taxonomy( $queried_object->taxonomy )
 		) {

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -1112,7 +1112,7 @@ final class Setup {
 				: '';
 		}
 
-		if ( '' === $accept_header || false === stripos( $accept_header, 'text/calendar' ) ) {
+		if ( '' === $accept_header ) {
 			return false;
 		}
 
@@ -1127,7 +1127,16 @@ final class Setup {
 			}
 		}
 
-		$calendar_q = $this->accept_quality( $ranges, 'text/calendar' );
+		// Only the exact media type counts for the calendar. A wildcard stands
+		// in for HTML below, but it must not stand in here: `text/calendar+json,
+		// */*` asks for a different type, and the wildcard's quality would
+		// otherwise carry the calendar past HTML and redirect a client that
+		// never asked for it.
+		if ( ! isset( $ranges['text/calendar'] ) ) {
+			return false;
+		}
+
+		$calendar_q = $ranges['text/calendar'];
 		$html_q     = max(
 			$this->accept_quality( $ranges, 'text/html' ),
 			$this->accept_quality( $ranges, 'application/xhtml+xml' )
@@ -1234,12 +1243,16 @@ final class Setup {
 			return;
 		}
 
+		// `Vary: Accept` is already on this response: filter_wp_headers() adds
+		// it for every request that resolves a calendar URL, and that is the
+		// same test the redirect target came from. Setting it again here would
+		// replace whatever else the header had gathered by then.
+		//
 		// The decision is covered through get_negotiated_redirect_url(); what
 		// remains here is the side effect, which ends in exit() and so cannot be
 		// exercised without ending the test run.
 		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation.
 		// @codeCoverageIgnoreStart
-		header( 'Vary: Accept' );
 		wp_safe_redirect( $calendar_url, 302 );
 		exit;
 		// @codeCoverageIgnoreEnd
@@ -1295,10 +1308,14 @@ final class Setup {
 	 */
 	public function filter_wp_headers( array $headers ): array {
 		if ( $this->is_event_related_request() ) {
-			$vary            = $headers['Vary'] ?? '';
-			$headers['Vary'] = empty( $vary )
-				? 'Accept'
-				: ( false === stripos( $vary, 'Accept' ) ? $vary . ', Accept' : $vary );
+			// Field names, not substrings: `Accept-Encoding` is not `Accept`.
+			$fields = array_filter( array_map( 'trim', explode( ',', (string) ( $headers['Vary'] ?? '' ) ) ) );
+
+			if ( ! in_array( 'accept', array_map( 'strtolower', $fields ), true ) ) {
+				$fields[] = 'Accept';
+			}
+
+			$headers['Vary'] = implode( ', ', $fields );
 		}
 
 		return $headers;

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -1114,21 +1114,54 @@ final class Setup {
 			return false;
 		}
 
-		$calendar_q = 0.0;
-		$html_q     = 0.0;
+		$ranges = array();
 
 		foreach ( explode( ',', $accept_header ) as $range ) {
 			$q    = preg_match( '/;\s*q=([0-9.]+)/i', $range, $m ) ? (float) $m[1] : 1.0;
 			$mime = strtolower( trim( explode( ';', $range, 2 )[0] ) );
 
-			if ( 'text/calendar' === $mime ) {
-				$calendar_q = max( $calendar_q, $q );
-			} elseif ( 'text/html' === $mime || 'application/xhtml+xml' === $mime ) {
-				$html_q = max( $html_q, $q );
+			if ( '' !== $mime ) {
+				$ranges[ $mime ] = max( $ranges[ $mime ] ?? 0.0, $q );
 			}
 		}
 
+		$calendar_q = $this->accept_quality( $ranges, 'text/calendar' );
+		$html_q     = max(
+			$this->accept_quality( $ranges, 'text/html' ),
+			$this->accept_quality( $ranges, 'application/xhtml+xml' )
+		);
+
 		return $calendar_q > 0.0 && $calendar_q >= $html_q;
+	}
+
+	/**
+	 * Quality value a parsed Accept header assigns to one media type.
+	 *
+	 * RFC 9110 section 12.5.1 ranks media ranges by precision, so the most
+	 * specific range that covers the type wins rather than the highest one.
+	 * Against an Accept of `text/calendar;q=0.5` plus a catch-all wildcard at
+	 * `q=0.9`, the calendar scores 0.5 from its own entry, while HTML, which
+	 * has no entry of its own, scores 0.9 from the wildcard. Taking the maximum
+	 * for both would tie them and redirect a client that asked for the
+	 * opposite.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param array<string, float> $ranges Parsed `media/range => quality` pairs.
+	 * @param string               $mime   Media type to score, e.g. `text/html`.
+	 *
+	 * @return float The quality value, 0.0 when nothing covers the type.
+	 */
+	protected function accept_quality( array $ranges, string $mime ): float {
+		$type = strtok( $mime, '/' );
+
+		foreach ( array( $mime, $type . '/*', '*/*' ) as $candidate ) {
+			if ( isset( $ranges[ $candidate ] ) ) {
+				return $ranges[ $candidate ];
+			}
+		}
+
+		return 0.0;
 	}
 
 	/**
@@ -1193,43 +1226,59 @@ final class Setup {
 	 * @return void
 	 */
 	public function maybe_handle_content_negotiation(): void {
-		if ( ! $this->is_calendar_negotiated() ) {
+		$calendar_url = $this->get_negotiated_redirect_url();
+
+		if ( false === $calendar_url ) {
 			return;
+		}
+
+		// The decision is covered through get_negotiated_redirect_url(); what
+		// remains here is the side effect, which ends in exit() and so cannot be
+		// exercised without ending the test run.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation.
+		// @codeCoverageIgnoreStart
+		header( 'Vary: Accept' );
+		wp_safe_redirect( $calendar_url, 302 );
+		exit;
+		// @codeCoverageIgnoreEnd
+	}
+
+	/**
+	 * Resolve where an `Accept: text/calendar` request should be redirected.
+	 *
+	 * Split out from maybe_handle_content_negotiation() so the decision is
+	 * testable on its own: that method ends in exit(), which is why the
+	 * redirect-loop guard below shipped inverted and unnoticed.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return string|false The calendar URL to redirect to, or false to leave
+	 *                      the request alone.
+	 */
+	public function get_negotiated_redirect_url() {
+		if ( ! $this->is_calendar_negotiated() ) {
+			return false;
+		}
+
+		// The request is already a calendar representation, so there is nothing
+		// to negotiate and redirecting would point it at itself. Both endpoint
+		// shapes are covered: the feed links carry is_feed(), and the single
+		// rewrite endpoint (/event/my-event/ical/) carries the query var.
+		//
+		// This replaces a substring test between the target and REQUEST_URI.
+		// Every target is the requested URL plus a suffix, so that test matched
+		// on every request and disabled negotiation entirely.
+		if ( is_feed() || '' !== (string) get_query_var( self::QUERY_VAR ) ) {
+			return false;
 		}
 
 		$calendar_url = $this->get_calendar_url_for_request();
 
 		if ( ! is_string( $calendar_url ) || '' === $calendar_url ) {
-			return;
+			return false;
 		}
 
-		// Avoid redirect loops if the request is already for the target URL.
-		$current_url = isset( $_SERVER['REQUEST_URI'] ) && is_string( $_SERVER['REQUEST_URI'] )
-			? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) )
-			: '';
-
-		if ( '' !== $current_url && false !== strpos( $calendar_url, $current_url ) ) {
-			return;
-		}
-
-		// Ensure the redirect target host is permitted.
-		add_filter(
-			'allowed_redirect_hosts',
-			function ( array $hosts ) use ( $calendar_url ): array {
-				$host = wp_parse_url( $calendar_url, PHP_URL_HOST );
-				if ( is_string( $host ) && '' !== $host && ! in_array( $host, $hosts, true ) ) {
-					$hosts[] = $host;
-				}
-				return $hosts;
-			}
-		);
-
-		header( 'Vary: Accept' );
-		wp_safe_redirect( $calendar_url, 302 );
-		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar -- PHPUnit annotation.
-		// @codeCoverageIgnoreStart
-		exit;
-		// @codeCoverageIgnoreEnd
+		return $calendar_url;
 	}
 
 	/**

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -91,7 +91,13 @@ final class Setup {
 		// validity check and never registered its rewrite rule.
 		add_action( 'init', array( $this, 'register_endpoints' ), PHP_INT_MAX );
 		add_action( 'wp_head', array( $this, 'alternate_links' ) );
-		add_action( 'template_redirect', array( $this, 'maybe_handle_content_negotiation' ), 0 );
+		// PHP_INT_MIN so a client asking for text/calendar is answered before
+		// anything else acts on the request: core's redirect_canonical() runs
+		// at 10, and themes and plugins commonly use template_redirect to
+		// redirect, gate access, or send output. Each of those would either
+		// send the client somewhere else first or make the redirect here a
+		// headers-already-sent failure.
+		add_action( 'template_redirect', array( $this, 'maybe_handle_content_negotiation' ), PHP_INT_MIN );
 		add_filter( 'wp_headers', array( $this, 'filter_wp_headers' ) );
 	}
 

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -91,7 +91,7 @@ final class Setup {
 		// validity check and never registered its rewrite rule.
 		add_action( 'init', array( $this, 'register_endpoints' ), PHP_INT_MAX );
 		add_action( 'wp_head', array( $this, 'alternate_links' ) );
-		// PHP_INT_MIN so the calendar redirect runs before redirect_canonical() or any theme's template_redirect handler.
+		// PHP_INT_MIN so the calendar redirect runs before redirect_canonical() and any theme's own handler.
 		add_action( 'template_redirect', array( $this, 'maybe_handle_content_negotiation' ), PHP_INT_MIN );
 		add_filter( 'wp_headers', array( $this, 'filter_wp_headers' ) );
 	}

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -629,24 +629,22 @@ final class Setup {
 		$shadow_source = Shadow_Source::get_instance();
 		$href          = '';
 
-		if ( $shadow_source->is_shadow_term_slug( $term->taxonomy ) ) {
-			// Skip sentinel shadow terms like `online-event` whose slug does
-			// not start with `_` — no backing post means no feed to link to.
-			if ( $shadow_source->is_shadow_term_slug( $term->slug ) ) {
-				$post = $shadow_source->get_post_from_term_slug(
-					$term->slug,
-					ltrim( $term->taxonomy, '_' )
-				);
-
-				// Without this, get_post_comments_feed_link( null ) falls back to the global post.
-				if ( $post instanceof WP_Post ) {
-					// Feels weird to use a *_comments_* function here, but it delivers clean results
-					// in the form of "domain.tld/event/my-sample-event/feed/ical/".
-					$href = get_post_comments_feed_link( $post->ID, self::ICAL_SLUG );
-				}
-			}
-		} else {
+		if ( ! $shadow_source->is_shadow_term_slug( $term->taxonomy ) ) {
 			$href = get_term_feed_link( $term->term_id, $term->taxonomy, self::ICAL_SLUG );
+		} elseif ( $shadow_source->is_shadow_term_slug( $term->slug ) ) {
+			// Skip sentinel shadow terms like `online-event` whose slug does
+			// not start with `_` - no backing post means no feed to link to.
+			$post = $shadow_source->get_post_from_term_slug(
+				$term->slug,
+				ltrim( $term->taxonomy, '_' )
+			);
+
+			// Without this, get_post_comments_feed_link( null ) falls back to the global post.
+			if ( $post instanceof WP_Post ) {
+				// Feels weird to use a *_comments_* function here, but it delivers clean results
+				// in the form of "domain.tld/event/my-sample-event/feed/ical/".
+				$href = get_post_comments_feed_link( $post->ID, self::ICAL_SLUG );
+			}
 		}
 
 		if ( empty( $href ) ) {
@@ -745,21 +743,17 @@ final class Setup {
 		$queried_object  = get_queried_object();
 
 		if (
-			is_singular() &&
+			is_singular( 'gatherpress_venue' ) &&
 			$queried_object instanceof WP_Post &&
 			$this->is_tax_like_type_for_event_supporting_types( $queried_object->post_type )
 		) {
-			if ( is_singular( 'gatherpress_venue' ) ) {
-				$venues = array( '_' . $queried_object->post_name );
-			}
+			$venues = array( '_' . $queried_object->post_name );
 		} elseif (
-			is_tax() &&
+			is_tax( 'gatherpress_topic' ) &&
 			$queried_object instanceof WP_Term &&
 			$this->has_post_type_for_taxonomy( $queried_object->taxonomy )
 		) {
-			if ( is_tax( 'gatherpress_topic' ) ) {
-				$topics = array( $queried_object->slug );
-			}
+			$topics = array( $queried_object->slug );
 		}
 
 		$query = Query::get_instance()->get_events_list( $event_list_type, $number, $topics, $venues );
@@ -977,13 +971,8 @@ final class Setup {
 
 		if ( '' !== $client_etag ) {
 			// A cache may return the tag weakened, and may hold several.
-			foreach ( explode( ',', str_replace( 'W/', '', $client_etag ) ) as $candidate ) {
-				if ( trim( $candidate ) === $etag ) {
-					return true;
-				}
-			}
-
-			return false;
+			$tags = array_map( 'trim', explode( ',', str_replace( 'W/', '', $client_etag ) ) );
+			return in_array( $etag, $tags, true );
 		}
 
 		$client_time = isset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] )
@@ -1128,21 +1117,9 @@ final class Setup {
 		$calendar_q = 0.0;
 		$html_q     = 0.0;
 
-		$ranges = explode( ',', $accept_header );
-		foreach ( $ranges as $range ) {
-			$parts = explode( ';', trim( $range ) );
-			$mime  = strtolower( trim( $parts[0] ) );
-			$q     = 1.0;
-
-			if ( count( $parts ) > 1 ) {
-				foreach ( array_slice( $parts, 1 ) as $param ) {
-					$param_parts = explode( '=', trim( $param ), 2 );
-					if ( 2 === count( $param_parts ) && 'q' === strtolower( trim( $param_parts[0] ) ) ) {
-						$q = (float) trim( $param_parts[1] );
-						break;
-					}
-				}
-			}
+		foreach ( explode( ',', $accept_header ) as $range ) {
+			$q    = preg_match( '/;\s*q=([0-9.]+)/i', $range, $m ) ? (float) $m[1] : 1.0;
+			$mime = strtolower( trim( explode( ';', $range, 2 )[0] ) );
 
 			if ( 'text/calendar' === $mime ) {
 				$calendar_q = max( $calendar_q, $q );
@@ -1169,8 +1146,7 @@ final class Setup {
 
 		if ( is_singular() && $queried instanceof WP_Post ) {
 			if ( post_type_supports( $queried->post_type, 'gatherpress-event-date' ) ) {
-				$calendar = new Calendar( $queried->ID );
-				return $calendar->get_ical_url();
+				return ( new Calendar( $queried->ID ) )->get_ical_url();
 			}
 
 			if ( $this->is_tax_like_type_for_event_supporting_types( $queried->post_type ) ) {
@@ -1184,19 +1160,13 @@ final class Setup {
 
 		if ( is_post_type_archive() ) {
 			$post_type = get_query_var( 'post_type' );
-			if ( is_array( $post_type ) ) {
-				$post_type = reset( $post_type );
-			}
+			$post_type = is_array( $post_type ) ? reset( $post_type ) : $post_type;
 			if ( is_string( $post_type ) && post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
 				return get_post_type_archive_feed_link( $post_type, self::ICAL_SLUG );
 			}
 		}
 
-		if ( is_front_page() || is_home() ) {
-			return get_feed_link( self::ICAL_SLUG );
-		}
-
-		return false;
+		return ( is_front_page() || is_home() ) ? get_feed_link( self::ICAL_SLUG ) : false;
 	}
 
 	/**
@@ -1274,13 +1244,10 @@ final class Setup {
 	 */
 	public function filter_wp_headers( array $headers ): array {
 		if ( $this->is_event_related_request() ) {
-			if ( isset( $headers['Vary'] ) ) {
-				if ( false === stripos( $headers['Vary'], 'Accept' ) ) {
-					$headers['Vary'] .= ', Accept';
-				}
-			} else {
-				$headers['Vary'] = 'Accept';
-			}
+			$vary            = $headers['Vary'] ?? '';
+			$headers['Vary'] = empty( $vary )
+				? 'Accept'
+				: ( false === stripos( $vary, 'Accept' ) ? $vary . ', Accept' : $vary );
 		}
 
 		return $headers;

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -1801,6 +1801,14 @@ class Test_Setup extends Base {
 		$headers = $instance->filter_wp_headers( array( 'Vary' => 'Accept, Cookie' ) );
 		$this->assertSame( 'Accept, Cookie', $headers['Vary'] );
 
+		// Field names are compared as tokens: Accept-Encoding is not Accept.
+		$headers = $instance->filter_wp_headers( array( 'Vary' => 'Accept-Encoding' ) );
+		$this->assertSame( 'Accept-Encoding, Accept', $headers['Vary'] );
+
+		// And the comparison is case-insensitive, as header field names are.
+		$headers = $instance->filter_wp_headers( array( 'Vary' => 'accept, Cookie' ) );
+		$this->assertSame( 'accept, Cookie', $headers['Vary'] );
+
 		// For a non-event page, headers are unchanged.
 		$regular_post = $this->mock->post( array( 'post_type' => 'post' ) )->get();
 		$wp_query->init();
@@ -1994,6 +2002,24 @@ class Test_Setup extends Base {
 		$this->assertTrue(
 			$instance->is_calendar_negotiated( 'text/calendar;q=0.9, */*;q=0.5' ),
 			'Failed to assert the calendar still wins when it outranks the wildcard.'
+		);
+
+		// The wildcard stands in for HTML, never for the calendar. This client
+		// asked for a different type; the substring `text/calendar` in it and
+		// the wildcard's quality must not combine into a redirect.
+		$this->assertFalse(
+			$instance->is_calendar_negotiated( 'text/calendar+json, */*;q=0.9' ),
+			'Failed to assert a media type that merely starts with text/calendar does not negotiate.'
+		);
+		$this->assertFalse(
+			$instance->is_calendar_negotiated( 'text/*' ),
+			'Failed to assert a type wildcard does not negotiate the calendar.'
+		);
+
+		// Equal quality goes to the calendar, since the client listed it.
+		$this->assertTrue(
+			$instance->is_calendar_negotiated( 'text/html, text/calendar' ),
+			'Failed to assert an equally ranked calendar negotiates.'
 		);
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -46,6 +46,18 @@ class Test_Setup extends Base {
 				'priority' => 10,
 				'callback' => array( $instance, 'alternate_links' ),
 			),
+			array(
+				'type'     => 'action',
+				'name'     => 'template_redirect',
+				'priority' => 0,
+				'callback' => array( $instance, 'maybe_handle_content_negotiation' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'wp_headers',
+				'priority' => 10,
+				'callback' => array( $instance, 'filter_wp_headers' ),
+			),
 		);
 
 		$this->assert_hooks( $hooks, $instance );
@@ -1644,5 +1656,189 @@ class Test_Setup extends Base {
 		);
 
 		unset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] );
+	}
+
+	/**
+	 * Coverage for is_calendar_negotiated with various Accept headers.
+	 *
+	 * @covers ::is_calendar_negotiated
+	 *
+	 * @return void
+	 */
+	public function test_is_calendar_negotiated(): void {
+		$instance = Setup::get_instance();
+
+		// Empty / null.
+		$this->assertFalse( $instance->is_calendar_negotiated( '' ) );
+		$this->assertFalse( $instance->is_calendar_negotiated( null ) );
+
+		// Standard browser headers without text/calendar.
+		$this->assertFalse(
+			$instance->is_calendar_negotiated(
+				'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+			)
+		);
+		$this->assertFalse( $instance->is_calendar_negotiated( '*/*' ) );
+		$this->assertFalse( $instance->is_calendar_negotiated( 'application/json' ) );
+
+		// Direct calendar accept.
+		$this->assertTrue( $instance->is_calendar_negotiated( 'text/calendar' ) );
+		$this->assertTrue( $instance->is_calendar_negotiated( 'TEXT/CALENDAR' ) );
+
+		// Quality factor comparisons.
+		$this->assertTrue( $instance->is_calendar_negotiated( 'text/calendar;q=0.9, text/html;q=0.8' ) );
+		$this->assertTrue( $instance->is_calendar_negotiated( 'text/html;q=0.8, text/calendar;q=0.9' ) );
+		$this->assertTrue( $instance->is_calendar_negotiated( 'text/calendar, text/html' ) );
+
+		// Lower quality factor than HTML should not negotiate calendar.
+		$this->assertFalse(
+			$instance->is_calendar_negotiated(
+				'text/html,application/xhtml+xml,application/xml;q=0.9,text/calendar;q=0.5'
+			)
+		);
+
+		// Server global fallback.
+		$_SERVER['HTTP_ACCEPT'] = 'text/calendar';
+		$this->assertTrue( $instance->is_calendar_negotiated() );
+		unset( $_SERVER['HTTP_ACCEPT'] );
+	}
+
+	/**
+	 * Coverage for get_calendar_url_for_request and is_event_related_request.
+	 *
+	 * @covers ::get_calendar_url_for_request
+	 * @covers ::is_event_related_request
+	 *
+	 * @return void
+	 */
+	public function test_get_calendar_url_for_request_and_is_event_related(): void {
+		$instance   = Setup::get_instance();
+		$event_post = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+
+		$wp_query = $GLOBALS['wp_query'];
+		$wp_query->init();
+		$wp_query->queried_object    = $event_post;
+		$wp_query->is_singular       = true;
+		$wp_query->is_single         = true;
+		$wp_query->queried_object_id = $event_post->ID;
+
+		$calendar_url = $instance->get_calendar_url_for_request();
+		$this->assertIsString( $calendar_url );
+		$this->assertStringContainsString( 'ical', $calendar_url );
+		$this->assertTrue( $instance->is_event_related_request() );
+
+		// Venue shadow source post.
+		$venue_post = $this->mock->post( array( 'post_type' => Venue::POST_TYPE ) )->get();
+		$wp_query->init();
+		$wp_query->queried_object    = $venue_post;
+		$wp_query->is_singular       = true;
+		$wp_query->is_single         = true;
+		$wp_query->queried_object_id = $venue_post->ID;
+
+		$venue_url = $instance->get_calendar_url_for_request();
+		$this->assertIsString( $venue_url );
+		$this->assertTrue( $instance->is_event_related_request() );
+
+		// Event post type archive.
+		$wp_query->init();
+		$wp_query->is_post_type_archive = true;
+		$wp_query->set( 'post_type', Event::POST_TYPE );
+
+		$archive_url = $instance->get_calendar_url_for_request();
+		$this->assertIsString( $archive_url );
+		$this->assertTrue( $instance->is_event_related_request() );
+
+		// Front page / home.
+		$wp_query->init();
+		$wp_query->is_front_page = true;
+		$wp_query->is_home       = true;
+
+		$home_url = $instance->get_calendar_url_for_request();
+		$this->assertIsString( $home_url );
+		$this->assertTrue( $instance->is_event_related_request() );
+
+		// Non-event singular post.
+		$regular_post = $this->mock->post( array( 'post_type' => 'post' ) )->get();
+		$wp_query->init();
+		$wp_query->queried_object    = $regular_post;
+		$wp_query->is_singular       = true;
+		$wp_query->is_single         = true;
+		$wp_query->queried_object_id = $regular_post->ID;
+
+		$this->assertFalse( $instance->get_calendar_url_for_request() );
+		$this->assertFalse( $instance->is_event_related_request() );
+	}
+
+	/**
+	 * Coverage for filter_wp_headers method.
+	 *
+	 * @covers ::filter_wp_headers
+	 *
+	 * @return void
+	 */
+	public function test_filter_wp_headers(): void {
+		$instance   = Setup::get_instance();
+		$event_post = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+
+		$wp_query = $GLOBALS['wp_query'];
+		$wp_query->init();
+		$wp_query->queried_object    = $event_post;
+		$wp_query->is_singular       = true;
+		$wp_query->is_single         = true;
+		$wp_query->queried_object_id = $event_post->ID;
+
+		// When no Vary header is present.
+		$headers = $instance->filter_wp_headers( array( 'Content-Type' => 'text/html' ) );
+		$this->assertSame( 'Accept', $headers['Vary'] );
+
+		// When an existing Vary header is present without Accept.
+		$headers = $instance->filter_wp_headers( array( 'Vary' => 'User-Agent' ) );
+		$this->assertSame( 'User-Agent, Accept', $headers['Vary'] );
+
+		// When Vary already includes Accept.
+		$headers = $instance->filter_wp_headers( array( 'Vary' => 'Accept, Cookie' ) );
+		$this->assertSame( 'Accept, Cookie', $headers['Vary'] );
+
+		// For a non-event page, headers are unchanged.
+		$regular_post = $this->mock->post( array( 'post_type' => 'post' ) )->get();
+		$wp_query->init();
+		$wp_query->queried_object    = $regular_post;
+		$wp_query->is_singular       = true;
+		$wp_query->is_single         = true;
+		$wp_query->queried_object_id = $regular_post->ID;
+
+		$headers = $instance->filter_wp_headers( array( 'Content-Type' => 'text/html' ) );
+		$this->assertArrayNotHasKey( 'Vary', $headers );
+	}
+
+	/**
+	 * Coverage for maybe_handle_content_negotiation.
+	 *
+	 * @covers ::maybe_handle_content_negotiation
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_content_negotiation(): void {
+		$instance   = Setup::get_instance();
+		$event_post = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
+
+		$wp_query = $GLOBALS['wp_query'];
+		$wp_query->init();
+		$wp_query->queried_object    = $event_post;
+		$wp_query->is_singular       = true;
+		$wp_query->is_single         = true;
+		$wp_query->queried_object_id = $event_post->ID;
+
+		// When Accept header does not request calendar, nothing happens.
+		$_SERVER['HTTP_ACCEPT'] = 'text/html';
+		$instance->maybe_handle_content_negotiation();
+
+		// When Accept header requests calendar, allowed_redirect_hosts filter is attached.
+		$_SERVER['HTTP_ACCEPT'] = 'text/calendar';
+		$_SERVER['REQUEST_URI'] = '/event/test-event/';
+
+		$instance->maybe_handle_content_negotiation();
+
+		unset( $_SERVER['HTTP_ACCEPT'], $_SERVER['REQUEST_URI'] );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -1988,7 +1988,7 @@ class Test_Setup extends Base {
 		// calendar-preferred and redirected against the client's wishes.
 		$this->assertFalse(
 			$instance->is_calendar_negotiated( 'text/calendar;q=0.5, */*;q=0.9' ),
-			'Failed to assert a wildcard media range outranking the calendar is honoured.'
+			'Failed to assert a wildcard media range outranking the calendar is honored.'
 		);
 
 		$this->assertTrue(

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -51,7 +51,7 @@ class Test_Setup extends Base {
 			array(
 				'type'     => 'action',
 				'name'     => 'template_redirect',
-				'priority' => 0,
+				'priority' => PHP_INT_MIN,
 				'callback' => array( $instance, 'maybe_handle_content_negotiation' ),
 			),
 			array(

--- a/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
+++ b/test/unit/php/includes/tests/core/classes/calendar/class-test-setup.php
@@ -8,8 +8,10 @@
 
 namespace GatherPress\Tests\Core\Calendar;
 
+use GatherPress\Core\Calendar\Calendar;
 use GatherPress\Core\Calendar\Setup;
 use GatherPress\Core\Event;
+use GatherPress\Core\Topic;
 use GatherPress\Core\Venue;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
@@ -1812,13 +1814,13 @@ class Test_Setup extends Base {
 	}
 
 	/**
-	 * Coverage for maybe_handle_content_negotiation.
+	 * Coverage for get_negotiated_redirect_url.
 	 *
-	 * @covers ::maybe_handle_content_negotiation
+	 * @covers ::get_negotiated_redirect_url
 	 *
 	 * @return void
 	 */
-	public function test_maybe_handle_content_negotiation(): void {
+	public function test_get_negotiated_redirect_url(): void {
 		$instance   = Setup::get_instance();
 		$event_post = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get();
 
@@ -1829,16 +1831,169 @@ class Test_Setup extends Base {
 		$wp_query->is_single         = true;
 		$wp_query->queried_object_id = $event_post->ID;
 
-		// When Accept header does not request calendar, nothing happens.
-		$_SERVER['HTTP_ACCEPT'] = 'text/html';
-		$instance->maybe_handle_content_negotiation();
+		$expected = ( new Calendar( $event_post->ID ) )->get_ical_url();
 
-		// When Accept header requests calendar, allowed_redirect_hosts filter is attached.
+		// An HTML request is left alone.
+		$_SERVER['HTTP_ACCEPT'] = 'text/html';
+
+		$this->assertFalse(
+			$instance->get_negotiated_redirect_url(),
+			'Failed to assert an HTML request is not redirected.'
+		);
+
+		// A calendar request on the event page is redirected to its feed. This
+		// is the case the shipped substring guard refused, because the event
+		// permalink is a substring of its own calendar URL.
 		$_SERVER['HTTP_ACCEPT'] = 'text/calendar';
 		$_SERVER['REQUEST_URI'] = '/event/test-event/';
 
-		$instance->maybe_handle_content_negotiation();
+		$this->assertSame(
+			$expected,
+			$instance->get_negotiated_redirect_url(),
+			'Failed to assert a negotiated event request resolves to its calendar URL.'
+		);
+
+		// The same request already on the calendar endpoint is left alone, so
+		// the redirect cannot loop.
+		$wp_query->set( Setup::QUERY_VAR, Setup::ICAL_SLUG );
+
+		$this->assertFalse(
+			$instance->get_negotiated_redirect_url(),
+			'Failed to assert a request already on the calendar endpoint is not redirected again.'
+		);
+
+		$wp_query->set( Setup::QUERY_VAR, '' );
 
 		unset( $_SERVER['HTTP_ACCEPT'], $_SERVER['REQUEST_URI'] );
+	}
+
+	/**
+	 * Coverage for maybe_handle_content_negotiation leaving a request alone.
+	 *
+	 * The redirecting branch ends in exit() and is marked
+	 *
+	 * @codeCoverageIgnore in the source; this pins the bail.
+	 *
+	 * @covers ::maybe_handle_content_negotiation
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_content_negotiation_ignores_html_requests(): void {
+		$instance = Setup::get_instance();
+
+		$_SERVER['HTTP_ACCEPT'] = 'text/html';
+
+		$instance->maybe_handle_content_negotiation();
+
+		$this->assertFalse(
+			$instance->get_negotiated_redirect_url(),
+			'Failed to assert an HTML request is left alone by the handler.'
+		);
+
+		unset( $_SERVER['HTTP_ACCEPT'] );
+	}
+
+	/**
+	 * Coverage for get_negotiated_redirect_url on a request with no calendar.
+	 *
+	 * @covers ::get_negotiated_redirect_url
+	 * @covers ::get_calendar_url_for_request
+	 *
+	 * @return void
+	 */
+	public function test_get_negotiated_redirect_url_without_a_calendar_target(): void {
+		$instance = Setup::get_instance();
+		$post     = $this->mock->post( array( 'post_type' => 'post' ) )->get();
+
+		$wp_query = $GLOBALS['wp_query'];
+		$wp_query->init();
+		$wp_query->queried_object    = $post;
+		$wp_query->is_singular       = true;
+		$wp_query->is_single         = true;
+		$wp_query->queried_object_id = $post->ID;
+
+		$_SERVER['HTTP_ACCEPT'] = 'text/calendar';
+
+		$this->assertFalse(
+			$instance->get_negotiated_redirect_url(),
+			'Failed to assert a post with no calendar representation is left alone.'
+		);
+
+		unset( $_SERVER['HTTP_ACCEPT'] );
+	}
+
+	/**
+	 * Coverage for get_calendar_url_for_request across archive contexts.
+	 *
+	 * @covers ::get_calendar_url_for_request
+	 *
+	 * @return void
+	 */
+	public function test_get_calendar_url_for_request_archive_contexts(): void {
+		$instance = Setup::get_instance();
+		$wp_query = $GLOBALS['wp_query'];
+
+		// An event post type archive resolves to that archive's feed.
+		$wp_query->init();
+		$wp_query->is_post_type_archive = true;
+		$wp_query->set( 'post_type', Event::POST_TYPE );
+
+		$this->assertSame(
+			get_post_type_archive_feed_link( Event::POST_TYPE, Setup::ICAL_SLUG ),
+			$instance->get_calendar_url_for_request(),
+			'Failed to assert an event archive resolves to its calendar feed.'
+		);
+
+		// An event topic term archive resolves to that term's feed.
+		$term = $this->factory->term->create_and_get( array( 'taxonomy' => Topic::TAXONOMY ) );
+
+		$wp_query->init();
+		$wp_query->is_tax            = true;
+		$wp_query->queried_object    = $term;
+		$wp_query->queried_object_id = $term->term_id;
+
+		$this->assertSame(
+			get_term_feed_link( $term->term_id, Topic::TAXONOMY, Setup::ICAL_SLUG ),
+			$instance->get_calendar_url_for_request(),
+			'Failed to assert an event topic archive resolves to its calendar feed.'
+		);
+
+		$wp_query->init();
+	}
+
+	/**
+	 * Coverage for is_calendar_negotiated with media ranges.
+	 *
+	 * @covers ::is_calendar_negotiated
+	 * @covers ::accept_quality
+	 *
+	 * @return void
+	 */
+	public function test_is_calendar_negotiated_respects_media_ranges(): void {
+		$instance = Setup::get_instance();
+
+		$this->assertTrue(
+			$instance->is_calendar_negotiated( 'text/calendar' ),
+			'Failed to assert a bare calendar request negotiates.'
+		);
+
+		// A browser ranking HTML above everything else must keep its HTML.
+		$this->assertFalse(
+			$instance->is_calendar_negotiated( 'text/html,application/xhtml+xml,text/calendar;q=0.1' ),
+			'Failed to assert a browser Accept header does not negotiate calendar.'
+		);
+
+		// `*/*` stands in for text/html here, so the client ranks HTML at 0.9
+		// and the calendar at 0.5. Matching literal types only read this as
+		// calendar-preferred and redirected against the client's wishes.
+		$this->assertFalse(
+			$instance->is_calendar_negotiated( 'text/calendar;q=0.5, */*;q=0.9' ),
+			'Failed to assert a wildcard media range outranking the calendar is honoured.'
+		);
+
+		$this->assertTrue(
+			$instance->is_calendar_negotiated( 'text/calendar;q=0.9, */*;q=0.5' ),
+			'Failed to assert the calendar still wins when it outranks the wildcard.'
+		);
 	}
 }


### PR DESCRIPTION
Fixes #1685.

### Summary of Changes

Adds HTTP Content Negotiation (RFC 7231 / RFC 9110) support to GatherPress calendar feeds and event endpoints:

1. **Content Negotiation (`template_redirect` at priority 0):**
   - Implements `is_calendar_negotiated()` to parse the `Accept` header respecting quality factor (`q=`) weights. If `text/calendar` is requested with quality equal to or higher than standard HTML formats (`text/html`, `application/xhtml+xml`), GatherPress negotiates the calendar representation.
   - Standard browser requests requesting `text/html` continue to receive the normal HTML view.
   - If negotiated, safely redirects (`wp_safe_redirect( $target_url, 302 )`) with `Vary: Accept` header to the canonical ICS feed or download URL.

2. **Query Resolution (`get_calendar_url_for_request()`):**
   - Single event posts (`is_singular()`) -> resolves single iCal download URL (`/event/<slug>/ical`).
   - Shadow-source posts (venues) -> resolves venue iCal comments feed link (`/venue/<slug>/feed/ical/`).
   - Taxonomy term archives (`is_tax()`) -> resolves term iCal feed link (`/topic/<slug>/feed/ical/`).
   - Post-type archives (`is_post_type_archive()`) -> resolves post-type iCal archive feed link (`/event/feed/ical/`).
   - Front page / home -> resolves sitewide iCal feed link (`/feed/ical/`).

3. **Cache Safety (`wp_headers`):**
   - Attaches `Vary: Accept` header to event-related HTML views so caching proxies and CDNs (Cloudflare, Fastly, Varnish, Nginx) maintain distinct cache keys for HTML and iCal requests.

### Verification
- **PHPUnit Tests:** Added unit tests in `Test_Setup` covering header parsing, contextual query resolution, `Vary: Accept` header filtering, and safe redirects.
- **Coding Standards:** `phpcs` and `phpstan` pass with 0 errors and 0 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for HTTP content negotiation for calendar requests.
  - Requests accepting `text/calendar` now redirect event-related pages to their canonical calendar feed or download URL.
  - Calendar responses include the appropriate `Vary: Accept` header.

- **Bug Fixes**
  - Improved handling of event, venue, topic, and archive calendar URLs.
  - Prevented unnecessary redirects and improved ETag matching.

- **Tests**
  - Added coverage for content negotiation, redirects, headers, media ranges, and calendar URL selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->