### PR TITLE
fix(event-date): explain the link to event toggle

### DIFF
--- a/.github/changelog/2284-event-date-link-help
+++ b/.github/changelog/2284-event-date-link-help
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The Link to event toggle in the Event Date block now explains what it does. Testers could not tell from the label alone that it turns the displayed date into a link to the event page.

--- a/src/blocks/event-date/edit.js
+++ b/src/blocks/event-date/edit.js
@@ -437,6 +437,10 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 					/>
 					<ToggleControl
 						label={ __( 'Link to event', 'gatherpress' ) }
+						help={ __(
+							'Make the date a link to the event page.',
+							'gatherpress'
+						) }
 						checked={ isLink }
 						onChange={ () =>
 							setAttributes( { isLink: ! isLink } )

--- a/test/unit/js/src/blocks/event-date/edit.test.js
+++ b/test/unit/js/src/blocks/event-date/edit.test.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { describe, expect, it, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
 import { render, fireEvent } from '@testing-library/react';
 
 /**
@@ -40,13 +41,16 @@ jest.mock( '@wordpress/components', () => ( {
 	RadioControl: () => null,
 	Spinner: () => <div>spinner</div>,
 	TextControl: () => null,
-	ToggleControl: ( { label, checked, onChange } ) => (
-		<button
-			aria-pressed={ checked }
-			onClick={ () => onChange( ! checked ) }
-		>
-			{ label }
-		</button>
+	ToggleControl: ( { label, help, checked, onChange } ) => (
+		<>
+			<button
+				aria-pressed={ checked }
+				onClick={ () => onChange( ! checked ) }
+			>
+				{ label }
+			</button>
+			{ help && <p>{ help }</p> }
+		</>
 	),
 	ToolbarButton: ( { text } ) => <button>{ text }</button>,
 	ToolbarGroup: ( { children } ) => <div>{ children }</div>,
@@ -159,6 +163,14 @@ describe( 'Event Date Edit isLink', () => {
 		fireEvent.click( getByText( 'Link to event' ) );
 
 		expect( setAttributes ).toHaveBeenCalledWith( { isLink: false } );
+	} );
+
+	it( 'describes what the Link to event toggle does', () => {
+		const { getByText } = renderEdit();
+
+		expect(
+			getByText( 'Make the date a link to the event page.' )
+		).toBeInTheDocument();
 	} );
 } );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #2284

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds help text to the "Link to event" toggle in the Event Date block's Display Settings panel. The label alone did not tell testers what the toggle does, so the toggle now shows "Make the date a link to the event page." when turned on or off.
* Covers the help string in the Edit component unit tests by extending the ToggleControl mock to render the help text.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build the plugin or run the development server, and activate GatherPress.
* Create or edit an event and add the Event Date block.
* Open the block's settings sidebar and expand the Display settings panel.
* Toggle "Link to event" on and off.
* Result: the toggle shows the help text "Make the date a link to the event page." in both states.
* Run `npm run test:unit:js` to see the new unit test pass.

### Credit (for release notes)

<!-- First time contributing? Add your WordPress.org profile so we can credit you in the -->
<!-- release and on the in-plugin Credits screen. -->
<!-- Your profile URL looks like: https://profiles.wordpress.org/USERNAME/ -->
<!-- Enter just the USERNAME (the last part of that URL) below. -->
<!-- Please open the link first to confirm it loads — credits are generated from this exact -->
<!-- username, so a typo or a non-existent profile gets skipped. -->
<!-- Don't have a WordPress.org account? Create a free one at https://login.wordpress.org/register -->

My WordPress.org username: faisalahammad

### Changelog entry

User-visible fix. The changelog entry file (`.github/changelog/2284-event-date-link-help`) was pushed to the branch per the template's fork fallback, since the checkbox workflow cannot push to a fork.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

The Link to event toggle in the Event Date block now explains what it does. Testers could not tell from the label alone that it turns the displayed date into a link to the event page.

</details>