### PR TITLE
i18n: add translator comments and contexts for tooltip format strings

### DIFF
--- a/.github/changelog/tooltip-translator-comments
+++ b/.github/changelog/tooltip-translator-comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add translator comments and contexts for all translatable strings in the inline tooltip format component.

--- a/src/formats/tooltip/edit.js
+++ b/src/formats/tooltip/edit.js
@@ -154,8 +154,10 @@ function TooltipPopover( {
 											minWidth: '120px',
 										} }
 									>
-										{ /* translators: Button label to toggle text color selection in the tooltip popover. */ }
-										{ __( 'Text Color', 'gatherpress' ) }
+										{
+											/* translators: Button label to toggle text color selection in the tooltip popover. */
+											__( 'Text Color', 'gatherpress' )
+										}
 									</Button>
 								</FlexItem>
 								<FlexItem>
@@ -173,8 +175,10 @@ function TooltipPopover( {
 											minWidth: '120px',
 										} }
 									>
-										{ /* translators: Button label to toggle background color selection in the tooltip popover. */ }
-										{ __( 'Background', 'gatherpress' ) }
+										{
+											/* translators: Button label to toggle background color selection in the tooltip popover. */
+											__( 'Background', 'gatherpress' )
+										}
 									</Button>
 								</FlexItem>
 							</Flex>
@@ -206,8 +210,10 @@ function TooltipPopover( {
 				<FlexItem>
 					<div className="gatherpress-tooltip-popover__preview">
 						<span className="gatherpress-tooltip-popover__preview-label">
-							{ /* translators: Label preceding the live preview box in the tooltip popover. */ }
-							{ __( 'Preview:', 'gatherpress' ) }
+							{
+								/* translators: Label preceding the live preview box in the tooltip popover. */
+								__( 'Preview:', 'gatherpress' )
+							}
 						</span>
 						<span
 							className="gatherpress-tooltip gatherpress-tooltip--preview"
@@ -225,12 +231,10 @@ function TooltipPopover( {
 								)
 							}
 						>
-							{ /* translators: Label text shown on the preview button demonstrating the tooltip hover interaction. */ }
-							{ _x(
-								'Hover me',
-								'tooltip preview button label',
-								'gatherpress'
-							) }
+							{
+								/* translators: Label text shown on the preview button demonstrating the tooltip hover interaction. */
+								_x( 'Hover me', 'tooltip preview button label', 'gatherpress' )
+							}
 						</span>
 					</div>
 				</FlexItem>
@@ -244,21 +248,27 @@ function TooltipPopover( {
 									onClick={ removeTooltip }
 									isDestructive
 								>
-									{ /* translators: Button label to remove tooltip formatting from selected text. */ }
-									{ __( 'Remove', 'gatherpress' ) }
+									{
+										/* translators: Button label to remove tooltip formatting from selected text. */
+										__( 'Remove', 'gatherpress' )
+									}
 								</Button>
 							</FlexItem>
 						) }
 						<FlexItem>
 							<Button variant="secondary" onClick={ onClose }>
-								{ /* translators: Button label to close the tooltip popover without applying changes. */ }
-								{ __( 'Cancel', 'gatherpress' ) }
+								{
+									/* translators: Button label to close the tooltip popover without applying changes. */
+									__( 'Cancel', 'gatherpress' )
+								}
 							</Button>
 						</FlexItem>
 						<FlexItem>
 							<Button variant="primary" onClick={ applyTooltip }>
-								{ /* translators: Button label to save and apply tooltip formatting to selected text. */ }
-								{ __( 'Apply', 'gatherpress' ) }
+								{
+									/* translators: Button label to save and apply tooltip formatting to selected text. */
+									__( 'Apply', 'gatherpress' )
+								}
 							</Button>
 						</FlexItem>
 					</Flex>

--- a/src/formats/tooltip/edit.js
+++ b/src/formats/tooltip/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState, useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	RichTextToolbarButton,
 	useCachedTruthy,
@@ -61,6 +61,7 @@ function TooltipPopover( {
 		editableContentElement: contentRef.current,
 		settings: {
 			name: FORMAT_NAME,
+			/* translators: Title and label for the inline tooltip formatting option. */
 			title: __( 'Tooltip', 'gatherpress' ),
 			tagName: 'span',
 			className: 'gatherpress-tooltip',
@@ -125,9 +126,11 @@ function TooltipPopover( {
 			>
 				<FlexItem>
 					<TextControl
+						/* translators: Label for the input field where users enter custom tooltip text. */
 						label={ __( 'Tooltip Text', 'gatherpress' ) }
 						value={ tooltipText }
 						onChange={ setTooltipText }
+						/* translators: Placeholder text shown in the tooltip text input field. */
 						placeholder={ __( 'Enter tooltip text…', 'gatherpress' ) }
 					/>
 				</FlexItem>
@@ -151,6 +154,7 @@ function TooltipPopover( {
 											minWidth: '120px',
 										} }
 									>
+										{ /* translators: Button label to toggle text color selection in the tooltip popover. */ }
 										{ __( 'Text Color', 'gatherpress' ) }
 									</Button>
 								</FlexItem>
@@ -169,6 +173,7 @@ function TooltipPopover( {
 											minWidth: '120px',
 										} }
 									>
+										{ /* translators: Button label to toggle background color selection in the tooltip popover. */ }
 										{ __( 'Background', 'gatherpress' ) }
 									</Button>
 								</FlexItem>
@@ -201,6 +206,7 @@ function TooltipPopover( {
 				<FlexItem>
 					<div className="gatherpress-tooltip-popover__preview">
 						<span className="gatherpress-tooltip-popover__preview-label">
+							{ /* translators: Label preceding the live preview box in the tooltip popover. */ }
 							{ __( 'Preview:', 'gatherpress' ) }
 						</span>
 						<span
@@ -211,10 +217,20 @@ function TooltipPopover( {
 							} }
 							data-gatherpress-tooltip={
 								tooltipText ||
-								__( 'Sample tooltip', 'gatherpress' )
+								/* translators: Default sample text shown inside the preview tooltip when no custom text is entered. */
+								_x(
+									'Sample tooltip',
+									'tooltip preview content',
+									'gatherpress'
+								)
 							}
 						>
-							{ __( 'Hover me', 'gatherpress' ) }
+							{ /* translators: Label text shown on the preview button demonstrating the tooltip hover interaction. */ }
+							{ _x(
+								'Hover me',
+								'tooltip preview button label',
+								'gatherpress'
+							) }
 						</span>
 					</div>
 				</FlexItem>
@@ -228,17 +244,20 @@ function TooltipPopover( {
 									onClick={ removeTooltip }
 									isDestructive
 								>
+									{ /* translators: Button label to remove tooltip formatting from selected text. */ }
 									{ __( 'Remove', 'gatherpress' ) }
 								</Button>
 							</FlexItem>
 						) }
 						<FlexItem>
 							<Button variant="secondary" onClick={ onClose }>
+								{ /* translators: Button label to close the tooltip popover without applying changes. */ }
 								{ __( 'Cancel', 'gatherpress' ) }
 							</Button>
 						</FlexItem>
 						<FlexItem>
 							<Button variant="primary" onClick={ applyTooltip }>
+								{ /* translators: Button label to save and apply tooltip formatting to selected text. */ }
 								{ __( 'Apply', 'gatherpress' ) }
 							</Button>
 						</FlexItem>
@@ -290,6 +309,7 @@ export function TooltipEdit( { value, onChange, isActive, contentRef } ) {
 		<>
 			<RichTextToolbarButton
 				icon={ comment }
+				/* translators: Title and accessible label for the toolbar button that opens tooltip settings. */
 				title={ __( 'Tooltip', 'gatherpress' ) }
 				onClick={ togglePopover }
 				isActive={ isActive }

--- a/src/formats/tooltip/index.js
+++ b/src/formats/tooltip/index.js
@@ -20,6 +20,7 @@ import './style.scss';
  * @since 0.34.0
  */
 registerFormatType( FORMAT_NAME, {
+	/* translators: Title and accessible label for the inline tooltip formatting option. */
 	title: __( 'Tooltip', 'gatherpress' ),
 	tagName: 'span',
 	className: 'gatherpress-tooltip',


### PR DESCRIPTION
## Description
Adds explicit `/* translators: ... */` comments and `_x()` contexts to all translatable strings in the inline tooltip formatting component (`src/formats/tooltip/edit.js` and `src/formats/tooltip/index.js`).

## Context
When translate.wordpress.org (GlotPress) scans SVN builds, JS strings point to minified `build/editor.js:2`. Adding translator comments and contexts directly to the translation calls ensures GlotPress displays the full usage context and meaning to translators directly in the GlotPress web UI without requiring them to inspect minified bundles in Trac.

## Testing Instructions
1. Run `npm run test:unit:js` - all tests should pass.
2. Run `npm run lint:js` - should pass cleanly.
3. Run `npm run build` - `/* translators: ... */` comments are preserved in `build/editor.js` for GlotPress parser.