### PR TITLE
Give PHPStan room to finish on a cold cache

### DIFF
--- a/.github/workflows/phpstan-tests.yml
+++ b/.github/workflows/phpstan-tests.yml
@@ -45,4 +45,4 @@ jobs:
         if: ${{ success() || failure() }}
         run: |
           vendor/bin/phpstan --version
-          vendor/bin/phpstan analyze -vv --memory-limit=2G --error-format=checkstyle | cs2pr
+          vendor/bin/phpstan analyze -vv --memory-limit=4G --error-format=checkstyle | cs2pr

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		"lint:errors": "@lint -n",
 		"test:phpmd": "phpmd . text phpmd.xml",
 		"test": "@php ./vendor/phpunit/phpunit/phpunit",
-		"test:phpstan": "@php ./vendor/bin/phpstan analyze -vv --memory-limit=2G",
+		"test:phpstan": "@php ./vendor/bin/phpstan analyze -vv --memory-limit=4G",
 		"hooks": "@php ./vendor/bin/extract-wp-hooks.php",
 		"changelog:add": [
 			"composer install",


### PR DESCRIPTION
CI runs PHPStan with `--memory-limit=2G` and no result cache, and the codebase has grown into that ceiling.

## Why now

A **passing** run on `enhancement/1169-event-date-query` reports:

```
144/144 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% 46 secs
Elapsed time: 46 seconds
Used memory: 2 GB
```

Two GB used against a two GB ceiling. Whether a pull request goes green now turns on a margin of a couple of percent rather than on anything in its diff.

Two unrelated pull requests are red for this right now, `feat/rsvp-check-in` (#2064) and `feature/event-status`, both crashing the same way after reaching 144/144:

```
Used memory: 2.05 GB
Child process error: PHPStan process crashed because it reached configured
PHP memory limit: 2G ... while running parallel worker
```

Their runs are interleaved in time with runs that passed, on the same runners, so this is not an infrastructure blip. Neither author can do anything about it from their own branch.

The `⚠️ Result is incomplete because of severe errors ⚠️` line those runs also print is a consequence of the worker dying, not a set of type errors waiting to be fixed.

## The change

`--memory-limit=2G` becomes `4G`, in the workflow and in the `test:phpstan` composer script, so a cold local run behaves the way CI does.

Runners have 16 GB, and `parallel.maximumNumberOfProcesses` is already `1` in `phpstan.neon.dist`, so there is no concurrency multiplying the ceiling. Locally the limit is rarely reached because the result cache drops a run to well under 1 GB; CI is always cold.

## Testing

`composer test:phpstan` passes with no errors. The real proof is this pull request's own PHPStan check, which exercises the raised limit on a cold cache.
