### PR TITLE
fix(events): resolve event posts by post type support instead of the gatherpress_event slug

### DIFF
--- a/.github/changelog/2289-event-helpers-post-type-support
+++ b/.github/changelog/2289-event-helpers-post-type-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Resolve event posts by post type support instead of the hardcoded `gatherpress_event` slug in the editor event helpers, the RSVP REST handlers, and the WXR importer, so blocks and endpoints pointed at a companion plugin's event post type read its settings instead of quietly falling back to defaults.

--- a/includes/core/classes/class-import.php
+++ b/includes/core/classes/class-import.php
@@ -97,15 +97,21 @@ final class Import extends Migrate {
 	}
 
 	/**
-	 * Checks if the currently imported post is of type 'gatherpress_event'.
+	 * Checks if the currently imported post belongs to an event-supporting post type.
+	 *
+	 * Mirrors the export side, which marks posts through `Validate::event_post_id()`,
+	 * so a companion plugin's event post type round-trips its datetimes too.
 	 *
 	 * @param  array<string, mixed> $post_data_raw The result of 'wp_import_post_data_raw'.
 	 *
-	 * @return bool                                True, when the currently imported post is of type
-	 *                                             'gatherpress_event', false otherwise.
+	 * @return bool                                True, when the currently imported post's type declares
+	 *                                             `gatherpress-event-date` support, false otherwise.
 	 */
 	protected function validate( array $post_data_raw ): bool {
-		return ( isset( $post_data_raw['post_type'] ) && Event::POST_TYPE === $post_data_raw['post_type'] );
+		return (
+			isset( $post_data_raw['post_type'] ) &&
+			post_type_supports( (string) $post_data_raw['post_type'], Event::SUPPORT )
+		);
 	}
 
 	/**

--- a/includes/core/classes/event/class-rest-api.php
+++ b/includes/core/classes/event/class-rest-api.php
@@ -482,9 +482,9 @@ final class Rest_Api {
 	/**
 	 * Send emails to selected members.
 	 *
-	 * This method is responsible for sending emails to specific members. It checks if the given
-	 * `$post_id` corresponds to a specific post type, retrieves the list of members to email, and sends the email with
-	 * the appropriate subject, body, and headers.
+	 * This method is responsible for sending emails to specific members. It checks that the given
+	 * `$post_id` belongs to a post type with RSVP support, retrieves the list of members to email, and sends the
+	 * email with the appropriate subject, body, and headers.
 	 *
 	 * @since 0.34.0
 	 * @since 0.36.0 Added `$subject` parameter for #827.
@@ -498,7 +498,7 @@ final class Rest_Api {
 	 * @return bool True if emails were successfully sent, false otherwise.
 	 */
 	public function send_emails( int $post_id, array $send, string $message, string $subject = '' ): bool {
-		if ( Event::POST_TYPE !== get_post_type( $post_id ) ) {
+		if ( ! post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT ) ) {
 			return false;
 		}
 
@@ -1039,7 +1039,7 @@ final class Rest_Api {
 	 * Handle RSVP responses REST endpoint request.
 	 *
 	 * Retrieves RSVP response data for a given event post ID. Validates that the post
-	 * is an event type before returning response data.
+	 * type declares RSVP support before returning response data.
 	 *
 	 * @since 0.34.0
 	 *
@@ -1062,7 +1062,7 @@ final class Rest_Api {
 		$success   = false;
 		$responses = array();
 
-		if ( Event::POST_TYPE === get_post_type( $post_id ) ) {
+		if ( post_type_supports( (string) get_post_type( $post_id ), Rsvp::SUPPORT ) ) {
 			$success   = true;
 			$rsvp      = new Rsvp( $post_id );
 			$responses = $rsvp->responses();

--- a/src/helpers/event.js
+++ b/src/helpers/event.js
@@ -422,9 +422,25 @@ export function hasEventPastNotice() {
  * @return {boolean} True if the event has the online-event term, false otherwise.
  */
 export function hasOnlineEventTerm( postId = null ) {
-	// Derive the venue taxonomy from the current editor post type.
-	const currentPostType = select( 'core/editor' )?.getCurrentPostType?.();
-	const venueTaxonomy = getVenueTaxonomy( getVenuePostType( currentPostType ) );
+	let post = null;
+	let eventPostType = select( 'core/editor' )?.getCurrentPostType?.();
+
+	// An override resolves the post across every event-supporting post
+	// type, so the venue taxonomy has to come from the post that was
+	// found rather than from whatever post type the editor has open.
+	if ( postId ) {
+		post = findEventPostById( select, postId );
+
+		if ( ! post ) {
+			return false;
+		}
+
+		eventPostType = post.type;
+	} else if ( ! isEventPostType() ) {
+		return false;
+	}
+
+	const venueTaxonomy = getVenueTaxonomy( getVenuePostType( eventPostType ) );
 
 	// Get the online-event term ID.
 	const onlineEventTerms = select( 'core' ).getEntityRecords(
@@ -438,31 +454,9 @@ export function hasOnlineEventTerm( postId = null ) {
 		return false;
 	}
 
-	// If postId is provided, check that specific post.
-	if ( postId ) {
-		const post = select( 'core' ).getEntityRecord(
-			'postType',
-			currentPostType || 'gatherpress_event',
-			postId
-		);
-		const venueTaxonomyIds = post?.[ venueTaxonomy ];
-
-		if ( ! venueTaxonomyIds?.length ) {
-			return false;
-		}
-
-		return venueTaxonomyIds.some(
-			( id ) => String( id ) === String( onlineEventTermId )
-		);
-	}
-
-	// Otherwise, check current post if it's an event.
-	if ( ! isEventPostType() ) {
-		return false;
-	}
-
-	const venueTaxonomyIds =
-		select( 'core/editor' ).getEditedPostAttribute( venueTaxonomy );
+	const venueTaxonomyIds = post
+		? post[ venueTaxonomy ]
+		: select( 'core/editor' ).getEditedPostAttribute( venueTaxonomy );
 
 	if ( ! venueTaxonomyIds?.length ) {
 		return false;
@@ -541,8 +535,9 @@ export function getEventMeta( selectFunc, postId, attributes ) {
 	const hasExplicitOverride = !! attributes?.postId;
 
 	if ( hasExplicitOverride && postId ) {
-		// Explicit override - fetch from post via core data store.
-		const post = selectFunc( 'core' ).getEntityRecord( 'postType', 'gatherpress_event', postId );
+		// Explicit override - resolve the post across every event-supporting
+		// post type rather than assuming the standard event slug.
+		const post = findEventPostById( selectFunc, postId );
 		maxLimit = post?.meta?.gatherpress_max_guest_limit;
 		// Stored as integer (0/1); undefined means not yet set, default to enabled.
 		enableRsvp = 0 !== post?.meta?.gatherpress_enable_rsvp;
@@ -550,7 +545,7 @@ export function getEventMeta( selectFunc, postId, attributes ) {
 	} else {
 		// No override - check if current post is an event and use editor for live edits.
 		const currentPostType = selectFunc( 'core/editor' )?.getCurrentPostType();
-		const isCurrentPostEvent = isEventPostType( currentPostType );
+		const isCurrentPostEvent = isEventSupportingType( selectFunc, currentPostType );
 
 		if ( isCurrentPostEvent ) {
 			const meta = selectFunc( 'core/editor' ).getEditedPostAttribute( 'meta' );

--- a/test/unit/js/src/helpers/event.test.js
+++ b/test/unit/js/src/helpers/event.test.js
@@ -1185,14 +1185,41 @@ describe( 'hasEventPastNotice', () => {
 describe( 'getEventMeta', () => {
 	let mockSelect;
 
+	/**
+	 * Builds a `core` store mock whose registry declares event-date support on
+	 * both the standard event type and a "production" companion type, and whose
+	 * `include` lookup answers from `recordsByType`.
+	 *
+	 * @param {Object} recordsByType Post records keyed by post type slug.
+	 *
+	 * @return {Object} The `core` store mock.
+	 */
+	function mockCoreWithEventTypes( recordsByType ) {
+		return {
+			getPostType: mockGetPostType,
+			getPostTypes: () => [
+				{ slug: 'page', supports: {} },
+				{
+					slug: 'gatherpress_event',
+					supports: { 'gatherpress-event-date': true },
+				},
+				{
+					slug: 'production',
+					supports: { 'gatherpress-event-date': true },
+				},
+			],
+			getEntityRecords: ( kind, slug, query ) =>
+				( recordsByType[ slug ] ?? [] ).filter( ( record ) =>
+					query?.include?.includes( record.id )
+				),
+		};
+	}
+
 	beforeEach( () => {
 		// Create mock select function.
 		mockSelect = jest.fn( ( store ) => {
 			if ( 'core' === store ) {
-				return {
-					getPostType: mockGetPostType,
-					getEntityRecord: jest.fn(),
-				};
+				return mockCoreWithEventTypes( {} );
 			}
 			if ( 'core/editor' === store ) {
 				return {
@@ -1293,20 +1320,18 @@ describe( 'getEventMeta', () => {
 	it( 'should get saved data when attributes.postId is explicitly set (override)', () => {
 		mockSelect.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
-				return {
-					getPostType: mockGetPostType,
-					getEntityRecord: jest.fn( ( postType, slug, postId ) => {
-						if ( 'gatherpress_event' === slug && 456 === postId ) {
-							return {
-								meta: {
-									gatherpress_max_guest_limit: 20,
-									gatherpress_enable_anonymous_rsvp: true,
-								},
-							};
-						}
-						return null;
-					} ),
-				};
+				return mockCoreWithEventTypes( {
+					gatherpress_event: [
+						{
+							id: 456,
+							status: 'publish',
+							meta: {
+								gatherpress_max_guest_limit: 20,
+								gatherpress_enable_anonymous_rsvp: true,
+							},
+						},
+					],
+				} );
 			}
 			if ( 'core/editor' === store ) {
 				return {
@@ -1327,15 +1352,75 @@ describe( 'getEventMeta', () => {
 		} );
 	} );
 
+	it( 'should read the override from a companion post type with event-date support', () => {
+		mockSelect.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return mockCoreWithEventTypes( {
+					production: [
+						{
+							id: 456,
+							status: 'publish',
+							meta: {
+								gatherpress_max_guest_limit: 7,
+								gatherpress_enable_rsvp: 0,
+								gatherpress_enable_anonymous_rsvp: false,
+							},
+						},
+					],
+				} );
+			}
+			if ( 'core/editor' === store ) {
+				return {
+					getCurrentPostType: jest.fn( () => 'page' ),
+					getEditedPostAttribute: jest.fn(),
+				};
+			}
+			return {};
+		} );
+
+		const result = getEventMeta( mockSelect, 456, { postId: 456 } );
+
+		expect( result ).toEqual( {
+			maxGuestLimit: 7,
+			enableRsvp: false,
+			enableAnonymousRsvp: false,
+		} );
+	} );
+
+	it( 'should return defaults when the override points at an unpublished event', () => {
+		mockSelect.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return mockCoreWithEventTypes( {
+					gatherpress_event: [
+						{
+							id: 456,
+							status: 'draft',
+							meta: {
+								gatherpress_max_guest_limit: 20,
+								gatherpress_enable_anonymous_rsvp: true,
+							},
+						},
+					],
+				} );
+			}
+			return {};
+		} );
+
+		const result = getEventMeta( mockSelect, 456, { postId: 456 } );
+
+		expect( result ).toEqual( {
+			maxGuestLimit: 0,
+			enableRsvp: true,
+			enableAnonymousRsvp: false,
+		} );
+	} );
+
 	it( 'should handle missing meta gracefully', () => {
 		mockSelect.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
-				return {
-					getPostType: mockGetPostType,
-					getEntityRecord: jest.fn( () => ( {
-						meta: {},
-					} ) ),
-				};
+				return mockCoreWithEventTypes( {
+					gatherpress_event: [ { id: 789, status: 'publish', meta: {} } ],
+				} );
 			}
 			return {};
 		} );
@@ -1352,10 +1437,7 @@ describe( 'getEventMeta', () => {
 	it( 'should handle null post gracefully', () => {
 		mockSelect.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
-				return {
-					getPostType: mockGetPostType,
-					getEntityRecord: jest.fn( () => null ),
-				};
+				return mockCoreWithEventTypes( {} );
 			}
 			return {};
 		} );
@@ -1428,12 +1510,56 @@ describe( 'getEventMeta', () => {
  * Coverage for hasOnlineEventTerm.
  */
 describe( 'hasOnlineEventTerm', () => {
+	/**
+	 * Builds a `core` store mock for the override path: the registry declares
+	 * event-date support on the standard event type and a "production"
+	 * companion type, term lookups answer with `terms`, and the `include`
+	 * lookup returns `post` only from the post type that owns it.
+	 *
+	 * @param {Object}      options            Mock options.
+	 * @param {Array|null}  options.terms      Records returned for the taxonomy lookup.
+	 * @param {Object|null} options.post       The post the override resolves to, if any.
+	 * @param {string[]}    options.taxonomies Collects the taxonomy slug of each term lookup.
+	 *
+	 * @return {Object} The `core` store mock.
+	 */
+	function mockCoreForOverride( { terms, post = null, taxonomies = [] } ) {
+		return {
+			getPostType: mockGetPostType,
+			getPostTypes: () => [
+				{
+					slug: 'gatherpress_event',
+					supports: { 'gatherpress-event-date': true },
+				},
+				{
+					slug: 'production',
+					supports: { 'gatherpress-event-date': true },
+				},
+			],
+			getEntityRecords: ( kind, slug, query ) => {
+				if ( 'taxonomy' === kind ) {
+					taxonomies.push( slug );
+					return terms;
+				}
+
+				return post?.type === slug && query?.include?.includes( post.id )
+					? [ post ]
+					: [];
+			},
+		};
+	}
+
 	it( 'returns false when online-event term does not exist', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
 				return {
 					getPostType: mockGetPostType,
 					getEntityRecords: () => null,
+				};
+			}
+			if ( 'core/editor' === store ) {
+				return {
+					getCurrentPostType: () => 'gatherpress_event',
 				};
 			}
 			return {};
@@ -1450,6 +1576,11 @@ describe( 'hasOnlineEventTerm', () => {
 					getEntityRecords: () => [],
 				};
 			}
+			if ( 'core/editor' === store ) {
+				return {
+					getCurrentPostType: () => 'gatherpress_event',
+				};
+			}
 			return {};
 		} );
 
@@ -1457,13 +1588,32 @@ describe( 'hasOnlineEventTerm', () => {
 	} );
 
 	it( 'returns false when postId provided but post not found', () => {
+		const taxonomies = [];
+
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
-				return {
-					getPostType: mockGetPostType,
-					getEntityRecords: () => [ { id: 1 } ],
-					getEntityRecord: () => null,
-				};
+				return mockCoreForOverride( { terms: [ { id: 1 } ], taxonomies } );
+			}
+			return {};
+		} );
+
+		expect( hasOnlineEventTerm( 123 ) ).toBe( false );
+		// Bails before the term lookup when no event owns the ID.
+		expect( taxonomies ).toEqual( [] );
+	} );
+
+	it( 'returns false when the override points at an unpublished event', () => {
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return mockCoreForOverride( {
+					terms: [ { id: 42 } ],
+					post: {
+						id: 123,
+						type: 'gatherpress_event',
+						status: 'draft',
+						_gatherpress_venue: [ 42 ],
+					},
+				} );
 			}
 			return {};
 		} );
@@ -1474,14 +1624,15 @@ describe( 'hasOnlineEventTerm', () => {
 	it( 'returns false when postId provided but post has no venue terms', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
-				return {
-					getPostType: mockGetPostType,
-					getEntityRecords: () => [ { id: 1 } ],
-					getEntityRecord: () => ( {
+				return mockCoreForOverride( {
+					terms: [ { id: 1 } ],
+					post: {
 						id: 123,
+						type: 'gatherpress_event',
+						status: 'publish',
 						_gatherpress_venue: [],
-					} ),
-				};
+					},
+				} );
 			}
 			return {};
 		} );
@@ -1492,13 +1643,10 @@ describe( 'hasOnlineEventTerm', () => {
 	it( 'returns false when postId provided but venue terms undefined', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
-				return {
-					getPostType: mockGetPostType,
-					getEntityRecords: () => [ { id: 1 } ],
-					getEntityRecord: () => ( {
-						id: 123,
-					} ),
-				};
+				return mockCoreForOverride( {
+					terms: [ { id: 1 } ],
+					post: { id: 123, type: 'gatherpress_event', status: 'publish' },
+				} );
 			}
 			return {};
 		} );
@@ -1511,14 +1659,15 @@ describe( 'hasOnlineEventTerm', () => {
 
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
-				return {
-					getPostType: mockGetPostType,
-					getEntityRecords: () => [ { id: onlineTermId } ],
-					getEntityRecord: () => ( {
+				return mockCoreForOverride( {
+					terms: [ { id: onlineTermId } ],
+					post: {
 						id: 123,
+						type: 'gatherpress_event',
+						status: 'publish',
 						_gatherpress_venue: [ onlineTermId ],
-					} ),
-				};
+					},
+				} );
 			}
 			return {};
 		} );
@@ -1526,17 +1675,53 @@ describe( 'hasOnlineEventTerm', () => {
 		expect( hasOnlineEventTerm( 123 ) ).toBe( true );
 	} );
 
+	it( 'derives the venue taxonomy from the post type that owns the override', () => {
+		const onlineTermId = 42;
+		const taxonomies = [];
+
+		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
+			if ( 'core' === store ) {
+				return mockCoreForOverride( {
+					terms: [ { id: onlineTermId } ],
+					post: {
+						id: 123,
+						type: 'production',
+						status: 'publish',
+						_location: [ onlineTermId ],
+					},
+					taxonomies,
+				} );
+			}
+			if ( 'core/editor' === store ) {
+				return {
+					// The editor has a page open; the override is what carries the event type.
+					getCurrentPostType: () => 'page',
+					getEditorSettings: () => ( {
+						gatherpress: {
+							config: { venuePostTypes: { production: 'location' } },
+						},
+					} ),
+				};
+			}
+			return {};
+		} );
+
+		expect( hasOnlineEventTerm( 123 ) ).toBe( true );
+		expect( taxonomies ).toEqual( [ '_location' ] );
+	} );
+
 	it( 'returns false when postId provided but term does not match', () => {
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
-				return {
-					getPostType: mockGetPostType,
-					getEntityRecords: () => [ { id: 42 } ],
-					getEntityRecord: () => ( {
+				return mockCoreForOverride( {
+					terms: [ { id: 42 } ],
+					post: {
 						id: 123,
+						type: 'gatherpress_event',
+						status: 'publish',
 						_gatherpress_venue: [ 99 ], // Different term ID.
-					} ),
-				};
+					},
+				} );
 			}
 			return {};
 		} );
@@ -1671,14 +1856,15 @@ describe( 'hasOnlineEventTerm', () => {
 
 		require( '@wordpress/data' ).select.mockImplementation( ( store ) => {
 			if ( 'core' === store ) {
-				return {
-					getPostType: mockGetPostType,
-					getEntityRecords: () => [ { id: onlineTermId } ],
-					getEntityRecord: () => ( {
+				return mockCoreForOverride( {
+					terms: [ { id: onlineTermId } ],
+					post: {
 						id: 123,
+						type: 'gatherpress_event',
+						status: 'publish',
 						_gatherpress_venue: [ 10, onlineTermId, 20 ], // Multiple terms.
-					} ),
-				};
+					},
+				} );
 			}
 			return {};
 		} );

--- a/test/unit/php/includes/tests/core/classes/class-test-import.php
+++ b/test/unit/php/includes/tests/core/classes/class-test-import.php
@@ -134,6 +134,25 @@ class Test_Import extends Base {
 			Utility::invoke_hidden_method( $instance, 'validate', array( $post_data_raw ) ),
 			'Failed to assert that validation passes for valid post data.'
 		);
+
+		$post_data_raw = array( 'post_type' => 'post' );
+		$this->assertFalse(
+			Utility::invoke_hidden_method( $instance, 'validate', array( $post_data_raw ) ),
+			'Failed to assert that validation fails for a post type without event-date support.'
+		);
+
+		$post_type = 'gp_import_custom';
+		register_post_type( $post_type, array( 'supports' => array( 'title', Event::SUPPORT ) ) );
+
+		$post_data_raw = array( 'post_type' => $post_type );
+		$valid         = Utility::invoke_hidden_method( $instance, 'validate', array( $post_data_raw ) );
+
+		unregister_post_type( $post_type );
+
+		$this->assertTrue(
+			$valid,
+			'Failed to assert that validation passes for a custom post type with event-date support.'
+		);
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
+++ b/test/unit/php/includes/tests/core/classes/event/class-test-rest-api.php
@@ -1132,6 +1132,81 @@ class Test_Rest_Api extends Base {
 	}
 
 	/**
+	 * Coverage for rsvp_responses with a custom post type that declares RSVP support.
+	 *
+	 * @covers ::rsvp_responses
+	 *
+	 * @return void
+	 */
+	public function test_rsvp_responses_custom_rsvp_post_type(): void {
+		$instance  = Rest_Api::get_instance();
+		$post_type = 'gp_rsvp_custom';
+
+		register_post_type(
+			$post_type,
+			array(
+				'public'   => true,
+				'supports' => array( 'title', Event::SUPPORT, Rsvp::SUPPORT ),
+			)
+		);
+
+		$post_id = $this->factory()->post->create( array( 'post_type' => $post_type ) );
+		$user_id = $this->factory()->user->create();
+		$rsvp    = new Rsvp( $post_id );
+		$rsvp->save( $user_id, 'attending', 0, 1 );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'post_id', $post_id );
+
+		$response = $instance->rsvp_responses( $request );
+		$data     = $response->get_data();
+
+		unregister_post_type( $post_type );
+
+		$this->assertTrue(
+			$data['success'],
+			'Failed to assert that a post type with RSVP support returns its responses.'
+		);
+		$this->assertArrayHasKey( 'attending', $data['data'] );
+	}
+
+	/**
+	 * Coverage for rsvp_responses with a post type that has event dates but no RSVP support.
+	 *
+	 * @covers ::rsvp_responses
+	 *
+	 * @return void
+	 */
+	public function test_rsvp_responses_event_date_only_post_type(): void {
+		$instance  = Rest_Api::get_instance();
+		$post_type = 'gp_date_only';
+
+		register_post_type(
+			$post_type,
+			array(
+				'public'   => true,
+				'supports' => array( 'title', Event::SUPPORT ),
+			)
+		);
+
+		$post_id = $this->factory()->post->create( array( 'post_type' => $post_type ) );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'post_id', $post_id );
+
+		$response = $instance->rsvp_responses( $request );
+		$data     = $response->get_data();
+
+		unregister_post_type( $post_type );
+
+		$this->assertFalse(
+			$data['success'],
+			'Failed to assert that event-date support alone does not expose RSVP responses.'
+		);
+		$this->assertEmpty( $data['data'] );
+	}
+
+	/**
 	 * Coverage for rsvp_status_html method.
 	 *
 	 * @covers ::rsvp_status_html
@@ -1374,6 +1449,43 @@ class Test_Rest_Api extends Base {
 		$result = $instance->send_emails( $post_id, array( 'all' => true ), '' );
 
 		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Coverage for send_emails with a custom post type that declares RSVP support.
+	 *
+	 * @covers ::send_emails
+	 *
+	 * @return void
+	 */
+	public function test_send_emails_custom_rsvp_post_type(): void {
+		add_filter( 'pre_wp_mail', '__return_false' );
+
+		$instance  = Rest_Api::get_instance();
+		$post_type = 'gp_rsvp_custom';
+
+		register_post_type(
+			$post_type,
+			array(
+				'public'   => true,
+				'supports' => array( 'title', Event::SUPPORT, Rsvp::SUPPORT ),
+			)
+		);
+
+		$post_id = $this->factory()->post->create( array( 'post_type' => $post_type ) );
+		$user_id = $this->factory()->user->create();
+		$rsvp    = new Rsvp( $post_id );
+		$rsvp->save( $user_id, 'attending' );
+
+		$result = $instance->send_emails( $post_id, array( 'attending' => true ), 'Test message' );
+
+		unregister_post_type( $post_type );
+		remove_filter( 'pre_wp_mail', '__return_false' );
+
+		$this->assertTrue(
+			$result,
+			'Failed to assert that a post type with RSVP support can send event emails.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Closes #2289

## What

`src/helpers/event.js` fetched override posts with a hardcoded `gatherpress_event` post type in two helpers. A block whose Post ID override points at a companion plugin's event type (a `production` that declares `gatherpress-event-date`) sent the request to the events endpoint with a foreign ID, got a 404, and quietly reported RSVP defaults.

Both helpers now go through the existing support-based resolver, `findEventPostById()`:

- `getEventMeta()` resolves the override across every event-supporting post type. The live-editor branch also uses the module's `selectFunc`-based support check so the read subscribes through the caller's `useSelect`.
- `hasOnlineEventTerm()` resolves the override the same way, and derives the venue taxonomy from the post type that owns the found post instead of whatever type the editor has open.

Scanning for the same pattern turned up three PHP call sites comparing `Event::POST_TYPE` where a support check belongs:

- `Rest_Api::send_emails()` and `Rest_Api::rsvp_responses()` now gate on `Rsvp::SUPPORT`. The routes already validate `post_id` through `Validate::event_post_id()`, which is support-based, so the handlers were the only thing refusing companion post types.
- `Import::validate()` now gates on `Event::SUPPORT`, matching the export side, which marks posts through `Validate::event_post_id()`. Companion event types round-trip their datetimes through WXR.

## Behavior change

`findEventPostById()` returns only published posts, where `getEntityRecord()` returned anything the user could edit. An override pointing at a draft event now reads defaults instead of the draft's meta. Each helper has a test for it.

## Left alone, on purpose

- The archive-page branches in `Event\Setup` and `Event\Setup::get_event_archive_mode()` compare `Event::POST_TYPE` because the archive settings only exist for the standard type (#1611).
- `Event\Meta::register_event_only_meta()` registers the RSVP and online-link meta on `Event::POST_TYPE` only, and its docblock says that is deliberate. A companion type with `gatherpress-rsvp` support therefore has no `gatherpress_enable_rsvp` meta in REST unless it registers its own. Flagging rather than changing here.

## Tests

- JS: the `getEventMeta` override tests moved from `getEntityRecord` mocks to `getPostTypes` and `getEntityRecords`, plus a companion-type case and a draft-override case. The `hasOnlineEventTerm` override tests likewise, plus a case asserting the taxonomy comes from the override's post type (`_location`) and an unpublished-override case. `src/helpers/event.js` sits at 100% statements, branches, functions and lines. Full JS suite passes.
- PHP: `test_rsvp_responses_custom_rsvp_post_type`, `test_rsvp_responses_event_date_only_post_type`, `test_send_emails_custom_rsvp_post_type`, and `test_validate` extended with a supported custom type and a plain `post`. `Test_Rest_Api` and `Test_Import` pass. phpcs, PHPStan, and PHPMD are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Event imports now support compatible custom content types that provide event-date support.
  - RSVP responses and event email notifications now work with compatible custom content types that provide RSVP support.
  - Event venue and metadata overrides now resolve correctly across supported custom event types.

- **Bug Fixes**
  - Improved handling of unpublished, missing, or incomplete event overrides.
  - Online event taxonomy and metadata lookups now use the correct content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->