### PR TITLE
Add the missing 0.35.2 link to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -523,6 +523,7 @@ Initial public release. Represents 18+ months of pre-1.0 development and ships t
 - Initial unit test suite with code coverage via SonarCloud.
 - Multilingual screenshots and i18n scaffolding.
 
+[0.35.2]: https://github.com/GatherPress/gatherpress/compare/0.35.1...0.35.2
 [0.35.1]: https://github.com/GatherPress/gatherpress/compare/0.35.0...0.35.1
 [0.35.0]: https://github.com/GatherPress/gatherpress/compare/0.34.1...0.35.0
 [0.34.1]: https://github.com/GatherPress/gatherpress/compare/0.34.0...0.34.1


### PR DESCRIPTION
The 0.35.2 rollup (#2164) wrote the `## [0.35.2]` heading but not its `[0.35.2]: …compare/0.35.1...0.35.2` link line, and changelogger refuses to roll a release on top of an unlinked heading. That is what failed the 0.35.3 tag run (33923852197) at "Roll up changelog", before the release, the wp.org deploy, or the alpha handoff ran, so nothing shipped.

One line. Verified by running the 0.35.3 rollup against a copy of `main` with this line in place. Merge with a merge commit, then delete and re-push the `0.35.3` tag at the new `main` HEAD. #2248 carries the same line to `develop`.

Skip Changelog.