### PR TITLE
Add screen-reader warning to links that open in a new tab (#2141)

### DIFF
--- a/.github/changelog/2141-new-tab-screen-reader-warning
+++ b/.github/changelog/2141-new-tab-screen-reader-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add screen-reader warning to links that open in a new tab.

--- a/src/blocks/add-to-calendar/template.js
+++ b/src/blocks/add-to-calendar/template.js
@@ -40,7 +40,7 @@ const TEMPLATE = [
 					[
 						'gatherpress/dropdown-item',
 						{
-							text: `<a href="#gatherpress-google-calendar" rel="noreferrer noopener nofollow" target="_blank">${ __( 'Google Calendar', 'gatherpress' ) }</a>`,
+							text: `<a href="#gatherpress-google-calendar" rel="noreferrer noopener nofollow" target="_blank">${ __( 'Google Calendar', 'gatherpress' ) }<span class="screen-reader-text"> ${ __( '(opens in a new tab)', 'gatherpress' ) }</span></a>`,
 							metadata: {
 								name: __( 'Google Calendar', 'gatherpress' ),
 							},
@@ -67,7 +67,7 @@ const TEMPLATE = [
 					[
 						'gatherpress/dropdown-item',
 						{
-							text: `<a href="#gatherpress-yahoo-calendar" rel="noreferrer noopener nofollow" target="_blank">${ __( 'Yahoo Calendar', 'gatherpress' ) }</a>`,
+							text: `<a href="#gatherpress-yahoo-calendar" rel="noreferrer noopener nofollow" target="_blank">${ __( 'Yahoo Calendar', 'gatherpress' ) }<span class="screen-reader-text"> ${ __( '(opens in a new tab)', 'gatherpress' ) }</span></a>`,
 							metadata: {
 								name: __( 'Yahoo Calendar', 'gatherpress' ),
 							},

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -420,6 +420,10 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 								'Date/time formatting documentation',
 								'gatherpress'
 							) }
+							<span className="screen-reader-text">
+								{ ' ' }
+								{ __( '(opens in a new tab)', 'gatherpress' ) }
+							</span>
 						</a>
 					</p>
 					<ToggleControl

--- a/src/blocks/form-field/edit.js
+++ b/src/blocks/form-field/edit.js
@@ -389,6 +389,13 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 										rel="noopener noreferrer"
 									>
 										{ __( 'Learn more', 'gatherpress' ) }
+										<span className="screen-reader-text">
+											{ ' ' }
+											{ __(
+												'(opens in a new tab)',
+												'gatherpress'
+											) }
+										</span>
 									</a>
 								</>
 							}

--- a/src/blocks/online-event-link/render.php
+++ b/src/blocks/online-event-link/render.php
@@ -50,6 +50,9 @@ $gatherpress_context_json = wp_json_encode(
 	array(
 		'postId'   => $gatherpress_current_post_id,
 		'linkText' => $gatherpress_link_text,
+		'i18n'     => array(
+			'opensInNewTab' => __( '(opens in a new tab)', 'gatherpress' ),
+		),
 	),
 	JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 );
@@ -63,6 +66,7 @@ $gatherpress_context_json = wp_json_encode(
 	<?php if ( $gatherpress_has_link ) : ?>
 		<a class="gatherpress-online-event__text" href="<?php echo esc_url( $gatherpress_online_event_link ); ?>" target="_blank" rel="noopener noreferrer">
 			<?php echo wp_kses_post( $gatherpress_link_text ); ?>
+			<span class="screen-reader-text"> <?php esc_html_e( '(opens in a new tab)', 'gatherpress' ); ?></span>
 		</a>
 	<?php else : ?>
 		<span class="gatherpress-online-event__text">

--- a/src/blocks/online-event-link/view.js
+++ b/src/blocks/online-event-link/view.js
@@ -69,11 +69,25 @@ const { state } = store( 'gatherpress', {
 				linkElement.target = '_blank';
 				linkElement.rel = 'noopener noreferrer';
 				linkElement.innerHTML = currentHTML;
+
+				// Append screen-reader warning if not already present in currentHTML.
+				if ( ! linkElement.querySelector( '.screen-reader-text' ) ) {
+					const warningText = context?.i18n?.opensInNewTab || '(opens in a new tab)';
+					const srSpan = document.createElement( 'span' );
+					srSpan.className = 'screen-reader-text';
+					srSpan.textContent = ` ${ warningText }`;
+					linkElement.appendChild( srSpan );
+				}
+
 				currentElement.replaceWith( linkElement );
 			} else if ( ! hasLink && isLink ) {
 				const spanElement = document.createElement( 'span' );
 				spanElement.className = 'gatherpress-online-event__text';
 				spanElement.innerHTML = currentHTML;
+
+				// Remove screen-reader warning since the element is now static text.
+				spanElement.querySelectorAll( '.screen-reader-text' ).forEach( ( el ) => el.remove() );
+
 				currentElement.replaceWith( spanElement );
 			} else if ( hasLink && isLink && currentElement.href !== onlineEventLink ) {
 				currentElement.href = onlineEventLink;

--- a/src/blocks/venue-detail/render.php
+++ b/src/blocks/venue-detail/render.php
@@ -71,13 +71,17 @@ switch ( $gatherpress_field_type ) {
 		}
 
 		$gatherpress_target_attr = '_blank' === $gatherpress_link_target ? ' target="_blank" rel="noopener noreferrer"' : '';
+		$gatherpress_sr_warning  = '_blank' === $gatherpress_link_target
+			? sprintf( '<span class="screen-reader-text"> %s</span>', esc_html__( '(opens in a new tab)', 'gatherpress' ) )
+			: '';
 
 		printf(
-			'<div %s><a class="gatherpress-venue-detail__url" href="%s"%s>%s</a></div>',
+			'<div %s><a class="gatherpress-venue-detail__url" href="%s"%s>%s%s</a></div>',
 			$gatherpress_wrapper_attributes, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			esc_url( $gatherpress_value ),
 			$gatherpress_target_attr, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			esc_html( $gatherpress_display_url )
+			esc_html( $gatherpress_display_url ),
+			$gatherpress_sr_warning // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		);
 		break;
 

--- a/src/blocks/venue-map/render.php
+++ b/src/blocks/venue-map/render.php
@@ -269,6 +269,9 @@ if ( '' !== $gatherpress_static_map_url ) {
 	}
 
 	if ( '' !== $gatherpress_href ) {
+		if ( '_blank' === $gatherpress_target ) {
+			printf( '<span class="screen-reader-text"> %s</span>', esc_html__( '(opens in a new tab)', 'gatherpress' ) );
+		}
 		echo '</a>';
 	}
 

--- a/test/unit/js/src/blocks/online-event-link/view.test.js
+++ b/test/unit/js/src/blocks/online-event-link/view.test.js
@@ -1,0 +1,215 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => {
+		const registries = {};
+
+		return {
+			store: ( name, config = {} ) => {
+				if ( ! registries[ name ] ) {
+					registries[ name ] = { state: { posts: {} }, actions: {}, callbacks: {} };
+				}
+
+				const registry = registries[ name ];
+
+				Object.assign( registry.state, config.state );
+				Object.assign( registry.actions, config.actions );
+				Object.assign( registry.callbacks, config.callbacks );
+
+				return registry;
+			},
+			getElement: jest.fn(),
+			getContext: jest.fn(),
+		};
+	},
+	{ virtual: true }
+);
+
+jest.mock(
+	'@src/helpers/interactivity',
+	() => ( {
+		initPostContext: jest.fn( ( state, postId ) => {
+			state.posts = state.posts ?? {};
+			if ( postId && ! state.posts[ postId ] ) {
+				state.posts[ postId ] = {};
+			}
+		} ),
+	} )
+);
+
+/**
+ * WordPress dependencies
+ */
+import { store, getElement, getContext } from '@wordpress/interactivity';
+
+/**
+ * Internal dependencies
+ */
+import '@src/blocks/online-event-link/view';
+
+describe( 'online-event-link updateOnlineEventLink', () => {
+	let callbacks;
+	let registry;
+	let container;
+
+	beforeEach( () => {
+		registry = store( 'gatherpress' );
+		registry.state.posts = {};
+		callbacks = registry.callbacks;
+
+		container = document.createElement( 'div' );
+		getElement.mockReturnValue( { ref: container } );
+		getContext.mockReturnValue( {
+			postId: 42,
+			i18n: { opensInNewTab: '(opens in a new tab)' },
+		} );
+	} );
+
+	it( 'returns early when postId is missing', () => {
+		getContext.mockReturnValue( {} );
+		callbacks.updateOnlineEventLink();
+		expect( registry.state.posts[ 42 ] ).toBeUndefined();
+	} );
+
+	it( 'returns early when currentElement is not found', () => {
+		callbacks.updateOnlineEventLink();
+		expect( registry.state.posts[ 42 ] ).toBeDefined();
+	} );
+
+	it( 'initializes state from DOM on first run and leaves DOM unchanged', () => {
+		const span = document.createElement( 'span' );
+		span.className = 'gatherpress-online-event__text';
+		span.textContent = 'Event Link Placeholder';
+		container.appendChild( span );
+
+		callbacks.updateOnlineEventLink();
+
+		expect( registry.state.posts[ 42 ].onlineEventLink ).toBe( '' );
+		expect( container.querySelector( 'span.gatherpress-online-event__text' ) ).toBe( span );
+		expect( container.querySelector( 'a' ) ).toBeNull();
+	} );
+
+	it( 'initializes state with href on first run when element is already a link', () => {
+		const link = document.createElement( 'a' );
+		link.className = 'gatherpress-online-event__text';
+		link.href = 'https://example.com/stream';
+		link.textContent = 'Watch Stream';
+		container.appendChild( link );
+
+		callbacks.updateOnlineEventLink();
+
+		expect( registry.state.posts[ 42 ].onlineEventLink ).toBe( 'https://example.com/stream' );
+		expect( container.querySelector( 'a.gatherpress-online-event__text' ) ).toBe( link );
+	} );
+
+	it( 'swaps span to anchor with screen-reader text when onlineEventLink is provided', () => {
+		const span = document.createElement( 'span' );
+		span.className = 'gatherpress-online-event__text';
+		span.textContent = 'Join Meeting';
+		container.appendChild( span );
+
+		// Simulate first run.
+		callbacks.updateOnlineEventLink();
+
+		// Now simulate state change from RSVP response.
+		registry.state.posts[ 42 ].onlineEventLink = 'https://meet.example.com/room1';
+		callbacks.updateOnlineEventLink();
+
+		const link = container.querySelector( 'a.gatherpress-online-event__text' );
+		expect( link ).not.toBeNull();
+		expect( link.href ).toBe( 'https://meet.example.com/room1' );
+		expect( link.target ).toBe( '_blank' );
+		expect( link.rel ).toBe( 'noopener noreferrer' );
+
+		const srText = link.querySelector( '.screen-reader-text' );
+		expect( srText ).not.toBeNull();
+		expect( srText.textContent ).toBe( ' (opens in a new tab)' );
+	} );
+
+	it( 'does not duplicate screen-reader-text if already present in inner HTML', () => {
+		const span = document.createElement( 'span' );
+		span.className = 'gatherpress-online-event__text';
+		span.innerHTML = 'Join Meeting<span class="screen-reader-text"> (opens in a new tab)</span>';
+		container.appendChild( span );
+
+		callbacks.updateOnlineEventLink();
+
+		registry.state.posts[ 42 ].onlineEventLink = 'https://meet.example.com/room1';
+		callbacks.updateOnlineEventLink();
+
+		const link = container.querySelector( 'a.gatherpress-online-event__text' );
+		const srSpans = link.querySelectorAll( '.screen-reader-text' );
+		expect( srSpans ).toHaveLength( 1 );
+	} );
+
+	it( 'swaps anchor back to span and strips screen-reader text when onlineEventLink becomes empty', () => {
+		const link = document.createElement( 'a' );
+		link.className = 'gatherpress-online-event__text';
+		link.href = 'https://meet.example.com/room1';
+		link.innerHTML = 'Join Meeting<span class="screen-reader-text"> (opens in a new tab)</span>';
+		container.appendChild( link );
+
+		callbacks.updateOnlineEventLink();
+
+		// State becomes empty (e.g. user cancelled RSVP).
+		registry.state.posts[ 42 ].onlineEventLink = '';
+		callbacks.updateOnlineEventLink();
+
+		const span = container.querySelector( 'span.gatherpress-online-event__text' );
+		expect( span ).not.toBeNull();
+		expect( span.querySelector( '.screen-reader-text' ) ).toBeNull();
+		expect( span.textContent.trim() ).toBe( 'Join Meeting' );
+	} );
+
+	it( 'uses default fallback text if context.i18n.opensInNewTab is not defined', () => {
+		getContext.mockReturnValue( { postId: 42 } );
+		const span = document.createElement( 'span' );
+		span.className = 'gatherpress-online-event__text';
+		span.textContent = 'Join Meeting';
+		container.appendChild( span );
+
+		callbacks.updateOnlineEventLink();
+
+		registry.state.posts[ 42 ].onlineEventLink = 'https://meet.example.com/room1';
+		callbacks.updateOnlineEventLink();
+
+		const link = container.querySelector( 'a.gatherpress-online-event__text' );
+		const srText = link.querySelector( '.screen-reader-text' );
+		expect( srText.textContent ).toBe( ' (opens in a new tab)' );
+	} );
+
+	it( 'leaves anchor untouched when onlineEventLink matches current href', () => {
+		const link = document.createElement( 'a' );
+		link.className = 'gatherpress-online-event__text';
+		link.href = 'https://meet.example.com/room1';
+		link.textContent = 'Join Meeting';
+		container.appendChild( link );
+
+		callbacks.updateOnlineEventLink();
+
+		// onlineEventLink matches existing href
+		registry.state.posts[ 42 ].onlineEventLink = 'https://meet.example.com/room1';
+		callbacks.updateOnlineEventLink();
+
+		expect( link.href ).toBe( 'https://meet.example.com/room1' );
+	} );
+
+	it( 'updates anchor href when onlineEventLink URL changes', () => {
+		const link = document.createElement( 'a' );
+		link.className = 'gatherpress-online-event__text';
+		link.href = 'https://meet.example.com/room1';
+		link.textContent = 'Join Meeting';
+		container.appendChild( link );
+
+		callbacks.updateOnlineEventLink();
+
+		registry.state.posts[ 42 ].onlineEventLink = 'https://meet.example.com/room2';
+		callbacks.updateOnlineEventLink();
+
+		expect( link.href ).toBe( 'https://meet.example.com/room2' );
+	} );
+} );


### PR DESCRIPTION
Fixes #2141.

## Proposed changes:
Adds an accessible `(opens in a new tab)` screen-reader notice (`<span class="screen-reader-text">`) to all links that open in a new tab (`target="_blank"`), addressing WCAG 3.2.5 (technique G201) so assistive technologies warn users of context changes:

1. **Online event link (`src/blocks/online-event-link/render.php` and `view.js`)**:
   - Emits `<span class="screen-reader-text"> (opens in a new tab)</span>` inside the anchor when the link is rendered on the server.
   - Passes localized string via context JSON to Interactivity API state.
   - When dynamically toggling between `<span>` and `<a>` on the client in `view.js`, injects or strips the `.screen-reader-text` span accordingly.
2. **Add to calendar (`src/blocks/add-to-calendar/template.js`)**:
   - Adds screen-reader text to the Google Calendar and Yahoo Calendar dropdown link templates.
3. **Venue website links (`src/blocks/venue-detail/render.php` and `src/blocks/venue-map/render.php`)**:
   - When configured to open in a new tab (`_blank`), appends screen-reader warning to the anchor.
4. **Editor links (`src/blocks/event-date/edit.js` and `src/blocks/form-field/edit.js`)**:
   - Adds screen-reader text to external documentation links that open in a new tab in the editor inspector.

### Other information:
- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
1. Create or edit an event with an Online Event link and Add to Calendar block.
2. Inspect the rendered links on frontend: confirm `<span class="screen-reader-text"> (opens in a new tab)</span>` is present inside `<a target="_blank">` elements and visually hidden.
3. In Venue details / Venue map, set target to open in a new tab: confirm screen-reader text is included.
4. In Event Date and Form Field inspector panels, inspect the external links: confirm screen-reader text is present.
5. Verify with a screen reader that "(opens in a new tab)" is announced after link text.

### Verification:
- `npm run test:unit:js`: 65 passed suites, 1146/1146 tests passed (including 100% coverage on new `online-event-link/view.test.js`).
- `npm run lint:js`: 0 errors, 0 warnings.
- `npm run lint:php`: 0 errors, 0 warnings.
- `npm run lint:phpstan`: 0 errors.
- `npm run build`: Webpack production build compiles cleanly without errors.