### PR TITLE
Filter the admin event list by event date

### DIFF
--- a/.extract-wp-hooks.json
+++ b/.extract-wp-hooks.json
@@ -9,8 +9,10 @@
 	],
 	"ignore_filter": [
 		"determine_current_user",
+		"months_dropdown_results",
 		"post_type_labels_gatherpress_event",
-		"post_type_labels_gatherpress_venue"
+		"post_type_labels_gatherpress_venue",
+		"pre_months_dropdown_query"
 	],
 	"github_wiki": false
 }

--- a/.github/changelog/1702-filter-by-event-date
+++ b/.github/changelog/1702-filter-by-event-date
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-A filter for the event date on the events admin list, alongside a relabeled filter for the published date.
+A filter for the event date on the events admin list, alongside a relabeled filter for the post date.

--- a/.github/changelog/1702-filter-by-event-date
+++ b/.github/changelog/1702-filter-by-event-date
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-A filter for the event date on the events admin list, alongside a relabeled filter for the post date.
+Filters for the event date and the topic on the events admin list, alongside a relabeled filter for the post date.

--- a/.github/changelog/1702-filter-by-event-date
+++ b/.github/changelog/1702-filter-by-event-date
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+A filter for the event date on the events admin list, alongside a relabeled filter for the published date.

--- a/.typos.toml
+++ b/.typos.toml
@@ -11,6 +11,10 @@ extend-exclude = [
     "**/node_modules/**",
     "build/**",
     "docs/media/**",
+    # Generated from GitHub usernames by the credits-sync workflow, so the
+    # words in them are nobody's to spell. "stein2nd" alone reads as a typo
+    # of "and" once typos splits it.
+    ".github/scripts/release/credits/**",
 ]
 ignore-hidden = false
 
@@ -21,9 +25,6 @@ extend-ignore-re = [
     "\\bEvent Organiser\\b",
     # Calibre (calibreapp.com) builds the image-actions image compressor.
     "\\bCalibre\\b",
-    # A contributor's GitHub username in the release credits; typos splits it
-    # into stein, 2 and nd and reads the last as a typo of "and".
-    "\\bstein2nd\\b",
 ]
 
 [default.extend-identifiers]

--- a/.typos.toml
+++ b/.typos.toml
@@ -38,6 +38,5 @@ extend-ignore-re = [
 
 # Case insensitive, matches inside word.
 # [default.extend-words]
-"Skelton" = "Skelton"
 # bellow = "below"
 # toi = "toi"

--- a/.typos.toml
+++ b/.typos.toml
@@ -19,7 +19,6 @@ ignore-hidden = false
 locale = "en-us"
 extend-ignore-re = [
     "\\biMatix\\b",
-    "\\bEvent Organiser\\b",
     # Calibre (calibreapp.com) builds the image-actions image compressor.
     "\\bCalibre\\b",
 ]

--- a/.typos.toml
+++ b/.typos.toml
@@ -21,6 +21,9 @@ extend-ignore-re = [
     "\\bEvent Organiser\\b",
     # Calibre (calibreapp.com) builds the image-actions image compressor.
     "\\bCalibre\\b",
+    # A contributor's GitHub username in the release credits; typos splits it
+    # into stein, 2 and nd and reads the last as a typo of "and".
+    "\\bstein2nd\\b",
 ]
 
 [default.extend-identifiers]

--- a/.typos.toml
+++ b/.typos.toml
@@ -11,9 +11,6 @@ extend-exclude = [
     "**/node_modules/**",
     "build/**",
     "docs/media/**",
-    # Generated from GitHub usernames by the credits-sync workflow, so the
-    # words in them are nobody's to spell. "stein2nd" alone reads as a typo
-    # of "and" once typos splits it.
     ".github/scripts/release/credits/**",
 ]
 ignore-hidden = false

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -19,6 +19,7 @@ use Exception;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp\Query as Rsvp_Query;
 use GatherPress\Core\Rsvp;
+use GatherPress\Core\Topic;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Venue\Setup as Venue_Setup;
@@ -75,6 +76,7 @@ final class Admin_List {
 		add_filter( 'query_vars', array( $this, 'query_vars' ) );
 		add_filter( 'disable_months_dropdown', array( $this, 'disable_months_dropdown' ), 10, 2 );
 		add_action( 'restrict_manage_posts', array( $this, 'render_date_filters' ) );
+		add_action( 'restrict_manage_posts', array( $this, 'render_taxonomy_filters' ) );
 		add_action( 'registered_post_type', array( $this, 'maybe_register_post_type_hooks' ) );
 	}
 
@@ -424,6 +426,103 @@ final class Admin_List {
 				esc_attr( $current_view )
 			);
 		}
+	}
+
+	/**
+	 * Render the taxonomy filters above the list table.
+	 *
+	 * Core builds a filter dropdown for the built-in category taxonomy only, so
+	 * topics reach the events list with an admin column but no way to filter by
+	 * them. This adds the one core would have if topics were categories.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string $post_type The post type the list table is rendering.
+	 *
+	 * @return void
+	 */
+	public function render_taxonomy_filters( string $post_type ): void {
+		if ( ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+			return;
+		}
+
+		$this->render_taxonomy_filter( $post_type, Topic::TAXONOMY );
+	}
+
+	/**
+	 * Render one taxonomy filter for the list table's filter form.
+	 *
+	 * Mirrors core's `WP_Posts_List_Table::categories_dropdown()`, down to
+	 * reading its two strings off the taxonomy's own labels so an extender's
+	 * taxonomy names itself. Terms submit by slug because that is what a
+	 * taxonomy's query var resolves against; the "all" choice submits a `0`,
+	 * which `WP_Query` reads as empty and skips.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string $post_type The post type the list table is rendering.
+	 * @param string $taxonomy  The taxonomy to offer as a filter.
+	 *
+	 * @return void
+	 */
+	protected function render_taxonomy_filter( string $post_type, string $taxonomy ): void {
+		if ( ! is_object_in_taxonomy( $post_type, $taxonomy ) ) {
+			return;
+		}
+
+		$taxonomy_object = get_taxonomy( $taxonomy );
+
+		if ( ! $taxonomy_object ) {
+			return;
+		}
+
+		// A taxonomy with no terms has nothing to offer, and an empty dropdown
+		// would still draw the Filter button the whole form shares.
+		$terms = get_terms(
+			array(
+				'taxonomy'   => $taxonomy,
+				'hide_empty' => false,
+				'number'     => 1,
+				'fields'     => 'ids',
+			)
+		);
+
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return;
+		}
+
+		// `filter_by_item` is only filled in by default for hierarchical
+		// taxonomies, so fall back to the plural name for the rest.
+		$filter_label = ! empty( $taxonomy_object->labels->filter_by_item )
+			? (string) $taxonomy_object->labels->filter_by_item
+			: (string) $taxonomy_object->labels->name;
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$selected = isset( $_GET[ $taxonomy ] ) && is_scalar( $_GET[ $taxonomy ] )
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			? sanitize_title( (string) wp_unslash( $_GET[ $taxonomy ] ) )
+			: '';
+
+		printf(
+			'<label class="screen-reader-text" for="%s">%s</label>',
+			esc_attr( $taxonomy ),
+			esc_html( $filter_label )
+		);
+
+		wp_dropdown_categories(
+			array(
+				'show_option_all' => $taxonomy_object->labels->all_items,
+				'taxonomy'        => $taxonomy,
+				'name'            => $taxonomy,
+				'id'              => $taxonomy,
+				'value_field'     => 'slug',
+				'selected'        => $selected,
+				'hierarchical'    => true,
+				'hide_empty'      => false,
+				'show_count'      => false,
+				'orderby'         => 'name',
+			)
+		);
 	}
 
 	/**

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -466,13 +466,9 @@ final class Admin_List {
 	 * @return void
 	 */
 	protected function render_taxonomy_filter( string $post_type, string $taxonomy ): void {
-		if ( ! is_object_in_taxonomy( $post_type, $taxonomy ) ) {
-			return;
-		}
-
 		$taxonomy_object = get_taxonomy( $taxonomy );
 
-		if ( ! $taxonomy_object ) {
+		if ( ! $taxonomy_object || ! is_object_in_taxonomy( $post_type, $taxonomy ) ) {
 			return;
 		}
 

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -364,7 +364,7 @@ final class Admin_List {
 	}
 
 	/**
-	 * Render the event date and published date filters above the list table.
+	 * Render the event date and post date filters above the list table.
 	 *
 	 * Replaces the dropdown removed in `disable_months_dropdown()` with a
 	 * labeled pair: one filtering the event date column, one filtering the
@@ -403,8 +403,8 @@ final class Admin_List {
 		$this->render_months_dropdown(
 			'm',
 			'filter-by-date',
-			__( 'Filter by published date', 'gatherpress' ),
-			__( 'All published dates', 'gatherpress' ),
+			__( 'Filter by post date', 'gatherpress' ),
+			__( 'All post dates', 'gatherpress' ),
 			$this->get_published_months( $post_type )
 		);
 

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -405,7 +405,7 @@ final class Admin_List {
 			'filter-by-date',
 			__( 'Filter by post date', 'gatherpress' ),
 			__( 'All post dates', 'gatherpress' ),
-			$this->get_published_months( $post_type )
+			$this->get_post_date_months( $post_type )
 		);
 
 		// The Upcoming and Past views travel in a query parameter core's filter
@@ -558,7 +558,7 @@ final class Admin_List {
 	 *
 	 * @return array<int, stdClass> Month rows carrying `year` and `month` properties.
 	 */
-	protected function get_published_months( string $post_type ): array {
+	protected function get_post_date_months( string $post_type ): array {
 		global $wpdb;
 
 		/** This filter is documented in wp-admin/includes/class-wp-list-table.php */

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -171,9 +171,9 @@ final class Admin_List {
 		$post_type = $screen->post_type;
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$current_view = isset( $_GET['gatherpress_event_query'] )
+		$current_view = isset( $_GET[ Query::EVENT_QUERY_PARAM ] )
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			? sanitize_text_field( wp_unslash( $_GET['gatherpress_event_query'] ) )
+			? sanitize_text_field( wp_unslash( $_GET[ Query::EVENT_QUERY_PARAM ] ) )
 			: '';
 
 		$counts    = $this->get_event_counts( $post_type );
@@ -190,10 +190,10 @@ final class Admin_List {
 				'<a href="%s"%s>%s <span class="count">(%s)</span></a>',
 				add_query_arg(
 					array(
-						'gatherpress_event_query' => $key,
-						'post_type'               => $post_type,
-						'order'                   => 'upcoming' === $key ? 'asc' : 'desc',
-						'orderby'                 => 'datetime',
+						Query::EVENT_QUERY_PARAM => $key,
+						'post_type'              => $post_type,
+						'order'                  => 'upcoming' === $key ? 'asc' : 'desc',
+						'orderby'                => 'datetime',
 					),
 					$base_url
 				),
@@ -335,7 +335,7 @@ final class Admin_List {
 	 * @return string[] Updated list of allowed query variables.
 	 */
 	public function query_vars( array $query_vars ): array {
-		$query_vars[] = 'gatherpress_event_query';
+		$query_vars[] = Query::EVENT_QUERY_PARAM;
 		$query_vars[] = Query::EVENT_DATE_QUERY_PARAM;
 		return $query_vars;
 	}

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -22,6 +22,7 @@ use GatherPress\Core\Rsvp;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Venue\Setup as Venue_Setup;
+use stdClass;
 use WP_Query;
 
 /**
@@ -72,6 +73,8 @@ final class Admin_List {
 	protected function setup_hooks(): void {
 		add_action( 'pre_get_posts', array( $this, 'handle_rsvp_sorting' ) );
 		add_filter( 'query_vars', array( $this, 'query_vars' ) );
+		add_filter( 'disable_months_dropdown', array( $this, 'disable_months_dropdown' ), 10, 2 );
+		add_action( 'restrict_manage_posts', array( $this, 'render_date_filters' ) );
 		add_action( 'registered_post_type', array( $this, 'maybe_register_post_type_hooks' ) );
 	}
 
@@ -321,7 +324,9 @@ final class Admin_List {
 	 * Allowlist for additional query parameters.
 	 *
 	 * Adds 'gatherpress_event_query' to the list of allowed query variables,
-	 * to be able to request 'upcoming' or 'past' events in the admin list view.
+	 * to be able to request 'upcoming' or 'past' events in the admin list view,
+	 * and 'gatherpress_event_date' to narrow that list to a single month of
+	 * event dates.
 	 *
 	 * @since 0.34.0
 	 *
@@ -331,7 +336,276 @@ final class Admin_List {
 	 */
 	public function query_vars( array $query_vars ): array {
 		$query_vars[] = 'gatherpress_event_query';
+		$query_vars[] = Query::EVENT_DATE_QUERY_PARAM;
 		return $query_vars;
+	}
+
+	/**
+	 * Take over the months dropdown on list tables for event post types.
+	 *
+	 * Core renders a single dropdown reading "All dates" that silently filters
+	 * on publish date. On a screen whose marquee column is the event date, that
+	 * is read as filtering by event date instead. `render_date_filters()` puts
+	 * both dropdowns back, each saying which date it filters.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param bool   $disable   Whether to remove core's months dropdown.
+	 * @param string $post_type The post type the list table is rendering.
+	 *
+	 * @return bool True for post types that render our own date filters.
+	 */
+	public function disable_months_dropdown( bool $disable, string $post_type ): bool {
+		if ( post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+			return true;
+		}
+
+		return $disable;
+	}
+
+	/**
+	 * Render the event date and published date filters above the list table.
+	 *
+	 * Replaces the dropdown removed in `disable_months_dropdown()` with a
+	 * labelled pair: one filtering the event date column, one filtering the
+	 * publish date through the same `m` parameter core uses, so existing links
+	 * into a filtered list keep working.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string $post_type The post type the list table is rendering.
+	 *
+	 * @return void
+	 */
+	public function render_date_filters( string $post_type ): void {
+		if ( ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+			return;
+		}
+
+		$singular = Utility::post_type_label( 'singular_name', $post_type );
+
+		$this->render_months_dropdown(
+			Query::EVENT_DATE_QUERY_PARAM,
+			'gatherpress-filter-by-event-date',
+			sprintf(
+				/* translators: %s: Singular post type label, e.g. "Event". */
+				__( 'Filter by %s date', 'gatherpress' ),
+				$singular
+			),
+			sprintf(
+				/* translators: %s: Singular post type label, e.g. "Event". */
+				__( 'All %s dates', 'gatherpress' ),
+				$singular
+			),
+			$this->get_event_date_months( $post_type )
+		);
+
+		$this->render_months_dropdown(
+			'm',
+			'filter-by-date',
+			__( 'Filter by published date', 'gatherpress' ),
+			__( 'All published dates', 'gatherpress' ),
+			$this->get_published_months( $post_type )
+		);
+
+		// The Upcoming and Past views travel in a query parameter core's filter
+		// form knows nothing about, so filtering by date from one of those views
+		// would otherwise drop the visitor back to All.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$current_view = isset( $_GET[ Query::EVENT_QUERY_PARAM ] )
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			? sanitize_text_field( wp_unslash( $_GET[ Query::EVENT_QUERY_PARAM ] ) )
+			: '';
+
+		if ( '' !== $current_view ) {
+			printf(
+				'<input type="hidden" name="%s" value="%s" />',
+				esc_attr( Query::EVENT_QUERY_PARAM ),
+				esc_attr( $current_view )
+			);
+		}
+	}
+
+	/**
+	 * Render one months dropdown for the list table's filter form.
+	 *
+	 * Mirrors the markup of core's `WP_List_Table::months_dropdown()`: rows
+	 * carrying no year are skipped, and a bucket with no months renders nothing
+	 * at all rather than a dropdown whose only choice is "all".
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string               $name      Query parameter the dropdown submits.
+	 * @param string               $id        HTML id tying the select to its label.
+	 * @param string               $label     Visually hidden label for the select.
+	 * @param string               $all_label Text of the unfiltered option.
+	 * @param array<int, stdClass> $months Month rows carrying `year` and `month` properties.
+	 *
+	 * @return void
+	 */
+	protected function render_months_dropdown(
+		string $name,
+		string $id,
+		string $label,
+		string $all_label,
+		array $months
+	): void {
+		global $wp_locale;
+
+		$months = array_filter(
+			$months,
+			static function ( stdClass $month ): bool {
+				return 0 !== (int) $month->year;
+			}
+		);
+
+		if ( empty( $months ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$selected = isset( $_GET[ $name ] ) ? (int) $_GET[ $name ] : 0;
+
+		printf(
+			'<label for="%1$s" class="screen-reader-text">%2$s</label>'
+			. '<select name="%3$s" id="%1$s"><option value="0"%4$s>%5$s</option>',
+			esc_attr( $id ),
+			esc_html( $label ),
+			esc_attr( $name ),
+			selected( $selected, 0, false ),
+			esc_html( $all_label )
+		);
+
+		foreach ( $months as $month ) {
+			$month_number = zeroise( $month->month, 2 );
+			$value        = $month->year . $month_number;
+
+			printf(
+				'<option value="%s"%s>%s</option>',
+				esc_attr( $value ),
+				selected( $selected, (int) $value, false ),
+				esc_html(
+					sprintf(
+						/* translators: 1: Month name, 2: 4-digit year. */
+						__( '%1$s %2$d', 'gatherpress' ),
+						$wp_locale->get_month( $month_number ),
+						$month->year
+					)
+				)
+			);
+		}
+
+		echo '</select>';
+	}
+
+	/**
+	 * Get the months that have events, newest first.
+	 *
+	 * Reads `datetime_start` rather than `datetime_start_gmt` so a month holds
+	 * the events the list table displays under it, since the event date column
+	 * renders in each event's own timezone. Events with no row in the events
+	 * table have no event date and appear under no month.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string $post_type The event post type to collect months for.
+	 *
+	 * @return array<int, stdClass> Month rows carrying `year` and `month` properties.
+	 */
+	protected function get_event_date_months( string $post_type ): array {
+		global $wpdb;
+
+		$table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+
+		// The appended status clause is one of two fixed strings, but the
+		// sniff cannot see through the call that picks between them.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$months = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT DISTINCT YEAR(%i.%i) AS year, MONTH(%i.%i) AS month'
+				. ' FROM %i INNER JOIN %i ON %i.ID = %i.post_id'
+				. ' WHERE %i.post_type = %s' . $this->get_months_status_clause()
+				. ' ORDER BY year DESC, month DESC',
+				$table,
+				'datetime_start',
+				$table,
+				'datetime_start',
+				$wpdb->posts,
+				$table,
+				$wpdb->posts,
+				$table,
+				$wpdb->posts,
+				$post_type
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		return (array) $months;
+	}
+
+	/**
+	 * Get the months that have posts, newest first.
+	 *
+	 * Repeats the query core's months dropdown runs, along with the two filters
+	 * that shape it, so replacing that dropdown leaves anything hooked to them
+	 * working as before.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string $post_type The post type to collect months for.
+	 *
+	 * @return array<int, stdClass> Month rows carrying `year` and `month` properties.
+	 */
+	protected function get_published_months( string $post_type ): array {
+		global $wpdb;
+
+		/** This filter is documented in wp-admin/includes/class-wp-list-table.php */
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$months = apply_filters( 'pre_months_dropdown_query', false, $post_type );
+
+		if ( ! is_array( $months ) ) {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+			$months = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT DISTINCT YEAR(post_date) AS year, MONTH(post_date) AS month'
+					. ' FROM %i WHERE post_type = %s' . $this->get_months_status_clause()
+					. ' ORDER BY post_date DESC',
+					$wpdb->posts,
+					$post_type
+				)
+			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		}
+
+		/** This filter is documented in wp-admin/includes/class-wp-list-table.php */
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		return (array) apply_filters( 'months_dropdown_results', $months, $post_type );
+	}
+
+	/**
+	 * Build the post status condition shared by both months queries.
+	 *
+	 * Follows core: the Trash view lists the months of trashed posts, every
+	 * other view hides them along with auto-drafts. Both arms are fixed SQL, so
+	 * nothing user-supplied reaches the clause.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return string SQL fragment to append to a months query's WHERE clause.
+	 */
+	private function get_months_status_clause(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$post_status = isset( $_GET['post_status'] ) ? sanitize_key( wp_unslash( $_GET['post_status'] ) ) : '';
+
+		if ( 'trash' === $post_status ) {
+			return " AND post_status = 'trash'";
+		}
+
+		return " AND post_status NOT IN ( 'auto-draft', 'trash' )";
 	}
 
 	/**

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -367,7 +367,7 @@ final class Admin_List {
 	 * Render the event date and published date filters above the list table.
 	 *
 	 * Replaces the dropdown removed in `disable_months_dropdown()` with a
-	 * labelled pair: one filtering the event date column, one filtering the
+	 * labeled pair: one filtering the event date column, one filtering the
 	 * publish date through the same `m` parameter core uses, so existing links
 	 * into a filtered list keep working.
 	 *

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -445,10 +445,14 @@ final class Query {
 	 * value leaves the clauses untouched, so a hand-edited URL degrades to an
 	 * unfiltered list rather than an empty one.
 	 *
-	 * Compares against `datetime_start` rather than `datetime_start_gmt` so an
+	 * An event belongs to a month when it overlaps it, so one running from
+	 * May 30 to June 2 answers to both. Filtering on the start alone would
+	 * hide a running event from the month it is actually happening in.
+	 *
+	 * Compares the local columns rather than their `_gmt` counterparts so an
 	 * event falls in the month the list table displays for it, which is
 	 * rendered in the event's own timezone. Events with no row in the events
-	 * table have no event date to bucket and drop out of every month.
+	 * table have no dates to overlap with and drop out of every month.
 	 *
 	 * @since 0.36.0
 	 *
@@ -465,17 +469,22 @@ final class Query {
 		}
 
 		$table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+		$year  = (int) $matches[1];
+		$month = (int) $matches[2];
 
-		// YEAR()/MONTH() rather than a datetime range, matching how core
-		// resolves its own `m` parameter in WP_Query.
+		// `t` resolves to the last day of the month, so the window closes on
+		// the final second rather than opening the next month's first.
+		$opens  = sprintf( '%04d-%02d-01 00:00:00', $year, $month );
+		$closes = gmdate( 'Y-m-t 23:59:59', (int) gmmktime( 0, 0, 0, $month, 1, $year ) );
+
 		$query_pieces['where'] .= $wpdb->prepare(
-			' AND YEAR(%i.%i) = %d AND MONTH(%i.%i) = %d',
+			' AND %i.%i <= %s AND %i.%i >= %s',
 			$table,
 			'datetime_start',
-			(int) $matches[1],
+			$closes,
 			$table,
-			'datetime_start',
-			(int) $matches[2]
+			'datetime_end',
+			$opens
 		);
 
 		return $query_pieces;

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -409,8 +409,11 @@ final class Query {
 		remove_filter( 'posts_clauses', array( $this, 'adjust_sorting_for_upcoming_events' ) );
 
 		// Admin event list views can be filtered by 'upcoming', 'past' or 'all' events.
-		$gatherpress_events_query = ( ! empty( $wp_query->get( self::EVENT_QUERY_PARAM ) ) )
-			? $wp_query->get( self::EVENT_QUERY_PARAM )
+		// Public query vars keep whatever shape the request gave them, arrays
+		// included, so both parameters are read back as scalars or not at all.
+		$gatherpress_events_view  = $wp_query->get( self::EVENT_QUERY_PARAM );
+		$gatherpress_events_query = is_scalar( $gatherpress_events_view ) && ! empty( $gatherpress_events_view )
+			? (string) $gatherpress_events_view
 			: 'all';
 
 		// Upcoming is inclusive (running events count as upcoming);
@@ -426,9 +429,11 @@ final class Query {
 			$inclusive
 		);
 
+		$gatherpress_event_month = $wp_query->get( self::EVENT_DATE_QUERY_PARAM );
+
 		return $this->adjust_event_month_sql(
 			$query_pieces,
-			(string) $wp_query->get( self::EVENT_DATE_QUERY_PARAM )
+			is_scalar( $gatherpress_event_month ) ? (string) $gatherpress_event_month : ''
 		);
 	}
 

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -48,6 +48,17 @@ final class Query {
 	const EVENT_QUERY_PARAM = 'gatherpress_event_query';
 
 	/**
+	 * Query parameter name for filtering the admin list by event month.
+	 *
+	 * Holds a `YYYYMM` value, the same shape WordPress core's `m` parameter
+	 * uses for publish dates.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	const EVENT_DATE_QUERY_PARAM = 'gatherpress_event_date';
+
+	/**
 	 * Class constructor.
 	 *
 	 * This method initializes the object and sets up necessary hooks.
@@ -413,6 +424,53 @@ final class Query {
 			$wp_query->get( 'order' ),
 			$wp_query->get( 'orderby' ),
 			$inclusive
+		);
+
+		return $this->adjust_event_month_sql(
+			$query_pieces,
+			(string) $wp_query->get( self::EVENT_DATE_QUERY_PARAM )
+		);
+	}
+
+	/**
+	 * Narrow the admin event list to a single month of event dates.
+	 *
+	 * The companion to WordPress core's `m` parameter, which buckets the same
+	 * list by publish date. `$month` takes core's `YYYYMM` shape; any other
+	 * value leaves the clauses untouched, so a hand-edited URL degrades to an
+	 * unfiltered list rather than an empty one.
+	 *
+	 * Compares against `datetime_start` rather than `datetime_start_gmt` so an
+	 * event falls in the month the list table displays for it, which is
+	 * rendered in the event's own timezone. Events with no row in the events
+	 * table have no event date to bucket and drop out of every month.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param array<string, string> $query_pieces An array containing pieces of the SQL query.
+	 * @param string                $month        Month to filter by, as `YYYYMM`.
+	 *
+	 * @return array<string, string> The query pieces, with the month condition appended when $month is valid.
+	 */
+	protected function adjust_event_month_sql( array $query_pieces, string $month ): array {
+		global $wpdb;
+
+		if ( 1 !== preg_match( '/^(\d{4})(0[1-9]|1[0-2])$/', $month, $matches ) ) {
+			return $query_pieces;
+		}
+
+		$table = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+
+		// YEAR()/MONTH() rather than a datetime range, matching how core
+		// resolves its own `m` parameter in WP_Query.
+		$query_pieces['where'] .= $wpdb->prepare(
+			' AND YEAR(%i.%i) = %d AND MONTH(%i.%i) = %d',
+			$table,
+			'datetime_start',
+			(int) $matches[1],
+			$table,
+			'datetime_start',
+			(int) $matches[2]
 		);
 
 		return $query_pieces;

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -1782,7 +1782,7 @@ class Test_Admin_List extends Base {
 	 * @covers ::render_date_filters
 	 * @covers ::render_months_dropdown
 	 * @covers ::get_event_date_months
-	 * @covers ::get_published_months
+	 * @covers ::get_post_date_months
 	 * @covers ::get_months_status_clause
 	 *
 	 * @return void
@@ -2026,13 +2026,13 @@ class Test_Admin_List extends Base {
 	}
 
 	/**
-	 * Coverage for get_published_months method firing core's filters.
+	 * Coverage for get_post_date_months method firing core's filters.
 	 *
-	 * @covers ::get_published_months
+	 * @covers ::get_post_date_months
 	 *
 	 * @return void
 	 */
-	public function test_get_published_months_fires_core_filters(): void {
+	public function test_get_post_date_months_fires_core_filters(): void {
 		$instance = Admin_List::get_instance();
 		$month    = new stdClass();
 
@@ -2048,7 +2048,7 @@ class Test_Admin_List extends Base {
 
 		$short_circuited = Utility::invoke_hidden_method(
 			$instance,
-			'get_published_months',
+			'get_post_date_months',
 			array( Event::POST_TYPE )
 		);
 
@@ -2062,7 +2062,7 @@ class Test_Admin_List extends Base {
 
 		$filtered = Utility::invoke_hidden_method(
 			$instance,
-			'get_published_months',
+			'get_post_date_months',
 			array( Event::POST_TYPE )
 		);
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -12,6 +12,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Event\Admin_List;
 use GatherPress\Core\Event\Setup as Event_Setup;
 use GatherPress\Core\Rsvp;
+use GatherPress\Core\Topic;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
 use stdClass;
@@ -58,6 +59,12 @@ class Test_Admin_List extends Base {
 				'name'     => 'restrict_manage_posts',
 				'priority' => 10,
 				'callback' => array( $instance, 'render_date_filters' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'restrict_manage_posts',
+				'priority' => 10,
+				'callback' => array( $instance, 'render_taxonomy_filters' ),
 			),
 			array(
 				'type'     => 'action',
@@ -2099,6 +2106,209 @@ class Test_Admin_List extends Base {
 			" AND post_status = 'trash'",
 			$trash,
 			'The Trash view should list the months of trashed posts.'
+		);
+	}
+
+	/**
+	 * Coverage for render_taxonomy_filters method.
+	 *
+	 * @covers ::render_taxonomy_filters
+	 * @covers ::render_taxonomy_filter
+	 *
+	 * @return void
+	 */
+	public function test_render_taxonomy_filters_renders_the_topic_dropdown(): void {
+		$instance = Admin_List::get_instance();
+
+		$this->factory->term->create(
+			array(
+				'taxonomy' => Topic::TAXONOMY,
+				'name'     => 'Accessibility',
+				'slug'     => 'accessibility',
+			)
+		);
+
+		ob_start();
+		$instance->render_taxonomy_filters( Event::POST_TYPE );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString(
+			"name='gatherpress_topic'",
+			$output,
+			'Should render a dropdown submitting the topic taxonomy query var.'
+		);
+		$this->assertStringContainsString(
+			'All Topics',
+			$output,
+			'Should offer the taxonomy\'s own "all" label.'
+		);
+		$this->assertStringContainsString(
+			'Filter by topic',
+			$output,
+			'Should label the dropdown for screen readers from the taxonomy.'
+		);
+		$this->assertStringContainsString(
+			'value="accessibility"',
+			$output,
+			'Terms should submit by slug, which is what the query var resolves.'
+		);
+	}
+
+	/**
+	 * Coverage for render_taxonomy_filters method with an unsupported post type.
+	 *
+	 * @covers ::render_taxonomy_filters
+	 *
+	 * @return void
+	 */
+	public function test_render_taxonomy_filters_skips_unsupported_post_type(): void {
+		$instance = Admin_List::get_instance();
+
+		$this->factory->term->create(
+			array(
+				'taxonomy' => Topic::TAXONOMY,
+				'name'     => 'Accessibility',
+			)
+		);
+
+		ob_start();
+		$instance->render_taxonomy_filters( 'post' );
+		$output = ob_get_clean();
+
+		$this->assertEmpty(
+			$output,
+			'Post types without event date support should render no taxonomy filters.'
+		);
+	}
+
+	/**
+	 * Coverage for render_taxonomy_filter method marking the filtered term.
+	 *
+	 * @covers ::render_taxonomy_filter
+	 *
+	 * @return void
+	 */
+	public function test_render_taxonomy_filter_marks_the_selected_term(): void {
+		$instance = Admin_List::get_instance();
+
+		$this->factory->term->create(
+			array(
+				'taxonomy' => Topic::TAXONOMY,
+				'name'     => 'Accessibility',
+				'slug'     => 'accessibility',
+			)
+		);
+
+		$_GET[ Topic::TAXONOMY ] = 'accessibility'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		ob_start();
+		$instance->render_taxonomy_filters( Event::POST_TYPE );
+		$output = ob_get_clean();
+
+		unset( $_GET[ Topic::TAXONOMY ] );
+
+		$this->assertMatchesRegularExpression(
+			'/<option class="level-0" value="accessibility" ?selected/',
+			$output,
+			'The topic being filtered on should come back selected.'
+		);
+	}
+
+	/**
+	 * Coverage for render_taxonomy_filter method with no terms to offer.
+	 *
+	 * @covers ::render_taxonomy_filter
+	 *
+	 * @return void
+	 */
+	public function test_render_taxonomy_filter_renders_nothing_without_terms(): void {
+		$instance = Admin_List::get_instance();
+
+		ob_start();
+		$instance->render_taxonomy_filters( Event::POST_TYPE );
+		$output = ob_get_clean();
+
+		$this->assertEmpty(
+			$output,
+			'A taxonomy with no terms should render no dropdown at all.'
+		);
+	}
+
+	/**
+	 * Coverage for render_taxonomy_filter method with an unattached taxonomy.
+	 *
+	 * @covers ::render_taxonomy_filter
+	 *
+	 * @return void
+	 */
+	public function test_render_taxonomy_filter_skips_an_unattached_taxonomy(): void {
+		$instance = Admin_List::get_instance();
+		$test_pt  = 'test_event_tax';
+
+		register_post_type( $test_pt, array( 'supports' => array( 'title' ) ) );
+		add_post_type_support( $test_pt, 'gatherpress-event-date' );
+
+		$this->factory->term->create(
+			array(
+				'taxonomy' => Topic::TAXONOMY,
+				'name'     => 'Accessibility',
+			)
+		);
+
+		ob_start();
+		$instance->render_taxonomy_filters( $test_pt );
+		$output = ob_get_clean();
+
+		unregister_post_type( $test_pt );
+
+		$this->assertEmpty(
+			$output,
+			'A post type the taxonomy is not registered for should get no dropdown.'
+		);
+	}
+
+	/**
+	 * Coverage for the topic filter narrowing the admin list.
+	 *
+	 * @covers ::render_taxonomy_filters
+	 *
+	 * @return void
+	 */
+	public function test_topic_filter_narrows_the_admin_list(): void {
+		$this->mock->user( true, 'admin' );
+		set_current_screen( 'edit-gatherpress_event' );
+
+		$term_id = $this->factory->term->create(
+			array(
+				'taxonomy' => Topic::TAXONOMY,
+				'name'     => 'Accessibility',
+				'slug'     => 'accessibility',
+			)
+		);
+
+		$tagged = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+		$other  = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+
+		wp_set_object_terms( $tagged, array( (int) $term_id ), Topic::TAXONOMY );
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => Event::POST_TYPE,
+				Topic::TAXONOMY  => 'accessibility',
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+			)
+		);
+
+		$this->assertSame(
+			array( $tagged ),
+			$query->posts,
+			'Filtering by a topic should leave only the events carrying it.'
+		);
+		$this->assertNotContains(
+			$other,
+			$query->posts,
+			'An event without the topic should drop out of the filtered list.'
 		);
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -14,6 +14,7 @@ use GatherPress\Core\Event\Setup as Event_Setup;
 use GatherPress\Core\Rsvp;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
+use stdClass;
 use WP_Query;
 
 /**
@@ -45,6 +46,18 @@ class Test_Admin_List extends Base {
 				'name'     => 'query_vars',
 				'priority' => 10,
 				'callback' => array( $instance, 'query_vars' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => 'disable_months_dropdown',
+				'priority' => 10,
+				'callback' => array( $instance, 'disable_months_dropdown' ),
+			),
+			array(
+				'type'     => 'action',
+				'name'     => 'restrict_manage_posts',
+				'priority' => 10,
+				'callback' => array( $instance, 'render_date_filters' ),
 			),
 			array(
 				'type'     => 'action',
@@ -861,11 +874,16 @@ class Test_Admin_List extends Base {
 			'Should add gatherpress_event_query to query vars.'
 		);
 		$this->assertContains(
+			'gatherpress_event_date',
+			$result,
+			'Should add gatherpress_event_date to query vars.'
+		);
+		$this->assertContains(
 			'existing_var',
 			$result,
 			'Should preserve existing query vars.'
 		);
-		$this->assertCount( 2, $result, 'Should have exactly 2 query vars.' );
+		$this->assertCount( 3, $result, 'Should have exactly 3 query vars.' );
 	}
 
 	/**
@@ -885,7 +903,7 @@ class Test_Admin_List extends Base {
 			$result,
 			'Should add gatherpress_event_query even with empty input.'
 		);
-		$this->assertCount( 1, $result, 'Should have exactly 1 query var.' );
+		$this->assertCount( 2, $result, 'Should have exactly 2 query vars.' );
 	}
 
 	/**
@@ -1731,6 +1749,356 @@ class Test_Admin_List extends Base {
 		$this->assertFalse(
 			has_filter( 'posts_orderby', array( $instance, 'rsvp_sorting_orderby' ) ),
 			'No RSVP orderby filter should be added for event-date-only post types.'
+		);
+	}
+
+	/**
+	 * Coverage for disable_months_dropdown method.
+	 *
+	 * @covers ::disable_months_dropdown
+	 *
+	 * @return void
+	 */
+	public function test_disable_months_dropdown(): void {
+		$instance = Admin_List::get_instance();
+
+		$this->assertTrue(
+			$instance->disable_months_dropdown( false, Event::POST_TYPE ),
+			'Core\'s months dropdown should be removed for event post types.'
+		);
+		$this->assertFalse(
+			$instance->disable_months_dropdown( false, 'post' ),
+			'Post types without event date support should keep core\'s dropdown.'
+		);
+		$this->assertTrue(
+			$instance->disable_months_dropdown( true, 'post' ),
+			'An earlier filter removing the dropdown should be left alone.'
+		);
+	}
+
+	/**
+	 * Coverage for render_date_filters method.
+	 *
+	 * @covers ::render_date_filters
+	 * @covers ::render_months_dropdown
+	 * @covers ::get_event_date_months
+	 * @covers ::get_published_months
+	 * @covers ::get_months_status_clause
+	 *
+	 * @return void
+	 */
+	public function test_render_date_filters_renders_both_dropdowns(): void {
+		$instance = Admin_List::get_instance();
+		$post_id  = $this->mock->post(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => '2025-03-04 10:00:00',
+			)
+		)->get()->ID;
+
+		$event = new Event( $post_id );
+		$event->save_datetimes(
+			array(
+				'datetime_start' => '2025-06-15 10:00:00',
+				'datetime_end'   => '2025-06-15 14:00:00',
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		ob_start();
+		$instance->render_date_filters( Event::POST_TYPE );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString(
+			'name="gatherpress_event_date"',
+			$output,
+			'Should render a dropdown submitting the event date parameter.'
+		);
+		$this->assertStringContainsString(
+			'All Event dates',
+			$output,
+			'Event date dropdown should name the date it filters.'
+		);
+		$this->assertStringContainsString(
+			'<option value="202506"',
+			$output,
+			'Event date dropdown should offer the month the event starts in.'
+		);
+		$this->assertStringContainsString(
+			'June 2025',
+			$output,
+			'Event date months should be labelled with month name and year.'
+		);
+		$this->assertStringContainsString(
+			'name="m"',
+			$output,
+			'Should keep rendering core\'s publish date parameter.'
+		);
+		$this->assertStringContainsString(
+			'All published dates',
+			$output,
+			'Publish date dropdown should say it filters the published date.'
+		);
+		$this->assertStringContainsString(
+			'<option value="202503"',
+			$output,
+			'Publish date dropdown should offer the month the event was published in.'
+		);
+	}
+
+	/**
+	 * Coverage for render_date_filters method with an unsupported post type.
+	 *
+	 * @covers ::render_date_filters
+	 *
+	 * @return void
+	 */
+	public function test_render_date_filters_skips_unsupported_post_type(): void {
+		$instance = Admin_List::get_instance();
+
+		$this->mock->post( array( 'post_type' => 'post' ) );
+
+		ob_start();
+		$instance->render_date_filters( 'post' );
+		$output = ob_get_clean();
+
+		$this->assertEmpty(
+			$output,
+			'Post types without event date support should render no date filters.'
+		);
+	}
+
+	/**
+	 * Coverage for render_date_filters method with an event whose date is unset.
+	 *
+	 * @covers ::render_date_filters
+	 * @covers ::render_months_dropdown
+	 * @covers ::get_event_date_months
+	 *
+	 * @return void
+	 */
+	public function test_render_date_filters_omits_events_without_a_date(): void {
+		$instance = Admin_List::get_instance();
+
+		$this->mock->post(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_status' => 'publish',
+				'post_date'   => '2025-03-04 10:00:00',
+			)
+		);
+
+		ob_start();
+		$instance->render_date_filters( Event::POST_TYPE );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'name="gatherpress_event_date"',
+			$output,
+			'An event with no date gives the event date dropdown nothing to offer.'
+		);
+		$this->assertStringContainsString(
+			'name="m"',
+			$output,
+			'The publish date dropdown should still render on its own.'
+		);
+	}
+
+	/**
+	 * Coverage for render_date_filters method marking the filtered month.
+	 *
+	 * @covers ::render_date_filters
+	 * @covers ::render_months_dropdown
+	 *
+	 * @return void
+	 */
+	public function test_render_date_filters_marks_the_selected_month(): void {
+		$instance = Admin_List::get_instance();
+		$post_id  = $this->mock->post(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		)->get()->ID;
+
+		$event = new Event( $post_id );
+		$event->save_datetimes(
+			array(
+				'datetime_start' => '2025-06-15 10:00:00',
+				'datetime_end'   => '2025-06-15 14:00:00',
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		$_GET['gatherpress_event_date'] = '202506'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		ob_start();
+		$instance->render_date_filters( Event::POST_TYPE );
+		$output = ob_get_clean();
+
+		unset( $_GET['gatherpress_event_date'] );
+
+		$this->assertMatchesRegularExpression(
+			'/<option value="202506" ?selected/',
+			$output,
+			'The month being filtered on should come back selected.'
+		);
+	}
+
+	/**
+	 * Coverage for render_date_filters method carrying the current view.
+	 *
+	 * @covers ::render_date_filters
+	 *
+	 * @return void
+	 */
+	public function test_render_date_filters_carries_the_current_view(): void {
+		$instance = Admin_List::get_instance();
+
+		$this->mock->post(
+			array(
+				'post_type'   => Event::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+
+		ob_start();
+		$instance->render_date_filters( Event::POST_TYPE );
+		$without_view = ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'name="gatherpress_event_query"',
+			$without_view,
+			'The All view has no view parameter to carry through the filter form.'
+		);
+
+		$_GET['gatherpress_event_query'] = 'upcoming'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		ob_start();
+		$instance->render_date_filters( Event::POST_TYPE );
+		$with_view = ob_get_clean();
+
+		unset( $_GET['gatherpress_event_query'] );
+
+		$this->assertStringContainsString(
+			'<input type="hidden" name="gatherpress_event_query" value="upcoming" />',
+			$with_view,
+			'Filtering by date from the Upcoming view should stay on the Upcoming view.'
+		);
+	}
+
+	/**
+	 * Coverage for render_months_dropdown method with nothing to offer.
+	 *
+	 * @covers ::render_months_dropdown
+	 *
+	 * @return void
+	 */
+	public function test_render_months_dropdown_renders_nothing_without_months(): void {
+		$instance  = Admin_List::get_instance();
+		$year_zero = new stdClass();
+
+		$year_zero->year  = '0';
+		$year_zero->month = '0';
+
+		ob_start();
+		Utility::invoke_hidden_method(
+			$instance,
+			'render_months_dropdown',
+			array( 'm', 'filter-by-date', 'Filter by published date', 'All published dates', array() )
+		);
+		$empty = ob_get_clean();
+
+		ob_start();
+		Utility::invoke_hidden_method(
+			$instance,
+			'render_months_dropdown',
+			array( 'm', 'filter-by-date', 'Filter by published date', 'All published dates', array( $year_zero ) )
+		);
+		$year_zero_only = ob_get_clean();
+
+		$this->assertEmpty( $empty, 'A bucket with no months should render no dropdown.' );
+		$this->assertEmpty(
+			$year_zero_only,
+			'A bucket holding only rows with no year should render no dropdown.'
+		);
+	}
+
+	/**
+	 * Coverage for get_published_months method firing core's filters.
+	 *
+	 * @covers ::get_published_months
+	 *
+	 * @return void
+	 */
+	public function test_get_published_months_fires_core_filters(): void {
+		$instance = Admin_List::get_instance();
+		$month    = new stdClass();
+
+		$month->year  = '2019';
+		$month->month = '11';
+
+		add_filter(
+			'pre_months_dropdown_query',
+			static function () use ( $month ): array {
+				return array( $month );
+			}
+		);
+
+		$short_circuited = Utility::invoke_hidden_method(
+			$instance,
+			'get_published_months',
+			array( Event::POST_TYPE )
+		);
+
+		$this->assertSame(
+			array( $month ),
+			$short_circuited,
+			'A pre_months_dropdown_query short circuit should replace the query.'
+		);
+
+		add_filter( 'months_dropdown_results', '__return_empty_array' );
+
+		$filtered = Utility::invoke_hidden_method(
+			$instance,
+			'get_published_months',
+			array( Event::POST_TYPE )
+		);
+
+		$this->assertSame(
+			array(),
+			$filtered,
+			'months_dropdown_results should still get the last word on the months.'
+		);
+	}
+
+	/**
+	 * Coverage for get_months_status_clause method.
+	 *
+	 * @covers ::get_months_status_clause
+	 *
+	 * @return void
+	 */
+	public function test_get_months_status_clause(): void {
+		$instance = Admin_List::get_instance();
+
+		$this->assertSame(
+			" AND post_status NOT IN ( 'auto-draft', 'trash' )",
+			Utility::invoke_hidden_method( $instance, 'get_months_status_clause' ),
+			'Views other than Trash should hide trashed posts and auto-drafts.'
+		);
+
+		$_GET['post_status'] = 'trash'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$trash = Utility::invoke_hidden_method( $instance, 'get_months_status_clause' );
+
+		unset( $_GET['post_status'] );
+
+		$this->assertSame(
+			" AND post_status = 'trash'",
+			$trash,
+			'The Trash view should list the months of trashed posts.'
 		);
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -1836,9 +1836,9 @@ class Test_Admin_List extends Base {
 			'Should keep rendering core\'s publish date parameter.'
 		);
 		$this->assertStringContainsString(
-			'All published dates',
+			'All post dates',
 			$output,
-			'Publish date dropdown should say it filters the published date.'
+			'Post date dropdown should say which date it filters.'
 		);
 		$this->assertStringContainsString(
 			'<option value="202503"',
@@ -2006,7 +2006,7 @@ class Test_Admin_List extends Base {
 		Utility::invoke_hidden_method(
 			$instance,
 			'render_months_dropdown',
-			array( 'm', 'filter-by-date', 'Filter by published date', 'All published dates', array() )
+			array( 'm', 'filter-by-date', 'Filter by post date', 'All post dates', array() )
 		);
 		$empty = ob_get_clean();
 
@@ -2014,7 +2014,7 @@ class Test_Admin_List extends Base {
 		Utility::invoke_hidden_method(
 			$instance,
 			'render_months_dropdown',
-			array( 'm', 'filter-by-date', 'Filter by published date', 'All published dates', array( $year_zero ) )
+			array( 'm', 'filter-by-date', 'Filter by post date', 'All post dates', array( $year_zero ) )
 		);
 		$year_zero_only = ob_get_clean();
 

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -2337,7 +2337,7 @@ class Test_Admin_List extends Base {
 	}
 
 	/**
-	 * Coverage for render_taxonomy_filter method labelling a flat taxonomy.
+	 * Coverage for render_taxonomy_filter method labeling a flat taxonomy.
 	 *
 	 * @covers ::render_taxonomy_filter
 	 *

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -1828,7 +1828,7 @@ class Test_Admin_List extends Base {
 		$this->assertStringContainsString(
 			'June 2025',
 			$output,
-			'Event date months should be labelled with month name and year.'
+			'Event date months should be labeled with month name and year.'
 		);
 		$this->assertStringContainsString(
 			'name="m"',

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -2275,9 +2275,6 @@ class Test_Admin_List extends Base {
 	 * @return void
 	 */
 	public function test_topic_filter_narrows_the_admin_list(): void {
-		$this->mock->user( true, 'admin' );
-		set_current_screen( 'edit-gatherpress_event' );
-
 		$term_id = $this->factory->term->create(
 			array(
 				'taxonomy' => Topic::TAXONOMY,
@@ -2290,6 +2287,11 @@ class Test_Admin_List extends Base {
 		$other  = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
 
 		wp_set_object_terms( $tagged, array( (int) $term_id ), Topic::TAXONOMY );
+
+		// Creating posts clears the current screen, so the admin list context
+		// only holds once the fixtures are in place.
+		$this->mock->user( true, 'admin' );
+		set_current_screen( 'edit-gatherpress_event' );
 
 		$query = new WP_Query(
 			array(

--- a/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-admin-list.php
@@ -2311,4 +2311,84 @@ class Test_Admin_List extends Base {
 			'An event without the topic should drop out of the filtered list.'
 		);
 	}
+
+	/**
+	 * Coverage for render_taxonomy_filter method with an unregistered taxonomy.
+	 *
+	 * @covers ::render_taxonomy_filter
+	 *
+	 * @return void
+	 */
+	public function test_render_taxonomy_filter_skips_an_unregistered_taxonomy(): void {
+		$instance = Admin_List::get_instance();
+
+		ob_start();
+		Utility::invoke_hidden_method(
+			$instance,
+			'render_taxonomy_filter',
+			array( Event::POST_TYPE, 'gatherpress_not_a_taxonomy' )
+		);
+		$output = ob_get_clean();
+
+		$this->assertEmpty(
+			$output,
+			'A taxonomy that is not registered should render no dropdown.'
+		);
+	}
+
+	/**
+	 * Coverage for render_taxonomy_filter method labelling a flat taxonomy.
+	 *
+	 * @covers ::render_taxonomy_filter
+	 *
+	 * @return void
+	 */
+	public function test_render_taxonomy_filter_falls_back_to_the_taxonomy_name(): void {
+		$instance = Admin_List::get_instance();
+		$taxonomy = 'test_event_tag';
+
+		// Non-hierarchical taxonomies get no `filter_by_item` label by default,
+		// which is the arm the fallback exists for.
+		register_taxonomy(
+			$taxonomy,
+			Event::POST_TYPE,
+			array(
+				'labels'       => array(
+					'name'      => 'Test Tags',
+					'all_items' => 'All Test Tags',
+				),
+				'hierarchical' => false,
+				'public'       => true,
+				'query_var'    => true,
+			)
+		);
+
+		$this->factory->term->create(
+			array(
+				'taxonomy' => $taxonomy,
+				'name'     => 'Flat Term',
+			)
+		);
+
+		ob_start();
+		Utility::invoke_hidden_method(
+			$instance,
+			'render_taxonomy_filter',
+			array( Event::POST_TYPE, $taxonomy )
+		);
+		$output = ob_get_clean();
+
+		unregister_taxonomy( $taxonomy );
+
+		$this->assertStringContainsString(
+			'<label class="screen-reader-text" for="test_event_tag">Test Tags</label>',
+			$output,
+			'A taxonomy with no filter label should fall back to its plural name.'
+		);
+		$this->assertStringContainsString(
+			'All Test Tags',
+			$output,
+			'The taxonomy\'s own "all" label should still be used.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -2278,4 +2278,103 @@ class Test_Query extends Base {
 			'Failed to assert anything that is not ASC falls back to DESC.'
 		);
 	}
+
+	/**
+	 * Coverage for adjust_event_month_sql method.
+	 *
+	 * @covers ::adjust_event_month_sql
+	 *
+	 * @return void
+	 */
+	public function test_adjust_event_month_sql(): void {
+		global $wpdb;
+
+		$instance = Query::get_instance();
+		$table    = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+
+		$pieces = Utility::invoke_hidden_method(
+			$instance,
+			'adjust_event_month_sql',
+			array( array( 'where' => '' ), '202609' )
+		);
+
+		$this->assertSame(
+			sprintf(
+				' AND YEAR(`%1$s`.`datetime_start`) = 2026 AND MONTH(`%1$s`.`datetime_start`) = 9',
+				$table
+			),
+			$pieces['where'],
+			'Should narrow the list to events starting in the requested month.'
+		);
+	}
+
+	/**
+	 * Coverage for adjust_event_month_sql method with a month it cannot use.
+	 *
+	 * @dataProvider data_adjust_event_month_sql_unusable_month
+	 *
+	 * @covers ::adjust_event_month_sql
+	 *
+	 * @param string $month Month value to pass through.
+	 *
+	 * @return void
+	 */
+	public function test_adjust_event_month_sql_leaves_unusable_month_alone( string $month ): void {
+		$instance = Query::get_instance();
+		$pieces   = array( 'where' => ' AND 1 = 1' );
+
+		$this->assertSame(
+			$pieces,
+			Utility::invoke_hidden_method( $instance, 'adjust_event_month_sql', array( $pieces, $month ) ),
+			'A month that is not YYYYMM should leave the query pieces untouched.'
+		);
+	}
+
+	/**
+	 * Data provider for unusable month values.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	public function data_adjust_event_month_sql_unusable_month(): array {
+		return array(
+			'empty'          => array( '' ),
+			'no month'       => array( '2026' ),
+			'month zero'     => array( '202600' ),
+			'month thirteen' => array( '202613' ),
+			'too short'      => array( '20269' ),
+			'too long'       => array( '2026091' ),
+			'separated'      => array( '2026-09' ),
+			'not a number'   => array( 'september' ),
+		);
+	}
+
+	/**
+	 * Coverage for adjust_admin_event_sorting method filtering by event month.
+	 *
+	 * @covers ::adjust_admin_event_sorting
+	 * @covers ::adjust_event_month_sql
+	 *
+	 * @return void
+	 */
+	public function test_adjust_admin_event_sorting_filters_by_event_month(): void {
+		global $wpdb;
+
+		$instance = Query::get_instance();
+		$wp_query = new WP_Query();
+		$table    = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+
+		$this->mock->user( true, 'admin' );
+		set_current_screen( 'edit-gatherpress_event' );
+
+		$wp_query->set( 'post_type', Event::POST_TYPE );
+		$wp_query->set( 'gatherpress_event_date', '202609' );
+
+		$pieces = $instance->adjust_admin_event_sorting( array( 'where' => '' ), $wp_query );
+
+		$this->assertStringContainsString(
+			sprintf( 'YEAR(`%s`.`datetime_start`) = 2026', $table ),
+			$pieces['where'],
+			'The event month filter should reach the admin list query.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -2377,4 +2377,40 @@ class Test_Query extends Base {
 			'The event month filter should reach the admin list query.'
 		);
 	}
+
+	/**
+	 * Coverage for adjust_admin_event_sorting method with array shaped parameters.
+	 *
+	 * @covers ::adjust_admin_event_sorting
+	 * @covers ::adjust_event_month_sql
+	 *
+	 * @return void
+	 */
+	public function test_adjust_admin_event_sorting_ignores_array_parameters(): void {
+		$instance = Query::get_instance();
+		$pieces   = array( 'where' => '' );
+
+		$this->mock->user( true, 'admin' );
+		set_current_screen( 'edit-gatherpress_event' );
+
+		$month_query = new WP_Query();
+		$month_query->set( 'post_type', Event::POST_TYPE );
+		$month_query->set( 'gatherpress_event_date', array( '202609' ) );
+
+		$this->assertSame(
+			'',
+			$instance->adjust_admin_event_sorting( $pieces, $month_query )['where'],
+			'An array shaped month should filter nothing rather than casting to "Array".'
+		);
+
+		$view_query = new WP_Query();
+		$view_query->set( 'post_type', Event::POST_TYPE );
+		$view_query->set( 'gatherpress_event_query', array( 'upcoming' ) );
+
+		$this->assertSame(
+			'',
+			$instance->adjust_admin_event_sorting( $pieces, $view_query )['where'],
+			'An array shaped view should fall back to all events rather than throwing.'
+		);
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -2300,11 +2300,12 @@ class Test_Query extends Base {
 
 		$this->assertSame(
 			sprintf(
-				' AND YEAR(`%1$s`.`datetime_start`) = 2026 AND MONTH(`%1$s`.`datetime_start`) = 9',
+				" AND `%1\$s`.`datetime_start` <= '2026-09-30 23:59:59'"
+				. " AND `%1\$s`.`datetime_end` >= '2026-09-01 00:00:00'",
 				$table
 			),
 			$pieces['where'],
-			'Should narrow the list to events starting in the requested month.'
+			'Should narrow the list to events overlapping the requested month.'
 		);
 	}
 
@@ -2372,7 +2373,7 @@ class Test_Query extends Base {
 		$pieces = $instance->adjust_admin_event_sorting( array( 'where' => '' ), $wp_query );
 
 		$this->assertStringContainsString(
-			sprintf( 'YEAR(`%s`.`datetime_start`) = 2026', $table ),
+			sprintf( "`%s`.`datetime_start` <= '2026-09-30 23:59:59'", $table ),
 			$pieces['where'],
 			'The event month filter should reach the admin list query.'
 		);
@@ -2411,6 +2412,137 @@ class Test_Query extends Base {
 			'',
 			$instance->adjust_admin_event_sorting( $pieces, $view_query )['where'],
 			'An array shaped view should fall back to all events rather than throwing.'
+		);
+	}
+
+	/**
+	 * Coverage for the month filter matching events that overlap the month.
+	 *
+	 * @covers ::adjust_admin_event_sorting
+	 * @covers ::adjust_event_month_sql
+	 *
+	 * @return void
+	 */
+	public function test_event_month_filter_matches_overlapping_events(): void {
+		$spanning = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+		$before   = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+		$within   = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+
+		// Starts in May, still running into June.
+		( new Event( $spanning ) )->save_datetimes(
+			array(
+				'datetime_start' => '2026-05-30 10:00:00',
+				'datetime_end'   => '2026-06-02 14:00:00',
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		// Starts and ends before June opens.
+		( new Event( $before ) )->save_datetimes(
+			array(
+				'datetime_start' => '2026-05-30 10:00:00',
+				'datetime_end'   => '2026-05-30 14:00:00',
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		( new Event( $within ) )->save_datetimes(
+			array(
+				'datetime_start' => '2026-06-15 10:00:00',
+				'datetime_end'   => '2026-06-15 14:00:00',
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		// Creating posts clears the current screen, so the admin list context
+		// only holds once the fixtures are in place.
+		$this->mock->user( true, 'admin' );
+		set_current_screen( 'edit-gatherpress_event' );
+
+		$query = new WP_Query(
+			array(
+				'post_type'              => Event::POST_TYPE,
+				'gatherpress_event_date' => '202606',
+				'fields'                 => 'ids',
+				'posts_per_page'         => -1,
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
+			)
+		);
+
+		$this->assertContains(
+			$spanning,
+			$query->posts,
+			'An event running into the month should answer to it.'
+		);
+		$this->assertContains(
+			$within,
+			$query->posts,
+			'An event held entirely within the month should answer to it.'
+		);
+		$this->assertNotContains(
+			$before,
+			$query->posts,
+			'An event finished before the month opened should not.'
+		);
+	}
+
+	/**
+	 * Coverage for the month filter matching an event that spans the whole month.
+	 *
+	 * @covers ::adjust_admin_event_sorting
+	 * @covers ::adjust_event_month_sql
+	 *
+	 * @return void
+	 */
+	public function test_event_month_filter_matches_an_event_spanning_the_month(): void {
+		$straddling = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+
+		// Opens in September, closes in November, so October passes underneath
+		// it without the event either starting or ending inside the month.
+		( new Event( $straddling ) )->save_datetimes(
+			array(
+				'datetime_start' => '2026-09-15 10:00:00',
+				'datetime_end'   => '2026-11-10 14:00:00',
+				'timezone'       => 'America/New_York',
+			)
+		);
+
+		// Creating posts clears the current screen, so the admin list context
+		// only holds once the fixtures are in place.
+		$this->mock->user( true, 'admin' );
+		set_current_screen( 'edit-gatherpress_event' );
+
+		foreach ( array( '202609', '202610', '202611' ) as $month ) {
+			$query = new WP_Query(
+				array(
+					'post_type'              => Event::POST_TYPE,
+					'gatherpress_event_date' => $month,
+					'fields'                 => 'ids',
+					'posts_per_page'         => -1,
+				)
+			);
+
+			$this->assertContains(
+				$straddling,
+				$query->posts,
+				sprintf( 'An event running from September to November should answer to %s.', $month )
+			);
+		}
+
+		$query = new WP_Query(
+			array(
+				'post_type'              => Event::POST_TYPE,
+				'gatherpress_event_date' => '202612',
+				'fields'                 => 'ids',
+				'posts_per_page'         => -1,
+			)
+		);
+
+		$this->assertNotContains(
+			$straddling,
+			$query->posts,
+			'A month the event never reaches should not list it.'
 		);
 	}
 }


### PR DESCRIPTION
Closes #1702.

Scoped to filtering, per the [direction on the issue](https://github.com/GatherPress/gatherpress/issues/1702#issuecomment-5081130294). Ordering is untouched: the All view still defaults to publish date, and the event date column header sorts the way it always has.

## The problem

Core renders a single months dropdown reading "All dates" that quietly filters on publish date. On a screen whose marquee column is "Event date & time", that reads as filtering by event date, which is the confusion that opened the issue.

## The change

For post types that declare `gatherpress-event-date` support, core's dropdown is taken over (`disable_months_dropdown`) and a labelled pair is rendered in its place, following @chekle's mockup:

- **All Event dates**, a new `gatherpress_event_date` parameter, filtering the event date column.
- **All post dates**, still the `m` parameter core uses, so existing links into a publish-date filtered list keep working.

Topics get a filter too. Core builds one for the built-in category taxonomy only, so topics reached this screen with an admin column but no way to filter by them. The dropdown follows core's `categories_dropdown()`, reading its "all" and "filter by" strings off the taxonomy's own labels and submitting terms by slug, which is what a taxonomy's query var resolves against. The renderer takes the taxonomy as an argument, so venues would be a one-line call if you want them later.

Both dropdowns keep core's markup and behavior: month rows with no year are skipped, a bucket with no months renders nothing at all, and the Trash view lists the months of trashed posts the way core does. The published-date months query re-fires core's own `pre_months_dropdown_query` and `months_dropdown_results` filters, so anything hooked to them is unaffected by the swap.

Two details worth a look:

- An event belongs to a month when it **overlaps** it, not when it starts in it. One running May 30 to June 2 answers to both months, and one running September to November answers to October as well, even though it neither starts nor ends there. Filtering on the start alone would hide a running event from the month it is actually happening in.
- The comparison runs against the local `datetime_start` and `datetime_end` rather than their `_gmt` counterparts, so an event lands in the month the list table displays for it, which renders in the event's own timezone. Events with no row in the events table have no dates to overlap with and appear under no month, the same way they sit outside the Upcoming and Past buckets today.
- `gatherpress_event_query` is carried through the filter form in a hidden input. Without it, filtering by date from the Upcoming or Past view drops you back to All, since core only carries `post_status`, `post_type`, `author` and `show_sticky` through. It is the same kind of "which subset am I looking at" parameter as `post_status`.

## Alternatives considered

Adding the event date dropdown next to core's untouched one is less code, but it leaves the publish-date filter still reading "All dates" next to "All Event dates", which is the ambiguity the issue is about. Happy to trim it back if you would rather not replace core's dropdown.

## Testing

1. Add events across at least two different months, and give one no date at all.
2. **Events > All Events**: three dropdowns, "All Event dates", "All post dates" and "All Topics".
3. Pick a month from **All Event dates** and hit Filter. Only events touching that month are listed. The dateless one is not.
4. Add an event running from one month into the next and confirm it is listed under both.
5. Pick a month from **All post dates**. Filtering is by the Date column, as before.
6. Go to **Upcoming**, filter by an event month, and confirm you stay on Upcoming.
7. Click the **Event date & time** column header and confirm sorting still works, and that the All view still lands on publish-date order.
8. Pick a topic from **All Topics** and hit Filter. Only events carrying that topic are listed, and it composes with a date filter.
9. Move an event to Trash and confirm the Trash view's dropdowns list the trashed event's months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate admin filters for event dates and publish dates.
  * Event lists can now be filtered by the month an event occurs.
  * Selected date filters remain active when navigating the event list.

* **Bug Fixes**
  * Invalid or unsupported month filter values no longer alter event queries.

* **Tests**
  * Added coverage for date filter rendering, selection, navigation, and query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

