### PR TITLE
Resolve date queries against event dates

### DIFF
--- a/.github/changelog/1169-event-date-query
+++ b/.github/changelog/1169-event-date-query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Event queries now filter by event date. A date query on a query of event post types resolves against when events happen rather than when their posts were published.

--- a/.github/playground/PR-2266-blueprint-override.json
+++ b/.github/playground/PR-2266-blueprint-override.json
@@ -1,0 +1,40 @@
+{
+	"$schema": "https://gatherpress.org/playground-preview/pr-override-schema.json",
+	"appendSteps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "url",
+				"url": "https://github.com/carstingaxion/gatherpress-calendar/releases/latest/download/gatherpress-calendar.zip"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "advanced-query-loop"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "query-monitor"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/mu-plugins/disable-gatherpress-calendar-filter.php",
+			"data": "<?php\n/**\n * Plugin Name: Disables GatherPress Calendar posts_where filter\n * Description: Forces the calendar to use gatherpress core event query capabilities\n */\nadd_action( 'plugins_loaded', function() {\n\tremove_filter( 'posts_where', 'GatherPress\\Calendar\\posts_where', 10 );\n\t} );\n"
+		}
+	]
+}

--- a/includes/core/classes/event/class-date-query.php
+++ b/includes/core/classes/event/class-date-query.php
@@ -66,6 +66,29 @@ final class Date_Query {
 	const EVENT_COLUMNS = array( self::DEFAULT_COLUMN, 'datetime_start' );
 
 	/**
+	 * Arguments a clause may carry and still be resolved.
+	 *
+	 * A clause carrying anything else is refused outright rather than
+	 * resolved in part. Honoring `year` while quietly dropping `week` would
+	 * hand back a window a whole year wide, and the caller lifts the original
+	 * `date_query` out of the query once a window comes back, so there is
+	 * nothing left to apply the dropped argument.
+	 *
+	 * @since 0.36.0
+	 * @var string[]
+	 */
+	const SUPPORTED_ARGS = array(
+		'after',
+		'before',
+		'column',
+		'day',
+		'inclusive',
+		'month',
+		'monthnum',
+		'year',
+	);
+
+	/**
 	 * Resolve a date query into the window an event has to touch.
 	 *
 	 * Reads the range-shaped arguments only: `after`, `before`, `year`,
@@ -75,8 +98,14 @@ final class Date_Query {
 	 * single answer across events in different timezones, so it is left alone
 	 * rather than answered wrongly.
 	 *
-	 * Only the first clause is read. Nested clauses and relations are a
-	 * generality nothing asks for yet.
+	 * A date query is resolved in full or not at all. One clause carrying only
+	 * arguments from `SUPPORTED_ARGS` resolves; anything else, including a
+	 * relation, a second clause, or one unreadable argument alongside readable
+	 * ones, resolves to nothing and is left for WordPress.
+	 *
+	 * Arguments narrow each other the way they do in a WordPress clause, so a
+	 * calendar span alongside an `after` or `before` yields their overlap
+	 * rather than whichever was read last.
 	 *
 	 * Boundaries come back in the clock of the column they will be compared
 	 * against: UTC for the GMT pair, the site's own time for the local pair. A
@@ -92,10 +121,15 @@ final class Date_Query {
 	 *         when nothing could be read.
 	 */
 	public static function resolve( array $date_query ): ?array {
-		$clause = self::first_clause( $date_query );
+		$clause = self::single_clause( $date_query );
+
+		if ( null === $clause ) {
+			return null;
+		}
+
 		$column = (string) ( $clause['column'] ?? self::DEFAULT_COLUMN );
 
-		if ( empty( $clause ) || ! in_array( $column, self::EVENT_COLUMNS, true ) ) {
+		if ( ! in_array( $column, self::EVENT_COLUMNS, true ) ) {
 			return null;
 		}
 
@@ -115,7 +149,8 @@ final class Date_Query {
 			if ( null !== $after ) {
 				// WordPress treats `after` as exclusive unless told otherwise,
 				// and the window is built to the second.
-				$start = $inclusive ? $after : $after->modify( '+1 second' );
+				$after = $inclusive ? $after : $after->modify( '+1 second' );
+				$start = ( null === $start || $after > $start ) ? $after : $start;
 			}
 		}
 
@@ -123,7 +158,8 @@ final class Date_Query {
 			$before = self::to_site_datetime( $clause['before'], true );
 
 			if ( null !== $before ) {
-				$end = $inclusive ? $before : $before->modify( '-1 second' );
+				$before = $inclusive ? $before : $before->modify( '-1 second' );
+				$end    = ( null === $end || $before < $end ) ? $before : $end;
 			}
 		}
 
@@ -141,22 +177,39 @@ final class Date_Query {
 	}
 
 	/**
-	 * Pull the clause to read out of a date query.
+	 * Pull the one clause a date query can be resolved from.
 	 *
-	 * A date query may carry its arguments at the top level or wrap them in a
-	 * list of clauses. Both shapes are common in the wild, so both are read.
+	 * A date query may carry its arguments at the top level or wrap a single
+	 * clause in a list. Both shapes are common in the wild, so both are read.
+	 * Anything else, a relation, a second clause, or an argument outside
+	 * `SUPPORTED_ARGS`, cannot be honored in full and so is not honored at all.
 	 *
 	 * @since 0.36.0
 	 *
 	 * @param array<int|string, mixed> $date_query A WordPress date query.
 	 *
-	 * @return array<string, mixed> The clause to read, or an empty array.
+	 * @return array<string, mixed>|null The clause to read, or null when there is not exactly one to read.
 	 */
-	private static function first_clause( array $date_query ): array {
-		if ( isset( $date_query[0] ) && is_array( $date_query[0] ) ) {
-			return $date_query[0];
+	private static function single_clause( array $date_query ): ?array {
+		$nested = array_filter( $date_query, 'is_int', ARRAY_FILTER_USE_KEY );
+
+		// A wrapped clause is read only when it is the whole date query, which
+		// rules out a relation or a sibling clause sitting beside it.
+		if ( ! empty( $nested ) ) {
+			$date_query = ( 1 === count( $nested ) && count( $nested ) === count( $date_query ) )
+				? (array) reset( $nested )
+				: array();
 		}
 
+		if ( empty( $date_query ) || ! empty( array_diff( array_keys( $date_query ), self::SUPPORTED_ARGS ) ) ) {
+			return null;
+		}
+
+		/**
+		 * The clause, now known to carry supported arguments only.
+		 *
+		 * @var array<string, mixed> $date_query
+		 */
 		return $date_query;
 	}
 

--- a/includes/core/classes/event/class-date-query.php
+++ b/includes/core/classes/event/class-date-query.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Resolves a WordPress date query into a window of event time.
+ *
+ * @package GatherPress\Core\Event
+ * @since 0.36.0
+ */
+
+namespace GatherPress\Core\Event;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+
+/**
+ * Turns a `date_query` into the window of time an event has to touch.
+ *
+ * WordPress resolves `date_query` against `post_date`, which for an event is
+ * the day someone wrote the post, not the day the event happens. This reads
+ * the same argument shapes and hands back a window that the events table can
+ * be compared against instead.
+ *
+ * Boundaries are reckoned in the site's timezone, the way WordPress reckons
+ * `post_date`, and returned as UTC. "Next month" therefore means the month
+ * the site is in, not the month each event's own timezone is in, which is the
+ * only reading that stays coherent across a schedule spanning many timezones.
+ *
+ * @package GatherPress\Core\Event
+ * @since 0.36.0
+ */
+final class Date_Query {
+
+	/**
+	 * Format both stored event datetimes and resolved boundaries use.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	const DATETIME_FORMAT = 'Y-m-d H:i:s';
+
+	/**
+	 * Column a date query resolves against unless it names another.
+	 *
+	 * The GMT pair is the only one comparable across events in different
+	 * timezones, so it is the default. Naming `datetime_start` instead buckets
+	 * by each event's own clock, which is what a list table wants when the
+	 * column beside the filter renders in that clock.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	const DEFAULT_COLUMN = 'datetime_start_gmt';
+
+	/**
+	 * Columns a date query may name to be resolved against event dates.
+	 *
+	 * Any other column, `post_date` included, is left for WordPress to handle
+	 * the way it always has.
+	 *
+	 * @since 0.36.0
+	 * @var string[]
+	 */
+	const EVENT_COLUMNS = array( self::DEFAULT_COLUMN, 'datetime_start' );
+
+	/**
+	 * Resolve a date query into the window an event has to touch.
+	 *
+	 * Reads the range-shaped arguments only: `after`, `before`, `year`,
+	 * `monthnum`, `month` and `day`, plus `inclusive`. Everything else
+	 * WordPress accepts (`week`, `dayofweek`, `hour`, and friends) describes a
+	 * repeating slice of the calendar rather than one stretch of it, and has no
+	 * single answer across events in different timezones, so it is left alone
+	 * rather than answered wrongly.
+	 *
+	 * Only the first clause is read. Nested clauses and relations are a
+	 * generality nothing asks for yet.
+	 *
+	 * Boundaries come back in the clock of the column they will be compared
+	 * against: UTC for the GMT pair, the site's own time for the local pair. A
+	 * clause naming a column outside `EVENT_COLUMNS` resolves to nothing, so
+	 * the caller leaves it to WordPress.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param array<int|string, mixed> $date_query A WordPress date query.
+	 *
+	 * @return array{start: ?string, end: ?string, column: string}|null The window and
+	 *         the start column it is for, either bound null when open ended, or null
+	 *         when nothing could be read.
+	 */
+	public static function resolve( array $date_query ): ?array {
+		$clause = self::first_clause( $date_query );
+		$column = (string) ( $clause['column'] ?? self::DEFAULT_COLUMN );
+
+		if ( empty( $clause ) || ! in_array( $column, self::EVENT_COLUMNS, true ) ) {
+			return null;
+		}
+
+		$inclusive = ! empty( $clause['inclusive'] );
+		$start     = null;
+		$end       = null;
+
+		$calendar = self::resolve_calendar_span( $clause );
+
+		if ( null !== $calendar ) {
+			list( $start, $end ) = $calendar;
+		}
+
+		if ( isset( $clause['after'] ) ) {
+			$after = self::to_site_datetime( $clause['after'], false );
+
+			if ( null !== $after ) {
+				// WordPress treats `after` as exclusive unless told otherwise,
+				// and the window is built to the second.
+				$start = $inclusive ? $after : $after->modify( '+1 second' );
+			}
+		}
+
+		if ( isset( $clause['before'] ) ) {
+			$before = self::to_site_datetime( $clause['before'], true );
+
+			if ( null !== $before ) {
+				$end = $inclusive ? $before : $before->modify( '-1 second' );
+			}
+		}
+
+		if ( null === $start && null === $end ) {
+			return null;
+		}
+
+		$in_utc = ( self::DEFAULT_COLUMN === $column );
+
+		return array(
+			'start'  => self::to_string( $start, $in_utc ),
+			'end'    => self::to_string( $end, $in_utc ),
+			'column' => $column,
+		);
+	}
+
+	/**
+	 * Pull the clause to read out of a date query.
+	 *
+	 * A date query may carry its arguments at the top level or wrap them in a
+	 * list of clauses. Both shapes are common in the wild, so both are read.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param array<int|string, mixed> $date_query A WordPress date query.
+	 *
+	 * @return array<string, mixed> The clause to read, or an empty array.
+	 */
+	private static function first_clause( array $date_query ): array {
+		if ( isset( $date_query[0] ) && is_array( $date_query[0] ) ) {
+			return $date_query[0];
+		}
+
+		return $date_query;
+	}
+
+	/**
+	 * Resolve `year`, `monthnum`/`month` and `day` into a calendar span.
+	 *
+	 * A year alone spans the year, a year and month span the month, and all
+	 * three span the day. A month or day without a year has no anchor to hang
+	 * on, so it resolves to nothing rather than guessing at the current year.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param array<string, mixed> $clause The clause being read.
+	 *
+	 * @return array{0: DateTimeImmutable, 1: DateTimeImmutable}|null The span, or null when there is no year.
+	 */
+	private static function resolve_calendar_span( array $clause ): ?array {
+		if ( ! isset( $clause['year'] ) || ! is_numeric( $clause['year'] ) ) {
+			return null;
+		}
+
+		$year  = (int) $clause['year'];
+		$month = $clause['monthnum'] ?? ( $clause['month'] ?? null );
+		$day   = $clause['day'] ?? null;
+
+		if ( ! is_numeric( $month ) ) {
+			$opens = sprintf( '%04d-01-01 00:00:00', $year );
+			$spans = '+1 year';
+		} elseif ( ! is_numeric( $day ) ) {
+			$opens = sprintf( '%04d-%02d-01 00:00:00', $year, (int) $month );
+			$spans = '+1 month';
+		} else {
+			$opens = sprintf( '%04d-%02d-%02d 00:00:00', $year, (int) $month, (int) $day );
+			$spans = '+1 day';
+		}
+
+		$start = self::site_datetime( $opens );
+
+		// A month of 13 or a day of 32 builds a string no calendar has.
+		if ( null === $start ) {
+			return null;
+		}
+
+		return array( $start, $start->modify( $spans )->modify( '-1 second' ) );
+	}
+
+	/**
+	 * Read an `after` or `before` value into a site-local datetime.
+	 *
+	 * WordPress accepts either a string it can parse or an array of date parts.
+	 * A value that names a day without naming a time covers the whole day, so
+	 * it opens at the first second and closes at the last.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param mixed $value    The value to read.
+	 * @param bool  $end_of_day Whether a bare day should resolve to its last second.
+	 *
+	 * @return DateTimeImmutable|null The datetime, or null when the value could not be read.
+	 */
+	private static function to_site_datetime( $value, bool $end_of_day ): ?DateTimeImmutable {
+		if ( is_array( $value ) ) {
+			$value = sprintf(
+				'%04d-%02d-%02d %02d:%02d:%02d',
+				(int) ( $value['year'] ?? 0 ),
+				(int) ( $value['month'] ?? ( $end_of_day ? 12 : 1 ) ),
+				(int) ( $value['day'] ?? ( $end_of_day ? 31 : 1 ) ),
+				(int) ( $value['hour'] ?? ( $end_of_day ? 23 : 0 ) ),
+				(int) ( $value['minute'] ?? ( $end_of_day ? 59 : 0 ) ),
+				(int) ( $value['second'] ?? ( $end_of_day ? 59 : 0 ) )
+			);
+		}
+
+		if ( ! is_string( $value ) || '' === trim( $value ) ) {
+			return null;
+		}
+
+		$datetime = self::site_datetime( trim( $value ) );
+
+		if ( null === $datetime ) {
+			return null;
+		}
+
+		// A bare day covers the whole day, so a `before` lands on its last
+		// second rather than on midnight, which would drop the day entirely.
+		if ( $end_of_day && 1 === preg_match( '/^\d{4}-\d{2}-\d{2}$/', trim( $value ) ) ) {
+			$datetime = $datetime->modify( '+1 day' )->modify( '-1 second' );
+		}
+
+		return $datetime;
+	}
+
+	/**
+	 * Build a datetime in the site's timezone.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string $value A value `DateTimeImmutable` can parse.
+	 *
+	 * @return DateTimeImmutable|null The datetime, or null when the value could not be parsed.
+	 */
+	private static function site_datetime( string $value ): ?DateTimeImmutable {
+		try {
+			return new DateTimeImmutable( $value, wp_timezone() );
+		} catch ( Exception $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Render a datetime as a string the events table can be compared against.
+	 *
+	 * The local columns hold each event's own wall clock with no zone attached,
+	 * so a site-local boundary compares against them as it is. The GMT columns
+	 * need the boundary shifted to UTC first.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param DateTimeImmutable|null $datetime The datetime to render.
+	 * @param bool                   $in_utc   Whether to shift it to UTC first.
+	 *
+	 * @return string|null The datetime, or null when there was nothing to render.
+	 */
+	private static function to_string( ?DateTimeImmutable $datetime, bool $in_utc ): ?string {
+		if ( null === $datetime ) {
+			return null;
+		}
+
+		if ( $in_utc ) {
+			$datetime = $datetime->setTimezone( new DateTimeZone( 'UTC' ) );
+		}
+
+		return $datetime->format( self::DATETIME_FORMAT );
+	}
+}

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -59,6 +59,18 @@ final class Query {
 	const EVENT_DATE_QUERY_PARAM = 'gatherpress_event_date';
 
 	/**
+	 * Query variable carrying a resolved event date window between hooks.
+	 *
+	 * Set on the query by `intercept_date_query()` during `pre_get_posts` and
+	 * read back by `adjust_event_date_window_sql()` on `posts_clauses`. Never
+	 * registered as a public query var, so it cannot arrive from a URL.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	const EVENT_DATE_WINDOW_PARAM = 'gatherpress_event_date_window';
+
+	/**
 	 * Class constructor.
 	 *
 	 * This method initializes the object and sets up necessary hooks.
@@ -82,6 +94,7 @@ final class Query {
 		add_action( 'pre_get_posts', array( $this, 'prepare_event_query_before_execution' ) );
 		// Priority 9 to run before the upcoming/past adjustments at priority 10.
 		add_filter( 'posts_clauses', array( $this, 'adjust_admin_event_sorting' ), 9, 2 );
+		add_filter( 'posts_clauses', array( $this, 'adjust_event_date_window_sql' ), 10, 2 );
 
 		// Filter adjacent post queries to join and sort by event datetime.
 		add_filter( 'get_previous_post_join', array( $this, 'get_adjacent_post_join' ), 10, 5 );
@@ -293,6 +306,8 @@ final class Query {
 				$query->set( 'tax_query', $existing_tax_query );
 			}
 		}
+
+		$this->intercept_date_query( $query );
 
 		switch ( $events_query ) {
 			case 'upcoming':
@@ -552,9 +567,8 @@ final class Query {
 		 */
 		$posts_table = esc_sql( $wpdb->posts );
 
-		$pieces['join'] .= ' LEFT JOIN ' . $events_table . ' ON ' . $posts_table . '.ID='
-						. $events_table . '.post_id';
-		$order           = strtoupper( $order );
+		$pieces = $this->ensure_events_join( $pieces );
+		$order  = strtoupper( $order );
 
 		if ( in_array( $order, array( 'DESC', 'ASC' ), true ) ) {
 			// ORDERBY is an array, which allows to orderby multiple values.
@@ -605,6 +619,160 @@ final class Query {
 		}
 
 		return $pieces;
+	}
+
+	/**
+	 * Join the events table onto a query once.
+	 *
+	 * Both the upcoming/past handlers and the date window handler need the
+	 * join, and either may run without the other, so each asks for it here
+	 * rather than appending its own and doubling the alias when both run.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param array<string, string> $pieces An array of query pieces, including join, where, orderby, and more.
+	 *
+	 * @return array<string, string> The pieces, with the events table joined.
+	 */
+	private function ensure_events_join( array $pieces ): array {
+		global $wpdb;
+
+		/**
+		 * Escaped events table name.
+		 *
+		 * @var string $events_table esc_sql() only returns an array when it is handed one.
+		 */
+		$events_table = esc_sql( sprintf( Event::TABLE_FORMAT, $wpdb->prefix ) );
+
+		/**
+		 * Escaped posts table name.
+		 *
+		 * @var string $posts_table esc_sql() only returns an array when it is handed one.
+		 */
+		$posts_table = esc_sql( $wpdb->posts );
+		$join        = (string) ( $pieces['join'] ?? '' );
+
+		if ( ! str_contains( $join, $events_table ) ) {
+			$join .= ' LEFT JOIN ' . $events_table . ' ON ' . $posts_table . '.ID=' . $events_table . '.post_id';
+		}
+
+		$pieces['join'] = $join;
+
+		return $pieces;
+	}
+
+	/**
+	 * Point a `date_query` at event dates rather than publish dates.
+	 *
+	 * WordPress reads `date_query` against `post_date`, which for an event is
+	 * the day its post was written. For a query made up entirely of event post
+	 * types the argument is lifted out here, before core turns it into SQL,
+	 * resolved into a window by `Date_Query`, and carried to `posts_clauses`
+	 * under `EVENT_DATE_WINDOW_PARAM`, where it is compared against the events
+	 * table instead.
+	 *
+	 * Three things are left for core to handle the way it always has: a clause
+	 * naming a core column such as `post_date`, which is how to keep filtering
+	 * an event query by publish date; a clause `Date_Query` cannot read; and a
+	 * query mixing event and non-event post types, whose non-event rows have no
+	 * event dates and would silently drop out.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param WP_Query $query The query being prepared.
+	 *
+	 * @return void
+	 */
+	private function intercept_date_query( WP_Query $query ): void {
+		$date_query = $query->get( 'date_query' );
+
+		if ( empty( $date_query ) || ! is_array( $date_query ) || ! $this->queries_event_post_types_only( $query ) ) {
+			return;
+		}
+
+		$window = Date_Query::resolve( $date_query );
+
+		if ( null === $window ) {
+			return;
+		}
+
+		$query->set( self::EVENT_DATE_WINDOW_PARAM, $window );
+		$query->set( 'date_query', array() );
+	}
+
+	/**
+	 * Whether every post type a query asks for carries event dates.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param WP_Query $query The query to inspect.
+	 *
+	 * @return bool True when the query is made up of event post types alone.
+	 */
+	private function queries_event_post_types_only( WP_Query $query ): bool {
+		$post_types = array_filter( (array) $query->get( 'post_type' ) );
+
+		if ( empty( $post_types ) ) {
+			return false;
+		}
+
+		foreach ( $post_types as $post_type ) {
+			if ( ! is_string( $post_type ) || ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Narrow a query to events touching the window a `date_query` resolved to.
+	 *
+	 * An event belongs to the window when it overlaps it: its start falls
+	 * before the window closes and its end falls after the window opens. An
+	 * open-ended window drops the bound it lacks. Compares the GMT pair or the
+	 * local pair according to the column the window was resolved for.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param array<string, string> $query_pieces An array containing pieces of the SQL query.
+	 * @param WP_Query              $query        The WP_Query instance (passed by reference).
+	 *
+	 * @return array<string, string> The query pieces, narrowed when the query carries a window.
+	 */
+	public function adjust_event_date_window_sql( array $query_pieces, WP_Query $query ): array {
+		global $wpdb;
+
+		$window = $query->get( self::EVENT_DATE_WINDOW_PARAM );
+
+		if ( empty( $window ) || ! is_array( $window ) || empty( $window['column'] ) ) {
+			return $query_pieces;
+		}
+
+		$query_pieces = $this->ensure_events_join( $query_pieces );
+		$table        = sprintf( Event::TABLE_FORMAT, $wpdb->prefix );
+		$start_column = (string) $window['column'];
+		$end_column   = str_replace( 'datetime_start', 'datetime_end', $start_column );
+
+		if ( ! empty( $window['end'] ) ) {
+			$query_pieces['where'] .= $wpdb->prepare(
+				' AND %i.%i <= %s',
+				$table,
+				$start_column,
+				$window['end']
+			);
+		}
+
+		if ( ! empty( $window['start'] ) ) {
+			$query_pieces['where'] .= $wpdb->prepare(
+				' AND %i.%i >= %s',
+				$table,
+				$end_column,
+				$window['start']
+			);
+		}
+
+		return $query_pieces;
 	}
 
 	/**

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -717,7 +717,7 @@ final class Query {
 		}
 
 		foreach ( $post_types as $post_type ) {
-			if ( ! is_string( $post_type ) || ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+			if ( ! is_string( $post_type ) || ! post_type_supports( $post_type, Event::SUPPORT ) ) {
 				return false;
 			}
 		}

--- a/test/unit/php/includes/tests/core/classes/event/class-test-date-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-date-query.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Class handles unit tests for GatherPress\Core\Event\Date_Query.
+ *
+ * @package GatherPress\Core\Event
+ * @since 0.36.0
+ */
+
+namespace GatherPress\Tests\Core\Event;
+
+use GatherPress\Core\Event\Date_Query;
+use GatherPress\Tests\Base;
+
+/**
+ * Class Test_Date_Query.
+ *
+ * @coversDefaultClass \GatherPress\Core\Event\Date_Query
+ */
+class Test_Date_Query extends Base {
+
+	/**
+	 * Set the site to a timezone that is not UTC.
+	 *
+	 * Every expectation below is written as UTC, so a site running on UTC would
+	 * pass whether or not the boundaries are reckoned in the site's timezone at
+	 * all. New York keeps that mistake visible, and straddles a DST change
+	 * between January and June.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		update_option( 'timezone_string', 'America/New_York' );
+	}
+
+	/**
+	 * Coverage for resolve method.
+	 *
+	 * @dataProvider data_resolve
+	 *
+	 * @covers ::resolve
+	 * @covers ::first_clause
+	 * @covers ::resolve_calendar_span
+	 * @covers ::to_site_datetime
+	 * @covers ::site_datetime
+	 * @covers ::to_string
+	 *
+	 * @param array<int|string, mixed>                                 $date_query The date query to resolve.
+	 * @param array{start: ?string, end: ?string, column: string}|null $expects The window it should resolve to.
+	 * @param string                                                   $message    Message to display on failure.
+	 *
+	 * @return void
+	 */
+	public function test_resolve( array $date_query, ?array $expects, string $message ): void {
+		$this->assertSame( $expects, Date_Query::resolve( $date_query ), $message );
+	}
+
+	/**
+	 * Data provider for resolve.
+	 *
+	 * @return array<int, array<int, mixed>>
+	 */
+	public function data_resolve(): array {
+		return array(
+			array(
+				array( 'year' => 2026 ),
+				array(
+					'start'  => '2026-01-01 05:00:00',
+					'end'    => '2027-01-01 04:59:59',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'A year should span the site\'s year, in UTC.',
+			),
+			array(
+				array(
+					'year'     => 2026,
+					'monthnum' => 6,
+				),
+				array(
+					'start'  => '2026-06-01 04:00:00',
+					'end'    => '2026-07-01 03:59:59',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'A month should span the site\'s month, on daylight time.',
+			),
+			array(
+				array(
+					'year'  => 2026,
+					'month' => 6,
+				),
+				array(
+					'start'  => '2026-06-01 04:00:00',
+					'end'    => '2026-07-01 03:59:59',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'`month` should be read the same way as `monthnum`.',
+			),
+			array(
+				array(
+					'year'     => 2026,
+					'monthnum' => 6,
+					'day'      => 15,
+				),
+				array(
+					'start'  => '2026-06-15 04:00:00',
+					'end'    => '2026-06-16 03:59:59',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'A day should span the site\'s day.',
+			),
+			array(
+				array( array( 'year' => 2026 ) ),
+				array(
+					'start'  => '2026-01-01 05:00:00',
+					'end'    => '2027-01-01 04:59:59',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'A clause wrapped in a list should be read the same as a bare one.',
+			),
+			array(
+				array( 'after' => '2026-06-01' ),
+				array(
+					'start'  => '2026-06-01 04:00:01',
+					'end'    => null,
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'`after` should be exclusive and leave the window open ended.',
+			),
+			array(
+				array(
+					'after'     => '2026-06-01',
+					'inclusive' => true,
+				),
+				array(
+					'start'  => '2026-06-01 04:00:00',
+					'end'    => null,
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'`inclusive` should keep the boundary itself.',
+			),
+			array(
+				array( 'before' => '2026-06-30' ),
+				array(
+					'start'  => null,
+					'end'    => '2026-07-01 03:59:58',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'A bare `before` day should cover that whole day, minus its last second.',
+			),
+			array(
+				array(
+					'before'    => '2026-06-30',
+					'inclusive' => true,
+				),
+				array(
+					'start'  => null,
+					'end'    => '2026-07-01 03:59:59',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'An inclusive `before` day should cover the whole day.',
+			),
+			array(
+				array(
+					'after'     => '2026-06-01 09:00:00',
+					'before'    => '2026-06-30 17:00:00',
+					'inclusive' => true,
+				),
+				array(
+					'start'  => '2026-06-01 13:00:00',
+					'end'    => '2026-06-30 21:00:00',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'A pair of times should resolve to both ends of the window.',
+			),
+			array(
+				array(
+					'after'     => array(
+						'year'  => 2026,
+						'month' => 6,
+						'day'   => 1,
+					),
+					'inclusive' => true,
+				),
+				array(
+					'start'  => '2026-06-01 04:00:00',
+					'end'    => null,
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'`after` should also be readable as date parts.',
+			),
+			array(
+				array(
+					'year'   => 2026,
+					'before' => '2026-06-30',
+				),
+				array(
+					'start'  => '2026-01-01 05:00:00',
+					'end'    => '2026-07-01 03:59:58',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'`before` should narrow the end of a calendar span.',
+			),
+			array(
+				array(),
+				null,
+				'An empty date query should resolve to nothing.',
+			),
+			array(
+				array( 'monthnum' => 6 ),
+				null,
+				'A month with no year has no anchor and should resolve to nothing.',
+			),
+			array(
+				array( 'week' => 24 ),
+				null,
+				'A repeating slice of the calendar should be left alone.',
+			),
+			array(
+				array( 'year' => 'soon' ),
+				null,
+				'A year that is not a number should resolve to nothing.',
+			),
+			array(
+				array( 'after' => 'whenever' ),
+				null,
+				'A value that cannot be parsed should resolve to nothing.',
+			),
+			array(
+				array( 'after' => '' ),
+				null,
+				'An empty value should resolve to nothing.',
+			),
+			array(
+				array(
+					'year'     => 2026,
+					'monthnum' => 13,
+				),
+				null,
+				'A month no calendar has should resolve to nothing.',
+			),
+			array(
+				array(
+					'year'   => 2026,
+					'column' => 'datetime_start',
+				),
+				array(
+					'start'  => '2026-01-01 00:00:00',
+					'end'    => '2026-12-31 23:59:59',
+					'column' => 'datetime_start',
+				),
+				'The local column should keep boundaries on the site\'s own clock.',
+			),
+			array(
+				array(
+					'year'   => 2026,
+					'column' => 'post_date',
+				),
+				null,
+				'A core column should be left for WordPress to resolve.',
+			),
+		);
+	}
+}

--- a/test/unit/php/includes/tests/core/classes/event/class-test-date-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-date-query.php
@@ -42,7 +42,7 @@ class Test_Date_Query extends Base {
 	 * @dataProvider data_resolve
 	 *
 	 * @covers ::resolve
-	 * @covers ::first_clause
+	 * @covers ::single_clause
 	 * @covers ::resolve_calendar_span
 	 * @covers ::to_site_datetime
 	 * @covers ::site_datetime
@@ -260,6 +260,76 @@ class Test_Date_Query extends Base {
 				),
 				null,
 				'A core column should be left for WordPress to resolve.',
+			),
+			array(
+				array(
+					'year' => 2026,
+					'week' => 24,
+				),
+				null,
+				'A clause carrying an argument that cannot be honored should resolve to nothing.',
+			),
+			array(
+				array(
+					'year'    => 2026,
+					'compare' => '>',
+				),
+				null,
+				'A comparison operator that cannot be honored should resolve to nothing.',
+			),
+			array(
+				array(
+					'relation' => 'AND',
+					array( 'year' => 2026 ),
+					array( 'year' => 2027 ),
+				),
+				null,
+				'A relation between clauses should resolve to nothing.',
+			),
+			array(
+				array(
+					array( 'year' => 2026 ),
+					array( 'year' => 2027 ),
+				),
+				null,
+				'More than one clause should resolve to nothing.',
+			),
+			array(
+				array(
+					'year'  => 2026,
+					'after' => '2025-12-01',
+				),
+				array(
+					'start'  => '2026-01-01 05:00:00',
+					'end'    => '2027-01-01 04:59:59',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'An `after` before the span opens should not widen it.',
+			),
+			array(
+				array(
+					'year'      => 2026,
+					'after'     => '2026-06-15',
+					'inclusive' => true,
+				),
+				array(
+					'start'  => '2026-06-15 04:00:00',
+					'end'    => '2027-01-01 04:59:59',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'An `after` inside the span should narrow its start.',
+			),
+			array(
+				array(
+					'year'   => 2026,
+					'before' => '2027-06-30',
+				),
+				array(
+					'start'  => '2026-01-01 05:00:00',
+					'end'    => '2027-01-01 04:59:59',
+					'column' => Date_Query::DEFAULT_COLUMN,
+				),
+				'A `before` after the span closes should not widen it.',
 			),
 		);
 	}

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -50,6 +50,12 @@ class Test_Query extends Base {
 			),
 			array(
 				'type'     => 'filter',
+				'name'     => 'posts_clauses',
+				'priority' => 10,
+				'callback' => array( $instance, 'adjust_event_date_window_sql' ),
+			),
+			array(
+				'type'     => 'filter',
 				'name'     => 'get_previous_post_join',
 				'priority' => 10,
 				'callback' => array( $instance, 'get_adjacent_post_join' ),
@@ -2543,6 +2549,257 @@ class Test_Query extends Base {
 			$straddling,
 			$query->posts,
 			'A month the event never reaches should not list it.'
+		);
+	}
+
+	/**
+	 * Build three events around June 2026, as the site's clock reckons it.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return array<string, int> Post IDs keyed by the part they play.
+	 */
+	protected function create_june_events(): array {
+		$events = array(
+			'within'   => array( '2026-06-15 10:00:00', '2026-06-15 14:00:00', 'America/New_York' ),
+			'before'   => array( '2026-05-15 10:00:00', '2026-05-15 14:00:00', 'America/New_York' ),
+			'spanning' => array( '2026-05-30 10:00:00', '2026-06-02 14:00:00', 'America/New_York' ),
+		);
+		$ids    = array();
+
+		foreach ( $events as $part => $datetimes ) {
+			$ids[ $part ] = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+
+			( new Event( $ids[ $part ] ) )->save_datetimes(
+				array(
+					'datetime_start' => $datetimes[0],
+					'datetime_end'   => $datetimes[1],
+					'timezone'       => $datetimes[2],
+				)
+			);
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Coverage for a date query narrowing an event query to a window.
+	 *
+	 * @covers ::intercept_date_query
+	 * @covers ::queries_event_post_types_only
+	 * @covers ::adjust_event_date_window_sql
+	 * @covers ::ensure_events_join
+	 *
+	 * @return void
+	 */
+	public function test_date_query_narrows_an_event_query_to_the_window(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$ids   = $this->create_june_events();
+		$query = new WP_Query(
+			array(
+				'post_type'      => Event::POST_TYPE,
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'date_query'     => array(
+					array(
+						'year'     => 2026,
+						'monthnum' => 6,
+					),
+				),
+			)
+		);
+
+		$this->assertContains(
+			$ids['within'],
+			$query->posts,
+			'An event held inside the window should answer to it.'
+		);
+		$this->assertContains(
+			$ids['spanning'],
+			$query->posts,
+			'An event running into the window should answer to it.'
+		);
+		$this->assertNotContains(
+			$ids['before'],
+			$query->posts,
+			'An event finished before the window opened should not.'
+		);
+	}
+
+	/**
+	 * Coverage for a date query composing with the upcoming and past views.
+	 *
+	 * @covers ::intercept_date_query
+	 * @covers ::adjust_event_date_window_sql
+	 * @covers ::ensure_events_join
+	 *
+	 * @return void
+	 */
+	public function test_date_query_composes_with_the_past_view(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$ids   = $this->create_june_events();
+		$query = new WP_Query(
+			array(
+				'post_type'              => Event::POST_TYPE,
+				'fields'                 => 'ids',
+				'posts_per_page'         => -1,
+				Query::EVENT_QUERY_PARAM => 'past',
+				'date_query'             => array(
+					array(
+						'year'     => 2026,
+						'monthnum' => 6,
+					),
+				),
+			)
+		);
+
+		$this->assertContains(
+			$ids['within'],
+			$query->posts,
+			'A past event inside the window should survive both filters.'
+		);
+		$this->assertNotContains(
+			$ids['before'],
+			$query->posts,
+			'The window should still exclude an event outside it.'
+		);
+	}
+
+	/**
+	 * Coverage for the two clocks disagreeing on a foreign timezone event.
+	 *
+	 * @covers ::intercept_date_query
+	 * @covers ::adjust_event_date_window_sql
+	 *
+	 * @return void
+	 */
+	public function test_date_query_reckons_the_window_in_the_chosen_clock(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$post_id = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+
+		// June 1 in Tokyo is still May 31 in New York, so the two clocks
+		// disagree about whether this event belongs to June at all.
+		( new Event( $post_id ) )->save_datetimes(
+			array(
+				'datetime_start' => '2026-06-01 10:00:00',
+				'datetime_end'   => '2026-06-01 12:00:00',
+				'timezone'       => 'Asia/Tokyo',
+			)
+		);
+
+		$absolute = new WP_Query(
+			array(
+				'post_type'      => Event::POST_TYPE,
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'date_query'     => array(
+					array(
+						'year'     => 2026,
+						'monthnum' => 6,
+					),
+				),
+			)
+		);
+
+		$bucketed = new WP_Query(
+			array(
+				'post_type'      => Event::POST_TYPE,
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'date_query'     => array(
+					array(
+						'year'     => 2026,
+						'monthnum' => 6,
+						'column'   => 'datetime_start',
+					),
+				),
+			)
+		);
+
+		$this->assertNotContains(
+			$post_id,
+			$absolute->posts,
+			'By the site\'s clock the event happens in May, so June should not list it.'
+		);
+		$this->assertContains(
+			$post_id,
+			$bucketed->posts,
+			'By its own clock the event happens in June, which is what the local column buckets by.'
+		);
+	}
+
+	/**
+	 * Coverage for date queries left alone.
+	 *
+	 * @covers ::intercept_date_query
+	 * @covers ::queries_event_post_types_only
+	 *
+	 * @return void
+	 */
+	public function test_date_query_is_left_alone_when_it_is_not_ours(): void {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$ids = $this->create_june_events();
+
+		// Naming a core column is how an event query keeps filtering by the
+		// day its posts were written, which the admin list relies on.
+		$by_publish_date = new WP_Query(
+			array(
+				'post_type'      => Event::POST_TYPE,
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'date_query'     => array(
+					array(
+						'year'   => 2026,
+						'column' => 'post_date',
+					),
+				),
+			)
+		);
+
+		$mixed = new WP_Query(
+			array(
+				'post_type'      => array( Event::POST_TYPE, 'post' ),
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'date_query'     => array(
+					array(
+						'year'     => 2026,
+						'monthnum' => 6,
+					),
+				),
+			)
+		);
+
+		$this->assertContains(
+			$ids['before'],
+			$by_publish_date->posts,
+			'A core column should filter on publish date, which every fixture shares.'
+		);
+		// A query naming no post type at all is core's business, not ours.
+		$untyped = new WP_Query(
+			array(
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'date_query'     => array(
+					array(
+						'year'     => 2026,
+						'monthnum' => 6,
+					),
+				),
+			)
+		);
+
+		$this->assertEmpty(
+			$mixed->posts,
+			'A query mixing post types should fall through to core, which finds nothing published in June 2026.'
+		);
+		$this->assertEmpty(
+			$untyped->posts,
+			'A query with no post type should fall through to core as well.'
 		);
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/event/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-query.php
@@ -2568,7 +2568,14 @@ class Test_Query extends Base {
 		$ids    = array();
 
 		foreach ( $events as $part => $datetimes ) {
-			$ids[ $part ] = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+			// An explicit publish date, so the test that filters on `post_date`
+			// keeps asserting the same thing after 2026 has passed.
+			$ids[ $part ] = $this->mock->post(
+				array(
+					'post_type' => Event::POST_TYPE,
+					'post_date' => '2026-02-01 09:00:00',
+				)
+			)->get()->ID;
 
 			( new Event( $ids[ $part ] ) )->save_datetimes(
 				array(
@@ -2777,7 +2784,12 @@ class Test_Query extends Base {
 		$this->assertContains(
 			$ids['before'],
 			$by_publish_date->posts,
-			'A core column should filter on publish date, which every fixture shares.'
+			'A core column should filter on the 2026 publish date every fixture was given.'
+		);
+		$this->assertContains(
+			$ids['within'],
+			$by_publish_date->posts,
+			'Publish-date filtering should ignore when the events themselves happen.'
 		);
 		// A query naming no post type at all is core's business, not ours.
 		$untyped = new WP_Query(


### PR DESCRIPTION
Part of #1169, which is three separate things. This is the mechanism underneath all of them, and it closes the second bullet on its own.

## The problem

WordPress resolves `date_query` against `post_date`. For an event that is the day someone wrote the post, not the day the event happens, so "events in June" answers with whatever was published in June.

## The change

For a query made up entirely of post types supporting `gatherpress-event-date`, `date_query` is lifted out of the query vars during `pre_get_posts` and resolved into a window compared against the events table instead.

The interception happens before core builds any SQL for it: `pre_get_posts` fires at `WP_Query` line 1916, the `date_query` clause is built at 2144. That is worth calling out because the existing workaround in [gatherpress-calendar](https://github.com/carstingaxion/gatherpress-calendar) and gatherpress-statistics has to regex the generated `YEAR()`/`MONTH()` clause back out of the `WHERE` string. Nothing needs stripping here, because nothing is ever built.

**Overlap, not start.** An event belongs to the window when its start falls before the window closes and its end falls after the window opens, matching the admin filter that shipped in #2263. One running May 30 to June 2 answers to both months; one running September to November answers to October, though it neither starts nor ends there.

**Boundaries are reckoned in the site's timezone**, the way WordPress reckons `post_date`, then converted once to UTC and compared against `datetime_start_gmt` / `datetime_end_gmt`. Plain range comparisons, so `KEY datetime_start_gmt` stays usable. This is the only reading that holds up across events in different timezones, which is the wrinkle GatherPress has and core does not: core's `post_date` is one timezone for the whole site.

**Two escape hatches**, both shaped like core's own `column` key:

- `'column' => 'datetime_start'` buckets by each event's own clock instead. Not index-backed, and not comparable between timezones, but it is what a list table wants when the column beside the filter renders in that clock.
- `'column' => 'post_date'` (or any other core column) leaves the clause entirely to WordPress. That is how an event query keeps filtering by publish date, which the admin list relies on.

`Date_Query::resolve()` reads the range-shaped arguments only: `after`, `before`, `year`, `monthnum`/`month`, `day` and `inclusive`. `week`, `dayofweek`, `hour` and friends describe a repeating slice of the calendar rather than one stretch of it and have no single answer across mixed timezones, so they are left alone rather than answered wrongly.

## What this does and does not close

- **Bullet 2, the `core/query-total` statistics case, is closed by this.**
- **Bullet 1, "Events next month" in a query loop, is closed for Advanced Query Loop users.** `aql_query_vars()` already passes AQL's built args through untouched, and AQL ships its own date controls, so its date range starts resolving against event dates as soon as this lands. The core Query Loop still has no date control; that UI is a separate PR.
- **Bullet 3, the admin filter, shipped in #2263** and is deliberately unaffected: it filters by publish date through core's `m` parameter, and its event-date filter has its own parameter.

## Two things worth a look

- **A query mixing event and non-event post types is left to core.** Non-event rows have no events-table row, so hijacking would silently drop them from results.
- **`adjust_event_sql()` used to append the events-table join unconditionally**, which was fine when only the upcoming and past handlers called it. The date window handler needs the same join and may run without them (an "all" query joins nothing today), so both now go through an idempotent `ensure_events_join()`.

## Testing

1. Add events across several months, including one that runs from one month into the next, and one in a distant timezone near a month boundary.
2. In a query loop using **Advanced Query Loop** with the event post type, set a date range and confirm it filters on event dates rather than publish dates.
3. Confirm the range picks up an event that merely overlaps it.
4. **Events > All Events**: confirm both admin dropdowns still behave as they did, since the admin list is deliberately untouched.

## Verification

Full suite green at 2020 tests. `class-date-query.php` 78/78 and `class-query.php` 330/330 lines covered. Mutating the interception away, the column allow-list away, and the join's idempotency away each fails the tests that should catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event searches using date filters now match events that overlap the requested date range, including year, month, day, and custom date boundaries.
  * Date filtering respects the site’s configured timezone and supports inclusive date ranges.

* **Bug Fixes**
  * Corrected event date filtering so it evaluates event dates rather than standard post publication dates.

* **Tests**
  * Added coverage for date-range filtering, timezone handling, boundary conditions, and mixed query types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->