### PR TITLE
fix(rsvp): exclude RSVPs from comment queries through type__not_in

### DIFF
--- a/.github/changelog/2282-rsvp-comment-query-exclusion
+++ b/.github/changelog/2282-rsvp-comment-query-exclusion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Exclude RSVPs from comment queries through `type__not_in` instead of an allow-list built from the stored comment types, so a site whose only comments are RSVPs no longer shows them as blank entries in the Discussion section, `type => 'all'` queries stay RSVP-free, and queries that only set `type__in` are no longer widened to every comment type.

--- a/docs/developer/rsvp/README.md
+++ b/docs/developer/rsvp/README.md
@@ -12,20 +12,25 @@ infrastructure for free.
 Because RSVPs live in `wp_comments`, generic comment queries (sidebar widgets,
 admin moderation lists, REST endpoints, federation plugins) would surface them
 alongside real comments unless filtered out. GatherPress hooks
-`pre_get_comments` and removes the `gatherpress_rsvp` type from each query's
-`type` / `type__in` vars in `Rsvp\Query::exclude_rsvp_from_comment_query()`
-([`includes/core/classes/rsvp/class-query.php`](../../../includes/core/classes/rsvp/class-query.php)).
+`pre_get_comments` in `Rsvp\Query::exclude_rsvp_from_comment_query()`
+([`includes/core/classes/rsvp/class-query.php`](../../../includes/core/classes/rsvp/class-query.php)),
+which strips the `gatherpress_rsvp` type from any `type` / `type__in`
+allow-list the caller passed and adds it to `type__not_in`. Core turns that
+into `comment_type NOT IN ('gatherpress_rsvp')`, so the exclusion holds
+whatever else is stored: a site whose only comments are RSVPs, a caller asking
+for `all`, and a query that only sets `type__in` all stay RSVP-free.
 
-The exclusion mutates query vars rather than appending a `WHERE comment_type !=
-…` clause because the `comment_type` column is not indexed in WordPress core
-(see [Trac #59488](https://core.trac.wordpress.org/ticket/59488)). Pre-populating
-the type list lets MySQL use the existing index and avoids a full-table scan on
-sites with large comment volumes.
+The `comment_type` column is not indexed in WordPress core (see
+[Trac #59488](https://core.trac.wordpress.org/ticket/59488)), so the type
+condition is evaluated per row after the post ID or approval index has
+narrowed the query. Sites with large comment volumes can add a `comment_type`
+index themselves; once one exists, whether core adds it or the site does, the
+`NOT IN` becomes a range scan on that index.
 
 ### When the default exclusion gets in the way
 
-Mutating shared query vars is the right trade-off for performance but can
-conflict with other plugins that read or write the same vars on
+The exclusion touches shared query vars, which can conflict with other plugins
+that read or write the same vars on
 `pre_get_comments`. The canonical example is the [ActivityPub
 plugin](https://github.com/Automattic/wordpress-activitypub) — federation
 interactions (likes, boosts, quotes) flow through `wp_comments` with their own

--- a/docs/developer/rsvp/README.md
+++ b/docs/developer/rsvp/README.md
@@ -14,11 +14,13 @@ admin moderation lists, REST endpoints, federation plugins) would surface them
 alongside real comments unless filtered out. GatherPress hooks
 `pre_get_comments` in `Rsvp\Query::exclude_rsvp_from_comment_query()`
 ([`includes/core/classes/rsvp/class-query.php`](../../../includes/core/classes/rsvp/class-query.php)),
-which strips the `gatherpress_rsvp` type from any `type` / `type__in`
-allow-list the caller passed and adds it to `type__not_in`. Core turns that
-into `comment_type NOT IN ('gatherpress_rsvp')`, so the exclusion holds
-whatever else is stored: a site whose only comments are RSVPs, a caller asking
-for `all`, and a query that only sets `type__in` all stay RSVP-free.
+which adds the `gatherpress_rsvp` type to `type__not_in` and leaves `type` /
+`type__in` as the caller wrote them. Core turns that into
+`comment_type NOT IN ('gatherpress_rsvp')` on top of any allow-list, so the
+exclusion holds whatever else is stored: a site whose only comments are RSVPs,
+a caller asking for `all`, and a query that only sets `type__in` all stay
+RSVP-free, and an allow-list naming only the RSVP type returns nothing while
+the exclusion is active.
 
 The `comment_type` column is not indexed in WordPress core (see
 [Trac #59488](https://core.trac.wordpress.org/ticket/59488)), so the type

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -154,8 +154,10 @@ final class Query {
 	/**
 	 * Exclude RSVP comments from a query.
 	 *
-	 * Strips the RSVP type out of any `type` / `type__in` allow-list the caller
-	 * passed, then excludes it through `type__not_in`. Excluding, rather than
+	 * Adds the RSVP type to `type__not_in` and leaves `type` / `type__in` as the
+	 * caller wrote them; core applies the `NOT IN` on top of any allow-list, so
+	 * a mixed list keeps its other types and a list naming only the RSVP type
+	 * returns nothing while the exclusion is active. Excluding, rather than
 	 * rebuilding an allow-list from the comment types stored in the database,
 	 * closes three gaps: the allow-list is empty when RSVPs are the only stored
 	 * type, and core reads an empty `type` as no restriction at all; a caller
@@ -200,38 +202,12 @@ final class Query {
 			return;
 		}
 
-		$query->query_vars['type'] = $this->remove_rsvp_type( $query->query_vars['type'] ?? '' );
-
-		if ( ! empty( $query->query_vars['type__in'] ) ) {
-			$query->query_vars['type__in'] = $this->remove_rsvp_type( $query->query_vars['type__in'] );
-		}
-
 		// Core accepts a string or an array here; drop the empty default so the
 		// RSVP type never sits next to a blank entry.
 		$type_not_in   = array_diff( (array) ( $query->query_vars['type__not_in'] ?? '' ), array( '' ) );
 		$type_not_in[] = Rsvp::COMMENT_TYPE;
 
 		$query->query_vars['type__not_in'] = array_values( array_unique( $type_not_in ) );
-	}
-
-	/**
-	 * Removes the RSVP comment type from a `type` or `type__in` query var.
-	 *
-	 * Keeps the shape the caller used: an array comes back reindexed without
-	 * the RSVP type, and a string naming only the RSVP type becomes empty.
-	 *
-	 * @since 0.36.0
-	 *
-	 * @param string|string[] $types The query var as the caller set it.
-	 *
-	 * @return string|string[] The query var without the RSVP type.
-	 */
-	protected function remove_rsvp_type( string|array $types ): string|array {
-		if ( is_array( $types ) ) {
-			return array_values( array_diff( $types, array( Rsvp::COMMENT_TYPE ) ) );
-		}
-
-		return Rsvp::COMMENT_TYPE === $types ? '' : $types;
 	}
 
 	/**

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -37,22 +37,6 @@ final class Query {
 	use Singleton;
 
 	/**
-	 * Cache key for storing comment types.
-	 *
-	 * @since 0.34.0
-	 * @var string
-	 */
-	const COMMENT_TYPES_CACHE_KEY = 'gatherpress_all_comment_types';
-
-	/**
-	 * Cache expiration time (24 hours).
-	 *
-	 * @since 0.34.0
-	 * @var int
-	 */
-	const CACHE_EXPIRATION = DAY_IN_SECONDS;
-
-	/**
 	 * Class constructor.
 	 *
 	 * This method initializes the object and sets up necessary hooks.
@@ -75,7 +59,6 @@ final class Query {
 	protected function setup_hooks(): void {
 		add_action( 'pre_get_comments', array( $this, 'exclude_rsvp_from_comment_query' ) );
 		add_filter( 'comments_clauses', array( $this, 'taxonomy_query' ), 10, 2 );
-		add_action( 'wp_insert_comment', array( $this, 'maybe_invalidate_comment_types_cache' ), 10, 2 );
 		add_filter( 'get_comment', array( $this, 'prepare_rsvp_comment' ) );
 		add_filter( 'rest_prepare_comment', array( $this, 'mask_anonymous_rsvp_rest_author' ), 10, 2 );
 	}
@@ -169,79 +152,16 @@ final class Query {
 	}
 
 	/**
-	 * Get all comment types registered in the database.
-	 *
-	 * This method queries the database for all distinct comment types
-	 * and caches the result for performance.
-	 *
-	 * @since 0.34.0
-	 *
-	 * @return string[] Array of all comment types in the database.
-	 */
-	protected function get_all_comment_types(): array {
-		$default_types = array( 'comment', 'pingback', 'trackback' );
-		$types         = get_transient( self::COMMENT_TYPES_CACHE_KEY );
-
-		if ( false === $types ) {
-			global $wpdb;
-
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$types = $wpdb->get_col(
-				$wpdb->prepare(
-					'SELECT DISTINCT comment_type FROM %i WHERE comment_type != %s',
-					$wpdb->comments,
-					''
-				)
-			);
-
-			// If no types found or database error, use WordPress defaults.
-			if ( empty( $types ) || ! is_array( $types ) ) {
-				$types = $default_types;
-			}
-
-			// Cache for 24 hours.
-			set_transient( self::COMMENT_TYPES_CACHE_KEY, $types, self::CACHE_EXPIRATION );
-		}
-
-		// Ensure we always return an array.
-		return is_array( $types ) ? $types : $default_types;
-	}
-
-	/**
-	 * Invalidate comment types cache when a new comment type is added.
-	 *
-	 * This method checks if a newly inserted comment has a type that's not
-	 * already in our cached types, and if so, invalidates the cache.
-	 *
-	 * @since 0.34.0
-	 *
-	 * @param int        $id      The comment ID.
-	 * @param WP_Comment $comment The comment object.
-	 *
-	 * @return void
-	 *
-	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-	 */
-	public function maybe_invalidate_comment_types_cache( int $id, WP_Comment $comment ): void {
-		// Skip if it's an empty comment type (regular comment).
-		if ( empty( $comment->comment_type ) ) {
-			return;
-		}
-
-		$cached_types = get_transient( self::COMMENT_TYPES_CACHE_KEY );
-
-		// If cache exists and this type isn't in it, invalidate the cache.
-		if ( false !== $cached_types && ! in_array( $comment->comment_type, $cached_types, true ) ) {
-			delete_transient( self::COMMENT_TYPES_CACHE_KEY );
-		}
-	}
-
-	/**
 	 * Exclude RSVP comments from a query.
 	 *
-	 * This method modifies the comment query to exclude comments of the RSVP type. It
-	 * ensures that RSVP comments are not included in the query results by adjusting the
-	 * comment types in the query variables.
+	 * Strips the RSVP type out of any `type` / `type__in` allow-list the caller
+	 * passed, then excludes it through `type__not_in`. Excluding, rather than
+	 * rebuilding an allow-list from the comment types stored in the database,
+	 * closes three gaps: the allow-list is empty when RSVPs are the only stored
+	 * type, and core reads an empty `type` as no restriction at all; a caller
+	 * asking for `all` was never narrowed; and a query that only set `type__in`
+	 * was widened to every stored type, because core merges `type` and
+	 * `type__in` into one `IN` list (#2282).
 	 *
 	 * Note: The comment_type field is not currently indexed in WordPress core,
 	 * which may impact query performance. See https://core.trac.wordpress.org/ticket/59488
@@ -276,39 +196,38 @@ final class Query {
 			return;
 		}
 
-		// Process 'type' query var.
-		$current_comment_types = $query->query_vars['type'];
+		$query->query_vars['type'] = $this->remove_rsvp_type( $query->query_vars['type'] ?? '' );
 
-		if ( ! empty( $current_comment_types ) ) {
-			if ( is_array( $current_comment_types ) ) {
-				$current_comment_types = array_values(
-					array_diff( $current_comment_types, array( Rsvp::COMMENT_TYPE ) )
-				);
-			} elseif ( Rsvp::COMMENT_TYPE === $current_comment_types ) {
-				$current_comment_types = '';
-			}
-		} else {
-			// Get all registered comment types from the database (cached).
-			$current_comment_types = $this->get_all_comment_types();
-			$current_comment_types = array_values( array_diff( $current_comment_types, array( Rsvp::COMMENT_TYPE ) ) );
+		if ( ! empty( $query->query_vars['type__in'] ) ) {
+			$query->query_vars['type__in'] = $this->remove_rsvp_type( $query->query_vars['type__in'] );
 		}
 
-		$query->query_vars['type'] = $current_comment_types;
+		// Core accepts a string or an array here; drop the empty default so the
+		// RSVP type never sits next to a blank entry.
+		$type_not_in   = array_diff( (array) ( $query->query_vars['type__not_in'] ?? '' ), array( '' ) );
+		$type_not_in[] = Rsvp::COMMENT_TYPE;
 
-		// Process 'type__in' query var.
-		$current_comment_types_in = $query->query_vars['type__in'];
+		$query->query_vars['type__not_in'] = array_values( array_unique( $type_not_in ) );
+	}
 
-		if ( ! empty( $current_comment_types_in ) ) {
-			if ( is_array( $current_comment_types_in ) ) {
-				$current_comment_types_in = array_values(
-					array_diff( $current_comment_types_in, array( Rsvp::COMMENT_TYPE ) )
-				);
-			} elseif ( Rsvp::COMMENT_TYPE === $current_comment_types_in ) {
-				$current_comment_types_in = '';
-			}
-
-			$query->query_vars['type__in'] = $current_comment_types_in;
+	/**
+	 * Removes the RSVP comment type from a `type` or `type__in` query var.
+	 *
+	 * Keeps the shape the caller used: an array comes back reindexed without
+	 * the RSVP type, and a string naming only the RSVP type becomes empty.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string|string[] $types The query var as the caller set it.
+	 *
+	 * @return string|string[] The query var without the RSVP type.
+	 */
+	protected function remove_rsvp_type( string|array $types ): string|array {
+		if ( is_array( $types ) ) {
+			return array_values( array_diff( $types, array( Rsvp::COMMENT_TYPE ) ) );
 		}
+
+		return Rsvp::COMMENT_TYPE === $types ? '' : $types;
 	}
 
 	/**

--- a/includes/core/classes/rsvp/class-query.php
+++ b/includes/core/classes/rsvp/class-query.php
@@ -163,8 +163,12 @@ final class Query {
 	 * was widened to every stored type, because core merges `type` and
 	 * `type__in` into one `IN` list (#2282).
 	 *
-	 * Note: The comment_type field is not currently indexed in WordPress core,
-	 * which may impact query performance. See https://core.trac.wordpress.org/ticket/59488
+	 * Note: The comment_type column is not indexed in WordPress core, so the
+	 * exclusion is evaluated per row after the post ID or approval index has
+	 * narrowed the query. Once a `comment_type` index exists, whether core adds
+	 * one (https://core.trac.wordpress.org/ticket/59488) or a large site adds
+	 * its own, the `NOT IN` becomes a range scan on that index, the same as an
+	 * allow-list would.
 	 *
 	 * @since 0.34.0
 	 *

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
@@ -13,7 +13,8 @@ use GatherPress\Core\Rsvp\Query;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp\Response\Status;
 use GatherPress\Tests\Base;
-use stdClass;
+use PMC\Unit_Test\Utility;
+use WP_Block;
 use WP_Comment;
 use WP_Comment_Query;
 use WP_REST_Response;
@@ -47,12 +48,6 @@ class Test_Query extends Base {
 				'name'     => 'comments_clauses',
 				'priority' => 10,
 				'callback' => array( $instance, 'taxonomy_query' ),
-			),
-			array(
-				'type'     => 'action',
-				'name'     => 'wp_insert_comment',
-				'priority' => 10,
-				'callback' => array( $instance, 'maybe_invalidate_comment_types_cache' ),
 			),
 			array(
 				'type'     => 'filter',
@@ -245,10 +240,11 @@ class Test_Query extends Base {
 	}
 
 	/**
-	 * Test excluding RSVP from empty type sets default comment types.
+	 * With no `type` set, the query var stays empty and the RSVP type lands in
+	 * `type__not_in`, so a site whose only stored comment type is the RSVP type
+	 * still excludes it (#2282).
 	 *
 	 * @covers ::exclude_rsvp_from_comment_query
-	 * @covers ::get_all_comment_types
 	 *
 	 * @return void
 	 */
@@ -256,37 +252,204 @@ class Test_Query extends Base {
 		$instance = Query::get_instance();
 		$query    = new WP_Comment_Query();
 
-		// Clear any existing transient.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
+		$query->query_vars['type']         = '';
+		$query->query_vars['type__in']     = '';
+		$query->query_vars['type__not_in'] = '';
 
-		// Create a custom comment type to test dynamic fetching.
-		$this->factory->comment->create(
-			array(
-				'comment_type' => 'custom_type',
-			)
+		$instance->exclude_rsvp_from_comment_query( $query );
+
+		$this->assertSame(
+			'',
+			$query->query_vars['type'],
+			'Type should stay empty rather than being rebuilt from the stored comment types.'
 		);
+		$this->assertSame(
+			array( Rsvp::COMMENT_TYPE ),
+			$query->query_vars['type__not_in'],
+			'RSVP type should be excluded through type__not_in.'
+		);
+	}
 
-		$query->query_vars['type']     = '';
+	/**
+	 * A caller asking for `all` keeps that, and the RSVP type is still excluded.
+	 *
+	 * @covers ::exclude_rsvp_from_comment_query
+	 *
+	 * @return void
+	 */
+	public function test_exclude_rsvp_from_type_all(): void {
+		$instance = Query::get_instance();
+		$query    = new WP_Comment_Query();
+
+		$query->query_vars['type']     = 'all';
 		$query->query_vars['type__in'] = '';
 
 		$instance->exclude_rsvp_from_comment_query( $query );
 
-		// Should include all types except RSVP.
-		$this->assertNotContains(
-			'gatherpress_rsvp',
-			$query->query_vars['type'],
-			'RSVP type should be excluded'
+		$this->assertSame( 'all', $query->query_vars['type'], 'Type should be left as the caller set it.' );
+		$this->assertSame(
+			array( Rsvp::COMMENT_TYPE ),
+			$query->query_vars['type__not_in'],
+			'RSVP type should be excluded through type__not_in.'
+		);
+	}
+
+	/**
+	 * The RSVP type is appended to whatever `type__not_in` the caller passed,
+	 * string or array, without duplicating it.
+	 *
+	 * @covers ::exclude_rsvp_from_comment_query
+	 *
+	 * @return void
+	 */
+	public function test_exclude_rsvp_merges_into_existing_type_not_in(): void {
+		$instance = Query::get_instance();
+		$query    = new WP_Comment_Query();
+
+		$query->query_vars['type']         = '';
+		$query->query_vars['type__in']     = '';
+		$query->query_vars['type__not_in'] = 'pingback';
+
+		$instance->exclude_rsvp_from_comment_query( $query );
+
+		$this->assertSame(
+			array( 'pingback', Rsvp::COMMENT_TYPE ),
+			$query->query_vars['type__not_in'],
+			'A string type__not_in should become an array that keeps the caller type.'
 		);
 
-		// Should include the custom type.
+		$query = new WP_Comment_Query();
+
+		$query->query_vars['type']         = '';
+		$query->query_vars['type__in']     = '';
+		$query->query_vars['type__not_in'] = array( 'trackback', Rsvp::COMMENT_TYPE );
+
+		$instance->exclude_rsvp_from_comment_query( $query );
+
+		$this->assertSame(
+			array( 'trackback', Rsvp::COMMENT_TYPE ),
+			$query->query_vars['type__not_in'],
+			'An RSVP type already in type__not_in should not be duplicated.'
+		);
+	}
+
+	/**
+	 * A query that only sets `type__in` keeps `type` empty, so core's merge of
+	 * the two does not widen it to every stored comment type (#1637).
+	 *
+	 * @covers ::exclude_rsvp_from_comment_query
+	 *
+	 * @return void
+	 */
+	public function test_exclude_rsvp_keeps_type_in_only_query_narrow(): void {
+		Query::get_instance();
+
+		$post_id = $this->factory->post->create();
+
+		$this->factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+		$this->factory->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => Rsvp::COMMENT_TYPE,
+			)
+		);
+		$custom_id = $this->factory->comment->create(
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_type'    => 'custom_type',
+			)
+		);
+
+		$query = new WP_Comment_Query(
+			array(
+				'post_id'  => $post_id,
+				'type__in' => array( 'custom_type' ),
+				'fields'   => 'ids',
+			)
+		);
+
+		$this->assertSame( '', $query->query_vars['type'], 'Type should not be rebuilt when only type__in is set.' );
+		$this->assertSame(
+			array( $custom_id ),
+			array_map( 'intval', $query->comments ),
+			'Only the type__in comment should be returned.'
+		);
+	}
+
+	/**
+	 * Reproduces #2282: with the RSVP type as the only comment type stored, the
+	 * comments block's query still comes back empty, and returns only the
+	 * ordinary comment once one exists.
+	 *
+	 * @covers ::exclude_rsvp_from_comment_query
+	 *
+	 * @return void
+	 */
+	public function test_rsvp_is_excluded_when_it_is_the_only_comment_type(): void {
+		Query::get_instance();
+
+		$post_id = $this->factory->post->create( array( 'post_type' => Event::POST_TYPE ) );
+		$user_id = $this->factory->user->create();
+
+		( new Rsvp( $post_id ) )->save( $user_id, 'attending' );
+
+		$block          = new WP_Block( array( 'blockName' => 'core/comments' ) );
+		$block->context = array( 'postId' => $post_id );
+
+		$query = new WP_Comment_Query( build_comment_query_vars_from_block( $block ) );
+
 		$this->assertContains(
-			'custom_type',
-			$query->query_vars['type'],
-			'Custom comment type should be included'
+			Rsvp::COMMENT_TYPE,
+			$query->query_vars['type__not_in'],
+			'The RSVP type should be excluded through type__not_in.'
 		);
+		$this->assertSame( array(), $query->comments, 'The RSVP should not surface as a comment.' );
 
-		// Clean up.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
+		$comment_id = $this->factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+
+		$query = new WP_Comment_Query( build_comment_query_vars_from_block( $block ) );
+
+		// Threaded results are keyed by comment ID, so compare values only.
+		$this->assertSame(
+			array( $comment_id ),
+			array_values(
+				array_map( static fn ( WP_Comment $comment ): int => (int) $comment->comment_ID, $query->comments )
+			),
+			'Only the ordinary comment should be returned.'
+		);
+	}
+
+	/**
+	 * Direct coverage for the `type` / `type__in` normalizer: arrays come back
+	 * reindexed without the RSVP type, an RSVP-only string becomes empty, and
+	 * any other string is left alone.
+	 *
+	 * @covers ::remove_rsvp_type
+	 *
+	 * @return void
+	 */
+	public function test_remove_rsvp_type(): void {
+		$instance = Query::get_instance();
+
+		$this->assertSame(
+			array( 'comment', 'pingback' ),
+			Utility::invoke_hidden_method(
+				$instance,
+				'remove_rsvp_type',
+				array( array( 'comment', Rsvp::COMMENT_TYPE, 'pingback' ) )
+			),
+			'An array should be reindexed without the RSVP type.'
+		);
+		$this->assertSame(
+			'',
+			Utility::invoke_hidden_method( $instance, 'remove_rsvp_type', array( Rsvp::COMMENT_TYPE ) ),
+			'An RSVP-only string should become empty.'
+		);
+		$this->assertSame(
+			'comment',
+			Utility::invoke_hidden_method( $instance, 'remove_rsvp_type', array( 'comment' ) ),
+			'Any other string should be left alone.'
+		);
 	}
 
 
@@ -486,232 +649,6 @@ class Test_Query extends Base {
 	}
 
 	/**
-	 * Test get_all_comment_types method caches results.
-	 *
-	 * @covers ::get_all_comment_types
-	 *
-	 * @return void
-	 */
-	public function test_get_all_comment_types_caching(): void {
-		$instance = Query::get_instance();
-
-		// Clear any existing transient.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
-
-		// Temporarily remove the cache invalidation hook for this test.
-		remove_action( 'wp_insert_comment', array( $instance, 'maybe_invalidate_comment_types_cache' ), 10 );
-
-		// Create some test comment types.
-		$this->factory->comment->create(
-			array(
-				'comment_type' => 'test_type_1',
-			)
-		);
-		$this->factory->comment->create(
-			array(
-				'comment_type' => 'test_type_2',
-			)
-		);
-
-		// Use reflection to access protected method.
-		$reflection = new \ReflectionClass( $instance );
-		$method     = $reflection->getMethod( 'get_all_comment_types' );
-		$method->setAccessible( true );
-
-		// First call should hit the database.
-		$types = $method->invoke( $instance );
-
-		// Should include our test types.
-		$this->assertContains( 'test_type_1', $types, 'First test type should be included' );
-		$this->assertContains( 'test_type_2', $types, 'Second test type should be included' );
-
-		// Verify transient was set.
-		$cached_types = get_transient( Query::COMMENT_TYPES_CACHE_KEY );
-		$this->assertEquals( $types, $cached_types, 'Transient should store the types' );
-
-		// Create another type after caching.
-		$this->factory->comment->create(
-			array(
-				'comment_type' => 'test_type_3',
-			)
-		);
-
-		// Second call should use cache and NOT include the new type.
-		$cached_result = $method->invoke( $instance );
-		$this->assertNotContains( 'test_type_3', $cached_result, 'New type should not be in cached result' );
-
-		// Clear transient and verify new type is included.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
-		$fresh_result = $method->invoke( $instance );
-		$this->assertContains( 'test_type_3', $fresh_result, 'New type should be included after cache clear' );
-
-		// Clean up and restore hook.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
-		add_action( 'wp_insert_comment', array( $instance, 'maybe_invalidate_comment_types_cache' ), 10, 2 );
-	}
-
-	/**
-	 * Test cache invalidation when new comment type is added.
-	 *
-	 * @covers ::maybe_invalidate_comment_types_cache
-	 *
-	 * @return void
-	 */
-	public function test_maybe_invalidate_comment_types_cache(): void {
-		$instance = Query::get_instance();
-
-		// Clear any existing transient.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
-
-		// Set up initial cache with known types.
-		set_transient(
-			Query::COMMENT_TYPES_CACHE_KEY,
-			array( 'comment', 'pingback', 'trackback' ),
-			Query::CACHE_EXPIRATION
-		);
-
-		// Create a comment with existing type (should not invalidate).
-		$comment_id = $this->factory->comment->create(
-			array(
-				'comment_type' => 'pingback',
-			)
-		);
-		$comment    = get_comment( $comment_id );
-		$instance->maybe_invalidate_comment_types_cache( $comment_id, $comment );
-
-		// Cache should still exist.
-		$this->assertNotFalse(
-			get_transient( Query::COMMENT_TYPES_CACHE_KEY ),
-			'Cache should not be invalidated for existing comment type'
-		);
-
-		// Create a comment with new type (should invalidate).
-		$comment_id = $this->factory->comment->create(
-			array(
-				'comment_type' => 'new_custom_type',
-			)
-		);
-		$comment    = get_comment( $comment_id );
-		$instance->maybe_invalidate_comment_types_cache( $comment_id, $comment );
-
-		// Cache should be cleared.
-		$this->assertFalse(
-			get_transient( Query::COMMENT_TYPES_CACHE_KEY ),
-			'Cache should be invalidated when new comment type is added'
-		);
-
-		// Clean up.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
-	}
-
-	/**
-	 * Test maybe_invalidate_comment_types_cache with empty comment type.
-	 *
-	 * Tests the early return path when comment_type is empty (regular comment).
-	 *
-	 * @covers ::maybe_invalidate_comment_types_cache
-	 *
-	 * @return void
-	 */
-	public function test_maybe_invalidate_comment_types_cache_with_empty_type(): void {
-		$instance = Query::get_instance();
-
-		// Set up cache.
-		set_transient(
-			Query::COMMENT_TYPES_CACHE_KEY,
-			array( 'pingback', 'trackback' ),
-			Query::CACHE_EXPIRATION
-		);
-
-		// Create a mock WP_Comment object with empty string comment_type.
-		$comment               = new WP_Comment( new stdClass() );
-		$comment->comment_ID   = 998;
-		$comment->comment_type = '';
-
-		// Verify comment_type is actually empty.
-		$this->assertEmpty(
-			$comment->comment_type,
-			'Comment type should be empty for this test'
-		);
-
-		$instance->maybe_invalidate_comment_types_cache( 998, $comment );
-
-		// Cache should still exist (method returns early for empty types).
-		$this->assertNotFalse(
-			get_transient( Query::COMMENT_TYPES_CACHE_KEY ),
-			'Cache should not be invalidated for empty comment type'
-		);
-
-		// Clean up.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
-	}
-
-	/**
-	 * Test maybe_invalidate_comment_types_cache with null comment type.
-	 *
-	 * @covers ::maybe_invalidate_comment_types_cache
-	 *
-	 * @return void
-	 */
-	public function test_maybe_invalidate_comment_types_cache_with_null_type(): void {
-		$instance = Query::get_instance();
-
-		// Set up cache.
-		set_transient(
-			Query::COMMENT_TYPES_CACHE_KEY,
-			array( 'comment', 'pingback' ),
-			Query::CACHE_EXPIRATION
-		);
-
-		// Create a mock WP_Comment object with null comment_type.
-		$comment               = new WP_Comment( new stdClass() );
-		$comment->comment_ID   = 999;
-		$comment->comment_type = null;
-
-		$instance->maybe_invalidate_comment_types_cache( 999, $comment );
-
-		// Cache should still exist (method returns early for empty types).
-		$this->assertNotFalse(
-			get_transient( Query::COMMENT_TYPES_CACHE_KEY ),
-			'Cache should not be invalidated for null comment type'
-		);
-
-		// Clean up.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
-	}
-
-	/**
-	 * Test maybe_invalidate_comment_types_cache when cache doesn't exist.
-	 *
-	 * @covers ::maybe_invalidate_comment_types_cache
-	 *
-	 * @return void
-	 */
-	public function test_maybe_invalidate_comment_types_cache_no_cache(): void {
-		$instance = Query::get_instance();
-
-		// Clear any existing transient.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
-
-		// Create a comment with custom type when cache doesn't exist.
-		$comment_id = $this->factory->comment->create(
-			array(
-				'comment_type' => 'custom_type',
-			)
-		);
-		$comment    = get_comment( $comment_id );
-
-		// Should not error and should do nothing since cache doesn't exist.
-		$instance->maybe_invalidate_comment_types_cache( $comment_id, $comment );
-
-		// Verify cache still doesn't exist.
-		$this->assertFalse(
-			get_transient( Query::COMMENT_TYPES_CACHE_KEY ),
-			'Cache should remain non-existent when it was not set'
-		);
-	}
-
-	/**
 	 * `get_rsvps()` honors a caller-provided `post_type` so per-post-type
 	 * callers (like the RSVPs admin pages) can narrow results, while still
 	 * defaulting to every RSVP-supporting post type (#1849).
@@ -833,49 +770,6 @@ class Test_Query extends Base {
 			$result['where'],
 			'Where should remain unchanged when tax_query is empty'
 		);
-	}
-
-	/**
-	 * Test get_all_comment_types returns defaults when database query fails.
-	 *
-	 * @covers ::get_all_comment_types
-	 *
-	 * @return void
-	 */
-	public function test_get_all_comment_types_with_empty_db_result(): void {
-		global $wpdb;
-
-		$instance = Query::get_instance();
-
-		// Clear any existing transient.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
-
-		// Suppress database errors to avoid output during test.
-		$wpdb->suppress_errors( true );
-
-		// Temporarily replace the comments table name to force empty result.
-		$original_comments = $wpdb->comments;
-		$wpdb->comments    = 'nonexistent_table_xyz';
-
-		// Use reflection to access protected method.
-		$reflection = new \ReflectionClass( $instance );
-		$method     = $reflection->getMethod( 'get_all_comment_types' );
-		$method->setAccessible( true );
-
-		// Should return defaults when query fails.
-		$types = $method->invoke( $instance );
-
-		// Restore original table name and error settings.
-		$wpdb->comments = $original_comments;
-		$wpdb->suppress_errors( false );
-
-		// Should return default types.
-		$this->assertContains( 'comment', $types, 'Should include default comment type' );
-		$this->assertContains( 'pingback', $types, 'Should include default pingback type' );
-		$this->assertContains( 'trackback', $types, 'Should include default trackback type' );
-
-		// Clean up.
-		delete_transient( Query::COMMENT_TYPES_CACHE_KEY );
 	}
 
 	/**

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-query.php
@@ -13,7 +13,6 @@ use GatherPress\Core\Rsvp\Query;
 use GatherPress\Core\Rsvp;
 use GatherPress\Core\Rsvp\Response\Status;
 use GatherPress\Tests\Base;
-use PMC\Unit_Test\Utility;
 use WP_Block;
 use WP_Comment;
 use WP_Comment_Query;
@@ -194,48 +193,101 @@ class Test_Query extends Base {
 	}
 
 	/**
-	 * Test excluding RSVP from type array removes RSVP and reindexes array.
+	 * Seeds one ordinary comment, one pingback, and one RSVP on a post.
+	 *
+	 * @param int $post_id The post to attach the comments to.
+	 *
+	 * @return array<string, int> Comment IDs keyed by `comment`, `pingback`, and `rsvp`.
+	 */
+	protected function seed_comment_mix( int $post_id ): array {
+		return array(
+			'comment'  => $this->factory->comment->create( array( 'comment_post_ID' => $post_id ) ),
+			'pingback' => $this->factory->comment->create(
+				array(
+					'comment_post_ID' => $post_id,
+					'comment_type'    => 'pingback',
+				)
+			),
+			'rsvp'     => $this->factory->comment->create(
+				array(
+					'comment_post_ID' => $post_id,
+					'comment_type'    => Rsvp::COMMENT_TYPE,
+				)
+			),
+		);
+	}
+
+	/**
+	 * Runs a comment query through the live `pre_get_comments` exclusion and
+	 * returns the matching comment IDs in date order.
+	 *
+	 * @param array<string, mixed> $args Query arguments.
+	 *
+	 * @return int[] Matching comment IDs.
+	 */
+	protected function query_comment_ids( array $args ): array {
+		Query::get_instance();
+
+		$query = new WP_Comment_Query(
+			array_merge(
+				array(
+					'fields'  => 'ids',
+					'orderby' => 'comment_ID',
+					'order'   => 'ASC',
+				),
+				$args
+			)
+		);
+
+		return array_values( array_map( 'intval', (array) $query->comments ) );
+	}
+
+	/**
+	 * A `type` array keeps every type the caller named, and the RSVP rows drop
+	 * out through `type__not_in`.
 	 *
 	 * @covers ::exclude_rsvp_from_comment_query
 	 *
 	 * @return void
 	 */
 	public function test_exclude_rsvp_from_type_array(): void {
-		$instance = Query::get_instance();
-		$query    = new WP_Comment_Query();
+		$post_id = $this->factory->post->create();
+		$ids     = $this->seed_comment_mix( $post_id );
 
-		$query->query_vars['type']     = array( 'comment', Rsvp::COMMENT_TYPE, 'pingback' );
-		$query->query_vars['type__in'] = '';
-
-		$instance->exclude_rsvp_from_comment_query( $query );
-
-		$this->assertEquals(
-			array( 'comment', 'pingback' ),
-			$query->query_vars['type'],
-			'RSVP comment type should be removed from type array and array should be reindexed'
+		$this->assertSame(
+			array( $ids['comment'], $ids['pingback'] ),
+			$this->query_comment_ids(
+				array(
+					'post_id' => $post_id,
+					'type'    => array( 'comment', Rsvp::COMMENT_TYPE, 'pingback' ),
+				)
+			),
+			'Every type the caller named except the RSVP type should be returned.'
 		);
 	}
 
 	/**
-	 * Test excluding RSVP when type is a single RSVP string sets type to empty.
+	 * A `type` naming only the RSVP type returns nothing while the exclusion
+	 * is active, rather than every other comment on the post.
 	 *
 	 * @covers ::exclude_rsvp_from_comment_query
 	 *
 	 * @return void
 	 */
 	public function test_exclude_rsvp_from_type_string(): void {
-		$instance = Query::get_instance();
-		$query    = new WP_Comment_Query();
+		$post_id = $this->factory->post->create();
 
-		$query->query_vars['type']     = Rsvp::COMMENT_TYPE;
-		$query->query_vars['type__in'] = '';
+		$this->seed_comment_mix( $post_id );
 
-		$instance->exclude_rsvp_from_comment_query( $query );
-
-		$this->assertEquals(
-			'',
-			$query->query_vars['type'],
-			'Type should be set to empty string when only RSVP comment type is present'
+		$this->assertSame(
+			array(),
+			$this->query_comment_ids(
+				array(
+					'post_id' => $post_id,
+					'type'    => Rsvp::COMMENT_TYPE,
+				)
+			),
+			'An RSVP-only allow-list should return no comments while the exclusion is active.'
 		);
 	}
 
@@ -271,26 +323,25 @@ class Test_Query extends Base {
 	}
 
 	/**
-	 * A caller asking for `all` keeps that, and the RSVP type is still excluded.
+	 * A caller asking for `all` still gets every non-RSVP comment and no RSVPs.
 	 *
 	 * @covers ::exclude_rsvp_from_comment_query
 	 *
 	 * @return void
 	 */
 	public function test_exclude_rsvp_from_type_all(): void {
-		$instance = Query::get_instance();
-		$query    = new WP_Comment_Query();
+		$post_id = $this->factory->post->create();
+		$ids     = $this->seed_comment_mix( $post_id );
 
-		$query->query_vars['type']     = 'all';
-		$query->query_vars['type__in'] = '';
-
-		$instance->exclude_rsvp_from_comment_query( $query );
-
-		$this->assertSame( 'all', $query->query_vars['type'], 'Type should be left as the caller set it.' );
 		$this->assertSame(
-			array( Rsvp::COMMENT_TYPE ),
-			$query->query_vars['type__not_in'],
-			'RSVP type should be excluded through type__not_in.'
+			array( $ids['comment'], $ids['pingback'] ),
+			$this->query_comment_ids(
+				array(
+					'post_id' => $post_id,
+					'type'    => 'all',
+				)
+			),
+			'Asking for all types should return everything but the RSVP.'
 		);
 	}
 
@@ -420,87 +471,57 @@ class Test_Query extends Base {
 	}
 
 	/**
-	 * Direct coverage for the `type` / `type__in` normalizer: arrays come back
-	 * reindexed without the RSVP type, an RSVP-only string becomes empty, and
-	 * any other string is left alone.
-	 *
-	 * @covers ::remove_rsvp_type
-	 *
-	 * @return void
-	 */
-	public function test_remove_rsvp_type(): void {
-		$instance = Query::get_instance();
-
-		$this->assertSame(
-			array( 'comment', 'pingback' ),
-			Utility::invoke_hidden_method(
-				$instance,
-				'remove_rsvp_type',
-				array( array( 'comment', Rsvp::COMMENT_TYPE, 'pingback' ) )
-			),
-			'An array should be reindexed without the RSVP type.'
-		);
-		$this->assertSame(
-			'',
-			Utility::invoke_hidden_method( $instance, 'remove_rsvp_type', array( Rsvp::COMMENT_TYPE ) ),
-			'An RSVP-only string should become empty.'
-		);
-		$this->assertSame(
-			'comment',
-			Utility::invoke_hidden_method( $instance, 'remove_rsvp_type', array( 'comment' ) ),
-			'Any other string should be left alone.'
-		);
-	}
-
-
-	/**
-	 * Test excluding RSVP from type__in array removes RSVP and reindexes array.
+	 * A `type__in` array keeps every type the caller named, and the RSVP rows
+	 * drop out through `type__not_in`.
 	 *
 	 * @covers ::exclude_rsvp_from_comment_query
 	 *
 	 * @return void
 	 */
 	public function test_exclude_rsvp_from_type_in_array(): void {
-		$instance = Query::get_instance();
-		$query    = new WP_Comment_Query();
+		$post_id = $this->factory->post->create();
+		$ids     = $this->seed_comment_mix( $post_id );
 
-		$query->query_vars['type']     = '';
-		$query->query_vars['type__in'] = array( 'comment', Rsvp::COMMENT_TYPE, 'custom' );
-
-		$instance->exclude_rsvp_from_comment_query( $query );
-
-		$this->assertEquals(
-			array( 'comment', 'custom' ),
-			$query->query_vars['type__in'],
-			'RSVP comment type should be removed from type__in array and array should be reindexed'
+		$this->assertSame(
+			array( $ids['comment'], $ids['pingback'] ),
+			$this->query_comment_ids(
+				array(
+					'post_id'  => $post_id,
+					'type__in' => array( 'comment', Rsvp::COMMENT_TYPE, 'pingback' ),
+				)
+			),
+			'Every type the caller named except the RSVP type should be returned.'
 		);
 	}
 
 	/**
-	 * Test excluding RSVP when type__in is a single RSVP string sets type__in to empty.
+	 * A `type__in` naming only the RSVP type returns nothing while the
+	 * exclusion is active, rather than every other comment on the post.
 	 *
 	 * @covers ::exclude_rsvp_from_comment_query
 	 *
 	 * @return void
 	 */
 	public function test_exclude_rsvp_from_type_in_string(): void {
-		$instance = Query::get_instance();
-		$query    = new WP_Comment_Query();
+		$post_id = $this->factory->post->create();
 
-		$query->query_vars['type']     = '';
-		$query->query_vars['type__in'] = Rsvp::COMMENT_TYPE;
+		$this->seed_comment_mix( $post_id );
 
-		$instance->exclude_rsvp_from_comment_query( $query );
-
-		$this->assertEquals(
-			'',
-			$query->query_vars['type__in'],
-			'Type__in should be set to empty string when only RSVP comment type is present'
+		$this->assertSame(
+			array(),
+			$this->query_comment_ids(
+				array(
+					'post_id'  => $post_id,
+					'type__in' => Rsvp::COMMENT_TYPE,
+				)
+			),
+			'An RSVP-only type__in should return no comments while the exclusion is active.'
 		);
 	}
 
 	/**
-	 * Test excluding RSVP from both type and type__in variables simultaneously.
+	 * `type` and `type__in` are both left as the caller wrote them; only
+	 * `type__not_in` changes.
 	 *
 	 * @covers ::exclude_rsvp_from_comment_query
 	 *
@@ -515,47 +536,44 @@ class Test_Query extends Base {
 
 		$instance->exclude_rsvp_from_comment_query( $query );
 
-		$this->assertEquals(
-			array( 'comment' ),
+		$this->assertSame(
+			array( 'comment', Rsvp::COMMENT_TYPE ),
 			$query->query_vars['type'],
-			'RSVP should be removed from type array'
+			'Type should be left as the caller set it.'
 		);
-		$this->assertEquals(
-			array( 'pingback' ),
+		$this->assertSame(
+			array( 'pingback', Rsvp::COMMENT_TYPE ),
 			$query->query_vars['type__in'],
-			'RSVP should be removed from type__in array'
+			'Type__in should be left as the caller set it.'
+		);
+		$this->assertSame(
+			array( Rsvp::COMMENT_TYPE ),
+			$query->query_vars['type__not_in'],
+			'RSVP type should be excluded through type__not_in.'
 		);
 	}
 
 	/**
 	 * Test the gatherpress_rsvp_comment_query_exclusion filter short-circuits
-	 * the exclusion when an integration returns false, leaving both `type` and
-	 * `type__in` untouched so the caller's original query vars survive.
+	 * the exclusion when an integration returns false, so the RSVP type never
+	 * reaches `type__not_in` and RSVP rows come back.
 	 *
 	 * @covers ::exclude_rsvp_from_comment_query
 	 *
 	 * @return void
 	 */
 	public function test_exclude_rsvp_filter_can_short_circuit(): void {
-		$instance = Query::get_instance();
-		$query    = new WP_Comment_Query();
-
-		$query->query_vars['type']     = array( 'comment', Rsvp::COMMENT_TYPE, 'pingback' );
-		$query->query_vars['type__in'] = array( 'comment', Rsvp::COMMENT_TYPE );
+		$post_id = $this->factory->post->create();
+		$ids     = $this->seed_comment_mix( $post_id );
 
 		add_filter( 'gatherpress_rsvp_comment_query_exclusion', '__return_false' );
-		$instance->exclude_rsvp_from_comment_query( $query );
+		$results = $this->query_comment_ids( array( 'post_id' => $post_id ) );
 		remove_filter( 'gatherpress_rsvp_comment_query_exclusion', '__return_false' );
 
-		$this->assertEquals(
-			array( 'comment', Rsvp::COMMENT_TYPE, 'pingback' ),
-			$query->query_vars['type'],
-			'Type array should be untouched when the filter returns false'
-		);
-		$this->assertEquals(
-			array( 'comment', Rsvp::COMMENT_TYPE ),
-			$query->query_vars['type__in'],
-			'Type__in array should be untouched when the filter returns false'
+		$this->assertSame(
+			array( $ids['comment'], $ids['pingback'], $ids['rsvp'] ),
+			$results,
+			'Opting out through the filter should let the RSVP through.'
 		);
 	}
 
@@ -613,15 +631,15 @@ class Test_Query extends Base {
 		$instance->exclude_rsvp_from_comment_query( $query );
 		remove_filter( 'gatherpress_rsvp_comment_query_exclusion', '__return_true' );
 
-		$this->assertEquals(
-			array( 'comment' ),
-			$query->query_vars['type'],
+		$this->assertSame(
+			array( Rsvp::COMMENT_TYPE ),
+			$query->query_vars['type__not_in'],
 			'Returning true from the filter should preserve the existing exclusion behavior'
 		);
 	}
 
 	/**
-	 * Test excluding RSVP makes no changes when RSVP is not present in arrays.
+	 * Test excluding RSVP leaves allow-lists alone when RSVP is not present in them.
 	 *
 	 * @covers ::exclude_rsvp_from_comment_query
 	 *
@@ -636,15 +654,20 @@ class Test_Query extends Base {
 
 		$instance->exclude_rsvp_from_comment_query( $query );
 
-		$this->assertEquals(
+		$this->assertSame(
 			array( 'comment', 'pingback' ),
 			$query->query_vars['type'],
 			'Type array should remain unchanged when RSVP is not present'
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			array( 'custom', 'review' ),
 			$query->query_vars['type__in'],
 			'Type__in array should remain unchanged when RSVP is not present'
+		);
+		$this->assertSame(
+			array( Rsvp::COMMENT_TYPE ),
+			$query->query_vars['type__not_in'],
+			'RSVP type should still be excluded through type__not_in'
 		);
 	}
 


### PR DESCRIPTION
Closes #2282

## What

`Rsvp\Query::exclude_rsvp_from_comment_query()` handled a query with no `type` by rebuilding an allow-list from the comment types stored in the database, minus `gatherpress_rsvp`. On a site whose only comments are RSVPs that list is empty, and `WP_Comment_Query` reads an empty `type` as no restriction at all, so every RSVP rendered as a blank comment in the `core/comments` block. It self-healed once one ordinary comment existed, which is why it only showed on fresh sites.

The exclusion now goes through `type__not_in`, which core applies as `comment_type NOT IN (...)` regardless of what else is stored. `type` and `type__in` are left exactly as the caller wrote them, and the RSVP type is appended to whatever `type__not_in` the caller already had. Core applies the `NOT IN` on top of any allow-list, so a mixed list keeps its other types, and a list naming only the RSVP type returns nothing while the exclusion is active, where it used to be rewritten to empty and return every other comment instead.

That closes two more gaps in the same method:

- `type => 'all'` was left alone, so it returned RSVPs.
- A query that only set `type__in` was widened to every stored type, because core merges `type` and `type__in` into one `IN` list. That is the shape of the ActivityPub conflict in #1637.

## Removed

Nothing reads the comment-types allow-list any more, so the `gatherpress_all_comment_types` transient, `get_all_comment_types()`, `maybe_invalidate_comment_types_cache()`, its `wp_insert_comment` hook, and the two cache constants are gone along with their six tests. A stale transient left on an existing site expires on its own within a day.

## Indexing

`comment_type` has no index in core today, so both the old allow-list and the new `NOT IN` are evaluated per row after the post ID or approval index has narrowed the query; their EXPLAIN plans are identical. What did scale badly was the old `SELECT DISTINCT comment_type` full-table scan that built the allow-list, and that is gone.

Assuming a `comment_type` index lands (WordPress/wordpress-develop#12183 against Trac #59488), or a large site adds one itself, the `NOT IN` uses it the same way an allow-list would. Measured on wp-env's MariaDB 12.3 with a temporary index and 40,000 seeded comments, 99% of them RSVPs:

| Query shape | Access | Key | Rows estimated |
|---|---|---|---|
| Admin list, `NOT IN ('gatherpress_rsvp')` | range | comment_type | 401 |
| Admin list, `IN ('comment','pingback','trackback')` | range | comment_type | 402 |
| Front end by post ID, `NOT IN` | range | comment_type | 401 |
| Front end by post ID, `IN` | range | comment_type | 402 |

The method's docblock and `docs/developer/rsvp/README.md` now describe the `type__not_in` approach and point large sites at adding the index.

## Tests

- `test_exclude_rsvp_from_empty_type` now asserts `type` stays empty and `type__not_in` carries the RSVP type.
- New: `type => 'all'`, merging into an existing string or array `type__not_in` without duplicates, a `type__in`-only query that runs against the database and returns only the requested type, a reproduction of the report through `build_comment_query_vars_from_block()` with an RSVP as the only stored comment, and the `type` / `type__in` cases now run real queries against a seeded comment, pingback, and RSVP, including RSVP-only allow-lists returning nothing and the filter opt-out letting the RSVP through.
- Full single-site PHPUnit suite passes. phpcs, PHPStan, and PHPMD are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
