### PR TITLE
Split unspaced East Asian addresses before geocoding

### DIFF
--- a/.github/changelog/2212-cjk-address-normalization
+++ b/.github/changelog/2212-cjk-address-normalization
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Japanese, Chinese and Korean venue addresses now geocode. Written without spaces, they reached the geocoder as one word and matched nothing, or matched the wrong continent; they are split at their administrative boundaries before being sent.

--- a/.typos.toml
+++ b/.typos.toml
@@ -21,6 +21,9 @@ extend-ignore-re = [
     "\\bEvent Organiser\\b",
     # Calibre (calibreapp.com) builds the image-actions image compressor.
     "\\bCalibre\\b",
+    # A contributor's GitHub username in the release credits; typos splits it
+    # into stein, 2 and nd and reads the last as a typo of "and".
+    "\\bstein2nd\\b",
 ]
 
 [default.extend-identifiers]

--- a/docs/developer/venue-address-format.md
+++ b/docs/developer/venue-address-format.md
@@ -121,6 +121,44 @@ of the mechanisms above; a callback attached to it is silently ignored. Port
 street-line callbacks to `gatherpress_formatted_address` (previous section) or,
 for locale-wide conventions, to a translation of the format strings.
 
+## Unspaced East Asian addresses
+
+Japanese and Chinese addresses are written without spaces, and Korean ones
+sometimes arrive that way when pasted. Photon tokenizes on whitespace, so such
+an address reaches it as a single token and either matches nothing or matches
+the wrong continent: `兵庫県神戸市中央区三宮町3-1-16` resolved to Paris.
+
+Before any request, `Geocoding\Query::normalize()` inserts a space at each
+administrative boundary and sends the result. Nothing is removed or reordered
+except a Japanese postal mark (`〒650-0021`), which the geocoder cannot use.
+Numbers and building names are kept, because they raise precision rather than
+lower it: with them the Kobe address above resolves to the named building.
+
+```text
+兵庫県神戸市中央区三宮町3-1-16   →  兵庫県 神戸市 中央区 三宮町 3-1-16
+北京市朝阳区建国路1号            →  北京市 朝阳区 建国路 1号
+대구광역시중구동성로2가          →  대구광역시 중구 동성로 2가
+서울특별시 중구 세종대로 110      →  unchanged
+```
+
+The top level (prefecture, province, metropolitan city) is matched against a
+fixed list rather than by its final character, because those characters also
+occur inside names: `京都市` contains `都`, `大구` contains `구`, and `广州市`
+contains `州`. A split there sends the geocoder a query that matches nothing.
+Lower levels are matched by their closing character, shortest match first, so
+`市川市` and `구로구` stay whole.
+
+An address the author already separated is left as it is; only tokens without
+whitespace are touched. This applies to both autocomplete and save-time
+geocoding, and the split form is what the response cache is keyed on.
+
+### `gatherpress_geocode_query`
+
+Runs after the built-in splitting. Use it to add boundaries for a script the
+plugin does not know, or to rewrite a local convention the geocoder trips over.
+It receives the split address and the address as received (postal mark already
+removed), and its return value is what is sent.
+
 ## Scope and limitations
 
 - Formatting applies to the **suggestion label** shown in the editor's address
@@ -133,6 +171,8 @@ for locale-wide conventions, to a translation of the format strings.
   verbatim and never passes through the format strings or the filter.
 - Already-saved addresses are not reformatted when translations or filters
   change — the stored address string stays the single source of truth.
+- Splitting is applied to the query only. The address the user typed is what
+  gets saved; the spaced form never replaces it.
 
 ## See also
 

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -15,6 +15,7 @@ namespace GatherPress\Core;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Geocoding\Query;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Venue\Meta as Venue_Meta;
@@ -676,7 +677,7 @@ final class Geocoding {
 	public function geocode_to_result( string $address ): array|WP_Error {
 		// Cap oversize input for parity with search_addresses(); protects
 		// upstream from pathological requests.
-		$address = mb_substr( trim( $address ), 0, 200 );
+		$address = Query::normalize( mb_substr( trim( $address ), 0, 200 ) );
 
 		if ( '' === $address ) {
 			return $this->build_not_found_payload();
@@ -834,6 +835,7 @@ final class Geocoding {
 			);
 		}
 
+		$query     = Query::normalize( $query );
 		$language  = $this->get_language_code();
 		$cache_key = self::SEARCH_CACHE_PREFIX . md5( $query . '|' . $language ); // NOSONAR.
 		$cached    = get_transient( $cache_key );

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -824,9 +824,16 @@ final class Geocoding {
 			);
 		}
 
-		$query = mb_substr( trim( $query ), 0, 200 );
+		$query     = mb_substr( trim( $query ), 0, 200 );
+		$too_short = mb_strlen( $query ) < self::ADDRESS_SEARCH_MIN_QUERY_LENGTH;
+		$query     = Query::normalize( $query );
 
-		if ( mb_strlen( $query ) < self::ADDRESS_SEARCH_MIN_QUERY_LENGTH ) {
+		// The minimum length weighs what the visitor typed, since it is about
+		// whether they have entered enough to be worth a lookup. The empty
+		// check weighs what would be sent: a search that was nothing but a
+		// postal code normalizes away to nothing, and would otherwise reach
+		// Photon as `q=` and be cached against a key every such search shares.
+		if ( $too_short || '' === $query ) {
 			return new WP_REST_Response(
 				array(
 					'suggestions' => array(),
@@ -835,7 +842,6 @@ final class Geocoding {
 			);
 		}
 
-		$query     = Query::normalize( $query );
 		$language  = $this->get_language_code();
 		$cache_key = self::SEARCH_CACHE_PREFIX . md5( $query . '|' . $language ); // NOSONAR.
 		$cached    = get_transient( $cache_key );

--- a/includes/core/classes/geocoding/class-query.php
+++ b/includes/core/classes/geocoding/class-query.php
@@ -164,7 +164,7 @@ class Query {
 	private const CITY_SUFFIXES = '市区郡县縣镇乡시군구';
 
 	/**
-	 * Suffixes closing a town, neighbourhood, road or block.
+	 * Suffixes closing a town, neighborhood, road or block.
 	 *
 	 * @since 0.36.0
 	 * @var string

--- a/includes/core/classes/geocoding/class-query.php
+++ b/includes/core/classes/geocoding/class-query.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Prepares an address for the geocoder.
+ *
+ * Japanese and Chinese addresses are written without spaces, and Korean ones
+ * sometimes arrive that way when pasted. Photon tokenizes on whitespace, so
+ * such an address reaches it as a single token and either matches nothing or
+ * matches the wrong continent. Inserting spaces at the administrative
+ * boundaries is enough for it to resolve, and to resolve to the right
+ * building rather than the right district.
+ *
+ * @package GatherPress\Core\Geocoding
+ * @since 0.36.0
+ */
+
+namespace GatherPress\Core\Geocoding;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+/**
+ * Class Query.
+ *
+ * Splits an unspaced East Asian address into its administrative units.
+ *
+ * @since 0.36.0
+ */
+class Query {
+	/**
+	 * Top-level units, matched by exact prefix.
+	 *
+	 * Matched from a list rather than by suffix because the suffix characters
+	 * also occur inside names: 京都市 contains 都 and 大구 contains 구, and a
+	 * split there sends the geocoder a query that matches nothing.
+	 *
+	 * @since 0.36.0
+	 * @var string[]
+	 */
+	private const TOP_LEVEL = array(
+		// Japan: the 47 prefectures.
+		'北海道',
+		'青森県',
+		'岩手県',
+		'宮城県',
+		'秋田県',
+		'山形県',
+		'福島県',
+		'茨城県',
+		'栃木県',
+		'群馬県',
+		'埼玉県',
+		'千葉県',
+		'東京都',
+		'神奈川県',
+		'新潟県',
+		'富山県',
+		'石川県',
+		'福井県',
+		'山梨県',
+		'長野県',
+		'岐阜県',
+		'静岡県',
+		'愛知県',
+		'三重県',
+		'滋賀県',
+		'京都府',
+		'大阪府',
+		'兵庫県',
+		'奈良県',
+		'和歌山県',
+		'鳥取県',
+		'島根県',
+		'岡山県',
+		'広島県',
+		'山口県',
+		'徳島県',
+		'香川県',
+		'愛媛県',
+		'高知県',
+		'福岡県',
+		'佐賀県',
+		'長崎県',
+		'熊本県',
+		'大分県',
+		'宮崎県',
+		'鹿児島県',
+		'沖縄県',
+		// China: provinces, municipalities, autonomous and special regions.
+		'北京市',
+		'天津市',
+		'上海市',
+		'重庆市',
+		'河北省',
+		'山西省',
+		'辽宁省',
+		'吉林省',
+		'黑龙江省',
+		'江苏省',
+		'浙江省',
+		'安徽省',
+		'福建省',
+		'江西省',
+		'山东省',
+		'河南省',
+		'湖北省',
+		'湖南省',
+		'广东省',
+		'海南省',
+		'四川省',
+		'贵州省',
+		'云南省',
+		'陕西省',
+		'甘肃省',
+		'青海省',
+		'内蒙古自治区',
+		'广西壮族自治区',
+		'西藏自治区',
+		'宁夏回族自治区',
+		'新疆维吾尔自治区',
+		'香港特别行政区',
+		'澳门特别行政区',
+		// Taiwan, in the traditional script its addresses use.
+		'台北市',
+		'臺北市',
+		'新北市',
+		'桃園市',
+		'台中市',
+		'臺中市',
+		'台南市',
+		'臺南市',
+		'高雄市',
+		// Korea: metropolitan cities and provinces, current and former names.
+		'서울특별시',
+		'부산광역시',
+		'대구광역시',
+		'인천광역시',
+		'광주광역시',
+		'대전광역시',
+		'울산광역시',
+		'세종특별자치시',
+		'경기도',
+		'강원특별자치도',
+		'강원도',
+		'충청북도',
+		'충청남도',
+		'전북특별자치도',
+		'전라북도',
+		'전라남도',
+		'경상북도',
+		'경상남도',
+		'제주특별자치도',
+	);
+
+	/**
+	 * Suffixes closing a city, ward, county or district.
+	 *
+	 * Japanese and Chinese share the Han characters; 縣 is the traditional
+	 * form of 县 used in Taiwan. 州 is deliberately absent: it closes a few
+	 * autonomous prefectures but sits inside 广州, 杭州 and 苏州.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	private const CITY_SUFFIXES = '市区郡县縣镇乡시군구';
+
+	/**
+	 * Suffixes closing a town, neighbourhood, road or block.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	private const STREET_SUFFIXES = '町村路街道巷弄동읍면로길';
+
+	/**
+	 * Insert spaces at the administrative boundaries of an address.
+	 *
+	 * Only tokens without whitespace are touched, so an address the author
+	 * already separated, which is how Korean is normally written, is left as
+	 * it is. Nothing is removed or reordered except a Japanese postal mark,
+	 * which the geocoder cannot use.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string $query Address as typed or pasted.
+	 *
+	 * @return string The address with its units separated by spaces.
+	 */
+	public static function normalize( string $query ): string {
+		$query = trim( preg_replace( '/〒\s*\d{3}-?\d{4}\s*/u', '', $query ) ?? $query );
+
+		if ( '' === $query ) {
+			return '';
+		}
+
+		$tokens = preg_split( '/\s+/u', $query );
+
+		if ( false === $tokens ) {
+			$tokens = array( $query );
+		}
+
+		$units = array_map(
+			static function ( string $token ): array {
+				return self::split_token( $token );
+			},
+			$tokens
+		);
+
+		$normalized = implode( ' ', array_merge( ...$units ) );
+
+		/**
+		 * Filters the address sent to the geocoder.
+		 *
+		 * Runs after the built-in splitting. Use it to add boundaries for a
+		 * script the plugin does not know, or to rewrite a local address
+		 * convention the geocoder trips over.
+		 *
+		 * @since 0.36.0
+		 *
+		 * @param string $normalized Address as it will be sent.
+		 * @param string $query      Address as received, postal mark removed.
+		 *
+		 * @return string
+		 */
+		return (string) apply_filters( 'gatherpress_geocode_query', $normalized, $query );
+	}
+
+	/**
+	 * Split one unspaced token into its units.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string $token A run of characters with no whitespace.
+	 *
+	 * @return string[] The units, in their original order.
+	 */
+	private static function split_token( string $token ): array {
+		if ( 1 !== preg_match( '/[\x{3040}-\x{30FF}\x{4E00}-\x{9FFF}\x{AC00}-\x{D7AF}]/u', $token ) ) {
+			return array( $token );
+		}
+
+		$units = array();
+
+		foreach ( self::TOP_LEVEL as $unit ) {
+			if ( str_starts_with( $token, $unit ) && mb_strlen( $token ) > mb_strlen( $unit ) ) {
+				$units[] = $unit;
+				$token   = mb_substr( $token, mb_strlen( $unit ) );
+				break;
+			}
+		}
+
+		foreach ( array( self::CITY_SUFFIXES, self::STREET_SUFFIXES ) as $suffixes ) {
+			$pattern = '/^(.+?[' . $suffixes . '])/u';
+
+			// Shortest match first, so 市川市 is one unit rather than 市 and
+			// 川市, and a trailing unit is taken whole so 구로구 does not fall
+			// through to the street pass and split on the 로 inside it.
+			while ( 1 === preg_match( $pattern, $token, $matches ) ) {
+				$units[] = $matches[1];
+				$token   = mb_substr( $token, mb_strlen( $matches[1] ) );
+			}
+		}
+
+		if ( '' !== $token ) {
+			$units[] = $token;
+		}
+
+		return $units;
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -3428,4 +3428,86 @@ class Test_Geocoding extends Base {
 			}
 		}
 	}
+
+	/**
+	 * Save-time geocoding sends the split form of an unspaced address.
+	 *
+	 * Photon tokenizes on whitespace, so an unspaced Japanese address reaches
+	 * it as one token and matches nothing, or matches Paris. The split is
+	 * applied before the request and before the cache key, so the same
+	 * address spaced or unspaced shares a cache entry.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::geocode_to_result
+	 *
+	 * @return void
+	 */
+	public function test_geocode_to_result_sends_the_split_address(): void {
+		$instance     = Geocoding::get_instance();
+		$captured_url = '';
+
+		$this->http_mock->mock(
+			'*',
+			array(
+				'body' => static function ( &$headers, $url ) use ( &$captured_url ) {
+					$captured_url = $url;
+					$headers      = 'HTTP/1.1 200 OK';
+
+					return wp_json_encode( array( 'features' => array() ) );
+				},
+			)
+		);
+
+		$instance->geocode_to_result( '兵庫県神戸市中央区三宮町3-1-16' );
+
+		$query = array();
+		wp_parse_str( (string) wp_parse_url( $captured_url, PHP_URL_QUERY ), $query );
+
+		$this->assertSame(
+			'兵庫県 神戸市 中央区 三宮町 3-1-16',
+			$query['q'] ?? '',
+			'Failed to assert the geocoder receives the address split at its boundaries.'
+		);
+	}
+
+	/**
+	 * Autocomplete sends the split form of an unspaced address.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::search_addresses
+	 *
+	 * @return void
+	 */
+	public function test_search_addresses_sends_the_split_address(): void {
+		$instance     = Geocoding::get_instance();
+		$captured_url = '';
+
+		$this->http_mock->mock(
+			'*',
+			array(
+				'body' => static function ( &$headers, $url ) use ( &$captured_url ) {
+					$captured_url = $url;
+					$headers      = 'HTTP/1.1 200 OK';
+
+					return wp_json_encode( array( 'features' => array() ) );
+				},
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'q', '北京市朝阳区建国路1号' );
+
+		$instance->search_addresses( $request );
+
+		$query = array();
+		wp_parse_str( (string) wp_parse_url( $captured_url, PHP_URL_QUERY ), $query );
+
+		$this->assertSame(
+			'北京市 朝阳区 建国路 1号',
+			$query['q'] ?? '',
+			'Failed to assert autocomplete receives the address split at its boundaries.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -978,6 +978,52 @@ class Test_Geocoding extends Base {
 	}
 
 	/**
+	 * Coverage for search_addresses with a query that is nothing but a postal code.
+	 *
+	 * Long enough to clear the minimum length, but `Query::normalize()` strips
+	 * the postal code and leaves nothing, so there is nothing to search for.
+	 *
+	 * @covers ::search_addresses
+	 *
+	 * @return void
+	 */
+	public function test_search_addresses_postal_code_only_query(): void {
+		$instance  = Geocoding::get_instance();
+		$requested = false;
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt ) use ( &$requested ) {
+				$requested = true;
+
+				return $preempt;
+			}
+		);
+
+		$request = new WP_REST_Request( 'GET' );
+		// A Japanese postal marker and code, which is all `Query::normalize()`
+		// has to work with. Written as an escape so the file stays ASCII.
+		$request->set_param( 'q', "\u{3012}100-0001" );
+
+		$response = $instance->search_addresses( $request );
+
+		$this->assertInstanceOf(
+			WP_REST_Response::class,
+			$response,
+			'Failed to assert response is WP_REST_Response.'
+		);
+		$this->assertSame(
+			array( 'suggestions' => array() ),
+			$response->get_data(),
+			'A search that normalizes away to nothing should offer no suggestions.'
+		);
+		$this->assertFalse(
+			$requested,
+			'An empty query should never be sent to the geocoder.'
+		);
+	}
+
+	/**
 	 * Coverage for search_addresses with short query (returns empty suggestions; min length matches JS).
 	 *
 	 * @covers ::search_addresses

--- a/test/unit/php/includes/tests/core/classes/geocoding/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/geocoding/class-test-query.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Class handles unit tests for GatherPress\Core\Geocoding\Query.
+ *
+ * @package GatherPress\Core
+ * @since 0.36.0
+ */
+
+namespace GatherPress\Tests\Core\Geocoding;
+
+use GatherPress\Core\Geocoding\Query;
+use GatherPress\Tests\Base;
+
+/**
+ * Class Test_Query.
+ *
+ * @coversDefaultClass \GatherPress\Core\Geocoding\Query
+ */
+class Test_Query extends Base {
+	/**
+	 * Addresses and how they should reach the geocoder.
+	 *
+	 * Every expected value here was sent to Photon and resolved to the right
+	 * place; every unspaced input either matched nothing or matched another
+	 * continent.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public function data_addresses(): array {
+		return array(
+			// Japanese, unspaced by convention.
+			'JA prefecture, ward, block'         => array(
+				'東京都港区芝公園4-2-8',
+				'東京都 港区 芝公園4-2-8',
+			),
+			'JA prefecture, city, ward, town'    => array(
+				'兵庫県神戸市中央区三宮町3-1-16',
+				'兵庫県 神戸市 中央区 三宮町 3-1-16',
+			),
+			'JA postal mark dropped, rest kept'  => array(
+				'〒650-0021 兵庫県神戸市中央区三宮町3-1-16 三星ビル 4階南室',
+				'兵庫県 神戸市 中央区 三宮町 3-1-16 三星ビル 4階南室',
+			),
+			'JA Hokkaido has no suffix to trip'  => array(
+				'北海道札幌市中央区北1条西2丁目',
+				'北海道 札幌市 中央区 北1条西2丁目',
+			),
+			// Names containing a suffix character.
+			'JA Kyoto is not split at 都'         => array(
+				'京都府京都市下京区東塩小路釜殿町',
+				'京都府 京都市 下京区 東塩小路 釜殿町',
+			),
+			'JA Machida is not split at 町'       => array(
+				'東京都町田市',
+				'東京都 町田市',
+			),
+			'JA Ichikawa is not split at 市'      => array(
+				'千葉県市川市',
+				'千葉県 市川市',
+			),
+			// Chinese, unspaced by convention.
+			'ZH municipality, district, road'    => array(
+				'北京市朝阳区建国路1号',
+				'北京市 朝阳区 建国路 1号',
+			),
+			'ZH province, city, district, road'  => array(
+				'广东省广州市天河区天河路',
+				'广东省 广州市 天河区 天河路',
+			),
+			'ZH Hangzhou is not split at 州'      => array(
+				'浙江省杭州市西湖区',
+				'浙江省 杭州市 西湖区',
+			),
+			'ZH municipality with district only' => array(
+				'重庆市渝中区',
+				'重庆市 渝中区',
+			),
+			// Korean, normally spaced; only an unspaced paste is touched.
+			'KO already spaced is untouched'     => array(
+				'서울특별시 중구 세종대로 110',
+				'서울특별시 중구 세종대로 110',
+			),
+			'KO unspaced paste is split'         => array(
+				'대구광역시중구동성로2가',
+				'대구광역시 중구 동성로 2가',
+			),
+			'KO Daegu is not split at 구'         => array(
+				'대구광역시중구',
+				'대구광역시 중구',
+			),
+			'KO Guro-gu is not split at 로'       => array(
+				'서울특별시구로구',
+				'서울특별시 구로구',
+			),
+			// Everything else passes through.
+			'Latin address is untouched'         => array(
+				'123 Main St, Montclair, NJ 07042',
+				'123 Main St, Montclair, NJ 07042',
+			),
+			'surrounding whitespace is trimmed'  => array(
+				"  東京都港区  \n",
+				'東京都 港区',
+			),
+			'empty stays empty'                  => array(
+				'',
+				'',
+			),
+			'only a postal mark becomes empty'   => array(
+				'〒100-0001',
+				'',
+			),
+		);
+	}
+
+	/**
+	 * Coverage for normalize.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::normalize
+	 * @covers ::split_token
+	 *
+	 * @dataProvider data_addresses
+	 *
+	 * @param string $input    Address as typed or pasted.
+	 * @param string $expected Address as it should reach the geocoder.
+	 *
+	 * @return void
+	 */
+	public function test_normalize( string $input, string $expected ): void {
+		$this->assertSame(
+			$expected,
+			Query::normalize( $input ),
+			'Failed to assert the address is split at its administrative boundaries.'
+		);
+	}
+
+	/**
+	 * Bytes that are not UTF-8 pass through untouched.
+	 *
+	 * With the `u` flag both `preg_replace()` and `preg_split()` refuse
+	 * invalid UTF-8, and the geocoder is left to make of it what it was
+	 * already making of it before this class existed.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::normalize
+	 * @covers ::split_token
+	 *
+	 * @return void
+	 */
+	public function test_normalize_leaves_invalid_utf8_alone(): void {
+		$bytes = "\xC3\x28\xE6\x9D\xB1";
+
+		$this->assertSame(
+			$bytes,
+			Query::normalize( $bytes ),
+			'Failed to assert bytes the regex engine refuses are passed through unchanged.'
+		);
+	}
+
+	/**
+	 * A site can rewrite the query after the built-in splitting.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::normalize
+	 *
+	 * @return void
+	 */
+	public function test_normalize_is_filterable(): void {
+		$seen = array();
+
+		add_filter(
+			'gatherpress_geocode_query',
+			static function ( string $normalized, string $query ) use ( &$seen ): string {
+				$seen = array( $normalized, $query );
+
+				return 'rewritten';
+			},
+			10,
+			2
+		);
+
+		$this->assertSame(
+			'rewritten',
+			Query::normalize( '〒100-0001 東京都港区' ),
+			'Failed to assert the filter decides what is sent.'
+		);
+		$this->assertSame(
+			array( '東京都 港区', '東京都港区' ),
+			$seen,
+			'Failed to assert the filter receives both the split and the received address.'
+		);
+	}
+}


### PR DESCRIPTION
Fixes #2212.

## Proposed changes:

The issue proposes a pluggable geocoder because public Photon cannot resolve Japanese addresses. That premise did not hold up. Photon resolves them fine; it just never received them in a form it could read.

Japanese and Chinese addresses are written without spaces, and Korean ones sometimes arrive that way when pasted. Photon tokenizes on whitespace, so the whole address reached it as one token. Split at its administrative boundaries, every address I tried resolved, and to a more precise point than the district:

| Address | As pasted | Split |
|---|---|---|
| `兵庫県神戸市中央区三宮町3-1-16` | Paris, France | 34.6893, 135.1905, the named building |
| `東京都港区芝公園4-2-8` | New York, USA | 35.6580, 139.7456 |
| `北京市朝阳区建国路1号` | no results | 39.9071, 116.4621 |
| `대구광역시중구동성로2가` | no results | 35.8693, 128.5946 |

`Geocoding\Query::normalize()` inserts a space at each boundary and nothing else, apart from a Japanese postal mark the geocoder cannot use. Numbers and building names stay, because they raise precision. Both send sites apply it ahead of the cache key.

### The trap

Splitting after any suffix character breaks on names that contain one: 京都市 contains 都, 대구 contains 구, 广州 contains 州. Each of those sent naively returns nothing. So the top level matches against the fixed lists of prefectures, provinces and metropolitan cities, and only the lower levels use suffix scanning, shortest match first so 市川市 and 구로구 stay whole. Those cases are pinned in the tests.

### Why not the provider abstraction

Nominatim sits on the same OpenStreetMap data and fails the same unspaced queries the same way, so swapping OSM-backed providers would have achieved nothing. A Google provider would work but needs a key, and this fixes wp.org installs with none. If a second provider is wanted later for other reasons, this change is orthogonal to it.

A `gatherpress_geocode_query` filter runs after the built-in splitting for scripts the plugin does not know.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Every expected value in the test data was sent to Photon and resolved to the right place. Coverage is 100% on both touched classes.

## Testing instructions:

* Set the site language to Japanese, edit a Venue, and enter `兵庫県神戸市中央区三宮町3-1-16` as the full address.
* Suggestions appear for Kobe rather than "temporarily unavailable", and after saving the map pins Sannomiya, not Paris.
* Repeat with `北京市朝阳区建国路1号` and `대구광역시중구동성로2가`.
* An English address behaves exactly as before.

### Credit (for release notes)

My WordPress.org username: mauteri

### Changelog entry

Added at `.github/changelog/2212-cjk-address-normalization`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved geocoding for unspaced Japanese, Chinese, and Korean addresses by adding spacing at administrative and street boundaries.
  * Applied address normalization to both autocomplete searches and saved-address geocoding.
  * Added a filter allowing advanced customization of geocoding queries.

* **Documentation**
  * Documented address normalization behavior, customization options, and saved-address handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->