### PR TITLE
Opt every editor control into the 40px size

### DIFF
--- a/.github/changelog/2276-40px-control-size
+++ b/.github/changelog/2276-40px-control-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Editor controls are all one height again. WordPress moved its components from 36px to 40px and asked plugins to opt in; only some of ours had, so panels mixed both sizes, most visibly in Form Field settings where a 40px dropdown sat above 36px text inputs. Every control now opts in, which also clears the deprecation warnings WordPress logs for the old size.

--- a/src/blocks/dropdown/edit.js
+++ b/src/blocks/dropdown/edit.js
@@ -266,6 +266,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 					initialOpen={ true }
 				>
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __( 'Dropdown Z-Index', 'gatherpress' ) }
 						value={ dropdownZIndex }
 						onChange={ ( value ) =>
@@ -275,6 +276,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 						max={ 9999 }
 					/>
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __( 'Dropdown Width', 'gatherpress' ) }
 						value={ parseInt( dropdownWidth, 10 ) }
 						onChange={ ( value ) =>
@@ -284,6 +286,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 						max={ 300 }
 					/>
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __( 'Dropdown Border Thickness', 'gatherpress' ) }
 						value={ dropdownBorderThickness || 1 }
 						onChange={ ( value ) =>
@@ -293,6 +296,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 						max={ 20 }
 					/>
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __( 'Dropdown Border Radius', 'gatherpress' ) }
 						value={ dropdownBorderRadius }
 						onChange={ ( value ) =>
@@ -302,6 +306,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 						max={ 50 }
 					/>
 					<BoxControl
+						__next40pxDefaultSize
 						label={ __( 'Item Padding', 'gatherpress' ) }
 						values={ itemPadding || 8 }
 						onChange={ ( value ) =>
@@ -309,6 +314,7 @@ const Edit = ( { attributes, setAttributes, clientId, context } ) => {
 						}
 					/>
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __( 'Item Divider Thickness', 'gatherpress' ) }
 						value={ itemDividerThickness || 1 }
 						onChange={ ( value ) =>

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -383,6 +383,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 					/>
 					{ 'both' === displayType && (
 						<TextControl
+							__next40pxDefaultSize
 							label={ __( 'Separator', 'gatherpress' ) }
 							value={ separator }
 							placeholder={ __( 'to', 'gatherpress' ) }
@@ -393,6 +394,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 					) }
 					{ showStartTime && (
 						<TextControl
+							__next40pxDefaultSize
 							label={ __( 'Start date format', 'gatherpress' ) }
 							value={ startDateFormat }
 							placeholder={ formatPlaceholder }
@@ -403,6 +405,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 					) }
 					{ showEndTime && (
 						<TextControl
+							__next40pxDefaultSize
 							label={ __( 'End date format', 'gatherpress' ) }
 							value={ endDateFormat }
 							placeholder={ formatPlaceholder }

--- a/src/blocks/form-field/edit.js
+++ b/src/blocks/form-field/edit.js
@@ -210,6 +210,7 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 						} }
 					/>
 					<TextControl
+						__next40pxDefaultSize
 						label={ __( 'Field Name', 'gatherpress' ) }
 						value={ fieldName }
 						onChange={ ( value ) => {
@@ -229,6 +230,7 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 
 					{ 'hidden' !== fieldType && (
 						<TextControl
+							__next40pxDefaultSize
 							label={ __( 'Help Text', 'gatherpress' ) }
 							value={ helpText }
 							onChange={ ( value ) =>
@@ -295,6 +297,7 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 					{ ! [ 'hidden', 'checkbox', 'radio', 'select' ].includes( fieldType ) && (
 						<>
 							<TextControl
+								__next40pxDefaultSize
 								label={ __( 'Placeholder', 'gatherpress' ) }
 								value={ placeholder }
 								onChange={ ( value ) =>
@@ -306,6 +309,7 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 								) }
 							/>
 							<NumberControl
+								__next40pxDefaultSize
 								label={
 									'number' === fieldType
 										? __( 'Minimum Value', 'gatherpress' )
@@ -334,6 +338,7 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 								}
 							/>
 							<NumberControl
+								__next40pxDefaultSize
 								label={
 									'number' === fieldType
 										? __( 'Maximum Value', 'gatherpress' )
@@ -366,6 +371,7 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 
 					{ ! [ 'hidden' ].includes( fieldType ) && (
 						<TextControl
+							__next40pxDefaultSize
 							label={ __( 'Autocomplete', 'gatherpress' ) }
 							value={ autocomplete }
 							onChange={ ( value ) => {

--- a/src/blocks/form-field/helpers.js
+++ b/src/blocks/form-field/helpers.js
@@ -270,6 +270,7 @@ export default function FieldValue( { fieldType, attributes, setAttributes } ) {
 		case 'email':
 			return (
 				<TextControl
+					__next40pxDefaultSize
 					label={ __( 'Default Value', 'gatherpress' ) }
 					type="email"
 					value={ fieldValue }
@@ -284,6 +285,7 @@ export default function FieldValue( { fieldType, attributes, setAttributes } ) {
 		case 'url':
 			return (
 				<TextControl
+					__next40pxDefaultSize
 					label={ __( 'Default Value', 'gatherpress' ) }
 					type="url"
 					value={ fieldValue }
@@ -295,6 +297,7 @@ export default function FieldValue( { fieldType, attributes, setAttributes } ) {
 		case 'tel':
 			return (
 				<TextControl
+					__next40pxDefaultSize
 					label={ __( 'Default Value', 'gatherpress' ) }
 					type="tel"
 					value={ fieldValue }
@@ -309,6 +312,7 @@ export default function FieldValue( { fieldType, attributes, setAttributes } ) {
 		case 'number':
 			return (
 				<TextControl
+					__next40pxDefaultSize
 					label={ __( 'Default Value', 'gatherpress' ) }
 					type="number"
 					value={ fieldValue }
@@ -357,6 +361,7 @@ export default function FieldValue( { fieldType, attributes, setAttributes } ) {
 		case 'hidden':
 			return (
 				<TextControl
+					__next40pxDefaultSize
 					label={ __( 'Value', 'gatherpress' ) }
 					value={ fieldValue }
 					onChange={ ( value ) => setAttributes( { fieldValue: value } ) }
@@ -367,6 +372,7 @@ export default function FieldValue( { fieldType, attributes, setAttributes } ) {
 		default:
 			return (
 				<TextControl
+					__next40pxDefaultSize
 					label={ __( 'Default Value', 'gatherpress' ) }
 					value={ fieldValue }
 					onChange={ ( value ) => setAttributes( { fieldValue: value } ) }

--- a/src/blocks/form-field/panels/checkbox-field-panels.js
+++ b/src/blocks/form-field/panels/checkbox-field-panels.js
@@ -28,8 +28,8 @@ export default function CheckboxFieldPanels( { attributes, setAttributes } ) {
 			<PanelBody title={ __( 'Label Styles', 'gatherpress' ) }>
 				<BaseControl>
 					<FontSizePicker
+						__next40pxDefaultSize
 						withReset={ true }
-						size="__unstable-large"
 						onChange={ ( value ) =>
 							setAttributes( { labelFontSize: value } )
 						}
@@ -37,6 +37,7 @@ export default function CheckboxFieldPanels( { attributes, setAttributes } ) {
 					/>
 				</BaseControl>
 				<RangeControl
+					__next40pxDefaultSize
 					label={ __( 'Line Height', 'gatherpress' ) }
 					value={ labelLineHeight }
 					onChange={ ( value ) =>

--- a/src/blocks/form-field/panels/default-field-panels.js
+++ b/src/blocks/form-field/panels/default-field-panels.js
@@ -57,6 +57,7 @@ export default function DefaultFieldPanels( { attributes, setAttributes } ) {
 					/>
 				) }
 				<RangeControl
+					__next40pxDefaultSize
 					label={ __( 'Field Width (%)', 'gatherpress' ) }
 					value={ fieldWidth }
 					onChange={ ( value ) => setAttributes( { fieldWidth: value } ) }
@@ -72,8 +73,8 @@ export default function DefaultFieldPanels( { attributes, setAttributes } ) {
 			<PanelBody title={ __( 'Label Styles', 'gatherpress' ) }>
 				<BaseControl>
 					<FontSizePicker
+						__next40pxDefaultSize
 						withReset={ true }
-						size="__unstable-large"
 						onChange={ ( value ) =>
 							setAttributes( { labelFontSize: value } )
 						}
@@ -81,6 +82,7 @@ export default function DefaultFieldPanels( { attributes, setAttributes } ) {
 					/>
 				</BaseControl>
 				<RangeControl
+					__next40pxDefaultSize
 					label={ __( 'Line Height', 'gatherpress' ) }
 					value={ labelLineHeight }
 					onChange={ ( value ) =>
@@ -95,8 +97,8 @@ export default function DefaultFieldPanels( { attributes, setAttributes } ) {
 			<PanelBody title={ __( 'Input Field Styles', 'gatherpress' ) }>
 				<BaseControl>
 					<FontSizePicker
+						__next40pxDefaultSize
 						withReset={ true }
-						size="__unstable-large"
 						onChange={ ( value ) =>
 							setAttributes( { inputFontSize: value } )
 						}
@@ -104,6 +106,7 @@ export default function DefaultFieldPanels( { attributes, setAttributes } ) {
 					/>
 				</BaseControl>
 				<RangeControl
+					__next40pxDefaultSize
 					label={ __( 'Line Height', 'gatherpress' ) }
 					value={ inputLineHeight }
 					onChange={ ( value ) =>
@@ -114,6 +117,7 @@ export default function DefaultFieldPanels( { attributes, setAttributes } ) {
 					step={ 0.1 }
 				/>
 				<RangeControl
+					__next40pxDefaultSize
 					label={ __( 'Padding (px)', 'gatherpress' ) }
 					value={ inputPadding }
 					onChange={ ( value ) => setAttributes( { inputPadding: value } ) }
@@ -122,6 +126,7 @@ export default function DefaultFieldPanels( { attributes, setAttributes } ) {
 				/>
 				{ 'textarea' === fieldType && (
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __( 'Rows', 'gatherpress' ) }
 						value={ textareaRows }
 						onChange={ ( value ) =>
@@ -136,6 +141,7 @@ export default function DefaultFieldPanels( { attributes, setAttributes } ) {
 					/>
 				) }
 				<RangeControl
+					__next40pxDefaultSize
 					label={ __( 'Border Width (px)', 'gatherpress' ) }
 					value={ inputBorderWidth }
 					onChange={ ( value ) =>
@@ -145,6 +151,7 @@ export default function DefaultFieldPanels( { attributes, setAttributes } ) {
 					max={ 10 }
 				/>
 				<RangeControl
+					__next40pxDefaultSize
 					label={ __( 'Border Radius (px)', 'gatherpress' ) }
 					value={ inputBorderRadius }
 					onChange={ ( value ) =>

--- a/src/blocks/form-field/panels/radio-field-panels.js
+++ b/src/blocks/form-field/panels/radio-field-panels.js
@@ -94,6 +94,7 @@ export default function RadioFieldPanels( { attributes, setAttributes } ) {
 						>
 							<FlexItem>
 								<TextControl
+									__next40pxDefaultSize
 									label={ `${ __( 'Option', 'gatherpress' ) } ${ index + 1 }` }
 									value={ option.label }
 									onChange={ ( value ) =>
@@ -162,8 +163,8 @@ export default function RadioFieldPanels( { attributes, setAttributes } ) {
 			<PanelBody title={ __( 'Label Styles', 'gatherpress' ) }>
 				<BaseControl>
 					<FontSizePicker
+						__next40pxDefaultSize
 						withReset={ true }
-						size="__unstable-large"
 						onChange={ ( value ) =>
 							setAttributes( { labelFontSize: value } )
 						}
@@ -171,6 +172,7 @@ export default function RadioFieldPanels( { attributes, setAttributes } ) {
 					/>
 				</BaseControl>
 				<RangeControl
+					__next40pxDefaultSize
 					label={ __( 'Line Height', 'gatherpress' ) }
 					value={ labelLineHeight }
 					onChange={ ( value ) =>
@@ -185,8 +187,8 @@ export default function RadioFieldPanels( { attributes, setAttributes } ) {
 			<PanelBody title={ __( 'Option Styles', 'gatherpress' ) }>
 				<BaseControl>
 					<FontSizePicker
+						__next40pxDefaultSize
 						withReset={ true }
-						size="__unstable-large"
 						onChange={ ( value ) =>
 							setAttributes( { optionFontSize: value } )
 						}
@@ -195,6 +197,7 @@ export default function RadioFieldPanels( { attributes, setAttributes } ) {
 				</BaseControl>
 
 				<RangeControl
+					__next40pxDefaultSize
 					label={ __( 'Line Height', 'gatherpress' ) }
 					value={ optionLineHeight }
 					onChange={ ( value ) =>

--- a/src/blocks/form-field/panels/select-field-panels.js
+++ b/src/blocks/form-field/panels/select-field-panels.js
@@ -91,6 +91,7 @@ export default function SelectFieldPanels( { attributes, setAttributes } ) {
 						>
 							<FlexItem>
 								<TextControl
+									__next40pxDefaultSize
 									label={ `${ __( 'Option', 'gatherpress' ) } ${ index + 1 }` }
 									value={ option.label }
 									onChange={ ( value ) =>
@@ -159,8 +160,8 @@ export default function SelectFieldPanels( { attributes, setAttributes } ) {
 			<PanelBody title={ __( 'Label Styles', 'gatherpress' ) }>
 				<BaseControl>
 					<FontSizePicker
+						__next40pxDefaultSize
 						withReset={ true }
-						size="__unstable-large"
 						onChange={ ( value ) =>
 							setAttributes( { labelFontSize: value } )
 						}
@@ -168,6 +169,7 @@ export default function SelectFieldPanels( { attributes, setAttributes } ) {
 					/>
 				</BaseControl>
 				<RangeControl
+					__next40pxDefaultSize
 					label={ __( 'Line Height', 'gatherpress' ) }
 					value={ labelLineHeight }
 					onChange={ ( value ) =>

--- a/src/blocks/modal-content/edit.js
+++ b/src/blocks/modal-content/edit.js
@@ -26,6 +26,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 			<InspectorControls>
 				<PanelBody title="Width Settings">
 					<RangeControl
+						__next40pxDefaultSize
 						label="Max Width"
 						value={ maxWidth }
 						onChange={ ( value ) =>

--- a/src/blocks/modal/edit.js
+++ b/src/blocks/modal/edit.js
@@ -61,6 +61,7 @@ const Edit = ( { attributes, setAttributes, clientId, isSelected } ) => {
 			<InspectorControls>
 				<PanelBody title={ __( 'Modal Settings', 'gatherpress' ) }>
 					<TextControl
+						__next40pxDefaultSize
 						label={ __( 'Modal Name', 'gatherpress' ) }
 						value={ metadata.name || __( 'Modal', 'gatherpress' ) }
 						onChange={ handleNameChange }
@@ -70,6 +71,7 @@ const Edit = ( { attributes, setAttributes, clientId, isSelected } ) => {
 						) }
 					/>
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __( 'Z-Index', 'gatherpress' ) }
 						value={ zIndex }
 						onChange={ ( newValue ) =>

--- a/src/blocks/online-event/edit.js
+++ b/src/blocks/online-event/edit.js
@@ -248,6 +248,7 @@ const Edit = ( { attributes, context } ) => {
 							/>
 							{ isOnlineEvent && (
 								<TextControl
+									__next40pxDefaultSize
 									type="url"
 									label={ sprintf(
 										/* translators: %s: Singular post type label, e.g. "Event". */

--- a/src/blocks/rsvp-count/edit.js
+++ b/src/blocks/rsvp-count/edit.js
@@ -184,6 +184,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 						) }
 					/>
 					<TextControl
+						__next40pxDefaultSize
 						label={ __( 'Singular Label', 'gatherpress' ) }
 						value={ singularLabel }
 						onChange={ ( value ) =>
@@ -196,6 +197,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 						) }
 					/>
 					<TextControl
+						__next40pxDefaultSize
 						label={ __( 'Plural Label', 'gatherpress' ) }
 						value={ pluralLabel }
 						onChange={ ( value ) =>

--- a/src/blocks/rsvp-response/edit.js
+++ b/src/blocks/rsvp-response/edit.js
@@ -348,6 +348,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 						/>
 						{ rsvpLimitEnabled && (
 							<NumberControl
+								__next40pxDefaultSize
 								label={ __( 'RSVP Display Limit', 'gatherpress' ) }
 								value={ rsvpLimit }
 								onChange={ ( value ) =>

--- a/src/blocks/rsvp-response/rsvp-manager.js
+++ b/src/blocks/rsvp-response/rsvp-manager.js
@@ -197,6 +197,7 @@ const RsvpManager = ( { defaultStatus, setDefaultStatus } ) => {
 				onChange={ ( status ) => setDefaultStatus( status ) }
 			/>
 			<FormTokenField
+				__next40pxDefaultSize
 				key="query-controls-topics-select"
 				label={ __( 'Members', 'gatherpress' ) }
 				value={

--- a/src/blocks/venue-map/edit.js
+++ b/src/blocks/venue-map/edit.js
@@ -657,6 +657,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 						}
 					/>
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __( 'Zoom level', 'gatherpress' ) }
 						value={ zoom }
 						onChange={ ( value ) =>
@@ -736,6 +737,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 					/>
 					{ isCustomAspectRatio && (
 						<TextControl
+							__next40pxDefaultSize
 							label={ __(
 								'Custom aspect ratio',
 								'gatherpress'
@@ -825,6 +827,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 									{ LINK_DESTINATION_CUSTOM ===
 										linkDestination && (
 										<TextControl
+											__next40pxDefaultSize
 											label={ __(
 												'Link URL',
 												'gatherpress'
@@ -860,6 +863,7 @@ const Edit = ( { attributes, setAttributes, context, clientId } ) => {
 												}
 											/>
 											<TextControl
+												__next40pxDefaultSize
 												label={ __(
 													'Link rel',
 													'gatherpress'

--- a/src/components/Autocomplete.js
+++ b/src/components/Autocomplete.js
@@ -84,6 +84,7 @@ const Autocomplete = ( props ) => {
 	return (
 		<>
 			<FormTokenField
+				__next40pxDefaultSize
 				key={ option }
 				label={ fieldOptions.label || __( 'Select Posts', 'gatherpress' ) }
 				name={ name }

--- a/src/components/GuestLimit.js
+++ b/src/components/GuestLimit.js
@@ -64,6 +64,7 @@ const GuestLimit = () => {
 
 	return (
 		<NumberControl
+			__next40pxDefaultSize
 			label={ __( 'Maximum Number of Guests', 'gatherpress' ) }
 			value={ guestLimit }
 			min={ 0 }

--- a/src/components/MaxAttendanceLimit.js
+++ b/src/components/MaxAttendanceLimit.js
@@ -68,6 +68,7 @@ const MaxAttendanceLimit = () => {
 
 	return (
 		<NumberControl
+			__next40pxDefaultSize
 			label={ __( 'Maximum Attendance Limit', 'gatherpress' ) }
 			value={ maxAttendanceLimit }
 			min={ 0 }

--- a/src/components/OnlineEvent.js
+++ b/src/components/OnlineEvent.js
@@ -165,6 +165,7 @@ const OnlineEvent = () => {
 			/>
 			{ isOnlineEvent && (
 				<TextControl
+					__next40pxDefaultSize
 					type="url"
 					label={ sprintf(
 						/* translators: %s: Singular post type label, e.g. "Event". */

--- a/src/components/VenueInformation.js
+++ b/src/components/VenueInformation.js
@@ -145,6 +145,7 @@ const VenueInformation = () => {
 				} }
 			/>
 			<TextControl
+				__next40pxDefaultSize
 				label={ __( 'Phone Number', 'gatherpress' ) }
 				value={ phone }
 				onChange={ ( value ) => {
@@ -152,6 +153,7 @@ const VenueInformation = () => {
 				} }
 			/>
 			<TextControl
+				__next40pxDefaultSize
 				label={ __( 'Website', 'gatherpress' ) }
 				value={ website }
 				type="url"

--- a/src/formats/tooltip/edit.js
+++ b/src/formats/tooltip/edit.js
@@ -127,6 +127,7 @@ function TooltipPopover( {
 			>
 				<FlexItem>
 					<TextControl
+						__next40pxDefaultSize
 						/* translators: Label for the input field where users enter custom tooltip text. */
 						label={ __( 'Tooltip Text', 'gatherpress' ) }
 						value={ tooltipText }

--- a/src/modals/email-communication/index.js
+++ b/src/modals/email-communication/index.js
@@ -128,6 +128,7 @@ const EventCommunicationModal = () => {
 					style={ { maxWidth: '550px' } }
 				>
 					<TextControl
+						__next40pxDefaultSize
 						label={ __( 'Subject', 'gatherpress' ) }
 						value={ subject }
 						placeholder={ defaultSubject }

--- a/src/variations/core/query/components.js
+++ b/src/variations/core/query/components.js
@@ -48,6 +48,7 @@ export const EventCountControls = ( { attributes, setAttributes } ) => {
 
 	return (
 		<RangeControl
+			__next40pxDefaultSize
 			label={ sprintf(
 			/* translators: %s: Plural post type label, e.g. "Events". */
 				__( '%s Per Page', 'gatherpress' ),
@@ -462,6 +463,7 @@ export const EventOffsetControls = ( { attributes, setAttributes } ) => {
 
 	return (
 		<RangeControl
+			__next40pxDefaultSize
 			label={ sprintf(
 				/* translators: %s: Singular post type label, e.g. "Event". */
 				__( '%s Offset', 'gatherpress' ),

--- a/test/unit/js/src/blocks/form-field/edit.test.js
+++ b/test/unit/js/src/blocks/form-field/edit.test.js
@@ -48,9 +48,6 @@ describe( 'Form Field Edit autocomplete help', () => {
 		const { getByRole } = renderEdit();
 		const link = getByRole( 'link', { name: /Learn more/ } );
 
-		// Core's controls warn about their 36px default size; not this block's concern here.
-		expect( console ).toHaveWarned();
-
 		expect( link.getAttribute( 'href' ) ).toBe(
 			'https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete'
 		);


### PR DESCRIPTION
Fixes #2276.

WordPress deprecated the 36px control size in 6.8 and removes the opt-in at 7.1, when 40px becomes the default whether a call site asked for it or not. Only `SelectControl` was ever swept for this, in #1661, so most controls still rendered at the old size and logged a deprecation warning each time they mounted.

The visible symptom is on WordPress 7.0, which is still our floor: the two sizes appeared side by side in the same panel. Form Field settings put a 40px select directly above 36px text inputs.

## Proposed changes:

* **62 call sites across 23 files** now pass `__next40pxDefaultSize`. It goes first on the tag, matching how the existing 26 are written.
* **Six `FontSizePicker`s move to the stable prop.** They already asked for the larger size through `size="__unstable-large"`, which core resolves to the same thing (`size === '__unstable-large' || props.__next40pxDefaultSize ? 'default' : 'small'`), so they were never warning. Carrying both would be redundant, and `__unstable-large` is an unstable string core can drop, so the old prop comes off. That leaves 56 call sites that were genuinely warning.
* **One test expectation removed.** `test/unit/js/src/blocks/form-field/edit.test.js` declared core's warning expected, which this change makes obsolete.

No control gains or loses any other behavior. The prop only selects between core's two sizes.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Nothing new to assert. The existing suites cover these components' behavior, and the change is a size token, not logic.

## Testing instructions:

**This wants eyes on the panels.** I verified programmatically, that all 62 sites are covered and none are left, but I could not sign into the local editor to look, so the visual pass belongs in review. The Playground link the workflow posts below is the quickest way.

* **The flagship case.** Add a Form Field block, open Field Settings in the inspector. Field Type, Field Name and Help Text should now be the same height. On `develop` the select is visibly taller than the inputs.
* **Console.** Open DevTools, switch context to the editor iframe, enable Warnings. The `36px default size` notices should be gone.
* **Worth a glance for cramped layouts**, since every control grew 4px: Dropdown settings (6 controls), the Form Field style panels (19 across four files), Venue Map settings, and the Event Query variation controls.
* **Font sizes specifically.** The four Form Field style panels render `FontSizePicker`; confirm it looks unchanged, since those six should be visually identical before and after.

### Changelog entry

Added at `.github/changelog/2276-40px-control-size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated editor controls across event, form, RSVP, venue, modal, tooltip, and communication settings to use a consistent 40px default size.
  * Refreshed text fields, number fields, range controls, token fields, font-size pickers, and related inputs for improved visual consistency.
  * Standardized sizing in autocomplete, attendance limits, venue information, and event query controls.
* **Tests**
  * Updated form-field editor tests to reflect the current control sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->