### PR TITLE
Add the missing 0.35.2 link to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -523,6 +523,7 @@ Initial public release. Represents 18+ months of pre-1.0 development and ships t
 - Initial unit test suite with code coverage via SonarCloud.
 - Multilingual screenshots and i18n scaffolding.
 
+[0.35.2]: https://github.com/GatherPress/gatherpress/compare/0.35.1...0.35.2
 [0.35.1]: https://github.com/GatherPress/gatherpress/compare/0.35.0...0.35.1
 [0.35.0]: https://github.com/GatherPress/gatherpress/compare/0.34.1...0.35.0
 [0.34.1]: https://github.com/GatherPress/gatherpress/compare/0.34.0...0.34.1


### PR DESCRIPTION
Same one-line fix as the `main` PR: the 0.35.2 rollup (#2164) never wrote the `[0.35.2]:` compare link, and changelogger refuses to roll a release on top of an unlinked heading. Keeps `develop` in parity so the next release merge does not reintroduce the gap.

Skip Changelog.