### PR TITLE
Ship the rolled changelog in the zip and the wp.org deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,17 @@ jobs:
           # composer script. Idempotent.
           php .github/scripts/link-changelog-prs.php
 
+      # The zip and the wp.org deploy check out the tag, whose CHANGELOG.md
+      # predates this rollup, so on their own they ship a changelog one
+      # release behind. Hand them the rolled file instead.
+      - name: Publish the rolled changelog for packaging
+        uses: actions/upload-artifact@v4
+        with:
+          name: rolled-changelog
+          path: CHANGELOG.md
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Extract release body from CHANGELOG.md
         id: extract
         env:
@@ -246,7 +257,7 @@ jobs:
   # Same artifact for both pre-release and stable paths.
   build:
     name: Build distro zip
-    needs: prepare
+    needs: [prepare, rollup]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -255,6 +266,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+
+      # Ship the changelog with this release's own section, not the tag's copy.
+      - name: Use the rolled changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: rolled-changelog
+          path: .
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -325,6 +343,13 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      # Ship the changelog with this release's own section, not the tag's copy.
+      - name: Use the rolled changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: rolled-changelog
+          path: .
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -373,6 +398,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+
+      # Ship the changelog with this release's own section, not the tag's copy.
+      - name: Use the rolled changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: rolled-changelog
+          path: .
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/docs/contributor/release-process.md
+++ b/docs/contributor/release-process.md
@@ -155,6 +155,7 @@ Testers downloading the pre-release zip see the same changelog body they'd see a
 
 - [ ] All issues in the release's milestone are closed or moved.
 - [ ] Queued `.github/changelog/` entries read correctly (skim, fix anything off).
+- [ ] Rehearse the rollup in a throwaway tree so the tag run cannot fail on the changelog: `git worktree add /tmp/rollup main && cd /tmp/rollup && ../<repo>/vendor/bin/changelogger write --use-version=X.Y.Z --yes`, then check `CHANGELOG.md` has the new `## [X.Y.Z]` section and its `[X.Y.Z]:` link, and discard the worktree. This catches a missing link line under the previous version's heading, which the parser refuses (see Troubleshooting).
 - [ ] Credits file for `X.Y.Z` added at `.github/scripts/release/credits/X.Y.Z.json` — by convention a copy of the latest pre-release file, roster corrections applied to the pre-release file first.
 - [ ] `npm run version:bump -- --version=X.Y.Z` (or the Version Bump workflow) + `npm i --package-lock-only`; version PRs opened and merged in order: credits file, alpha sync, core `version-X.Y.Z` → develop.
 
@@ -193,7 +194,7 @@ git push origin X.Y.Z
 1. Detects the tag is stable (no `-alpha.` / `-beta.` / `-rc.` suffix).
 2. Aggregates every entry file in `.github/changelog/` into a new `## [X.Y.Z] - YYYY-MM-DD` section at the top of `CHANGELOG.md`, appending `[#NNNN]` PR references, and **deletes** the entry files (dotfiles like `.gitkeep` survive, which is why the directory persists in git).
 3. Commits that rollup to a new `release/X.Y.Z` branch and **opens an auto-PR back to `develop`** (with the `Skip Changelog` label).
-4. Builds `gatherpress.X.Y.Z.zip`.
+4. Builds `gatherpress.X.Y.Z.zip` with the rolled-up `CHANGELOG.md` from step 2 in it. The tag commit's own copy predates the rollup, so the build and the wp.org deploy take the rolled file from the rollup job rather than the checkout; before this, every shipped changelog was one release behind.
 5. Creates a GitHub **Release** with the zip attached, marked as **latest**, with the `[X.Y.Z]` section as the body.
 6. Deploys to wordpress.org via the `10up/action-wordpress-plugin-deploy` action using the `SVN_USERNAME` / `SVN_PASSWORD` secrets.
 
@@ -326,6 +327,20 @@ vendor/bin/changelogger write \
   --deduplicate=-1 \
   --yes
 ```
+
+### "Heading seems to have a linked version, but link was not found"
+
+The rollup job fails before anything ships, with changelogger naming the
+previous release's heading (`## [X.Y.Z-1] - ...`). That heading has no
+matching `[X.Y.Z-1]: https://github.com/GatherPress/gatherpress/compare/...`
+line at the bottom of `CHANGELOG.md`; changelogger validates the heading it
+is about to push down, so a rollup that wrote a heading without its link
+only fails on the *next* release. The 0.35.2 rollup did this and 0.35.3's
+first tag run caught it.
+
+Add the missing link line on `main` (PR, merge commit) and on `develop`
+(PR, squash) so parity holds, then delete and re-push the tag. The
+pre-flight rehearsal above catches it before tagging.
 
 ### The changelog contains entries from the previous release
 

--- a/docs/contributor/release-process.md
+++ b/docs/contributor/release-process.md
@@ -210,6 +210,19 @@ Every one of these is required; skipping any of them bites the next release:
   auto-merge (squash), so it lands on its own once checks pass — this brings
   the rolled-up `CHANGELOG.md` to develop and removes the consumed entry
   files. If it's still open, see Troubleshooting.
+
+  Know what that PR is before you touch it: the workflow branches
+  `release/X.Y.Z` **off the tag commit on `main`**, so GitHub's diff view
+  shows everything `main` gained since the last release merge, often
+  dozens of commits and a hundred files. Almost all of it is
+  content-identical to what `develop` already has. The only real change is
+  the rollup commit itself: the new section, its link line, and the deleted
+  entry files. If the PR is `DIRTY`, do **not** resolve it by merging
+  `main`'s state into `develop`; see "The rollup PR is DIRTY" below.
+- [ ] **Check `CHANGELOG.md` on both branches has exactly one `## [X.Y.Z]`
+  heading and a matching `[X.Y.Z]:` link line**, and that `main` has no
+  duplicate headings. A re-run of the tag after the entries were consumed
+  writes a second, empty heading (see "I need to move the tag" below).
 - [ ] **Check the PR numbers in the new changelog section are links.**
   `changelogger --add-pr-num` only emits bare `[#1234]` markers; the rollup
   job runs `.github/scripts/link-changelog-prs.php` immediately afterward to
@@ -221,14 +234,26 @@ Every one of these is required; skipping any of them bites the next release:
   Without this, the next patch release cut from main re-rolls every
   already-released entry into its changelog.
 - [ ] **Release GatherPress Alpha**: merge its `version-X.Y.Z` sync PR if
-  not already done, then let the core release workflow's `alpha-handoff` job
+  not already done, **and make sure alpha has a changelog entry file for
+  `X.Y.Z` on the branch it releases from** (`.github/changelog/sync-X-Y-Z`,
+  "Track the GatherPress X.Y.Z release, which the plugin is version-locked
+  to."). Alpha's rollup has nothing to write without it and its release
+  fails at "Extract release body" before tagging; 0.35.3 needed a second
+  PR for exactly this. Then let the core release workflow's `alpha-handoff` job
   dispatch alpha's release (automatic with the `GATHERPRESS_ALPHA_TOKEN`
   secret; otherwise run the `gh workflow run release.yml` one-liner from the
   job summary — a manual `git tag X.Y.Z && git push origin X.Y.Z` on alpha
   still works too, tagged on the branch that version lives on: `main` for a
   stable, `develop` for a pre-release). Alpha's release train mirrors core's,
   so its stable releases also want a develop→main merge before the tag.
-  Merge alpha's own rollup PR afterward.
+  Merge alpha's own rollup PR afterward, then do alpha's **changelog parity**
+  too: since alpha split `develop` from `main` (alpha #74) its rollup lands
+  on one branch only, so cherry-pick that squash across to the other, the
+  same way as core's parity step above. Alpha's `main` also runs whatever
+  copy of the workflow it has, which lags `develop` until alpha's next
+  release merge; if a dispatch from the Actions tab builds the wrong
+  branch, dispatch with `--ref main` (alpha #79 makes the checkout follow
+  the version instead).
 - [ ] **Bring the demo data in line with the new version**: follow the
   "Preparing demo-data for a new version of GatherPress" steps in the
   [gatherpress-demo-data README](https://github.com/GatherPress/gatherpress-demo-data#readme)
@@ -263,6 +288,7 @@ Every one of these is required; skipping any of them bites the next release:
 **Verify:**
 
 - [GitHub Releases page](https://github.com/GatherPress/gatherpress/releases) shows the new tag as "Latest release" with the zip attached.
+- The shipped changelog is the rolled one: `unzip -p gatherpress.X.Y.Z.zip gatherpress/CHANGELOG.md | head -20` opens with `## [X.Y.Z]`, and so does <https://plugins.svn.wordpress.org/gatherpress/tags/X.Y.Z/CHANGELOG.md>. Every release before 0.35.3 shipped the previous version's changelog here, because the build and deploy jobs checked out the tag commit while the rollup wrote the section in its own job; the workflow now hands the rolled file to both. If a shipped copy is wrong anyway, see "The shipped CHANGELOG.md is one release behind" below.
 - wp.org listing at <https://wordpress.org/plugins/gatherpress/> shows the new version (after the confirmation click; the directory can lag a few minutes).
 - `develop` and `main` both have the `[X.Y.Z]` CHANGELOG section and an empty `.github/changelog/`.
 
@@ -375,6 +401,64 @@ repo-level merge settings allow them, and a direct push of a merge commit is
 rejected with "This branch must not contain merge commits." Uncheck
 *Require linear history* in the `main` protection rule for the merge, and
 re-enable afterward if that's the standing policy.
+
+### The rollup PR is DIRTY (or shows hundreds of files)
+
+`release/X.Y.Z` is branched off the tag commit, so it carries `main`'s whole
+state. That merged cleanly while `develop` had not moved past the release,
+but once the next cycle is open (`X.Y+1.0-alpha.0` on develop) the version
+strings conflict and the PR goes `DIRTY`, and auto-merge cannot fire.
+
+Rebuild the branch as `develop` plus only the rollup commit, and let
+auto-merge take it from there:
+
+```bash
+git fetch origin
+git checkout -B release/X.Y.Z origin/develop
+git cherry-pick -x <rollup commit sha>   # "Roll up changelog for X.Y.Z" on release/X.Y.Z
+git diff --stat origin/develop..HEAD      # must be CHANGELOG.md + deleted entry files, nothing else
+git push --force-with-lease origin release/X.Y.Z
+```
+
+Never resolve it by merging `main` into `develop` through this PR: that would
+carry the release's version strings, credits, and rollups onto `develop`.
+
+### I need to move the tag after the rollup ran
+
+Re-pushing `X.Y.Z` re-runs the whole workflow with the entry files already
+consumed. changelogger then writes a second, empty `## [X.Y.Z]` heading and
+the rollup job opens another `release/X.Y.Z` PR whose only real change is
+that heading. Close that PR and delete its branch (nothing was consumed, so
+the double-roll guard is satisfied). The zip is rebuilt from the new tag
+commit, which is the point of moving it; the wp.org deploy sees
+`tags/X.Y.Z` already exists and bails without touching SVN; the alpha
+handoff dispatches again. Move the tag only after the parity cherry-pick,
+so the new tree carries its own section.
+
+### The shipped CHANGELOG.md is one release behind
+
+The zip and the wp.org tag carried the tag commit's `CHANGELOG.md`, which
+predates the rollup, on every release up to 0.35.3. The workflow now ships
+the rolled file. If it happens anyway, fix the copies that shipped:
+
+- **wp.org**: commit the rolled file into both the tag and trunk. Sparse
+  checkouts keep it to one file each:
+
+  ```bash
+  svn checkout --depth empty https://plugins.svn.wordpress.org/gatherpress/tags/X.Y.Z t && svn update t/CHANGELOG.md
+  svn checkout --depth empty https://plugins.svn.wordpress.org/gatherpress/trunk trunk && svn update trunk/CHANGELOG.md
+  git show main:CHANGELOG.md > t/CHANGELOG.md && git show main:CHANGELOG.md > trunk/CHANGELOG.md
+  svn diff t trunk        # must be the new section and its link line, nothing else
+  svn commit --username gatherpress -m "Add the X.Y.Z changelog section" t/CHANGELOG.md trunk/CHANGELOG.md
+  ```
+
+  Do this before clicking the wp.org release confirmation and nobody
+  downloads the stale copy.
+- **GitHub Release asset**: replace only `CHANGELOG.md` *inside CI's own
+  zip*, never a local rebuild (compiled chunk hashes differ from CI's), then
+  `gh release upload X.Y.Z gatherpress.X.Y.Z.zip --clobber` and confirm
+  every other entry's hash is unchanged. Re-tagging after parity has the
+  same effect through the workflow, with the caveats in the entry above.
 
 ### The rollup auto-PR didn't merge on its own
 


### PR DESCRIPTION
## Proposed changes:

* The rollup job publishes its rolled `CHANGELOG.md` as an artifact. The build job now waits for the rollup and packages that file, and both wp.org deploy jobs take it over the tag checkout before rsync. Until now the zip and the wp.org tag shipped the tag commit's `CHANGELOG.md`, which predates the rollup, so every release's changelog was one version behind (wp.org `tags/0.35.2` tops out at 0.35.1, `tags/0.35.3` at 0.35.2). The GitHub Release body was never affected; it comes from the rollup job directly.
* Runbook: a rollup rehearsal in the pre-flight, and a troubleshooting entry for the unlinked-heading failure that stopped 0.35.3's first tag run.

Cost: the build job starts after the rollup instead of alongside it, about a minute.

**The release workflow runs from the tag's ref, so this only takes effect once it is on `main`**: it rides the next develop→main release merge, or gets cherry-picked onto `main` before the next patch.

### Other information:

- [x] Have you written new tests for your changes, if applicable? Workflow-only; YAML validated, no unit surface.

## Testing instructions:

* Cut the next pre-release tag; the `build` job should show "Use the rolled changelog" and the zip's `CHANGELOG.md` should open with that version's section.

### Credit (for release notes)

My WordPress.org username: mauteri

Skip Changelog.