### PR TITLE
Name post type supports with constants instead of string literals (#2244)

### DIFF
--- a/.github/changelog/2244-post-type-supports-constants
+++ b/.github/changelog/2244-post-type-supports-constants
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Define class constants for post type supports across Event, Rsvp, Venue, and Shadow_Source, replacing string literals across internal call sites.

--- a/includes/core/classes/blocks/class-add-to-calendar.php
+++ b/includes/core/classes/blocks/class-add-to-calendar.php
@@ -88,7 +88,7 @@ final class Add_To_Calendar {
 
 		// Validate that the post type supports event_date.
 		if (
-			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), Event::SUPPORT ) ||
 			! Event::is_viewable( $post_id )
 		) {
 			return '';

--- a/includes/core/classes/blocks/class-event-date.php
+++ b/includes/core/classes/blocks/class-event-date.php
@@ -86,7 +86,7 @@ final class Event_Date {
 
 		// Validate that the post type supports event_date.
 		if (
-			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), Event::SUPPORT ) ||
 			! Event::is_viewable( $post_id )
 		) {
 			return '';

--- a/includes/core/classes/blocks/class-event-query.php
+++ b/includes/core/classes/blocks/class-event-query.php
@@ -116,7 +116,7 @@ final class Event_Query {
 	 * @return void
 	 */
 	public function register_existing_event_date_post_types(): void {
-		foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $post_type ) {
+		foreach ( get_post_types_by_support( Event::SUPPORT ) as $post_type ) {
 			$this->maybe_register_event_date_rest_hooks( $post_type );
 		}
 	}
@@ -131,7 +131,7 @@ final class Event_Query {
 	 * @return void
 	 */
 	public function maybe_register_event_date_rest_hooks( string $post_type ): void {
-		if ( ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( $post_type, Event::SUPPORT ) ) {
 			return;
 		}
 
@@ -299,7 +299,7 @@ final class Event_Query {
 		// the block didn't pick one explicitly.
 		$query_args['post_type'] = ! empty( $block_query['postType'] )
 			? $block_query['postType']
-			: get_post_types_by_support( 'gatherpress-event-date' );
+			: get_post_types_by_support( Event::SUPPORT );
 
 		// Type of event list: 'upcoming', 'past', or 'all',
 		// @see wp-content/plugins/gatherpress/includes/core/classes/class-event-query.php.
@@ -538,7 +538,7 @@ final class Event_Query {
 		// Only process if querying GatherPress events.
 		$post_type = $block_query['postType'] ?? '';
 
-		if ( ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( $post_type, Event::SUPPORT ) ) {
 			return $query_args;
 		}
 

--- a/includes/core/classes/blocks/class-general-block.php
+++ b/includes/core/classes/blocks/class-general-block.php
@@ -19,6 +19,7 @@ use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
+use GatherPress\Core\Venue;
 use WP_HTML_Tag_Processor;
 
 /**
@@ -165,7 +166,7 @@ final class General_Block {
 		// fall back to the current post). Verify it's actually a venue.
 		$venue_post_id = $block['attrs']['postId'] ?? get_the_ID();
 
-		if ( ! post_type_supports( (string) get_post_type( $venue_post_id ), 'gatherpress-venue-information' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $venue_post_id ), Venue::SUPPORT ) ) {
 			return $block_content;
 		}
 
@@ -243,7 +244,7 @@ final class General_Block {
 
 		// Only process if the post type supports RSVP.
 		if (
-			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT ) ||
 			! Event::is_viewable( $post_id )
 		) {
 			return $block_content;
@@ -294,7 +295,7 @@ final class General_Block {
 
 		// Only process if the post type supports RSVP.
 		if (
-			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT ) ||
 			! Event::is_viewable( $post_id )
 		) {
 			return $block_content;

--- a/includes/core/classes/blocks/class-online-event.php
+++ b/includes/core/classes/blocks/class-online-event.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Event;
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Venue;
 use GatherPress\Core\Venue\Setup;
 use WP_Block;
 use WP_Post;
@@ -119,7 +120,7 @@ final class Online_Event {
 		$event_post_type = (string) get_post_type( $post_id );
 
 		// Only render for post types that support online events.
-		if ( ! post_type_supports( $event_post_type, 'gatherpress-online-event' ) ) {
+		if ( ! post_type_supports( $event_post_type, Venue::ONLINE_SUPPORT ) ) {
 			return false;
 		}
 
@@ -148,7 +149,7 @@ final class Online_Event {
 		// Event::is_viewable() does not ask about a password, and a direct
 		// visit to a protected event shows the form rather than the content.
 		return $post instanceof WP_Post
-			&& post_type_supports( $post->post_type, 'gatherpress-event-date' )
+			&& post_type_supports( $post->post_type, Event::SUPPORT )
 			&& Event::is_viewable( $post->ID )
 			&& ! post_password_required( $post );
 	}

--- a/includes/core/classes/blocks/class-rsvp-form.php
+++ b/includes/core/classes/blocks/class-rsvp-form.php
@@ -132,7 +132,7 @@ final class Rsvp_Form {
 		$rsvp = new Rsvp( $post_id );
 
 		if (
-			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' )
+			! post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT )
 			|| ! Event::is_viewable( $post_id )
 			|| ! $rsvp->is_enabled()
 			|| ! $rsvp->allows_open_rsvp()

--- a/includes/core/classes/blocks/class-rsvp-response.php
+++ b/includes/core/classes/blocks/class-rsvp-response.php
@@ -98,7 +98,7 @@ final class Rsvp_Response {
 		// its responses to viewers allowed to read it, so organizers see the
 		// roster on a draft or private event rather than an empty block.
 		if (
-			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT ) ||
 			! Event::is_viewable( $post_id )
 		) {
 			return '';

--- a/includes/core/classes/blocks/class-rsvp-template.php
+++ b/includes/core/classes/blocks/class-rsvp-template.php
@@ -130,7 +130,7 @@ final class Rsvp_Template {
 		// keeps its responses to viewers allowed to read it, so organizers see
 		// the roster on a draft or private event rather than an empty block.
 		if (
-			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT ) ||
 			! Event::is_viewable( $post_id )
 		) {
 			return $block_content;

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -105,7 +105,7 @@ final class Rsvp {
 
 		// Validate that the post type supports RSVP.
 		if (
-			! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ||
+			! post_type_supports( (string) get_post_type( $post_id ), Core_Rsvp::SUPPORT ) ||
 			! Event::is_viewable( $post_id )
 		) {
 			return '';

--- a/includes/core/classes/blocks/class-venue.php
+++ b/includes/core/classes/blocks/class-venue.php
@@ -155,7 +155,7 @@ final class Venue {
 		if (
 			isset( $block['attrs']['selectedPostId'] )
 			&& is_int( $block['attrs']['selectedPostId'] )
-			&& post_type_supports( $source_post_type, 'gatherpress-shadow-source' )
+			&& post_type_supports( $source_post_type, Shadow_Source::SUPPORT )
 		) {
 			$selected = get_post( $block['attrs']['selectedPostId'] );
 

--- a/includes/core/classes/calendar/class-cache.php
+++ b/includes/core/classes/calendar/class-cache.php
@@ -23,7 +23,9 @@ namespace GatherPress\Core\Calendar;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Event;
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Venue;
 
 /**
  * Caching for the iCalendar responses.
@@ -301,7 +303,7 @@ final class Cache {
 	 * @return bool True for event-bearing and venue post types.
 	 */
 	private function is_calendar_post_type( string $post_type ): bool {
-		return post_type_supports( $post_type, 'gatherpress-event-date' )
-			|| post_type_supports( $post_type, 'gatherpress-venue-information' );
+		return post_type_supports( $post_type, Event::SUPPORT )
+			|| post_type_supports( $post_type, Venue::SUPPORT );
 	}
 }

--- a/includes/core/classes/calendar/class-setup.php
+++ b/includes/core/classes/calendar/class-setup.php
@@ -20,6 +20,7 @@ namespace GatherPress\Core\Calendar;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Event;
 use GatherPress\Core\Event\Query;
 use GatherPress\Core\Shadow_Source;
 use GatherPress\Core\Topic;
@@ -109,7 +110,7 @@ final class Setup {
 	 * @return void
 	 */
 	public function register_endpoints(): void {
-		$event_types = get_post_types_by_support( 'gatherpress-event-date' );
+		$event_types = get_post_types_by_support( Event::SUPPORT );
 		if ( empty( $event_types ) ) {
 			return;
 		}
@@ -142,7 +143,7 @@ final class Setup {
 	 * @return void
 	 */
 	public function init_events( string $post_type ): void {
-		if ( ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( $post_type, Event::SUPPORT ) ) {
 			return;
 		}
 
@@ -408,7 +409,7 @@ final class Setup {
 	protected function collect_post_type_archive_alternate_links( array $args ): array {
 		$links = array();
 
-		foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $post_type ) {
+		foreach ( get_post_types_by_support( Event::SUPPORT ) as $post_type ) {
 			$feed_link = get_post_type_archive_feed_link( $post_type, self::ICAL_SLUG );
 
 			// A post type registered without an archive has no archive feed to advertise.
@@ -457,7 +458,7 @@ final class Setup {
 		$queried = get_queried_object();
 
 		if ( is_singular() && $queried instanceof WP_Post ) {
-			if ( post_type_supports( $queried->post_type, 'gatherpress-event-date' ) ) {
+			if ( post_type_supports( $queried->post_type, Event::SUPPORT ) ) {
 				return $this->collect_singular_event_alternate_links( $queried, $args );
 			}
 
@@ -812,7 +813,7 @@ final class Setup {
 		$filename       = 'calendar';
 
 		if ( is_singular() && $queried_object instanceof WP_Post ) {
-			if ( post_type_supports( $queried_object->post_type, 'gatherpress-event-date' ) ) {
+			if ( post_type_supports( $queried_object->post_type, Event::SUPPORT ) ) {
 				$calendar  = new Calendar( $queried_object->ID );
 				$date      = $calendar->event->get_datetime_start( 'Y-m-d' );
 				$post_name = $queried_object->post_name;
@@ -1065,7 +1066,7 @@ final class Setup {
 	 * @return bool
 	 */
 	protected function has_post_type_for_taxonomy( string $taxonomy ): bool {
-		$post_types = get_post_types_by_support( 'gatherpress-event-date' );
+		$post_types = get_post_types_by_support( Event::SUPPORT );
 		foreach ( $post_types as $post_type ) {
 			if ( is_object_in_taxonomy( $post_type, $taxonomy ) ) {
 				return true;
@@ -1088,7 +1089,7 @@ final class Setup {
 	 * @return bool
 	 */
 	protected function is_tax_like_type_for_event_supporting_types( string $post_type ): bool {
-		return post_type_supports( $post_type, 'gatherpress-shadow-source' ) &&
+		return post_type_supports( $post_type, Shadow_Source::SUPPORT ) &&
 			$this->has_post_type_for_taxonomy( Shadow_Source::get_instance()->get_taxonomy( $post_type ) );
 	}
 
@@ -1190,7 +1191,7 @@ final class Setup {
 		$queried = get_queried_object();
 
 		if ( is_singular() && $queried instanceof WP_Post ) {
-			if ( post_type_supports( $queried->post_type, 'gatherpress-event-date' ) ) {
+			if ( post_type_supports( $queried->post_type, Event::SUPPORT ) ) {
 				return ( new Calendar( $queried->ID ) )->get_ical_url();
 			}
 
@@ -1206,7 +1207,7 @@ final class Setup {
 		if ( is_post_type_archive() ) {
 			$post_type = get_query_var( 'post_type' );
 			$post_type = is_array( $post_type ) ? reset( $post_type ) : $post_type;
-			if ( is_string( $post_type ) && post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+			if ( is_string( $post_type ) && post_type_supports( $post_type, Event::SUPPORT ) ) {
 				return get_post_type_archive_feed_link( $post_type, self::ICAL_SLUG );
 			}
 		}

--- a/includes/core/classes/class-assets.php
+++ b/includes/core/classes/class-assets.php
@@ -522,7 +522,7 @@ final class Assets {
 	 * @return void
 	 */
 	public function event_communication_modal(): void {
-		if ( post_type_supports( (string) get_post_type(), 'gatherpress-event-date' ) ) {
+		if ( post_type_supports( (string) get_post_type(), Event::SUPPORT ) ) {
 			echo '<div id="gatherpress-event-communication-modal"></div>';
 		}
 	}

--- a/includes/core/classes/class-feed.php
+++ b/includes/core/classes/class-feed.php
@@ -156,7 +156,7 @@ final class Feed {
 	 */
 	public function get_default_event_excerpt( string $excerpt ): string {
 		// Only apply to events.
-		if ( ! post_type_supports( (string) get_post_type(), 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( (string) get_post_type(), Event::SUPPORT ) ) {
 			return $excerpt;
 		}
 
@@ -209,7 +209,7 @@ final class Feed {
 	 */
 	public function get_default_event_content( string $content ): string {
 		// Only apply to events.
-		if ( ! post_type_supports( (string) get_post_type(), 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( (string) get_post_type(), Event::SUPPORT ) ) {
 			return $content;
 		}
 
@@ -261,7 +261,7 @@ final class Feed {
 	 */
 	public function apply_event_excerpt( string $excerpt ): string {
 		// Only apply to events.
-		if ( ! post_type_supports( (string) get_post_type(), 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( (string) get_post_type(), Event::SUPPORT ) ) {
 			return $excerpt;
 		}
 
@@ -304,7 +304,7 @@ final class Feed {
 	 */
 	public function apply_event_content( string $content ): string {
 		// Only apply to events.
-		if ( ! post_type_supports( (string) get_post_type(), 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( (string) get_post_type(), Event::SUPPORT ) ) {
 			return $content;
 		}
 

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -246,7 +246,7 @@ final class Geocoding {
 			return;
 		}
 
-		if ( ! post_type_supports( $post->post_type, 'gatherpress-venue-information' ) ) {
+		if ( ! post_type_supports( $post->post_type, Venue::SUPPORT ) ) {
 			return;
 		}
 
@@ -375,7 +375,7 @@ final class Geocoding {
 			return;
 		}
 
-		if ( ! post_type_supports( $post->post_type, 'gatherpress-venue-information' ) ) {
+		if ( ! post_type_supports( $post->post_type, Venue::SUPPORT ) ) {
 			return;
 		}
 

--- a/includes/core/classes/class-setup.php
+++ b/includes/core/classes/class-setup.php
@@ -364,7 +364,7 @@ final class Setup {
 		$term_slug = 'online-event';
 
 		// Ensure the online-event term exists in each registered venue taxonomy.
-		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $venue_post_type ) {
+		foreach ( get_post_types_by_support( Venue::SUPPORT ) as $venue_post_type ) {
 			$taxonomy = Venue\Setup::get_instance()->get_taxonomy( $venue_post_type );
 			$term     = term_exists( $term_slug, $taxonomy );
 

--- a/includes/core/classes/class-shadow-source.php
+++ b/includes/core/classes/class-shadow-source.php
@@ -49,6 +49,14 @@ final class Shadow_Source {
 	use Singleton;
 
 	/**
+	 * Post type support that gives a post type a shadow taxonomy.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	const SUPPORT = 'gatherpress-shadow-source';
+
+	/**
 	 * Class constructor.
 	 *
 	 * @since 0.34.0
@@ -94,7 +102,7 @@ final class Shadow_Source {
 	 * @return void
 	 */
 	public function maybe_register_post_type_hooks( string $post_type ): void {
-		if ( ! post_type_supports( $post_type, 'gatherpress-shadow-source' ) ) {
+		if ( ! post_type_supports( $post_type, self::SUPPORT ) ) {
 			return;
 		}
 
@@ -126,7 +134,7 @@ final class Shadow_Source {
 	 * @return void
 	 */
 	public function register_taxonomies(): void {
-		foreach ( get_post_types_by_support( 'gatherpress-shadow-source' ) as $post_type ) {
+		foreach ( get_post_types_by_support( self::SUPPORT ) as $post_type ) {
 			register_taxonomy(
 				$this->get_taxonomy( $post_type ),
 				array(),
@@ -155,7 +163,7 @@ final class Shadow_Source {
 	 * @return void
 	 */
 	public function attach_taxonomies_to_object_types(): void {
-		foreach ( get_post_types_by_support( 'gatherpress-shadow-source' ) as $source_post_type ) {
+		foreach ( get_post_types_by_support( self::SUPPORT ) as $source_post_type ) {
 			$taxonomy = $this->get_taxonomy( $source_post_type );
 
 			/**
@@ -273,7 +281,7 @@ final class Shadow_Source {
 		// Skip non-shadow-source post types, updates (we only insert on the
 		// initial publish), un-named or non-published posts in one guard so
 		// the function reads top-down rather than as a return chain.
-		if ( ! post_type_supports( $post->post_type, 'gatherpress-shadow-source' )
+		if ( ! post_type_supports( $post->post_type, self::SUPPORT )
 			|| $update
 			|| empty( $post->post_name )
 			|| 'publish' !== $post->post_status
@@ -318,7 +326,7 @@ final class Shadow_Source {
 		// Combined guard: only run on shadow-source post types, only for
 		// publish/trash transitions, and only when slug or title actually
 		// changed (saves are otherwise no-ops here).
-		if ( ! post_type_supports( $post_type, 'gatherpress-shadow-source' )
+		if ( ! post_type_supports( $post_type, self::SUPPORT )
 			|| ! in_array( $post_after->post_status, array( 'publish', 'trash' ), true )
 			|| (
 				$post_before->post_name === $post_after->post_name
@@ -371,7 +379,7 @@ final class Shadow_Source {
 	public function delete_term( int $post_id ): void {
 		$post_type = (string) get_post_type( $post_id );
 
-		if ( ! post_type_supports( $post_type, 'gatherpress-shadow-source' ) ) {
+		if ( ! post_type_supports( $post_type, self::SUPPORT ) ) {
 			return;
 		}
 
@@ -539,13 +547,13 @@ final class Shadow_Source {
 			$queried = get_queried_object();
 
 			if ( $queried instanceof WP_Post ) {
-				if ( post_type_supports( $queried->post_type, 'gatherpress-shadow-source' ) ) {
+				if ( post_type_supports( $queried->post_type, self::SUPPORT ) ) {
 					// The page itself is a shadow source (e.g. a single venue or
 					// season): scope the query to it directly.
 					$resolved = $queried;
 				} elseif (
 					'' !== $context_post_type
-					&& post_type_supports( $context_post_type, 'gatherpress-shadow-source' )
+					&& post_type_supports( $context_post_type, self::SUPPORT )
 				) {
 					// The page is an event (Single Event template). Resolve the
 					// source post of the requested type from the event's own
@@ -565,7 +573,7 @@ final class Shadow_Source {
 		if (
 			$context_post_id <= 0
 			|| '' === $context_post_type
-			|| ! post_type_supports( $context_post_type, 'gatherpress-shadow-source' )
+			|| ! post_type_supports( $context_post_type, self::SUPPORT )
 		) {
 			return null;
 		}

--- a/includes/core/classes/class-validate.php
+++ b/includes/core/classes/class-validate.php
@@ -66,7 +66,7 @@ final class Validate {
 		// positive_number() short-circuits first, so the cast only ever runs on a numeric ID.
 		return (
 			self::positive_number( $param ) &&
-			post_type_supports( (string) get_post_type( (int) $param ), 'gatherpress-event-date' )
+			post_type_supports( (string) get_post_type( (int) $param ), Event::SUPPORT )
 		);
 	}
 

--- a/includes/core/classes/commands/class-event-cli.php
+++ b/includes/core/classes/commands/class-event-cli.php
@@ -73,7 +73,7 @@ final class Event_Cli extends WP_CLI {
 		$status    = ! empty( $assoc_args['status'] ) ? (string) $assoc_args['status'] : 'attending';
 
 		// The error message names this support, so gate on it rather than on event dates.
-		if ( ! post_type_supports( (string) get_post_type( $event_id ), 'gatherpress-rsvp' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $event_id ), Rsvp::SUPPORT ) ) {
 			self::error(
 				sprintf(
 					/* translators: %d: event ID. */

--- a/includes/core/classes/event/class-admin-list.php
+++ b/includes/core/classes/event/class-admin-list.php
@@ -91,7 +91,7 @@ final class Admin_List {
 	 * @return void
 	 */
 	public function maybe_register_post_type_hooks( string $post_type ): void {
-		if ( ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( $post_type, Event::SUPPORT ) ) {
 			return;
 		}
 
@@ -143,7 +143,7 @@ final class Admin_List {
 			? (string) $screen->post_type
 			: Event::POST_TYPE;
 
-		if ( post_type_supports( $post_type, 'gatherpress-rsvp' ) ) {
+		if ( post_type_supports( $post_type, Rsvp::SUPPORT ) ) {
 			// Add 'rsvps' as a sortable column.
 			$columns['rsvps'] = 'rsvps';
 		}
@@ -358,7 +358,7 @@ final class Admin_List {
 	 * @return bool True for post types that render our own date filters.
 	 */
 	public function disable_months_dropdown( bool $disable, string $post_type ): bool {
-		if ( post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+		if ( post_type_supports( $post_type, Event::SUPPORT ) ) {
 			return true;
 		}
 
@@ -380,7 +380,7 @@ final class Admin_List {
 	 * @return void
 	 */
 	public function render_date_filters( string $post_type ): void {
-		if ( ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( $post_type, Event::SUPPORT ) ) {
 			return;
 		}
 
@@ -442,7 +442,7 @@ final class Admin_List {
 	 * @return void
 	 */
 	public function render_taxonomy_filters( string $post_type ): void {
-		if ( ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( $post_type, Event::SUPPORT ) ) {
 			return;
 		}
 
@@ -725,7 +725,7 @@ final class Admin_List {
 		// otherwise issue a pointless comments-table join. Multi-post-type queries
 		// (array `post_type`) fall through to `handle_column_sorting()`'s own
 		// array guard so its early-return arm stays exercised.
-		if ( is_string( $post_type ) && ! post_type_supports( $post_type, 'gatherpress-rsvp' ) ) {
+		if ( is_string( $post_type ) && ! post_type_supports( $post_type, Rsvp::SUPPORT ) ) {
 			return;
 		}
 
@@ -767,7 +767,7 @@ final class Admin_List {
 
 		// Only proceed if we're in admin, on the main query, and dealing with an event post type.
 		if ( ! is_admin() || ! $query->is_main_query()
-			|| ! post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+			|| ! post_type_supports( $post_type, Event::SUPPORT ) ) {
 			return;
 		}
 
@@ -1030,7 +1030,7 @@ final class Admin_List {
 		// Only show the RSVPs column for post types that declare gatherpress-rsvp support.
 		// Event-date-only post types (e.g. theater productions tagged with a premiere date)
 		// have no RSVP storage and should not advertise an empty RSVP column.
-		if ( post_type_supports( $post_type, 'gatherpress-rsvp' ) ) {
+		if ( post_type_supports( $post_type, Rsvp::SUPPORT ) ) {
 			$insert['rsvps'] = __( 'RSVPs', 'gatherpress' );
 		}
 
@@ -1065,7 +1065,7 @@ final class Admin_List {
 			? (string) $screen->post_type
 			: Event::POST_TYPE;
 
-		if ( ! post_type_supports( $post_type, 'gatherpress-rsvp' ) ) {
+		if ( ! post_type_supports( $post_type, Rsvp::SUPPORT ) ) {
 			return $columns;
 		}
 

--- a/includes/core/classes/event/class-event.php
+++ b/includes/core/classes/event/class-event.php
@@ -69,6 +69,14 @@ class Event {
 	const POST_TYPE = 'gatherpress_event';
 
 	/**
+	 * Post type support that makes a post type an event.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	const SUPPORT = 'gatherpress-event-date';
+
+	/**
 	 * Capability for reading a specific event.
 	 *
 	 * A meta capability, so it is always paired with the event's post ID and
@@ -145,7 +153,7 @@ class Event {
 	 * @param int $post_id The event post ID.
 	 */
 	public function __construct( int $post_id ) {
-		if ( post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
+		if ( post_type_supports( (string) get_post_type( $post_id ), self::SUPPORT ) ) {
 			$this->post = get_post( $post_id );
 		}
 	}
@@ -191,7 +199,7 @@ class Event {
 		$post = get_post( $post_id );
 
 		// A post that is gone, or one that never takes RSVPs, has no roster.
-		if ( ! $post instanceof WP_Post || ! post_type_supports( $post->post_type, 'gatherpress-rsvp' ) ) {
+		if ( ! $post instanceof WP_Post || ! post_type_supports( $post->post_type, Rsvp::SUPPORT ) ) {
 			return false;
 		}
 

--- a/includes/core/classes/event/class-meta.php
+++ b/includes/core/classes/event/class-meta.php
@@ -86,7 +86,7 @@ final class Meta {
 	 * @return void
 	 */
 	public function register( string $post_type ): void {
-		if ( post_type_supports( $post_type, 'gatherpress-event-date' ) ) {
+		if ( post_type_supports( $post_type, Event::SUPPORT ) ) {
 			$this->register_event_date_meta( $post_type );
 		}
 

--- a/includes/core/classes/event/class-query.php
+++ b/includes/core/classes/event/class-query.php
@@ -149,7 +149,7 @@ final class Query {
 		$order = ( 'past' === $event_list_type ) ? 'DESC' : 'ASC';
 
 		$args = array(
-			'post_type'             => get_post_types_by_support( 'gatherpress-event-date' ),
+			'post_type'             => get_post_types_by_support( Event::SUPPORT ),
 			'fields'                => 'ids',
 			'no_found_rows'         => true,
 			'posts_per_page'        => $number,
@@ -232,7 +232,7 @@ final class Query {
 						$page_id      = $query->queried_object_id;
 						$events_query = $key;
 
-						$query->set( 'post_type', get_post_types_by_support( 'gatherpress-event-date' ) );
+						$query->set( 'post_type', get_post_types_by_support( Event::SUPPORT ) );
 						$query->set( self::EVENT_QUERY_PARAM, $key );
 						$query->is_page              = false;
 						$query->is_singular          = false;
@@ -399,7 +399,7 @@ final class Query {
 		if (
 			! $current_screen ||
 			'edit' !== $current_screen->base ||
-			! post_type_supports( $current_screen->post_type, 'gatherpress-event-date' ) ||
+			! post_type_supports( $current_screen->post_type, Event::SUPPORT ) ||
 			$wp_query->get( 'post_type' ) !== $current_screen->post_type
 		) {
 			return $query_pieces;
@@ -624,7 +624,7 @@ final class Query {
 	private function build_venue_tax_query( array $venues ): array {
 		$venue_tax_query = array( 'relation' => 'OR' );
 
-		foreach ( get_post_types_by_support( 'gatherpress-venue-information' ) as $venue_post_type ) {
+		foreach ( get_post_types_by_support( Venue::SUPPORT ) as $venue_post_type ) {
 			$venue_tax_query[] = array(
 				'taxonomy' => Setup::get_instance()->get_taxonomy( $venue_post_type ),
 				'field'    => 'slug',
@@ -784,7 +784,7 @@ final class Query {
 	 * @return bool Whether to join, compare, and sort by the event start.
 	 */
 	protected function follows_event_datetime( WP_Post $post ): bool {
-		return post_type_supports( $post->post_type, 'gatherpress-event-date' )
+		return post_type_supports( $post->post_type, Event::SUPPORT )
 			&& '' !== ( new Event( $post->ID ) )->get_datetime()['datetime_start_gmt'];
 	}
 

--- a/includes/core/classes/event/class-setup.php
+++ b/includes/core/classes/event/class-setup.php
@@ -23,6 +23,7 @@ use GatherPress\Core\Settings;
 use GatherPress\Core\Starter_Pattern_Loader;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
+use GatherPress\Core\Venue;
 use stdClass;
 use WP_Block;
 use WP_Post;
@@ -143,7 +144,7 @@ final class Setup {
 		}
 
 		$settings['gatherpress']['config']['eventPostTypes'] = array_values(
-			get_post_types_by_support( 'gatherpress-event-date' )
+			get_post_types_by_support( Event::SUPPORT )
 		);
 
 		return $settings;
@@ -225,10 +226,10 @@ final class Setup {
 					'comments',
 					'revisions',
 					'custom-fields',
-					'gatherpress-event-date',
-					'gatherpress-rsvp',
-					'gatherpress-venue',
-					'gatherpress-online-event',
+					Event::SUPPORT,
+					Rsvp::SUPPORT,
+					Venue::ASSIGNMENT_SUPPORT,
+					Venue::ONLINE_SUPPORT,
 				),
 				'menu_icon'     => 'dashicons-nametag',
 				// Note: has_archive must be true for event feed URLs (/event/feed/) to work.
@@ -309,7 +310,7 @@ final class Setup {
 	 * @return void
 	 */
 	public function register_starter_pattern(): void {
-		$post_types = get_post_types_by_support( 'gatherpress-event-date' );
+		$post_types = get_post_types_by_support( Event::SUPPORT );
 
 		if ( empty( $post_types ) ) {
 			return;
@@ -412,7 +413,7 @@ final class Setup {
 		// event-date support.
 		if ( ! is_post_type_archive()
 			|| ! is_string( $post_type )
-			|| ! post_type_supports( $post_type, 'gatherpress-event-date' )
+			|| ! post_type_supports( $post_type, Event::SUPPORT )
 		) {
 			return;
 		}
@@ -604,7 +605,7 @@ final class Setup {
 	 * @return void
 	 */
 	public function check_waiting_list( int $post_id ): void {
-		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT ) ) {
 			return;
 		}
 
@@ -628,7 +629,7 @@ final class Setup {
 	public function delete_event( int $post_id ): void {
 		global $wpdb;
 
-		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), Event::SUPPORT ) ) {
 			return;
 		}
 
@@ -672,7 +673,7 @@ final class Setup {
 		// get_the_ID() returns false when there is no post in the loop to date.
 		if (
 			false === $post_id
-			|| ! post_type_supports( (string) $post_type, 'gatherpress-event-date' )
+			|| ! post_type_supports( (string) $post_type, Event::SUPPORT )
 			|| 1 !== intval( $use_event_date )
 		) {
 			return $the_date;
@@ -714,7 +715,7 @@ final class Setup {
 		// Bail when there's no post, when the post type doesn't carry event-date
 		// support, or when the "use event date" setting isn't enabled.
 		if ( ! $post_id
-			|| ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' )
+			|| ! post_type_supports( (string) get_post_type( $post_id ), Event::SUPPORT )
 			|| 1 !== intval( $use_event_date )
 		) {
 			return $block_content;
@@ -798,7 +799,7 @@ final class Setup {
 	 * @return void
 	 */
 	public function set_datetimes( int $post_id ): void {
-		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), Event::SUPPORT ) ) {
 			return;
 		}
 
@@ -867,7 +868,7 @@ final class Setup {
 		foreach ( array_keys( $pending ) as $post_id ) {
 			// The post can be gone by shutdown -- a duplicate that failed, or
 			// an insert rolled back after this hook ran.
-			if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-event-date' ) ) {
+			if ( ! post_type_supports( (string) get_post_type( $post_id ), Event::SUPPORT ) ) {
 				continue;
 			}
 

--- a/includes/core/classes/rsvp/class-list-table.php
+++ b/includes/core/classes/rsvp/class-list-table.php
@@ -186,7 +186,7 @@ final class List_Table extends WP_List_Table {
 			'<div class="alignleft actions gatherpress-rsvp-filters"' .
 			' data-post-types="%1$s" data-post-id="%2$s" data-label="%3$s"' .
 			' data-statuses="%4$s" data-selected="%5$s">%6$s%7$s%8$s</div>',
-			esc_attr( implode( ',', get_post_types_by_support( 'gatherpress-event-date' ) ) ),
+			esc_attr( implode( ',', get_post_types_by_support( Event::SUPPORT ) ) ),
 			absint( $post_id ),
 			esc_attr__( 'Filter by event', 'gatherpress' ),
 			esc_attr( (string) wp_json_encode( $statuses ) ),

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -14,6 +14,7 @@ namespace GatherPress\Core\Rsvp;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Traits\Singleton;
 use WP_Comment;
 use WP_Comment_Query;
@@ -126,7 +127,7 @@ final class Query {
 		// Default to every RSVP-supporting post type; callers may narrow
 		// this down, like the per-post-type RSVPs admin pages do (#1849).
 		if ( empty( $args['post_type'] ) ) {
-			$args['post_type'] = array_values( get_post_types_by_support( 'gatherpress-rsvp' ) );
+			$args['post_type'] = array_values( get_post_types_by_support( Rsvp::SUPPORT ) );
 		}
 
 		remove_action( 'pre_get_comments', array( $this, 'exclude_rsvp_from_comment_query' ) );

--- a/includes/core/classes/rsvp/class-rsvp.php
+++ b/includes/core/classes/rsvp/class-rsvp.php
@@ -85,6 +85,14 @@ final class Rsvp {
 	public const COMMENT_TYPE = 'gatherpress_rsvp';
 
 	/**
+	 * Post type support that lets a post type take RSVPs.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	public const SUPPORT = 'gatherpress-rsvp';
+
+	/**
 	 * Comment meta key flagging a response as anonymous.
 	 *
 	 * @since 0.35.1
@@ -233,7 +241,7 @@ final class Rsvp {
 			return;
 		}
 
-		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), self::SUPPORT ) ) {
 			return;
 		}
 
@@ -433,7 +441,7 @@ final class Rsvp {
 
 		if (
 			'disabled' === $rsvp_mode
-			|| ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' )
+			|| ! post_type_supports( (string) get_post_type( $post_id ), self::SUPPORT )
 		) {
 			return false;
 		}

--- a/includes/core/classes/rsvp/class-setup.php
+++ b/includes/core/classes/rsvp/class-setup.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Assets;
 use GatherPress\Core\Event;
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp\Response\Provider\Base as Provider;
 use GatherPress\Core\Rsvp\Response\Provider_Registry;
 use GatherPress\Core\Rsvp\Response\Status;
@@ -191,8 +192,8 @@ final class Setup {
 			return;
 		}
 
-		foreach ( get_post_types_by_support( 'gatherpress-rsvp' ) as $post_type ) {
-			remove_post_type_support( $post_type, 'gatherpress-rsvp' );
+		foreach ( get_post_types_by_support( Rsvp::SUPPORT ) as $post_type ) {
+			remove_post_type_support( $post_type, Rsvp::SUPPORT );
 		}
 	}
 
@@ -276,7 +277,7 @@ final class Setup {
 	 * @return int Adjusted number of comments.
 	 */
 	public function adjust_comments_number( int $comments_number, int $post_id ): int {
-		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT ) ) {
 			return $comments_number;
 		}
 
@@ -298,7 +299,7 @@ final class Setup {
 	 * @return void
 	 */
 	public function maybe_process_waiting_list( int $post_id ): void {
-		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT ) ) {
 			return;
 		}
 
@@ -318,7 +319,7 @@ final class Setup {
 	 */
 	public function maybe_set_rsvp_meta_default( int $post_id ): void {
 		// Skip non-event post types early to avoid an unnecessary Rsvp instantiation.
-		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-rsvp' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT ) ) {
 			return;
 		}
 
@@ -348,7 +349,7 @@ final class Setup {
 		// When no post type declares `gatherpress-rsvp` support — e.g. a
 		// companion plugin removed it from the event post type — the loop
 		// simply adds nothing (#1849).
-		foreach ( get_post_types_by_support( 'gatherpress-rsvp' ) as $post_type ) {
+		foreach ( get_post_types_by_support( Rsvp::SUPPORT ) as $post_type ) {
 			$hook = add_submenu_page(
 				sprintf( 'edit.php?post_type=%s', $post_type ),
 				__( 'RSVPs', 'gatherpress' ),
@@ -387,7 +388,7 @@ final class Setup {
 		// Fall back to the event post type when the screen doesn't carry a
 		// supporting post type (defensive; the submenu is only registered
 		// for supporting post types).
-		if ( ! post_type_supports( $screen_post_type, 'gatherpress-rsvp' ) ) {
+		if ( ! post_type_supports( $screen_post_type, Rsvp::SUPPORT ) ) {
 			$screen_post_type = Event::POST_TYPE;
 		}
 
@@ -592,7 +593,7 @@ final class Setup {
 
 			// Each RSVP-supporting post type has its own RSVPs page, so
 			// highlight whichever post type menu the page lives under (#1849).
-			$post_type = ( ! empty( $typenow ) && post_type_supports( $typenow, 'gatherpress-rsvp' ) )
+			$post_type = ( ! empty( $typenow ) && post_type_supports( $typenow, Rsvp::SUPPORT ) )
 				? $typenow
 				: Event::POST_TYPE;
 

--- a/includes/core/classes/rsvp/class-token.php
+++ b/includes/core/classes/rsvp/class-token.php
@@ -12,6 +12,7 @@
 
 namespace GatherPress\Core\Rsvp;
 
+use GatherPress\Core\Rsvp;
 use GatherPress\Core\Utility;
 use WP_Comment;
 use WP_Post;
@@ -282,7 +283,7 @@ final class Token {
 
 		$post = get_post( (int) $comment->comment_post_ID );
 
-		if ( ! $post || ! post_type_supports( (string) get_post_type( $post ), 'gatherpress-rsvp' ) ) {
+		if ( ! $post || ! post_type_supports( (string) get_post_type( $post ), Rsvp::SUPPORT ) ) {
 			return null;
 		}
 

--- a/includes/core/classes/venue/class-admin-list.php
+++ b/includes/core/classes/venue/class-admin-list.php
@@ -12,6 +12,7 @@ namespace GatherPress\Core\Venue;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Venue;
 
 /**
  * Class Admin_List.
@@ -54,7 +55,7 @@ final class Admin_List {
 	 * @return void
 	 */
 	public function maybe_register_post_type_hooks( string $post_type ): void {
-		if ( ! post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
+		if ( ! post_type_supports( $post_type, Venue::SUPPORT ) ) {
 			return;
 		}
 

--- a/includes/core/classes/venue/class-meta.php
+++ b/includes/core/classes/venue/class-meta.php
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Validate;
+use GatherPress\Core\Venue;
 use GatherPress\Core\Venue\Map;
 use stdClass;
 use WP_REST_Request;
@@ -156,7 +157,7 @@ final class Meta {
 	 * @return void
 	 */
 	public function register( string $post_type ): void {
-		if ( post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
+		if ( post_type_supports( $post_type, Venue::SUPPORT ) ) {
 			$this->register_venue_information_meta( $post_type );
 		}
 

--- a/includes/core/classes/venue/class-setup.php
+++ b/includes/core/classes/venue/class-setup.php
@@ -25,6 +25,7 @@ use GatherPress\Core\Shadow_Source;
 use GatherPress\Core\Starter_Pattern_Loader;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
+use GatherPress\Core\Venue;
 use GatherPress\Core\Venue\Map\Setup as Map_Setup;
 use stdClass;
 use WP_Block_Patterns_Registry;
@@ -135,11 +136,11 @@ final class Setup {
 	 * @return void
 	 */
 	public function maybe_link_shadow_source_support( string $post_type ): void {
-		if ( ! post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
+		if ( ! post_type_supports( $post_type, Venue::SUPPORT ) ) {
 			return;
 		}
 
-		add_post_type_support( $post_type, 'gatherpress-shadow-source' );
+		add_post_type_support( $post_type, Shadow_Source::SUPPORT );
 	}
 
 	/**
@@ -244,9 +245,9 @@ final class Setup {
 					'thumbnail',
 					'revisions',
 					'custom-fields',
-					'gatherpress-venue-information',
+					Venue::SUPPORT,
 					'gatherpress-venue-map',
-					'gatherpress-shadow-source',
+					Shadow_Source::SUPPORT,
 				),
 				'menu_icon'    => 'dashicons-location',
 				'has_archive'  => true,
@@ -296,7 +297,7 @@ final class Setup {
 	 * @return string[] The augmented list of event CPTs.
 	 */
 	public function attach_venue_taxonomy_to_event_types( array $object_types, string $source_post_type ): array {
-		foreach ( get_post_types_by_support( 'gatherpress-venue' ) as $event_post_type ) {
+		foreach ( get_post_types_by_support( Venue::ASSIGNMENT_SUPPORT ) as $event_post_type ) {
 			if ( $this->get_venue_post_type( $event_post_type ) === $source_post_type ) {
 				$object_types[] = $event_post_type;
 			}
@@ -327,7 +328,7 @@ final class Setup {
 	 * @return void
 	 */
 	public function register_starter_pattern(): void {
-		$post_types = get_post_types_by_support( 'gatherpress-venue-information' );
+		$post_types = get_post_types_by_support( Venue::SUPPORT );
 
 		if ( empty( $post_types ) ) {
 			return;
@@ -484,7 +485,7 @@ final class Setup {
 
 		$venue = null;
 
-		if ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
+		if ( post_type_supports( $post_type, Venue::ASSIGNMENT_SUPPORT ) ) {
 			$event       = new Event( $post_id );
 			$venue_terms = get_the_terms( $post_id, $this->taxonomy_for_event_post_type( $post_type ) );
 			$venue_slug  = ( is_array( $venue_terms ) && ! empty( $venue_terms ) ) ? $venue_terms[0]->slug : null;
@@ -497,7 +498,7 @@ final class Setup {
 			if ( $venue_post instanceof WP_Post ) {
 				$venue = new Venue( $venue_post->ID );
 			}
-		} elseif ( post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
+		} elseif ( post_type_supports( $post_type, Venue::SUPPORT ) ) {
 			$venue = new Venue( $post_id );
 		}
 
@@ -702,7 +703,7 @@ final class Setup {
 	public function get_venue_post_type_map(): array {
 		$map = array();
 
-		foreach ( get_post_types_by_support( 'gatherpress-venue' ) as $event_post_type ) {
+		foreach ( get_post_types_by_support( Venue::ASSIGNMENT_SUPPORT ) as $event_post_type ) {
 			$map[ $event_post_type ] = $this->get_venue_post_type( $event_post_type );
 		}
 

--- a/includes/core/classes/venue/class-venue.php
+++ b/includes/core/classes/venue/class-venue.php
@@ -49,6 +49,34 @@ final class Venue {
 	const TAXONOMY = '_gatherpress_venue';
 
 	/**
+	 * Post type support that makes a post type a venue.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	const SUPPORT = 'gatherpress-venue-information';
+
+	/**
+	 * Post type support that lets a post type be assigned a venue.
+	 *
+	 * Any post type can declare it; it is what binds `TAXONOMY` to that type.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	const ASSIGNMENT_SUPPORT = 'gatherpress-venue';
+
+	/**
+	 * Post type support for a post type whose venue may be online.
+	 *
+	 * A post records it with the `online-event` term in `TAXONOMY`.
+	 *
+	 * @since 0.36.0
+	 * @var string
+	 */
+	const ONLINE_SUPPORT = 'gatherpress-online-event';
+
+	/**
 	 * Venue post object.
 	 *
 	 * Null when the post_id passed to the constructor does not resolve to a
@@ -72,7 +100,7 @@ final class Venue {
 	 * @param int $post_id The venue post ID.
 	 */
 	public function __construct( int $post_id ) {
-		if ( post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-venue-information' ) ) {
+		if ( post_type_supports( (string) get_post_type( $post_id ), self::SUPPORT ) ) {
 			$this->venue = get_post( $post_id );
 		}
 	}

--- a/includes/core/classes/venue/map/class-map.php
+++ b/includes/core/classes/venue/map/class-map.php
@@ -458,7 +458,7 @@ final class Map {
 	 * @return void
 	 */
 	public function maybe_register_delete_hook( string $post_type ): void {
-		if ( ! post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
+		if ( ! post_type_supports( $post_type, Venue::SUPPORT ) ) {
 			return;
 		}
 
@@ -487,7 +487,7 @@ final class Map {
 			return;
 		}
 
-		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-venue-information' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), Venue::SUPPORT ) ) {
 			return;
 		}
 
@@ -686,7 +686,7 @@ final class Map {
 			return;
 		}
 
-		if ( ! post_type_supports( (string) get_post_type( $post_id ), 'gatherpress-venue-information' ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), Venue::SUPPORT ) ) {
 			return;
 		}
 
@@ -900,9 +900,9 @@ final class Map {
 	): ?array {
 		$venue_post_id = 0;
 
-		if ( post_type_supports( $post_type, 'gatherpress-venue-information' ) ) {
+		if ( post_type_supports( $post_type, Venue::SUPPORT ) ) {
 			$venue_post_id = $post_id;
-		} elseif ( post_type_supports( $post_type, 'gatherpress-venue' ) ) {
+		} elseif ( post_type_supports( $post_type, Venue::ASSIGNMENT_SUPPORT ) ) {
 			$venue_post = Setup::get_instance()->get_venue_post_from_event_post_id( $post_id );
 
 			if ( $venue_post instanceof WP_Post ) {

--- a/includes/core/classes/venue/map/class-prewarm.php
+++ b/includes/core/classes/venue/map/class-prewarm.php
@@ -29,6 +29,7 @@ namespace GatherPress\Core\Venue\Map;
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
 use GatherPress\Core\Traits\Singleton;
+use GatherPress\Core\Venue;
 use GatherPress\Core\Venue\Setup as Venue_Setup;
 use WP_Post;
 
@@ -231,9 +232,9 @@ final class Prewarm {
 
 		if ( in_array( $post->post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
 			$this->enqueue_for_all_venues( $this->collect_combos_from_content( $post->post_content ) );
-		} elseif ( post_type_supports( $post->post_type, 'gatherpress-venue-information' ) ) {
+		} elseif ( post_type_supports( $post->post_type, Venue::SUPPORT ) ) {
 			$this->enqueue_for_venue( $post_id );
-		} elseif ( post_type_supports( $post->post_type, 'gatherpress-venue' ) ) {
+		} elseif ( post_type_supports( $post->post_type, Venue::ASSIGNMENT_SUPPORT ) ) {
 			// Event post types (or any post type that carries venue-map inside
 			// a gatherpress/venue parent). Collect combos from the post's own
 			// content, but enqueue those combos against the associated venue,
@@ -310,7 +311,7 @@ final class Prewarm {
 			return;
 		}
 
-		$types = get_post_types_by_support( 'gatherpress-venue-information' );
+		$types = get_post_types_by_support( Venue::SUPPORT );
 		if ( empty( $types ) ) {
 			return;
 		}
@@ -436,7 +437,7 @@ final class Prewarm {
 	 */
 	protected function collect_all_template_combos(): array {
 		$combos               = $this->collect_combos_from_block_templates();
-		$venue_carrying_types = get_post_types_by_support( 'gatherpress-venue' );
+		$venue_carrying_types = get_post_types_by_support( Venue::ASSIGNMENT_SUPPORT );
 
 		if ( ! empty( $venue_carrying_types ) ) {
 			$combos = array_merge( $combos, $this->collect_combos_from_venue_posts( $venue_carrying_types ) );
@@ -652,7 +653,7 @@ final class Prewarm {
 	 * @return int[]
 	 */
 	protected function get_venue_post_ids(): array {
-		$types = get_post_types_by_support( 'gatherpress-venue-information' );
+		$types = get_post_types_by_support( Venue::SUPPORT );
 		if ( empty( $types ) ) {
 			return array();
 		}

--- a/includes/core/classes/venue/map/class-rest-api.php
+++ b/includes/core/classes/venue/map/class-rest-api.php
@@ -109,7 +109,7 @@ final class Rest_Api {
 				return $post_id > 0
 					&& post_type_supports(
 						(string) get_post_type( $post_id ),
-						'gatherpress-venue-information'
+						Venue::SUPPORT
 					);
 			},
 		);

--- a/test/unit/php/includes/tests/core/classes/class-test-shadow-source.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-shadow-source.php
@@ -65,6 +65,15 @@ class Test_Shadow_Source extends Base {
 	}
 
 	/**
+	 * Asserts that the class constants are correctly defined.
+	 *
+	 * @return void
+	 */
+	public function test_constants(): void {
+		$this->assertSame( 'gatherpress-shadow-source', Shadow_Source::SUPPORT );
+	}
+
+	/**
 	 * Coverage for maybe_register_post_type_hooks — wires per-post-type
 	 * save and delete actions when the given post type declares
 	 * `gatherpress-shadow-source` support.

--- a/test/unit/php/includes/tests/core/classes/event/class-test-event.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-event.php
@@ -76,6 +76,15 @@ class Test_Event extends Base {
 	}
 
 	/**
+	 * Asserts that the class constants are correctly defined.
+	 *
+	 * @return void
+	 */
+	public function test_constants(): void {
+		$this->assertSame( 'gatherpress-event-date', Event::SUPPORT );
+	}
+
+	/**
 	 * Data provider for get_display_datetime test.
 	 *
 	 * @return array

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-rsvp.php
@@ -63,6 +63,15 @@ class Test_Rsvp extends Base {
 	}
 
 	/**
+	 * Asserts that the class constants are correctly defined.
+	 *
+	 * @return void
+	 */
+	public function test_constants(): void {
+		$this->assertSame( 'gatherpress-rsvp', Rsvp::SUPPORT );
+	}
+
+	/**
 	 * Coverage for get method.
 	 *
 	 * @covers ::get

--- a/test/unit/php/includes/tests/core/classes/venue/class-test-venue.php
+++ b/test/unit/php/includes/tests/core/classes/venue/class-test-venue.php
@@ -57,6 +57,17 @@ class Test_Venue extends Base {
 	}
 
 	/**
+	 * Asserts that the class constants are correctly defined.
+	 *
+	 * @return void
+	 */
+	public function test_constants(): void {
+		$this->assertSame( 'gatherpress-venue-information', Venue::SUPPORT );
+		$this->assertSame( 'gatherpress-venue', Venue::ASSIGNMENT_SUPPORT );
+		$this->assertSame( 'gatherpress-online-event', Venue::ONLINE_SUPPORT );
+	}
+
+	/**
 	 * Construct a Venue instance from a post ID and read it back.
 	 *
 	 * @covers ::__construct


### PR DESCRIPTION
Fixes #2244

## Proposed changes:

Defines class constants for the post type supports and replaces string literals across internal call sites:
* `Event::SUPPORT = 'gatherpress-event-date'`
* `Rsvp::SUPPORT = 'gatherpress-rsvp'`
* `Venue::SUPPORT = 'gatherpress-venue-information'`
* `Venue::ASSIGNMENT_SUPPORT = 'gatherpress-venue'`
* `Venue::ONLINE_SUPPORT = 'gatherpress-online-event'`
* `Shadow_Source::SUPPORT = 'gatherpress-shadow-source'`

Replaces literal occurrences across core classes, blocks, event, RSVP, and venue subsystems.
Adds unit tests asserting the constant values in `Test_Event`, `Test_Rsvp`, `Test_Venue`, and `Test_Shadow_Source`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

All tests pass, PHPCS, PHPMD, and PHPStan clean.

## Testing instructions:

1. Run unit test suite: `composer test` or verify CI tests.
2. Run linters: `npm run lint:php`, `npm run lint:phpstan`, `composer run test:phpmd`.
3. Verify that events, venues, and RSVPs continue to function as expected without regressions.

### Credit (for release notes)

My WordPress.org username: motylanogha