### PR TITLE
Add configurable geocoding provider and map tile settings

### DIFF
--- a/.github/changelog/1267-osm-configuration
+++ b/.github/changelog/1267-osm-configuration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin settings for the geocoding service and map tile source: a configurable Photon-compatible geocoding API URL, a country-code filter for geocoding results, and a custom tile layer URL/attribution for self-hosted or third-party OpenStreetMap tiles.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,8 +38,17 @@ The settings screen is organized into tabs: **Events**, **Venues**, **RSVP**, **
 These settings choose the mapping platform and the defaults applied to newly added venue map blocks. Changing a default does not alter maps already placed in your content.
 
 - **Mapping Platform** selects **OpenStreetMap** (the default, no account needed) or **Google Maps**. Selecting Google Maps reveals a field for your Google Maps API key.
+- **Custom Tile Layer URL** and **Custom Attribution** point OpenStreetMap maps at a self-hosted or third-party XYZ tile server instead of the built-in CARTO tiles, and let you replace the credit line shown alongside the map. Leave both empty to use the defaults.
+- **CARTO API Key** is required for the default (unmodified) OpenStreetMap tiles; it's ignored once a custom tile layer URL is set.
 - **Default Render Mode** chooses between an interactive map and a static map image for new blocks.
 - **Default Zoom Level**, **Default Height**, **Default Width**, **Default Aspect Ratio**, and **Default Scale** set the initial appearance of new venue map blocks. Height and width can be left empty for automatic sizing derived from the aspect ratio.
+
+### Geocoding
+
+These settings control the address lookup service used for venue autocomplete and geocoding.
+
+- **Geocoding API URL** points at a Photon-API-compatible geocoding service — a self-hosted [Photon](https://photon.komoot.io/) instance or compatible drop-in. Leave empty to use the public Photon service.
+- **Country Code Filter** restricts geocoding results to a comma-separated list of ISO 3166-1 alpha-2 country codes (e.g. `us,ca`). Leave empty for no restriction.
 
 ### Venue permalink
 

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -15,6 +15,7 @@ namespace GatherPress\Core;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
 use GatherPress\Core\Venue\Meta as Venue_Meta;
@@ -119,6 +120,13 @@ final class Geocoding {
 	 * @since 0.34.0
 	 */
 	private const GEOCODE_CACHE_TTL = 15 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Number of Photon results requested when a country filter is active.
+	 *
+	 * @since 0.36.0
+	 */
+	private const COUNTRY_FILTER_SEARCH_LIMIT = 10;
 
 	/**
 	 * Cron action fired to backfill structured-address venue meta after a
@@ -682,9 +690,12 @@ final class Geocoding {
 			return $this->build_not_found_payload();
 		}
 
-		$language  = $this->get_language_code();
-		$cache_key = self::GEOCODE_CACHE_PREFIX . md5( $address . '|' . $language ); // NOSONAR.
-		$cached    = get_transient( $cache_key );
+		$language       = $this->get_language_code();
+		$country_filter = $this->get_country_filter();
+		// Keeps the unfiltered cache key's original shape.
+		$cache_suffix = array() === $country_filter ? '' : '|' . implode( ',', $country_filter );
+		$cache_key    = self::GEOCODE_CACHE_PREFIX . md5( $address . '|' . $language . $cache_suffix ); // NOSONAR.
+		$cached       = get_transient( $cache_key );
 
 		// Cached entry written before structured pieces existed lacks a
 		// `house_number` slot. Treat as miss and refetch so the cache
@@ -699,10 +710,11 @@ final class Geocoding {
 			return $cached;
 		}
 
+		// A country filter needs more candidates to pick from.
 		$url = add_query_arg(
 			array(
 				'q'     => $address,
-				'limit' => 1,
+				'limit' => array() === $country_filter ? 1 : self::COUNTRY_FILTER_SEARCH_LIMIT,
 				'lang'  => $language,
 			),
 			$this->get_photon_api_url()
@@ -745,8 +757,10 @@ final class Geocoding {
 
 		$this->maybe_log_json_decode_failure( $body, $data, 'geocode_address' );
 
-		if ( ! empty( $data['features'] ) && isset( $data['features'][0]['geometry']['coordinates'] ) ) {
-			$feature     = $data['features'][0];
+		$features = ( is_array( $data ) && is_array( $data['features'] ?? null ) ) ? $data['features'] : array();
+		$feature  = $this->select_geocode_feature( $features, $country_filter );
+
+		if ( null !== $feature ) {
 			$coordinates = $feature['geometry']['coordinates'];
 			$properties  = isset( $feature['properties'] ) && is_array( $feature['properties'] )
 				? $feature['properties']
@@ -771,6 +785,41 @@ final class Geocoding {
 		set_transient( $cache_key, $not_found, self::GEOCODE_CACHE_TTL );
 
 		return $not_found;
+	}
+
+	/**
+	 * Picks the first Photon feature with usable coordinates matching the country filter.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param array<int, mixed> $features       Decoded Photon `features` array.
+	 * @param string[]          $country_filter Lowercased country codes to restrict to; empty means unrestricted.
+	 *
+	 * @return array<string, mixed>|null The selected feature, or null when nothing qualifies.
+	 */
+	private function select_geocode_feature( array $features, array $country_filter ): ?array {
+		foreach ( $features as $feature ) {
+			if ( ! is_array( $feature ) || ! isset( $feature['geometry']['coordinates'] ) ) {
+				continue;
+			}
+
+			if ( array() === $country_filter ) {
+				return $feature;
+			}
+
+			$properties   = isset( $feature['properties'] ) && is_array( $feature['properties'] )
+				? $feature['properties']
+				: array();
+			$country_code = isset( $properties['countrycode'] ) && is_scalar( $properties['countrycode'] )
+				? strtolower( (string) $properties['countrycode'] )
+				: '';
+
+			if ( in_array( $country_code, $country_filter, true ) ) {
+				return $feature;
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -834,9 +883,12 @@ final class Geocoding {
 			);
 		}
 
-		$language  = $this->get_language_code();
-		$cache_key = self::SEARCH_CACHE_PREFIX . md5( $query . '|' . $language ); // NOSONAR.
-		$cached    = get_transient( $cache_key );
+		$language       = $this->get_language_code();
+		$country_filter = $this->get_country_filter();
+		// Keeps the unfiltered cache key's original shape.
+		$cache_suffix = array() === $country_filter ? '' : '|' . implode( ',', $country_filter );
+		$cache_key    = self::SEARCH_CACHE_PREFIX . md5( $query . '|' . $language . $cache_suffix ); // NOSONAR.
+		$cached       = get_transient( $cache_key );
 
 		if ( is_array( $cached ) ) {
 			return new WP_REST_Response(
@@ -847,10 +899,11 @@ final class Geocoding {
 			);
 		}
 
+		// A country filter needs more candidates to still fill 5 suggestions.
 		$url = add_query_arg(
 			array(
 				'q'     => $query,
-				'limit' => 5,
+				'limit' => array() === $country_filter ? 5 : self::COUNTRY_FILTER_SEARCH_LIMIT,
 				'lang'  => $language,
 			),
 			$this->get_photon_api_url()
@@ -893,7 +946,7 @@ final class Geocoding {
 
 		$this->maybe_log_json_decode_failure( $body, $data, 'search_addresses' );
 
-		return $this->build_search_suggestions_response( $data, $cache_key );
+		return $this->build_search_suggestions_response( $data, $cache_key, $country_filter );
 	}
 
 	/**
@@ -907,14 +960,20 @@ final class Geocoding {
 	 * and PHPMD-clean.
 	 *
 	 * @since 0.34.0
+	 * @since 0.36.0 Added `$country_filter`.
 	 *
-	 * @param mixed  $data      Decoded JSON body. Treated as "no results"
-	 *                          when not an array or missing `features`.
-	 * @param string $cache_key Transient key for the cached suggestions.
+	 * @param mixed    $data           Decoded JSON body. Treated as "no results"
+	 *                                 when not an array or missing `features`.
+	 * @param string   $cache_key      Transient key for the cached suggestions.
+	 * @param string[] $country_filter Lowercased country codes to restrict to; empty means unrestricted.
 	 *
 	 * @return WP_REST_Response The response with a `suggestions` array (possibly empty).
 	 */
-	private function build_search_suggestions_response( $data, string $cache_key ): WP_REST_Response {
+	private function build_search_suggestions_response(
+		$data,
+		string $cache_key,
+		array $country_filter = array()
+	): WP_REST_Response {
 		if ( ! is_array( $data ) || empty( $data['features'] ) || ! is_array( $data['features'] ) ) {
 			set_transient( $cache_key, array(), self::SEARCH_CACHE_TTL );
 
@@ -929,6 +988,10 @@ final class Geocoding {
 		$suggestions = array();
 
 		foreach ( $data['features'] as $feature ) {
+			if ( count( $suggestions ) >= 5 ) {
+				break;
+			}
+
 			if ( ! is_array( $feature ) ) {
 				continue;
 			}
@@ -941,6 +1004,14 @@ final class Geocoding {
 			$properties = isset( $feature['properties'] ) && is_array( $feature['properties'] )
 				? $feature['properties']
 				: array();
+
+			$country_code = isset( $properties['countrycode'] ) && is_scalar( $properties['countrycode'] )
+				? strtolower( (string) $properties['countrycode'] )
+				: '';
+
+			if ( array() !== $country_filter && ! in_array( $country_code, $country_filter, true ) ) {
+				continue;
+			}
 
 			$label = $this->format_photon_feature_label( $properties );
 
@@ -1246,11 +1317,19 @@ final class Geocoding {
 	/**
 	 * Photon API base URL (filterable for self-hosted instances).
 	 *
+	 * Layers the `geocoding_provider_url` setting under the filter.
+	 *
 	 * @since 0.34.0
+	 * @since 0.36.0 Layered under the `geocoding_provider_url` setting.
 	 *
 	 * @return string Base URL for Photon `/api` requests.
 	 */
 	private function get_photon_api_url(): string {
+		$configured = trim( (string) Settings::get_instance()->get( 'geocoding_provider_url' ) );
+		$default    = ( '' !== $configured && false !== wp_http_validate_url( $configured ) )
+			? $configured
+			: self::PHOTON_API_URL;
+
 		/**
 		 * Filters the Photon API base URL used for geocoding and address search.
 		 *
@@ -1258,7 +1337,7 @@ final class Geocoding {
 		 *
 		 * @param string $url Default Photon API URL (e.g. https://photon.komoot.io/api).
 		 */
-		$filtered = (string) apply_filters( 'gatherpress_photon_api_url', self::PHOTON_API_URL );
+		$filtered = (string) apply_filters( 'gatherpress_photon_api_url', $default );
 
 		// Fall back to the default when a filter produces an unusable URL; keeps
 		// outbound requests routed through wp_safe_remote_get against a real host.
@@ -1267,6 +1346,21 @@ final class Geocoding {
 		}
 
 		return $filtered;
+	}
+
+	/**
+	 * Country codes the `geocoding_country_filter` setting restricts results to.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return string[] Lowercased ISO 3166-1 alpha-2 codes; empty when unrestricted.
+	 */
+	private function get_country_filter(): array {
+		$raw = (string) Settings::get_instance()->get( 'geocoding_country_filter' );
+
+		$codes = array_filter( array_map( 'trim', explode( ',', strtolower( $raw ) ) ) );
+
+		return array_values( array_unique( $codes ) );
 	}
 
 	/**

--- a/includes/core/classes/class-geocoding.php
+++ b/includes/core/classes/class-geocoding.php
@@ -692,8 +692,9 @@ final class Geocoding {
 
 		$language       = $this->get_language_code();
 		$country_filter = $this->get_country_filter();
-		// Keeps the unfiltered cache key's original shape.
-		$cache_suffix = array() === $country_filter ? '' : '|' . implode( ',', $country_filter );
+		$provider_url   = $this->get_photon_api_url();
+		// Keeps the unfiltered/default-provider cache key's original shape.
+		$cache_suffix = $this->get_cache_key_suffix( $provider_url, $country_filter );
 		$cache_key    = self::GEOCODE_CACHE_PREFIX . md5( $address . '|' . $language . $cache_suffix ); // NOSONAR.
 		$cached       = get_transient( $cache_key );
 
@@ -717,7 +718,7 @@ final class Geocoding {
 				'limit' => array() === $country_filter ? 1 : self::COUNTRY_FILTER_SEARCH_LIMIT,
 				'lang'  => $language,
 			),
-			$this->get_photon_api_url()
+			$provider_url
 		);
 
 		$response = wp_safe_remote_get(
@@ -799,7 +800,7 @@ final class Geocoding {
 	 */
 	private function select_geocode_feature( array $features, array $country_filter ): ?array {
 		foreach ( $features as $feature ) {
-			if ( ! is_array( $feature ) || ! isset( $feature['geometry']['coordinates'] ) ) {
+			if ( ! is_array( $feature ) || ! $this->has_valid_coordinates( $feature ) ) {
 				continue;
 			}
 
@@ -820,6 +821,24 @@ final class Geocoding {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Whether a Photon feature has usable `[longitude, latitude]` coordinates.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param array<string, mixed> $feature Decoded Photon feature.
+	 *
+	 * @return bool
+	 */
+	private function has_valid_coordinates( array $feature ): bool {
+		$coordinates = $feature['geometry']['coordinates'] ?? null;
+
+		return is_array( $coordinates )
+			&& isset( $coordinates[0], $coordinates[1] )
+			&& is_numeric( $coordinates[0] )
+			&& is_numeric( $coordinates[1] );
 	}
 
 	/**
@@ -885,8 +904,9 @@ final class Geocoding {
 
 		$language       = $this->get_language_code();
 		$country_filter = $this->get_country_filter();
-		// Keeps the unfiltered cache key's original shape.
-		$cache_suffix = array() === $country_filter ? '' : '|' . implode( ',', $country_filter );
+		$provider_url   = $this->get_photon_api_url();
+		// Keeps the unfiltered/default-provider cache key's original shape.
+		$cache_suffix = $this->get_cache_key_suffix( $provider_url, $country_filter );
 		$cache_key    = self::SEARCH_CACHE_PREFIX . md5( $query . '|' . $language . $cache_suffix ); // NOSONAR.
 		$cached       = get_transient( $cache_key );
 
@@ -906,7 +926,7 @@ final class Geocoding {
 				'limit' => array() === $country_filter ? 5 : self::COUNTRY_FILTER_SEARCH_LIMIT,
 				'lang'  => $language,
 			),
-			$this->get_photon_api_url()
+			$provider_url
 		);
 
 		$response = wp_safe_remote_get(
@@ -992,14 +1012,11 @@ final class Geocoding {
 				break;
 			}
 
-			if ( ! is_array( $feature ) ) {
+			if ( ! is_array( $feature ) || ! $this->has_valid_coordinates( $feature ) ) {
 				continue;
 			}
 
-			$coords = $feature['geometry']['coordinates'] ?? null;
-			if ( ! is_array( $coords ) || count( $coords ) < 2 ) {
-				continue;
-			}
+			$coords = $feature['geometry']['coordinates'];
 
 			$properties = isset( $feature['properties'] ) && is_array( $feature['properties'] )
 				? $feature['properties']
@@ -1361,6 +1378,31 @@ final class Geocoding {
 		$codes = array_filter( array_map( 'trim', explode( ',', strtolower( $raw ) ) ) );
 
 		return array_values( array_unique( $codes ) );
+	}
+
+	/**
+	 * Cache-key suffix for a resolved provider URL and country filter.
+	 *
+	 * Empty for the default provider with no filter, so that common case's
+	 * cache key keeps its pre-existing shape; a custom provider and/or an
+	 * active filter each add their own segment, so switching either one
+	 * can't serve a stale result cached under the other.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string   $provider_url   Resolved Photon API base URL.
+	 * @param string[] $country_filter Lowercased country codes to restrict to; empty means unrestricted.
+	 *
+	 * @return string
+	 */
+	private function get_cache_key_suffix( string $provider_url, array $country_filter ): string {
+		$suffix = self::PHOTON_API_URL === $provider_url ? '' : '|provider:' . $provider_url;
+
+		if ( array() !== $country_filter ) {
+			$suffix .= '|' . implode( ',', $country_filter );
+		}
+
+		return $suffix;
 	}
 
 	/**

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -277,7 +277,18 @@ class Settings {
 		 */
 		$filtered = (string) apply_filters( 'gatherpress_interactive_map_tile_url', $default );
 
-		return self::add_map_tile_key( '' !== $filtered ? $filtered : self::MAP_TILE_URL );
+		if ( '' === $filtered ) {
+			return self::add_map_tile_key( self::MAP_TILE_URL );
+		}
+
+		// The CARTO key belongs only to the built-in default: a custom URL
+		// is documented as overriding CARTO entirely, even when it happens
+		// to resolve to a CARTO-allowlisted host.
+		if ( '' !== $custom ) {
+			return $filtered;
+		}
+
+		return self::add_map_tile_key( $filtered );
 	}
 
 	/**

--- a/includes/core/classes/class-settings.php
+++ b/includes/core/classes/class-settings.php
@@ -257,11 +257,17 @@ class Settings {
 	/**
 	 * Returns the map tile layer URL, allowing sites to override the default.
 	 *
+	 * Layers the `map_tile_url_custom` setting under the filter.
+	 *
 	 * @since 0.34.0
+	 * @since 0.36.0 Layered under the `map_tile_url_custom` setting.
 	 *
 	 * @return string Leaflet-compatible tile URL template.
 	 */
 	public static function get_map_tile_url(): string {
+		$custom  = trim( (string) self::get_instance()->get( 'map_tile_url_custom' ) );
+		$default = '' !== $custom ? $custom : self::MAP_TILE_URL;
+
 		/**
 		 * Filters the Leaflet tile layer URL used by the venue map.
 		 *
@@ -269,7 +275,7 @@ class Settings {
 		 *
 		 * @param string $url Default tile URL template (CartoDB Positron).
 		 */
-		$filtered = (string) apply_filters( 'gatherpress_interactive_map_tile_url', self::MAP_TILE_URL );
+		$filtered = (string) apply_filters( 'gatherpress_interactive_map_tile_url', $default );
 
 		return self::add_map_tile_key( '' !== $filtered ? $filtered : self::MAP_TILE_URL );
 	}
@@ -315,23 +321,30 @@ class Settings {
 	/**
 	 * Returns the map attribution string, allowing sites to override the default.
 	 *
+	 * Layers the `map_tile_attribution_custom` setting under the filter.
+	 *
 	 * @since 0.34.0
+	 * @since 0.36.0 Layered under the `map_tile_attribution_custom` setting.
 	 *
 	 * @return string HTML attribution credit shown on the map.
 	 */
 	public static function get_map_tile_attribution(): string {
-		$default = sprintf(
-			/* translators: 1: OpenStreetMap credit link, 2: CARTO credit link. */
-			__( '© %1$s contributors © %2$s', 'gatherpress' ),
-			sprintf(
-				'<a href="%s">OpenStreetMap</a>',
-				esc_url( self::MAP_TILE_ATTRIBUTION_OSM_URL )
-			),
-			sprintf(
-				'<a href="%s">CARTO</a>',
-				esc_url( self::MAP_TILE_ATTRIBUTION_CARTO_URL )
-			)
-		);
+		$custom = trim( (string) self::get_instance()->get( 'map_tile_attribution_custom' ) );
+
+		$default = '' !== $custom
+			? esc_html( $custom )
+			: sprintf(
+				/* translators: 1: OpenStreetMap credit link, 2: CARTO credit link. */
+				__( '© %1$s contributors © %2$s', 'gatherpress' ),
+				sprintf(
+					'<a href="%s">OpenStreetMap</a>',
+					esc_url( self::MAP_TILE_ATTRIBUTION_OSM_URL )
+				),
+				sprintf(
+					'<a href="%s">CARTO</a>',
+					esc_url( self::MAP_TILE_ATTRIBUTION_CARTO_URL )
+				)
+			);
 
 		/**
 		 * Filters the attribution HTML rendered with the venue map.

--- a/includes/core/classes/settings/class-venues.php
+++ b/includes/core/classes/settings/class-venues.php
@@ -15,6 +15,7 @@ namespace GatherPress\Core\Settings;
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
+use GatherPress\Core\Geocoding;
 use GatherPress\Core\Settings;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
@@ -87,7 +88,7 @@ final class Venues extends Base {
 	 */
 	protected function get_sections(): array {
 		return array(
-			'maps' => array(
+			'maps'      => array(
 				'name'        => __( 'Maps', 'gatherpress' ),
 				'description' => __(
 					'Configure the mapping platform and defaults applied to new venue map blocks.',
@@ -114,6 +115,44 @@ final class Venues extends Base {
 							),
 						),
 					),
+					'map_tile_url_custom'            => array(
+						'labels'      => array(
+							'name' => __( 'Custom Tile Layer URL', 'gatherpress' ),
+						),
+						'description' => __(
+							// phpcs:disable Generic.Files.LineLength.TooLong -- One translator string for the full guidance sentence.
+							'Optional. XYZ tile URL template (e.g. https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png) for a self-hosted or third-party tile server. Leave empty to use the built-in CARTO tiles.',
+							// phpcs:enable Generic.Files.LineLength.TooLong
+							'gatherpress'
+						),
+						'field'       => array(
+							'label' => __( 'Tile layer URL:', 'gatherpress' ),
+							'type'  => 'text',
+							'size'  => 'regular',
+						),
+						'show_if'     => array(
+							'map_platform' => 'osm',
+						),
+					),
+					'map_tile_attribution_custom'    => array(
+						'labels'      => array(
+							'name' => __( 'Custom Attribution', 'gatherpress' ),
+						),
+						'description' => __(
+							// phpcs:disable Generic.Files.LineLength.TooLong -- One translator string for the full guidance sentence.
+							'Optional. Plain-text attribution shown alongside the map. Leave empty for the built-in OpenStreetMap/CARTO credit.',
+							// phpcs:enable Generic.Files.LineLength.TooLong
+							'gatherpress'
+						),
+						'field'       => array(
+							'label' => __( 'Attribution text:', 'gatherpress' ),
+							'type'  => 'text',
+							'size'  => 'regular',
+						),
+						'show_if'     => array(
+							'map_platform' => 'osm',
+						),
+					),
 					'carto_api_key'                  => array(
 						'labels'      => array(
 							'name' => __( 'CARTO API Key', 'gatherpress' ),
@@ -122,7 +161,7 @@ final class Venues extends Base {
 							sprintf(
 								// phpcs:disable Generic.Files.LineLength.TooLong -- One translator string for the full key guidance sentence.
 								/* translators: %s: link to CARTO's free basemap key request form. */
-								__( 'Required. Without a key, map tiles are watermarked. Free up to 5 million tiles a month. %s.', 'gatherpress' ),
+								__( 'Required for the default tile provider. Without a key, map tiles are watermarked. Free up to 5 million tiles a month. Ignored when a custom tile layer URL is set above. %s.', 'gatherpress' ),
 								// phpcs:enable Generic.Files.LineLength.TooLong
 								'<a href="https://carto.com/basemaps/apikey/"'
 								. ' target="_blank" rel="noopener noreferrer">'
@@ -307,7 +346,51 @@ final class Venues extends Base {
 					),
 				),
 			),
-			'urls' => array(
+			'geocoding' => array(
+				'name'        => __( 'Geocoding', 'gatherpress' ),
+				'description' => __(
+					'Configure the address lookup service used for venue autocomplete and geocoding.',
+					'gatherpress'
+				),
+				'options'     => array(
+					'geocoding_provider_url'   => array(
+						'labels'      => array(
+							'name' => __( 'Geocoding API URL', 'gatherpress' ),
+						),
+						'description' => __(
+							// phpcs:disable Generic.Files.LineLength.TooLong -- One translator string for the full guidance sentence.
+							'Base URL of a Photon-API-compatible geocoding service (a self-hosted Photon instance or compatible drop-in). Leave empty to use the public Photon service.',
+							// phpcs:enable Generic.Files.LineLength.TooLong
+							'gatherpress'
+						),
+						'field'       => array(
+							'label'   => __( 'Geocoding API URL:', 'gatherpress' ),
+							'type'    => 'text',
+							'size'    => 'regular',
+							'options' => array(
+								'default' => Geocoding::PHOTON_API_URL,
+							),
+						),
+					),
+					'geocoding_country_filter' => array(
+						'labels'      => array(
+							'name' => __( 'Country Code Filter', 'gatherpress' ),
+						),
+						'description' => __(
+							// phpcs:disable Generic.Files.LineLength.TooLong -- One translator string for the full guidance sentence.
+							'Optional. Comma-separated ISO 3166-1 alpha-2 country codes (e.g. "us,ca") to restrict geocoding results to. Leave empty for no restriction.',
+							// phpcs:enable Generic.Files.LineLength.TooLong
+							'gatherpress'
+						),
+						'field'       => array(
+							'label' => __( 'Country codes:', 'gatherpress' ),
+							'type'  => 'text',
+							'size'  => 'regular',
+						),
+					),
+				),
+			),
+			'urls'      => array(
 				'name'        => __( 'Permalinks', 'gatherpress' ),
 				'description' => __( 'Change permalink bases.', 'gatherpress' ),
 				'options'     => array(

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -392,6 +392,13 @@ final class OSM extends Base {
 		// Static compositor makes direct requests, so `{s}` needs resolving.
 		$template = str_replace( '{s}', 'a', $template );
 
+		// The CARTO key belongs only to the built-in default: a custom URL
+		// is documented as overriding CARTO entirely, even when it happens
+		// to resolve to a CARTO-allowlisted host.
+		if ( '' !== $custom ) {
+			return $template;
+		}
+
 		return Settings::add_map_tile_key( $template );
 	}
 

--- a/includes/core/classes/venue/map/provider/class-osm.php
+++ b/includes/core/classes/venue/map/provider/class-osm.php
@@ -369,15 +369,17 @@ final class OSM extends Base {
 	}
 
 	/**
-	 * Tile URL template. Filterable so site owners can repoint at a
-	 * different XYZ provider (self-hosted, Stamen, Maptiler, etc.) without
-	 * forking the provider class.
+	 * Tile URL template, filterable and layered under `map_tile_url_custom`.
 	 *
 	 * @since 0.34.0
+	 * @since 0.36.0 Layered under the `map_tile_url_custom` setting; resolves `{s}`.
 	 *
 	 * @return string
 	 */
 	protected function get_tile_url_template(): string {
+		$custom  = trim( (string) Settings::get_instance()->get( 'map_tile_url_custom' ) );
+		$default = '' !== $custom ? $custom : self::DEFAULT_TILE_URL;
+
 		/**
 		 * Filter the tile URL template used by the OSM static map provider.
 		 *
@@ -385,9 +387,12 @@ final class OSM extends Base {
 		 *
 		 * @param string $template Tile URL with `{z}`, `{x}`, `{y}` placeholders.
 		 */
-		return Settings::add_map_tile_key(
-			(string) apply_filters( 'gatherpress_static_map_tile_url', self::DEFAULT_TILE_URL )
-		);
+		$template = (string) apply_filters( 'gatherpress_static_map_tile_url', $default );
+
+		// Static compositor makes direct requests, so `{s}` needs resolving.
+		$template = str_replace( '{s}', 'a', $template );
+
+		return Settings::add_map_tile_key( $template );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -1916,6 +1916,95 @@ class Test_Geocoding extends Base {
 	}
 
 	/**
+	 * The geocoding_provider_url setting (#1267) is honored by the public request path, not just the resolver.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::geocode_to_result
+	 * @covers ::search_addresses
+	 *
+	 * @return void
+	 */
+	public function test_public_geocoding_methods_use_configured_provider_url(): void {
+		$instance          = Geocoding::get_instance();
+		$settings_instance = Settings::get_instance();
+		$captured_url      = '';
+
+		$settings_instance->set( 'geocoding_provider_url', 'https://example.com/custom-photon' );
+
+		$this->http_mock->mock(
+			'*',
+			array(
+				'body' => static function ( &$headers, $url ) use ( &$captured_url ) {
+					$captured_url = $url;
+					$headers      = 'HTTP/1.1 200 OK';
+					return wp_json_encode( array( 'features' => array() ) );
+				},
+			)
+		);
+
+		$instance->geocode_to_result( 'Provider URL public path test address' );
+
+		$this->assertStringStartsWith(
+			'https://example.com/custom-photon',
+			$captured_url,
+			'Failed to assert geocode_to_result() requests the configured provider URL.'
+		);
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'q', 'Provider URL public path search test' );
+		$instance->search_addresses( $request );
+
+		$this->assertStringStartsWith(
+			'https://example.com/custom-photon',
+			$captured_url,
+			'Failed to assert search_addresses() requests the configured provider URL.'
+		);
+
+		$settings_instance->set( 'geocoding_provider_url', '' );
+	}
+
+	/**
+	 * Switching geocoding_provider_url (#1267) must not serve a cache entry from the previous provider.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::geocode_to_result
+	 *
+	 * @return void
+	 */
+	public function test_geocode_to_result_provider_url_cache_key_isolation(): void {
+		$instance          = Geocoding::get_instance();
+		$settings_instance = Settings::get_instance();
+		$address           = 'Provider cache isolation test address';
+
+		$default_key = 'gatherpress_photon_geocode_' . md5( $address . '|default' );
+		$custom_key  = 'gatherpress_photon_geocode_'
+			. md5( $address . '|default|provider:https://example.com/custom-photon' );
+		delete_transient( $default_key );
+		delete_transient( $custom_key );
+
+		$this->mock_photon_response( array( $this->build_photon_feature( array( 'city' => 'Verona' ) ) ) );
+		$default_result = $instance->geocode_to_result( $address );
+		$this->assertSame( 'Verona', $default_result['city'] );
+
+		$settings_instance->set( 'geocoding_provider_url', 'https://example.com/custom-photon' );
+
+		$this->mock_photon_response( array( $this->build_photon_feature( array( 'city' => 'Newark' ) ) ) );
+		$custom_result = $instance->geocode_to_result( $address );
+
+		$this->assertSame(
+			'Newark',
+			$custom_result['city'],
+			'Failed to assert the custom-provider request hit Photon again rather than reusing the old cache entry.'
+		);
+
+		delete_transient( $default_key );
+		delete_transient( $custom_key );
+		$settings_instance->set( 'geocoding_provider_url', '' );
+	}
+
+	/**
 	 * Non-array entries in GeoJSON features are ignored.
 	 *
 	 * @covers ::search_addresses
@@ -2521,7 +2610,7 @@ class Test_Geocoding extends Base {
 	public function test_select_geocode_feature_branches(): void {
 		$instance = Geocoding::get_instance();
 
-		// Invalid entries are skipped.
+		// Invalid entries — including malformed/non-numeric coordinates — are skipped.
 		$valid  = $this->build_photon_feature( array( 'countrycode' => 'us' ) );
 		$result = Utility::invoke_hidden_method(
 			$instance,
@@ -2530,6 +2619,8 @@ class Test_Geocoding extends Base {
 				array(
 					'not-an-array',
 					array( 'properties' => array() ), // Missing geometry entirely.
+					array( 'geometry' => array( 'coordinates' => array( 'not', 'numeric' ) ) ),
+					array( 'geometry' => array( 'coordinates' => array( 1.0 ) ) ), // Only one element.
 					$valid,
 				),
 				array(),
@@ -2572,6 +2663,42 @@ class Test_Geocoding extends Base {
 			array( array( $matching ), array( 'us' ) )
 		);
 		$this->assertSame( $matching, $result, 'Failed to assert a matching-country feature is returned.' );
+	}
+
+	/**
+	 * Direct branch coverage for has_valid_coordinates() (#1267, xdebug tracing gap).
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::has_valid_coordinates
+	 *
+	 * @return void
+	 */
+	public function test_has_valid_coordinates_branches(): void {
+		$instance = Geocoding::get_instance();
+
+		$cases = array(
+			'missing geometry'      => array( 'properties' => array() ),
+			'non-array coordinates' => array( 'geometry' => array( 'coordinates' => 'nope' ) ),
+			'only one element'      => array( 'geometry' => array( 'coordinates' => array( 1.0 ) ) ),
+			'non-numeric values'    => array( 'geometry' => array( 'coordinates' => array( 'a', 'b' ) ) ),
+		);
+
+		foreach ( $cases as $label => $feature ) {
+			$this->assertFalse(
+				Utility::invoke_hidden_method( $instance, 'has_valid_coordinates', array( $feature ) ),
+				sprintf( 'Failed to assert "%s" is treated as invalid coordinates.', $label )
+			);
+		}
+
+		$this->assertTrue(
+			Utility::invoke_hidden_method(
+				$instance,
+				'has_valid_coordinates',
+				array( array( 'geometry' => array( 'coordinates' => array( -74.0, 40.0 ) ) ) )
+			),
+			'Failed to assert valid numeric coordinates pass.'
+		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -9,6 +9,7 @@
 namespace GatherPress\Tests\Core;
 
 use GatherPress\Core\Geocoding;
+use GatherPress\Core\Settings;
 use GatherPress\Core\Utility as GP_Utility;
 use GatherPress\Core\Venue\Meta as Venue_Meta;
 use GatherPress\Core\Venue;
@@ -1868,6 +1869,53 @@ class Test_Geocoding extends Base {
 	}
 
 	/**
+	 * The geocoding_provider_url setting (#1267): default, fallback, filter wins.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers \GatherPress\Core\Geocoding::get_photon_api_url
+	 *
+	 * @return void
+	 */
+	public function test_geocoding_private_get_photon_api_url_setting(): void {
+		$instance          = Geocoding::get_instance();
+		$settings_instance = Settings::get_instance();
+
+		$settings_instance->set( 'geocoding_provider_url', 'https://example.com/photon' );
+
+		$this->assertSame(
+			'https://example.com/photon',
+			$this->invoke_geocoding_private( $instance, 'get_photon_api_url' ),
+			'Failed to assert the geocoding_provider_url setting is used.'
+		);
+
+		add_filter(
+			'gatherpress_photon_api_url',
+			static function (): string {
+				return 'https://example.com/filtered-api';
+			}
+		);
+
+		$this->assertSame(
+			'https://example.com/filtered-api',
+			$this->invoke_geocoding_private( $instance, 'get_photon_api_url' ),
+			'Failed to assert the filter still overrides the geocoding_provider_url setting.'
+		);
+
+		remove_all_filters( 'gatherpress_photon_api_url' );
+
+		$settings_instance->set( 'geocoding_provider_url', 'not-a-url' );
+
+		$this->assertSame(
+			'https://photon.komoot.io/api',
+			$this->invoke_geocoding_private( $instance, 'get_photon_api_url' ),
+			'Failed to assert an invalid setting value falls back to the default.'
+		);
+
+		$settings_instance->set( 'geocoding_provider_url', '' );
+	}
+
+	/**
 	 * Non-array entries in GeoJSON features are ignored.
 	 *
 	 * @covers ::search_addresses
@@ -2459,6 +2507,288 @@ class Test_Geocoding extends Base {
 		$this->assertSame( '', $result['street'], 'Non-scalar properties must skip rather than cast to "Array".' );
 		// Other (well-formed) properties on the same feature still come through.
 		$this->assertSame( '07044', $result['postcode'] );
+	}
+
+	/**
+	 * Direct branch coverage for select_geocode_feature() (#1267, xdebug tracing gap).
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::select_geocode_feature
+	 *
+	 * @return void
+	 */
+	public function test_select_geocode_feature_branches(): void {
+		$instance = Geocoding::get_instance();
+
+		// Invalid entries are skipped.
+		$valid  = $this->build_photon_feature( array( 'countrycode' => 'us' ) );
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'select_geocode_feature',
+			array(
+				array(
+					'not-an-array',
+					array( 'properties' => array() ), // Missing geometry entirely.
+					$valid,
+				),
+				array(),
+			)
+		);
+		$this->assertSame(
+			$valid,
+			$result,
+			'Failed to assert invalid entries are skipped and the valid feature is returned.'
+		);
+
+		// Empty filter returns the first feature with usable coordinates.
+		$first  = $this->build_photon_feature( array( 'countrycode' => 'ca' ) );
+		$result = Utility::invoke_hidden_method(
+			$instance,
+			'select_geocode_feature',
+			array( array( $first ), array() )
+		);
+		$this->assertSame( $first, $result, 'Failed to assert the first feature is returned when unfiltered.' );
+
+		// Missing properties/countrycode fall back to '', which won't match.
+		$no_properties = array(
+			'geometry' => array( 'coordinates' => array( -74.0, 40.0 ) ),
+		);
+		$result        = Utility::invoke_hidden_method(
+			$instance,
+			'select_geocode_feature',
+			array( array( $no_properties ), array( 'us' ) )
+		);
+		$this->assertNull(
+			$result,
+			'Failed to assert a feature with no properties is skipped under a country filter.'
+		);
+
+		// A matching country code returns the feature.
+		$matching = $this->build_photon_feature( array( 'countrycode' => 'us' ) );
+		$result   = Utility::invoke_hidden_method(
+			$instance,
+			'select_geocode_feature',
+			array( array( $matching ), array( 'us' ) )
+		);
+		$this->assertSame( $matching, $result, 'Failed to assert a matching-country feature is returned.' );
+	}
+
+	/**
+	 * The country filter (#1267) picks the first matching-country feature.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::geocode_to_result
+	 * @covers ::select_geocode_feature
+	 * @covers \GatherPress\Core\Geocoding::get_country_filter
+	 *
+	 * @return void
+	 */
+	public function test_geocode_to_result_country_filter_selects_matching_feature(): void {
+		$instance = Geocoding::get_instance();
+
+		Settings::get_instance()->set( 'geocoding_country_filter', 'us' );
+
+		$this->mock_photon_response(
+			array(
+				$this->build_photon_feature(
+					array(
+						'countrycode' => 'ca',
+						'city'        => 'Toronto',
+					)
+				),
+				$this->build_photon_feature(
+					array(
+						'countrycode' => 'us',
+						'city'        => 'Verona',
+					)
+				),
+			)
+		);
+
+		$result = $instance->geocode_to_result( 'Country filter matching test address' );
+
+		$this->assertSame( 'us', $result['country_code'], 'Failed to assert the non-matching CA feature was skipped.' );
+		$this->assertSame( 'Verona', $result['city'], 'Failed to assert the matching US feature was selected.' );
+
+		Settings::get_instance()->set( 'geocoding_country_filter', '' );
+	}
+
+	/**
+	 * No matching country (#1267) falls back to the "not found" payload.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::geocode_to_result
+	 * @covers ::select_geocode_feature
+	 *
+	 * @return void
+	 */
+	public function test_geocode_to_result_country_filter_no_match_returns_not_found(): void {
+		$instance = Geocoding::get_instance();
+
+		Settings::get_instance()->set( 'geocoding_country_filter', 'us' );
+
+		$this->mock_photon_response(
+			array(
+				$this->build_photon_feature( array( 'countrycode' => 'ca' ) ),
+			)
+		);
+
+		$result = $instance->geocode_to_result( 'Country filter no match test address' );
+
+		$this->assertSame( '', $result['latitude'], 'Failed to assert not-found payload has empty latitude.' );
+		$this->assertNotNull( $result['error'], 'Failed to assert not-found payload carries an error message.' );
+
+		Settings::get_instance()->set( 'geocoding_country_filter', '' );
+	}
+
+	/**
+	 * The country filter (#1267) excludes non-matching search suggestions.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::search_addresses
+	 * @covers ::build_search_suggestions_response
+	 *
+	 * @return void
+	 */
+	public function test_search_addresses_country_filter_excludes_non_matching(): void {
+		$instance  = Geocoding::get_instance();
+		$cache_key = 'gatherpress_photon_search_' . md5( 'Country filter search test|default|us' );
+		delete_transient( $cache_key );
+
+		Settings::get_instance()->set( 'geocoding_country_filter', 'us' );
+
+		$this->mock_photon_response(
+			array(
+				$this->build_photon_feature(
+					array(
+						'countrycode' => 'ca',
+						'city'        => 'Toronto',
+					)
+				),
+				$this->build_photon_feature(
+					array(
+						'countrycode' => 'us',
+						'city'        => 'Verona',
+					)
+				),
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'q', 'Country filter search test' );
+
+		$response    = $instance->search_addresses( $request );
+		$suggestions = $response->get_data()['suggestions'];
+
+		$this->assertCount( 1, $suggestions, 'Failed to assert only the matching-country suggestion is returned.' );
+		$this->assertStringContainsString( 'Verona', $suggestions[0]['label'] );
+
+		delete_transient( $cache_key );
+		Settings::get_instance()->set( 'geocoding_country_filter', '' );
+	}
+
+	/**
+	 * A country filter (#1267) still caps suggestions at 5.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::search_addresses
+	 * @covers ::build_search_suggestions_response
+	 *
+	 * @return void
+	 */
+	public function test_search_addresses_country_filter_caps_at_five_suggestions(): void {
+		$instance  = Geocoding::get_instance();
+		$cache_key = 'gatherpress_photon_search_' . md5( 'Country filter cap test|default|us' );
+		delete_transient( $cache_key );
+
+		Settings::get_instance()->set( 'geocoding_country_filter', 'us' );
+
+		$features = array();
+		foreach ( range( 1, 7 ) as $i ) {
+			$features[] = $this->build_photon_feature(
+				array(
+					'countrycode' => 'us',
+					'city'        => "City {$i}",
+				)
+			);
+		}
+		$this->mock_photon_response( $features );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'q', 'Country filter cap test' );
+
+		$response    = $instance->search_addresses( $request );
+		$suggestions = $response->get_data()['suggestions'];
+
+		$this->assertCount(
+			5,
+			$suggestions,
+			'Failed to assert suggestions are capped at 5 even with more matches available.'
+		);
+
+		delete_transient( $cache_key );
+		Settings::get_instance()->set( 'geocoding_country_filter', '' );
+	}
+
+	/**
+	 * Changing the country filter (#1267) must not serve a stale cache entry.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::geocode_to_result
+	 *
+	 * @return void
+	 */
+	public function test_geocode_to_result_country_filter_cache_key_isolation(): void {
+		$instance = Geocoding::get_instance();
+		$address  = 'Cache isolation test address';
+
+		$unfiltered_key = 'gatherpress_photon_geocode_' . md5( $address . '|default' );
+		$us_filter_key  = 'gatherpress_photon_geocode_' . md5( $address . '|default|us' );
+		delete_transient( $unfiltered_key );
+		delete_transient( $us_filter_key );
+
+		$this->mock_photon_response(
+			array(
+				$this->build_photon_feature(
+					array(
+						'countrycode' => 'us',
+						'city'        => 'Verona',
+					)
+				),
+			)
+		);
+		$unfiltered_result = $instance->geocode_to_result( $address );
+		$this->assertSame( 'Verona', $unfiltered_result['city'] );
+
+		Settings::get_instance()->set( 'geocoding_country_filter', 'us' );
+
+		$this->mock_photon_response(
+			array(
+				$this->build_photon_feature(
+					array(
+						'countrycode' => 'us',
+						'city'        => 'Newark',
+					)
+				),
+			)
+		);
+		$filtered_result = $instance->geocode_to_result( $address );
+
+		$this->assertSame(
+			'Newark',
+			$filtered_result['city'],
+			'Failed to assert the filtered request hit Photon again rather than reusing the unfiltered cache entry.'
+		);
+
+		delete_transient( $unfiltered_key );
+		delete_transient( $us_filter_key );
+		Settings::get_instance()->set( 'geocoding_country_filter', '' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-geocoding.php
@@ -2748,6 +2748,59 @@ class Test_Geocoding extends Base {
 	}
 
 	/**
+	 * Direct branch coverage for get_cache_key_suffix() (#1267, xdebug tracing gap).
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_cache_key_suffix
+	 *
+	 * @return void
+	 */
+	public function test_get_cache_key_suffix_branches(): void {
+		$instance = Geocoding::get_instance();
+
+		$this->assertSame(
+			'',
+			Utility::invoke_hidden_method(
+				$instance,
+				'get_cache_key_suffix',
+				array( Geocoding::PHOTON_API_URL, array() )
+			),
+			'Failed to assert the default provider with no filter has no suffix.'
+		);
+
+		$this->assertSame(
+			'|us,ca',
+			Utility::invoke_hidden_method(
+				$instance,
+				'get_cache_key_suffix',
+				array( Geocoding::PHOTON_API_URL, array( 'us', 'ca' ) )
+			),
+			'Failed to assert the default provider with a filter only adds the filter segment.'
+		);
+
+		$this->assertSame(
+			'|provider:https://example.com/photon',
+			Utility::invoke_hidden_method(
+				$instance,
+				'get_cache_key_suffix',
+				array( 'https://example.com/photon', array() )
+			),
+			'Failed to assert a custom provider with no filter only adds the provider segment.'
+		);
+
+		$this->assertSame(
+			'|provider:https://example.com/photon|us',
+			Utility::invoke_hidden_method(
+				$instance,
+				'get_cache_key_suffix',
+				array( 'https://example.com/photon', array( 'us' ) )
+			),
+			'Failed to assert a custom provider with a filter adds both segments.'
+		);
+	}
+
+	/**
 	 * The country filter (#1267) picks the first matching-country feature.
 	 *
 	 * @since 0.36.0

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -349,6 +349,42 @@ class Test_Settings extends Base {
 	}
 
 	/**
+	 * The custom tile URL setting (#1267) is used as the default, but a filter still wins.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_map_tile_url
+	 *
+	 * @return void
+	 */
+	public function test_get_map_tile_url_custom_setting(): void {
+		$instance = Settings::get_instance();
+		$instance->set( 'map_tile_url_custom', 'https://custom.example.com/{z}/{x}/{y}.png' );
+
+		$this->assertSame(
+			'https://custom.example.com/{z}/{x}/{y}.png',
+			Settings::get_map_tile_url(),
+			'Failed to assert the custom tile URL setting is used.'
+		);
+
+		add_filter(
+			'gatherpress_interactive_map_tile_url',
+			static function (): string {
+				return 'https://filtered.example.com/{z}/{x}/{y}.png';
+			}
+		);
+
+		$this->assertSame(
+			'https://filtered.example.com/{z}/{x}/{y}.png',
+			Settings::get_map_tile_url(),
+			'Failed to assert the filter still overrides the custom tile URL setting.'
+		);
+
+		remove_all_filters( 'gatherpress_interactive_map_tile_url' );
+		$instance->set( 'map_tile_url_custom', '' );
+	}
+
+	/**
 	 * Default map attribution is filterable.
 	 *
 	 * @covers ::get_map_tile_attribution
@@ -374,6 +410,64 @@ class Test_Settings extends Base {
 		$this->assertSame( 'Custom attribution', Settings::get_map_tile_attribution() );
 
 		remove_all_filters( 'gatherpress_interactive_map_tile_attribution' );
+	}
+
+	/**
+	 * The custom attribution setting (#1267) is used as the default, but a filter still wins.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_map_tile_attribution
+	 *
+	 * @return void
+	 */
+	public function test_get_map_tile_attribution_custom_setting(): void {
+		$instance = Settings::get_instance();
+		$instance->set( 'map_tile_attribution_custom', 'My Custom Credit' );
+
+		$this->assertSame(
+			'My Custom Credit',
+			Settings::get_map_tile_attribution(),
+			'Failed to assert the custom attribution setting is used.'
+		);
+
+		add_filter(
+			'gatherpress_interactive_map_tile_attribution',
+			static function (): string {
+				return 'Filtered attribution';
+			}
+		);
+
+		$this->assertSame(
+			'Filtered attribution',
+			Settings::get_map_tile_attribution(),
+			'Failed to assert the filter still overrides the custom attribution setting.'
+		);
+
+		remove_all_filters( 'gatherpress_interactive_map_tile_attribution' );
+		$instance->set( 'map_tile_attribution_custom', '' );
+	}
+
+	/**
+	 * HTML in the custom attribution setting (#1267) is escaped — plain text only.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_map_tile_attribution
+	 *
+	 * @return void
+	 */
+	public function test_get_map_tile_attribution_custom_setting_escapes_html(): void {
+		$instance = Settings::get_instance();
+		$instance->set( 'map_tile_attribution_custom', '<script>alert(1)</script>' );
+
+		$this->assertSame(
+			'&lt;script&gt;alert(1)&lt;/script&gt;',
+			Settings::get_map_tile_attribution(),
+			'Failed to assert the custom attribution setting is escaped.'
+		);
+
+		$instance->set( 'map_tile_attribution_custom', '' );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/class-test-settings.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-settings.php
@@ -3559,4 +3559,33 @@ class Test_Settings extends Base {
 
 		$instance->set( 'carto_api_key', '' );
 	}
+
+	/**
+	 * A custom tile URL is never keyed, even when it resolves to a CARTO host.
+	 *
+	 * The settings UI documents the CARTO key as "ignored when a custom tile
+	 * layer URL is set above" — that has to hold regardless of which host the
+	 * custom URL happens to point at.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_map_tile_url
+	 *
+	 * @return void
+	 */
+	public function test_get_map_tile_url_custom_setting_on_a_carto_host_is_not_keyed(): void {
+		$instance = Settings::get_instance();
+
+		$instance->set( 'carto_api_key', 'abc123' );
+		$instance->set( 'map_tile_url_custom', 'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png' );
+
+		$this->assertSame(
+			'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+			Settings::get_map_tile_url(),
+			'Failed to assert a custom URL on a CARTO host is left unkeyed.'
+		);
+
+		$instance->set( 'carto_api_key', '' );
+		$instance->set( 'map_tile_url_custom', '' );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
+++ b/test/unit/php/includes/tests/core/classes/settings/class-test-venues.php
@@ -8,6 +8,7 @@
 
 namespace GatherPress\Tests\Core\Settings;
 
+use GatherPress\Core\Geocoding;
 use GatherPress\Core\Settings\Venues;
 use GatherPress\Tests\Base;
 use PMC\Unit_Test\Utility;
@@ -125,6 +126,52 @@ class Test_Venues extends Base {
 			array( 'map_platform' => 'google' ),
 			$section['maps']['options']['venue_map_default_type']['show_if'],
 			'Failed to assert Default Map Type is gated to the Google platform.'
+		);
+
+		// Custom tile URL / attribution (#1267): optional, gated to OSM.
+		foreach ( array( 'map_tile_url_custom', 'map_tile_attribution_custom' ) as $key ) {
+			$this->assertArrayHasKey(
+				$key,
+				$section['maps']['options'],
+				sprintf( 'Failed to assert %s option is present.', $key )
+			);
+			$this->assertSame(
+				'text',
+				$section['maps']['options'][ $key ]['field']['type'],
+				sprintf( 'Failed to assert %s uses text field.', $key )
+			);
+			$this->assertSame(
+				array( 'map_platform' => 'osm' ),
+				$section['maps']['options'][ $key ]['show_if'],
+				sprintf( 'Failed to assert %s is gated to the OSM platform.', $key )
+			);
+		}
+
+		// Geocoding (#1267): Photon URL + country filter.
+		$this->assertSame(
+			'Geocoding',
+			$section['geocoding']['name'],
+			'Failed to assert geocoding section name is Geocoding.'
+		);
+		$this->assertArrayHasKey(
+			'geocoding_provider_url',
+			$section['geocoding']['options'],
+			'Failed to assert geocoding_provider_url option is present.'
+		);
+		$this->assertSame(
+			Geocoding::PHOTON_API_URL,
+			$section['geocoding']['options']['geocoding_provider_url']['field']['options']['default'],
+			'Failed to assert geocoding_provider_url defaults to the public Photon API URL.'
+		);
+		$this->assertArrayHasKey(
+			'geocoding_country_filter',
+			$section['geocoding']['options'],
+			'Failed to assert geocoding_country_filter option is present.'
+		);
+		$this->assertSame(
+			'text',
+			$section['geocoding']['options']['geocoding_country_filter']['field']['type'],
+			'Failed to assert geocoding_country_filter uses text field.'
 		);
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -780,4 +780,33 @@ class Test_OSM extends Base {
 
 		$settings->set( 'map_tile_url_custom', '' );
 	}
+
+	/**
+	 * A custom tile URL is never keyed, even when it resolves to a CARTO host.
+	 *
+	 * The settings UI documents the CARTO key as "ignored when a custom tile
+	 * layer URL is set above" — that has to hold regardless of which host the
+	 * custom URL happens to point at.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_tile_url_template
+	 *
+	 * @return void
+	 */
+	public function test_get_tile_url_template_custom_setting_on_a_carto_host_is_not_keyed(): void {
+		$settings = Settings::get_instance();
+
+		$settings->set( 'carto_api_key', 'abc123' );
+		$settings->set( 'map_tile_url_custom', 'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png' );
+
+		$this->assertSame(
+			'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+			Utility::invoke_hidden_method( new OSM(), 'get_tile_url_template' ),
+			'Failed to assert a custom URL on a CARTO host is left unkeyed.'
+		);
+
+		$settings->set( 'carto_api_key', '' );
+		$settings->set( 'map_tile_url_custom', '' );
+	}
 }

--- a/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
+++ b/test/unit/php/includes/tests/core/classes/venue/map/provider/class-test-osm.php
@@ -720,4 +720,64 @@ class Test_OSM extends Base {
 
 		$settings->set( 'carto_api_key', '' );
 	}
+
+	/**
+	 * The map_tile_url_custom setting (#1267) is used as the default, but a filter still wins.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_tile_url_template
+	 *
+	 * @return void
+	 */
+	public function test_get_tile_url_template_uses_custom_setting(): void {
+		$settings = Settings::get_instance();
+
+		$settings->set( 'map_tile_url_custom', 'https://custom.example.test/{z}/{x}/{y}.png' );
+
+		$this->assertSame(
+			'https://custom.example.test/{z}/{x}/{y}.png',
+			Utility::invoke_hidden_method( new OSM(), 'get_tile_url_template' ),
+			'Failed to assert the custom tile URL setting is used.'
+		);
+
+		add_filter(
+			'gatherpress_static_map_tile_url',
+			static function (): string {
+				return 'https://filtered.example.test/{z}/{x}/{y}.png';
+			}
+		);
+
+		$this->assertSame(
+			'https://filtered.example.test/{z}/{x}/{y}.png',
+			Utility::invoke_hidden_method( new OSM(), 'get_tile_url_template' ),
+			'Failed to assert the filter still overrides the custom tile URL setting.'
+		);
+
+		remove_all_filters( 'gatherpress_static_map_tile_url' );
+		$settings->set( 'map_tile_url_custom', '' );
+	}
+
+	/**
+	 * A custom tile URL's `{s}` placeholder resolves to a fixed subdomain.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @covers ::get_tile_url_template
+	 *
+	 * @return void
+	 */
+	public function test_get_tile_url_template_resolves_subdomain_placeholder(): void {
+		$settings = Settings::get_instance();
+
+		$settings->set( 'map_tile_url_custom', 'https://{s}.tile.example.test/{z}/{x}/{y}.png' );
+
+		$this->assertSame(
+			'https://a.tile.example.test/{z}/{x}/{y}.png',
+			Utility::invoke_hidden_method( new OSM(), 'get_tile_url_template' ),
+			'Failed to assert the {s} placeholder resolves to a fixed subdomain.'
+		);
+
+		$settings->set( 'map_tile_url_custom', '' );
+	}
 }


### PR DESCRIPTION
Exposes the existing filter-only Photon/tile-URL customization as admin settings under Settings -> Venues: a geocoding API URL and country-code result filter, plus a custom tile layer URL/attribution for OSM maps.

Fixes #1267

## Proposed changes:

* New "Geocoding" section on Settings -> Venues: **Geocoding API URL** (Photon-compatible endpoint, defaults to the public Photon service) and **Country Code Filter** (comma-separated ISO codes, restricts geocode/address-search results).
* Two new fields in the existing "Maps" section: **Custom Tile Layer URL** and **Custom Attribution**, gated to the OpenStreetMap platform.
* All four settings are layered under their existing PHP filter hooks (`gatherpress_photon_api_url`, `gatherpress_interactive_map_tile_url`/`_attribution`, `gatherpress_static_map_tile_url`) as the default value, so an existing filter callback still wins.
* Country-code filtering applied to both single-address geocoding and address-search suggestions, with cache keys correctly isolated per filter value.
* Fixed a latent `{s}` Leaflet-subdomain-placeholder bug in the static map compositor that a shared custom tile URL would otherwise have hit.

## Testing instructions:

* Go to `Events -> Settings -> Venues`.
* **Country filter**: set Country Code Filter to `us`, save. Create/edit a venue, type "Paris" into Full Address — only US results appear (Paris, TX/KY/AR/IL/TN), no Paris, France. Clear the filter, search "Paris" again — Paris, Île-de-France reappears.
* **Tile URL**: set Custom Tile Layer URL to `https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png` and Custom Attribution to any text, save. Without a CARTO key configured, the default tiles show an "API KEY REQUIRED" watermark — after saving, open a venue with an address: both the block-editor map and the published page's static map render cleanly (no watermark), with the custom attribution shown.

### Credit (for release notes)

My WordPress.org username: <!-- fill in if you want release credit -->

### Changelog entry

- [x] Automatically create a changelog entry from the details below.

<details>
<summary>Changelog Entry Details</summary>

#### Significance
- [x] Patch
- [ ] Minor
- [ ] Major

#### Type
- [ ] Added - for new features
- [ ] Changed - for changes in existing functionality
- [ ] Deprecated - for soon-to-be removed features
- [ ] Removed - for now removed features
- [ ] Fixed - for any bug fixes
- [ ] Security - in case of vulnerabilities


</details>



Authored by jmarx, assisted by Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable OpenStreetMap tile URL and attribution settings for venue maps.
  - Added configurable Photon-compatible geocoding URL and optional country-code filtering.
  - Added support for custom map tiles without requiring a CARTO API key.
  - Geocoding and address suggestions now respect country filters, with suggestions limited to five results.
- **Documentation**
  - Updated Venues configuration documentation with map tile, attribution, CARTO API key, geocoding URL, and country filter guidance.
- **Bug Fixes**
  - Improved geocoding result selection and handling when no matching result is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->