### PR TITLE
Make the welcome notice's dismiss link absolute

### DIFF
--- a/.github/changelog/2233-welcome-notice-dismiss
+++ b/.github/changelog/2233-welcome-notice-dismiss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dismiss the welcome notice for good: the dismiss link was relative, so the browser resolved it against the current directory and the dismissal never ran. The notice icon and headline now follow the admin color scheme instead of a hardcoded blue.

--- a/includes/core/classes/admin/notices/class-base.php
+++ b/includes/core/classes/admin/notices/class-base.php
@@ -237,8 +237,20 @@ abstract class Base {
 			return '';
 		}
 
+		// add_query_arg() with no URL falls back to REQUEST_URI, which is a
+		// path. wp_nonce_url() escapes it and the browser resolves it against
+		// the current directory, so /wp-admin/edit.php became
+		// /wp-admin/wp-admin/edit.php and the dismissal never ran (#2233).
+		// Rebuild the current admin request as an absolute URL instead.
+		$request = isset( $_SERVER['REQUEST_URI'] )
+			? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+			: '';
+		$query   = (string) wp_parse_url( $request, PHP_URL_QUERY );
+		$screen  = basename( (string) wp_parse_url( $request, PHP_URL_PATH ) );
+		$current = admin_url( $screen . ( '' !== $query ? '?' . $query : '' ) );
+
 		return wp_nonce_url(
-			add_query_arg( 'gatherpress_dismiss_notice', $this->get_slug() ),
+			add_query_arg( 'gatherpress_dismiss_notice', $this->get_slug(), $current ),
 			'gatherpress_dismiss_notice_' . $this->get_slug()
 		);
 	}
@@ -397,7 +409,8 @@ abstract class Base {
 
 		return sprintf(
 			'<div style="display:flex;align-items:flex-start;gap:1.25rem;position:relative;">%1$s<div>'
-			. '<p style="margin:0 0 0.375rem;font-size:0.875rem;font-weight:600;color:#1769AA;">%2$s</p>'
+			. '<p style="margin:0 0 0.375rem;font-size:0.875rem;font-weight:600;'
+			. 'color:var(--wp-admin-theme-color, #1769AA);">%2$s</p>'
 			. '<p style="margin:0 0 0.75rem;">%3$s</p>%4$s</div>%5$s</div>',
 			$this->get_mark(),
 			esc_html( $this->get_headline() ),
@@ -456,8 +469,9 @@ abstract class Base {
 	 */
 	protected function get_mark(): string {
 		return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="60" height="60"'
-			. ' aria-hidden="true" focusable="false" style="flex-shrink:0;">'
-			. '<path fill="#1769AA" d="'
+			. ' aria-hidden="true" focusable="false"'
+			. ' style="flex-shrink:0;color:var(--wp-admin-theme-color, #1769AA);">'
+			. '<path fill="currentColor" d="'
 			. 'M125.4,50.8V13.4c0-6.8-5.6-12.4-12.4-12.4H88.1c-6.8,0-12.4,5.6-'
 			. '12.4,12.4v37.3c0,6.8,5.6,12.4,12.4,12.4h24.9C119.8,63.2,125.4,57.6,125.4,50.8zM100.5,13.4c6.8,0'
 			. ',12.4,5.6,12.4,12.4s-5.6,12.4-12.4,12.4s-12.4-5.6-12.4-'

--- a/test/unit/php/includes/tests/core/classes/admin/notices/class-test-base.php
+++ b/test/unit/php/includes/tests/core/classes/admin/notices/class-test-base.php
@@ -665,6 +665,23 @@ class Test_Base extends Unit_Test_Base {
 			'Failed to assert the dismissal argument is present.'
 		);
 
+		// WP-CLI and cron have no REQUEST_URI at all; the URL still has to be
+		// a usable admin URL rather than a bare nonce on nothing.
+		unset( $_SERVER['REQUEST_URI'] );
+
+		$url = html_entity_decode( ( new Welcome() )->get_dismiss_url() );
+
+		$this->assertStringStartsWith(
+			admin_url(),
+			$url,
+			'Failed to assert the dismiss URL is absolute without a request.'
+		);
+		$this->assertStringContainsString(
+			'gatherpress_dismiss_notice=gatherpress_welcome',
+			$url,
+			'Failed to assert the dismissal argument survives without a request.'
+		);
+
 		if ( null === $original ) {
 			unset( $_SERVER['REQUEST_URI'] );
 		} else {

--- a/test/unit/php/includes/tests/core/classes/admin/notices/class-test-base.php
+++ b/test/unit/php/includes/tests/core/classes/admin/notices/class-test-base.php
@@ -10,6 +10,7 @@ namespace GatherPress\Tests\Core\Admin\Notices;
 
 use GatherPress\Core\Admin\Notices\Base;
 use GatherPress\Core\Admin\Notices\Missing_Build;
+use GatherPress\Core\Admin\Notices\Welcome;
 use GatherPress\Tests\Base as Unit_Test_Base;
 use PMC\Unit_Test\Utility;
 
@@ -619,5 +620,55 @@ class Test_Base extends Unit_Test_Base {
 			$notice->allow_mark_markup( array(), 'data' ),
 			'Failed to assert other contexts are left alone.'
 		);
+	}
+
+	/**
+	 * The dismiss link is absolute, so the browser cannot resolve it twice.
+	 *
+	 * `add_query_arg()` with no URL falls back to REQUEST_URI, a path. The
+	 * browser resolved that against the current directory, turning
+	 * /wp-admin/edit.php into /wp-admin/wp-admin/edit.php, so the dismissal
+	 * never ran and the notice came back (#2233).
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_dismiss_url
+	 *
+	 * @return void
+	 */
+	public function test_get_dismiss_url_is_absolute(): void {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- stashing the test runner's own value to restore it.
+		$original = isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : null;
+
+		$_SERVER['REQUEST_URI'] = '/wp-admin/edit.php?post_type=gatherpress_event';
+
+		$url = html_entity_decode( ( new Welcome() )->get_dismiss_url() );
+
+		$this->assertStringStartsWith(
+			admin_url( 'edit.php' ),
+			$url,
+			'Failed to assert the dismiss URL is absolute.'
+		);
+		$this->assertStringNotContainsString(
+			'wp-admin/wp-admin',
+			$url,
+			'Failed to assert the admin path is not doubled.'
+		);
+		$this->assertStringContainsString(
+			'post_type=gatherpress_event',
+			$url,
+			'Failed to assert the current screen is preserved.'
+		);
+		$this->assertStringContainsString(
+			'gatherpress_dismiss_notice=gatherpress_welcome',
+			$url,
+			'Failed to assert the dismissal argument is present.'
+		);
+
+		if ( null === $original ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $original;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2233.

## Proposed changes:

* `Base::get_dismiss_url()` called `add_query_arg()` with no URL, so it fell back to `REQUEST_URI`, a path. The browser resolved that against the current directory and requested `/wp-admin/wp-admin/edit.php?…`, which is why @carstingaxion's X redirected to the event archive and the notice came back. The current admin request is rebuilt as an absolute URL with `admin_url()`.
* The icon and headline used a hardcoded `#1769AA`. Both now use `var(--wp-admin-theme-color, #1769AA)`, the icon via `currentColor`, so the notice follows the user's admin color scheme. Also @carstingaxion's, in the same issue.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Deactivate and reactivate GatherPress, then go to Dashboard > Events.
* Click the X. You stay on the same screen and the notice is gone.
* Go back to Dashboard > Events. It stays gone.
* Switch your admin color scheme in your profile; the icon and headline follow it.

### Credit (for release notes)

My WordPress.org username: mauteri

### Changelog entry

Added at `.github/changelog/2233-welcome-notice-dismiss`.