### PR TITLE
fix(email): bound featured image size in event emails

### DIFF
--- a/.github/changelog/fix-2283-email-featured-image-size
+++ b/.github/changelog/fix-2283-email-featured-image-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Event notification emails now embed a bounded, email-safe featured image instead of the full-size original.

--- a/includes/templates/admin/emails/event-email.php
+++ b/includes/templates/admin/emails/event-email.php
@@ -43,22 +43,23 @@ $gatherpress_venue       = $gatherpress_event->get_venue_information()['name'];
 		<?php if ( $gatherpress_event_image ) : ?>
 			<!-- Featured Image -->
 			<?php
-			echo wp_get_attachment_image(
-				$gatherpress_event_image,
-				'full',
-				false,
-				array(
-					'alt'   => esc_attr(
-						sprintf(
-							/* translators: %s: Singular post type label, e.g. "Event". */
-							__( '%s Image', 'gatherpress' ),
-							Utility::post_type_label( 'singular_name', (string) get_post_type( $event_id ) )
-						)
-					),
-					'style' => 'max-width: 100%;',
-				)
+			$gatherpress_image = wp_get_attachment_image_src( $gatherpress_event_image, 'large' );
+			$gatherpress_alt   = sprintf(
+				/* translators: %s: Singular post type label, e.g. "Event". */
+				__( '%s Image', 'gatherpress' ),
+				Utility::post_type_label( 'singular_name', (string) get_post_type( $event_id ) )
 			);
 			?>
+			<?php if ( is_array( $gatherpress_image ) ) : ?>
+				<?php $gatherpress_dimensions = wp_constrain_dimensions( $gatherpress_image[1], $gatherpress_image[2], 600, 0 ); ?>
+				<img
+					src="<?php echo esc_url( $gatherpress_image[0] ); ?>"
+					width="<?php echo esc_attr( (string) $gatherpress_dimensions[0] ); ?>"
+					height="<?php echo esc_attr( (string) $gatherpress_dimensions[1] ); ?>"
+					alt="<?php echo esc_attr( $gatherpress_alt ); ?>"
+					style="max-width: 100%; height: auto;"
+				/>
+			<?php endif; ?>
 		<?php endif; ?>
 
 		<!-- Event Title -->

--- a/test/unit/php/includes/tests/core/templates/class-test-event-email.php
+++ b/test/unit/php/includes/tests/core/templates/class-test-event-email.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Class handles unit tests for the event email template.
+ *
+ * @package GatherPress\Core\Templates
+ * @since 0.36.0
+ */
+
+namespace GatherPress\Tests\Core\Templates;
+
+use GatherPress\Core\Event;
+use GatherPress\Core\Utility;
+use GatherPress\Tests\Base;
+
+/**
+ * Class Test_Event_Email.
+ *
+ * @coversNothing
+ */
+class Test_Event_Email extends Base {
+
+	/**
+	 * Tests the featured image uses bounded dimensions and email-safe attributes.
+	 *
+	 * @return void
+	 */
+	public function test_featured_image_uses_bounded_dimensions(): void {
+		$event_id      = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+		$attachment_id = $this->factory()->post->create( array( 'post_type' => 'attachment' ) );
+		// Set meta directly as the test theme does not register post-thumbnail support.
+		update_post_meta( $event_id, '_thumbnail_id', $attachment_id );
+
+		$image_downsize = static function () {
+			return array( 'https://example.org/event.jpg', 1200, 800, true );
+		};
+		add_filter( 'image_downsize', $image_downsize );
+		// The fixture attachment has no real file, so let the image check pass through.
+		$is_image = '__return_true';
+		add_filter( 'wp_attachment_is_image', $is_image );
+
+		$output = Utility::render_template(
+			GATHERPRESS_CORE_PATH . '/includes/templates/admin/emails/event-email.php',
+			array(
+				'event_id' => $event_id,
+				'message'  => '',
+			)
+		);
+
+		remove_filter( 'image_downsize', $image_downsize );
+		remove_filter( 'wp_attachment_is_image', $is_image );
+
+		$this->assertStringContainsString( 'src="https://example.org/event.jpg"', $output );
+		$this->assertStringContainsString( 'width="600"', $output );
+		$this->assertStringContainsString( 'height="400"', $output );
+		$this->assertStringContainsString( 'max-width: 100%; height: auto;', $output );
+		$this->assertStringNotContainsString( 'srcset=', $output );
+		$this->assertStringNotContainsString( 'sizes=', $output );
+		$this->assertStringNotContainsString( 'loading=', $output );
+	}
+
+	/**
+	 * Tests the template omits the image when no featured image is set.
+	 *
+	 * @return void
+	 */
+	public function test_featured_image_is_omitted_when_not_set(): void {
+		$event_id = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+
+		$output = Utility::render_template(
+			GATHERPRESS_CORE_PATH . '/includes/templates/admin/emails/event-email.php',
+			array(
+				'event_id' => $event_id,
+				'message'  => '',
+			)
+		);
+
+		$this->assertStringNotContainsString( '<img', $output );
+	}
+
+	/**
+	 * Tests the template omits an image when its source cannot be resolved.
+	 *
+	 * @return void
+	 */
+	public function test_featured_image_is_omitted_when_source_is_unavailable(): void {
+		$event_id      = $this->mock->post( array( 'post_type' => Event::POST_TYPE ) )->get()->ID;
+		$attachment_id = $this->factory()->post->create( array( 'post_type' => 'attachment' ) );
+		// Set meta directly as the test theme does not register post-thumbnail support.
+		update_post_meta( $event_id, '_thumbnail_id', $attachment_id );
+
+		$image_downsize = static function () {
+			return false;
+		};
+		add_filter( 'image_downsize', $image_downsize );
+
+		$output = Utility::render_template(
+			GATHERPRESS_CORE_PATH . '/includes/templates/admin/emails/event-email.php',
+			array(
+				'event_id' => $event_id,
+				'message'  => '',
+			)
+		);
+
+		remove_filter( 'image_downsize', $image_downsize );
+
+		$this->assertStringNotContainsString( '<img', $output );
+	}
+}


### PR DESCRIPTION
Fixes #2283

## Proposed changes:
Event notification emails embedded the full-size featured image and relied on an inline `max-width` style alone. Outlook on Windows ignores inline styles in favor of the hard `width` and `height` attributes, so recipients got the original multi-megabyte image at full resolution. The `srcset` and `sizes` attributes the old markup emitted are useless in email clients.

The image section in `includes/templates/admin/emails/event-email.php` now builds the `<img>` tag by hand:

- Pulls the `large` variant (1024px) via `wp_get_attachment_image_src()` instead of the full-size original.
- Constrains it to 600px wide with `wp_constrain_dimensions()`, matching the email body width used elsewhere in the template.
- Sets hard `width` and `height` attributes, which Outlook honors, plus `max-width: 100%; height: auto;` inline styles for responsive clients.
- Keeps the generated alt text and drops `srcset`, `sizes`, and `loading="lazy"`.

Fallback behavior is unchanged: when no featured image is set or the attachment has no usable image source, no image renders at all.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

New PHPUnit tests in `test/unit/php/includes/tests/core/templates/class-test-event-email.php` cover all three render branches: bounded image with hard width/height and no `srcset`, omitted image when no featured image is set, and omitted image when the image source is unavailable. Template renders via `Utility::render_template()` with an `image_downsize` filter fixture. All 85 tests in the affected suite pass, PHPStan and PHPCS are clean.

## Testing instructions:

* Build the plugin and install it on a test site.
* Create an event with a large featured image (2000px wide works well) and a venue.
* Trigger an event notification email (for example, the RSVP confirmation email to an attendee).
* Open the received email's HTML source.
* Confirm the featured image `<img>` tag points at a `-1024x...` (large) variant URL, not the original full-size file.
* Confirm it carries `width="600"` with a proportional `height`, and has no `srcset` or `sizes` attributes.
* View the email in a client that ignores inline styles (Outlook on Windows, if available) and confirm the image stays bounded.
* Remove the featured image and trigger another email. Expected result: no `<img>` tag renders and the email still displays correctly.

### Credit (for release notes)

My WordPress.org username: faisalahammad

### Changelog entry

User-visible fix. The changelog entry file (`.github/changelog/fix-2283-email-featured-image-size`) is already pushed to the branch per the template's fork fallback, since the checkbox workflow cannot push to a fork.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [x] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

Event notification emails now embed a bounded, email-safe featured image instead of the full-size original.

</details>