### PR TITLE
Stop sending Photon a language it rejects

### DIFF
--- a/.github/changelog/2211-carto-api-key
+++ b/.github/changelog/2211-carto-api-key
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+A CARTO API key setting for OpenStreetMap venue maps. CARTO began requiring one in August 2026, and without it map tiles arrive stamped "API KEY REQUIRED". Keys are free for up to 5 million tiles a month.

--- a/.github/changelog/2211-carto-api-key
+++ b/.github/changelog/2211-carto-api-key
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-A CARTO API key setting for OpenStreetMap venue maps. CARTO began requiring one in August 2026, and without it map tiles arrive stamped "API KEY REQUIRED". Keys are free for up to 5 million tiles a month.
+A CARTO API key setting for OpenStreetMap venue maps. Without a key, map tiles are watermarked.

--- a/.github/changelog/2211-photon-language-allowlist
+++ b/.github/changelog/2211-photon-language-allowlist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Venue address autocomplete and save-time geocoding no longer fail on sites whose language the geocoder does not serve, such as Japanese, Chinese and Korean.

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -71,6 +71,17 @@ final class Geocoding {
 	const PHOTON_API_URL = 'https://photon.komoot.io/api';
 
 	/**
+	 * Languages the public Photon API accepts.
+	 *
+	 * Anything else is rejected with HTTP 400, which takes autocomplete and
+	 * save-time geocoding down with it.
+	 *
+	 * @since 0.36.0
+	 * @var string[]
+	 */
+	private const PHOTON_LANGUAGES = array( 'default', 'de', 'en', 'fr' );
+
+	/**
 	 * Minimum trimmed query length before calling Photon for search.
 	 *
 	 * This value is the single source of truth: it is also exposed to the block
@@ -1266,10 +1277,26 @@ final class Geocoding {
 	 * @return string Language code (e.g., 'en', 'de').
 	 */
 	private function get_language_code(): string {
-		$locale = get_locale();
-
 		// Convert 'en_US' to 'en'.
-		return explode( '_', $locale )[0];
+		$language = explode( '_', get_locale() )[0];
+
+		/**
+		 * Filters the language sent to the geocoding provider.
+		 *
+		 * Photon serves a short list; a site pointing
+		 * `gatherpress_photon_api_url` at another instance may serve more.
+		 *
+		 * @since 0.36.0
+		 *
+		 * @param string[] $languages Accepted language codes.
+		 *
+		 * @return string[]
+		 */
+		$languages = (array) apply_filters( 'gatherpress_geocoding_languages', self::PHOTON_LANGUAGES );
+
+		// `default` asks Photon for each result's own local-language name,
+		// which is the closest thing to correct for a locale it cannot serve.
+		return in_array( $language, $languages, true ) ? $language : 'default';
 	}
 
 	/**

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -1281,18 +1281,19 @@ final class Geocoding {
 		$language = explode( '_', get_locale() )[0];
 
 		/**
-		 * Filters the language sent to the geocoding provider.
+		 * Filters the languages the geocoder is willing to be asked for.
 		 *
-		 * Photon serves a short list; a site pointing
-		 * `gatherpress_photon_api_url` at another instance may serve more.
+		 * Widen this when `gatherpress_photon_api_url` points at a Photon
+		 * instance that serves more languages than the public one, so a site
+		 * gets results named in its own locale instead of falling back.
 		 *
 		 * @since 0.36.0
 		 *
-		 * @param string[] $languages Accepted language codes.
+		 * @param string[] $languages Language codes the geocoder accepts.
 		 *
 		 * @return string[]
 		 */
-		$languages = (array) apply_filters( 'gatherpress_geocoding_languages', self::PHOTON_LANGUAGES );
+		$languages = (array) apply_filters( 'gatherpress_geocode_languages', self::PHOTON_LANGUAGES );
 
 		// `default` asks Photon for each result's own local-language name,
 		// which is the closest thing to correct for a locale it cannot serve.

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -83,6 +83,24 @@ class Settings {
 	const MAP_TILE_URL = 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
 
 	/**
+	 * Hosts the CARTO key may be sent to.
+	 *
+	 * The tile URL is filterable, so the key is only ever attached to hosts
+	 * known to be CARTO's. A site pointing its tiles elsewhere does not hand
+	 * its key to that host.
+	 *
+	 * @since 0.36.0
+	 * @var string[]
+	 */
+	private const CARTO_TILE_HOSTS = array(
+		'basemaps.cartocdn.com',
+		'cartodb-basemaps-a.global.ssl.fastly.net',
+		'cartodb-basemaps-b.global.ssl.fastly.net',
+		'cartodb-basemaps-c.global.ssl.fastly.net',
+		'cartodb-basemaps-d.global.ssl.fastly.net',
+	);
+
+	/**
 	 * URL used in the default map attribution credit to OpenStreetMap.
 	 *
 	 * @since 0.34.0
@@ -276,11 +294,16 @@ class Settings {
 			return $url;
 		}
 
-		$is_carto = str_contains( $url, 'cartocdn.com' ) || str_contains( $url, 'cartodb-basemaps' );
+		// `{s}` stands in for a subdomain, so it is resolved before the host
+		// is read; a bare placeholder does not parse as one.
+		$host = (string) wp_parse_url( str_replace( '{s}', 'a', $url ), PHP_URL_HOST );
 
-		// Left alone when the URL already names a key, or when it has been
-		// filtered to a host that does not want one.
-		if ( ! $is_carto || str_contains( $url, 'key=' ) ) {
+		$is_carto = in_array( $host, self::CARTO_TILE_HOSTS, true )
+			|| str_ends_with( $host, '.basemaps.cartocdn.com' );
+
+		// Matched at a parameter boundary, so `api_key=` is not mistaken for
+		// a key that is already there.
+		if ( ! $is_carto || 1 === preg_match( '/[?&]key=/', $url ) ) {
 			return $url;
 		}
 

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -253,7 +253,40 @@ class Settings {
 		 */
 		$filtered = (string) apply_filters( 'gatherpress_interactive_map_tile_url', self::MAP_TILE_URL );
 
-		return '' !== $filtered ? $filtered : self::MAP_TILE_URL;
+		return self::add_map_tile_key( '' !== $filtered ? $filtered : self::MAP_TILE_URL );
+	}
+
+	/**
+	 * Append the configured CARTO key to a tile URL.
+	 *
+	 * CARTO began enforcing keys on its basemaps in August 2026. Without one
+	 * every tile comes back stamped "API KEY REQUIRED", so both the Leaflet
+	 * basemap and the server-side compositor carry the key.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string $url Tile URL template.
+	 *
+	 * @return string The template, with the key appended when there is one.
+	 */
+	public static function add_map_tile_key( string $url ): string {
+		$key = trim( (string) self::get_instance()->get( 'carto_api_key' ) );
+
+		if ( '' === $key ) {
+			return $url;
+		}
+
+		$is_carto = str_contains( $url, 'cartocdn.com' ) || str_contains( $url, 'cartodb-basemaps' );
+
+		// Left alone when the URL already names a key, or when it has been
+		// filtered to a host that does not want one.
+		if ( ! $is_carto || str_contains( $url, 'key=' ) ) {
+			return $url;
+		}
+
+		// Concatenated rather than added with add_query_arg(), which cannot
+		// parse the `{s}` subdomain placeholder as a host.
+		return $url . ( str_contains( $url, '?' ) ? '&' : '?' ) . 'key=' . rawurlencode( $key );
 	}
 
 	/**

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -114,6 +114,37 @@ final class Venues extends Base {
 							),
 						),
 					),
+					'carto_api_key'                  => array(
+						'labels'      => array(
+							'name' => __( 'CARTO API Key', 'gatherpress' ),
+						),
+						'description' => wp_kses(
+							sprintf(
+								// phpcs:disable Generic.Files.LineLength.TooLong -- One translator string for the full API key guidance sentence.
+								/* translators: %s: link to CARTO's free basemap key request form. */
+								__( 'Required. CARTO began enforcing keys on its basemaps in August 2026; without one, tiles arrive stamped "API KEY REQUIRED". Keys are free for up to 5 million tiles a month. %s', 'gatherpress' ),
+								// phpcs:enable Generic.Files.LineLength.TooLong
+								'<a href="https://carto.com/basemaps/apikey/"'
+								. ' target="_blank" rel="noopener noreferrer">'
+								. esc_html__( 'Request a free key', 'gatherpress' ) . '</a>'
+							),
+							array(
+								'a' => array(
+									'href'   => array(),
+									'target' => array(),
+									'rel'    => array(),
+								),
+							)
+						),
+						'field'       => array(
+							'label' => __( 'CARTO API key:', 'gatherpress' ),
+							'type'  => 'text',
+							'size'  => 'regular',
+						),
+						'show_if'     => array(
+							'map_platform' => 'osm',
+						),
+					),
 					'google_maps_api_key'            => array(
 						'labels'      => array(
 							'name' => __( 'Google Maps API Key', 'gatherpress' ),

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -126,7 +126,7 @@ final class Venues extends Base {
 								// phpcs:enable Generic.Files.LineLength.TooLong
 								'<a href="https://carto.com/basemaps/apikey/"'
 								. ' target="_blank" rel="noopener noreferrer">'
-								. esc_html__( 'Request a free key', 'gatherpress' ) . '</a>'
+								. __( 'Request a free key', 'gatherpress' ) . '</a>'
 							),
 							array(
 								'a' => array(

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -120,9 +120,9 @@ final class Venues extends Base {
 						),
 						'description' => wp_kses(
 							sprintf(
-								// phpcs:disable Generic.Files.LineLength.TooLong -- One translator string for the full API key guidance sentence.
+								// phpcs:disable Generic.Files.LineLength.TooLong -- One translator string for the full key guidance sentence.
 								/* translators: %s: link to CARTO's free basemap key request form. */
-								__( 'Required. CARTO began enforcing keys on its basemaps in August 2026; without one, tiles arrive stamped "API KEY REQUIRED". Keys are free for up to 5 million tiles a month. %s', 'gatherpress' ),
+								__( 'Required. Without a key, map tiles are watermarked. Free up to 5 million tiles a month. %s.', 'gatherpress' ),
 								// phpcs:enable Generic.Files.LineLength.TooLong
 								'<a href="https://carto.com/basemaps/apikey/"'
 								. ' target="_blank" rel="noopener noreferrer">'

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -18,6 +18,7 @@ namespace GatherPress\Core\Venue\Map\Provider;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Settings;
 use GatherPress\Core\Venue\Map;
 use GdImage;
 use Throwable;
@@ -384,7 +385,9 @@ final class OSM extends Base {
 		 *
 		 * @param string $template Tile URL with `{z}`, `{x}`, `{y}` placeholders.
 		 */
-		return (string) apply_filters( 'gatherpress_static_map_tile_url', self::DEFAULT_TILE_URL );
+		return Settings::add_map_tile_key(
+			(string) apply_filters( 'gatherpress_static_map_tile_url', self::DEFAULT_TILE_URL )
+		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -452,37 +452,98 @@ class Test_Geocoding extends Base {
 	}
 
 	/**
+	 * Data provider for language codes.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public function data_language_codes(): array {
+		return array(
+			'a language Photon serves'          => array( 'en_US', 'en' ),
+			'another language Photon serves'    => array( 'de_DE', 'de' ),
+			'French'                            => array( 'fr_FR', 'fr' ),
+			'a regional variant still resolves' => array( 'de_AT', 'de' ),
+			'Japanese falls back'               => array( 'ja', 'default' ),
+			'Chinese falls back'                => array( 'zh_CN', 'default' ),
+			'Korean falls back'                 => array( 'ko_KR', 'default' ),
+		);
+	}
+
+	/**
 	 * Coverage for get_language_code method.
+	 *
+	 * Photon answers HTTP 400 for a language it does not serve, which takes
+	 * address autocomplete and save-time geocoding with it. A locale it cannot
+	 * serve falls back to `default` rather than being sent as-is.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_language_code
+	 *
+	 * @dataProvider data_language_codes
+	 *
+	 * @param string $locale   WordPress locale.
+	 * @param string $expected Language sent to the geocoder.
+	 *
+	 * @return void
+	 */
+	public function test_get_language_code( string $locale, string $expected ): void {
+		$instance = Geocoding::get_instance();
+
+		add_filter(
+			'locale',
+			static function () use ( $locale ) {
+				return $locale;
+			},
+			20
+		);
+
+		$this->assertSame(
+			$expected,
+			Utility::invoke_hidden_method( $instance, 'get_language_code' ),
+			'Failed to assert the language sent to the geocoder.'
+		);
+
+		remove_all_filters( 'locale' );
+	}
+
+	/**
+	 * A Photon instance serving more languages can say so.
+	 *
+	 * @since 0.36.0
 	 *
 	 * @covers ::get_language_code
 	 *
 	 * @return void
 	 */
-	public function test_get_language_code(): void {
+	public function test_get_language_code_respects_the_filter(): void {
 		$instance = Geocoding::get_instance();
 
-		// Test with en_US locale.
 		add_filter(
 			'locale',
 			static function () {
-				return 'en_US';
-			}
-		);
-
-		$language_code = Utility::invoke_hidden_method( $instance, 'get_language_code' );
-		$this->assertEquals( 'en', $language_code, 'Failed to assert language code is en.' );
-
-		// Test with de_DE locale.
-		add_filter(
-			'locale',
-			static function () {
-				return 'de_DE';
+				return 'ja_JP';
 			},
 			20
 		);
+		add_filter(
+			'gatherpress_geocode_languages',
+			static function ( $languages ) {
+				$languages[] = 'ja';
 
-		$language_code = Utility::invoke_hidden_method( $instance, 'get_language_code' );
-		$this->assertEquals( 'de', $language_code, 'Failed to assert language code is de.' );
+				return $languages;
+			}
+		);
+
+		$this->assertSame(
+			'ja',
+			Utility::invoke_hidden_method( $instance, 'get_language_code' ),
+			'Failed to assert a filtered language is sent through.'
+		);
+
+		remove_all_filters( 'locale' );
+		remove_all_filters( 'gatherpress_geocode_languages' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -503,8 +503,6 @@ class Test_Geocoding extends Base {
 			Utility::invoke_hidden_method( $instance, 'get_language_code' ),
 			'Failed to assert the language sent to the geocoder.'
 		);
-
-		remove_all_filters( 'locale' );
 	}
 
 	/**
@@ -539,9 +537,6 @@ class Test_Geocoding extends Base {
 			Utility::invoke_hidden_method( $instance, 'get_language_code' ),
 			'Failed to assert a filtered language is sent through.'
 		);
-
-		remove_all_filters( 'locale' );
-		remove_all_filters( 'gatherpress_geocode_languages' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -495,8 +495,7 @@ class Test_Geocoding extends Base {
 			'locale',
 			static function () use ( $locale ) {
 				return $locale;
-			},
-			20
+			}
 		);
 
 		$this->assertSame(
@@ -524,8 +523,7 @@ class Test_Geocoding extends Base {
 			'locale',
 			static function () {
 				return 'ja_JP';
-			},
-			20
+			}
 		);
 		add_filter(
 			'gatherpress_geocode_languages',

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -3348,6 +3348,18 @@ class Test_Settings extends Base {
 				'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 				'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			),
+			'a lookalike host gets nothing'      => array(
+				'https://attacker-cartocdn.com/light_all/{z}/{x}/{y}.png',
+				'https://attacker-cartocdn.com/light_all/{z}/{x}/{y}.png',
+			),
+			'a lookalike subdomain too'          => array(
+				'https://basemaps.cartocdn.com.evil.test/light_all/{z}/{x}/{y}.png',
+				'https://basemaps.cartocdn.com.evil.test/light_all/{z}/{x}/{y}.png',
+			),
+			'another key argument is not ours'   => array(
+				'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?api_key=old',
+				'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?api_key=old&key=abc123',
+			),
 		);
 	}
 
@@ -3423,6 +3435,32 @@ class Test_Settings extends Base {
 			'?key=a%20b%26c',
 			Settings::add_map_tile_key( 'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png' ),
 			'Failed to assert the key is encoded.'
+		);
+
+		$instance->set( 'carto_api_key', '' );
+	}
+
+	/**
+	 * The Leaflet basemap URL carries the key.
+	 *
+	 * Covers the call site rather than the helper, so dropping the wrapper
+	 * call is caught.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_map_tile_url
+	 *
+	 * @return void
+	 */
+	public function test_get_map_tile_url_carries_the_key(): void {
+		$instance = Settings::get_instance();
+
+		$instance->set( 'carto_api_key', 'abc123' );
+
+		$this->assertSame(
+			Settings::MAP_TILE_URL . '?key=abc123',
+			Settings::get_map_tile_url(),
+			'Failed to assert the Leaflet basemap URL carries the key.'
 		);
 
 		$instance->set( 'carto_api_key', '' );

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -3318,4 +3318,113 @@ class Test_Settings extends Base {
 
 		delete_option( Settings::OPTION_NAME );
 	}
+
+	/**
+	 * Data provider for tile URLs handed to add_map_tile_key.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public function data_map_tile_keys(): array {
+		return array(
+			'the Leaflet basemap gets the key'   => array(
+				'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+				'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key=abc123',
+			),
+			'the compositor host gets it too'    => array(
+				'https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
+				'https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png?key=abc123',
+			),
+			'an existing key is left alone'      => array(
+				'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key=existing',
+				'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key=existing',
+			),
+			'another query argument is kept'     => array(
+				'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?foo=bar',
+				'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?foo=bar&key=abc123',
+			),
+			'a host that wants no key is spared' => array(
+				'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+				'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+			),
+		);
+	}
+
+	/**
+	 * Coverage for add_map_tile_key.
+	 *
+	 * CARTO began enforcing keys on its basemaps in August 2026. Without one
+	 * every tile comes back stamped "API KEY REQUIRED", so the configured key
+	 * rides along on both the Leaflet basemap and the server-side compositor.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::add_map_tile_key
+	 *
+	 * @dataProvider data_map_tile_keys
+	 *
+	 * @param string $url      Tile URL template.
+	 * @param string $expected Template after the key is applied.
+	 *
+	 * @return void
+	 */
+	public function test_add_map_tile_key( string $url, string $expected ): void {
+		$instance = Settings::get_instance();
+
+		$instance->set( 'carto_api_key', 'abc123' );
+
+		$this->assertSame(
+			$expected,
+			Settings::add_map_tile_key( $url ),
+			'Failed to assert the CARTO key is applied to the tile URL.'
+		);
+
+		$instance->set( 'carto_api_key', '' );
+	}
+
+	/**
+	 * Without a key the tile URL is untouched.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::add_map_tile_key
+	 * @covers ::get_map_tile_url
+	 *
+	 * @return void
+	 */
+	public function test_add_map_tile_key_without_a_key(): void {
+		$instance = Settings::get_instance();
+
+		$instance->set( 'carto_api_key', '' );
+
+		$this->assertSame(
+			Settings::MAP_TILE_URL,
+			Settings::get_map_tile_url(),
+			'Failed to assert the tile URL is unchanged without a key.'
+		);
+	}
+
+	/**
+	 * The key is url-encoded on its way into the query string.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::add_map_tile_key
+	 *
+	 * @return void
+	 */
+	public function test_add_map_tile_key_encodes_the_key(): void {
+		$instance = Settings::get_instance();
+
+		$instance->set( 'carto_api_key', 'a b&c' );
+
+		$this->assertStringEndsWith(
+			'?key=a%20b%26c',
+			Settings::add_map_tile_key( 'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png' ),
+			'Failed to assert the key is encoded.'
+		);
+
+		$instance->set( 'carto_api_key', '' );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -13,6 +13,7 @@
 namespace GatherPress\Tests\Core\Venue\Map\Provider;
 
 use ErrorException;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Venue\Map;
 use GatherPress\Core\Venue\Map\Provider\OSM;
 use GatherPress\Tests\Base;
@@ -692,5 +693,31 @@ class Test_OSM extends Base {
 			$provider->render( 40.7128, -74.0060, 12, 320, -1 ),
 			'A negative height is unrenderable.'
 		);
+	}
+
+	/**
+	 * The compositor's tile URL carries the CARTO key.
+	 *
+	 * Covers the call site rather than the helper, so dropping the wrapper
+	 * call is caught.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_tile_url_template
+	 *
+	 * @return void
+	 */
+	public function test_get_tile_url_template_carries_the_key(): void {
+		$settings = Settings::get_instance();
+
+		$settings->set( 'carto_api_key', 'abc123' );
+
+		$this->assertSame(
+			OSM::DEFAULT_TILE_URL . '?key=abc123',
+			Utility::invoke_hidden_method( new OSM(), 'get_tile_url_template' ),
+			'Failed to assert the compositor tile URL carries the key.'
+		);
+
+		$settings->set( 'carto_api_key', '' );
 	}
 }


### PR DESCRIPTION
Fixes #2211.

## Proposed changes:

Photon accepts `default`, `de`, `en` and `fr`. We sent the site locale's primary subtag, so a Japanese, Chinese or Korean site asked for `lang=ja`, `zh` or `ko` and got HTTP 400 on every request. Confirmed against the live API:

| lang | response |
|---|---|
| `default`, `de`, `en`, `fr` | 200 |
| `ja`, `zh`, `ko` | 400 `Language is not supported` |

The editor turned that into "Address suggestions are temporarily unavailable. Try again in a moment", which reads as a blip but never recovered. Save-time geocoding used the same language, so venues on those sites also never got coordinates and the map sat on "Map is being prepared".

`get_language_code()` now falls back to `default` for a language Photon does not serve. `default` asks Photon for each result's own local-language name, which is closer to right for these locales than forcing `en`.

The list is filterable through `gatherpress_geocode_languages`, because `gatherpress_photon_api_url` already lets a site point at its own Photon instance, and that instance may serve more languages than the public one.

### Scope

This restores HTTP 200. It does not make Photon good at Japanese addresses, which is #2212 and needs its own decision. Worth knowing while reviewing: with `lang=default`, `兵庫県神戸市中央区三宮町3-1-16` returns three results and all of them are wrong, the first being the 16th arrondissement of Paris. So on those locales the failure mode after this PR is a wrong pin rather than no pin. That is #2212's problem to solve, not this one's, but it is the reason #2212 matters.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:

* Set the site language to Japanese.
* Edit a Venue, open Venue settings, and type an address into Full Address.
* Suggestions come back instead of "temporarily unavailable".
* Save the venue and confirm coordinates are stored.

### Credit (for release notes)

My WordPress.org username: mauteri

### Changelog entry

Added at `.github/changelog/2211-photon-language-allowlist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a CARTO API key in map settings when using OpenStreetMap.
  * Automatically applies the configured key to supported CARTO map tile URLs while preserving existing parameters.
  * Improved geocoding language handling by using supported Photon languages and falling back to the default when needed.
  * Added filter-based customization for supported geocoding languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
### Also in this PR: CARTO now requires an API key

Unrelated to the Photon fix but found while testing it. CARTO began enforcing API keys on its basemaps in August 2026. Tiles still return HTTP 200 with a valid PNG, so nothing looks wrong server-side, but each one arrives with `API KEY REQUIRED` watermarked across it. Every site on the OpenStreetMap platform is showing that today.

A key setting sits under venue map settings, shown for OpenStreetMap the way the Google key is shown for Google, and rides on both tile paths: the Leaflet basemap and the server-side compositor. It is only attached to CARTO's own hosts, so a site that filtered its tile URL elsewhere never hands over its key. Keys are free to 5 million tiles a month.
