### PR TITLE
feat(rsvp): add no-JS RSVP fallback

### DIFF
--- a/.github/changelog/2039-rsvp-no-js-fallback
+++ b/.github/changelog/2039-rsvp-no-js-fallback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a no-JavaScript RSVP fallback form for logged-in users so the RSVP trigger still works when JavaScript fails to load.

--- a/includes/core/classes/blocks/class-rsvp.php
+++ b/includes/core/classes/blocks/class-rsvp.php
@@ -16,6 +16,8 @@ use GatherPress\Core\Blocks\Form_Field;
 use GatherPress\Core\Blocks\General_Block;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp as Core_Rsvp;
+use GatherPress\Core\Rsvp\Form;
+use GatherPress\Core\Rsvp\Response\Status;
 use GatherPress\Core\Rsvp\Setup as Rsvp_Setup;
 use GatherPress\Core\Traits\Singleton;
 use GatherPress\Core\Utility;
@@ -41,6 +43,15 @@ final class Rsvp {
 	 * @var string
 	 */
 	const BLOCK_NAME = 'gatherpress/rsvp';
+
+	/**
+	 * Constant representing the class that flags a trigger for the no-JS RSVP form.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @var string
+	 */
+	const NO_SCRIPT_TRIGGER_CLASS = 'gatherpress-rsvp--trigger-no-script';
 
 	/**
 	 * Class constructor.
@@ -69,6 +80,7 @@ final class Rsvp {
 		add_filter( $render_block_hook, array( $this, 'apply_rsvp_button_interactivity' ) );
 		// Priority 11 ensures this runs after transform_block_content which modifies the block structure.
 		add_filter( $render_block_hook, array( $this, 'apply_guest_count_watch' ), 11 );
+		add_filter( $render_block_hook, array( $this, 'render_no_script_fallback' ), 12, 2 );
 		// Priority 9 ensures this runs before transform_block_content to properly register form field hooks.
 		add_filter( $render_block_hook, array( $this, 'apply_guests_input_interactivity' ), 9 );
 
@@ -199,6 +211,87 @@ final class Rsvp {
 		}
 
 		return $block_content;
+	}
+
+	/**
+	 * Adds a no-JavaScript RSVP form for marked triggers.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @param string               $block_content The block content.
+	 * @param array<string, mixed> $block         The block data.
+	 *
+	 * @return string The block content with the fallback form.
+	 */
+	public function render_no_script_fallback( string $block_content, array $block ): string {
+		if (
+			! is_user_logged_in()
+			|| ! str_contains( $block_content, self::NO_SCRIPT_TRIGGER_CLASS )
+		) {
+			return $block_content;
+		}
+
+		$post_id = Setup::get_instance()->get_post_id( $block );
+		$rsvp    = new Core_Rsvp( $post_id );
+
+		if ( ! $post_id || ! $rsvp->is_enabled() ) {
+			return $block_content;
+		}
+
+		if ( ( new Event( $post_id ) )->has_event_past() ) {
+			return $block_content;
+		}
+
+		$user_identifier = Rsvp_Setup::get_instance()->get_user_identifier();
+		$user_data       = $rsvp->get( $user_identifier ) ?? array();
+		$current_status  = $user_data['status'] ?? Status::NO_STATUS->value;
+
+		if ( in_array( $current_status, array( Status::NOT_ATTENDING->value, Status::NO_STATUS->value ), true ) ) {
+			$next_status = Status::ATTENDING->value;
+			$button_text = __( 'Attend', 'gatherpress' );
+		} else {
+			$next_status = Status::NOT_ATTENDING->value;
+			$button_text = __( 'Not Attending', 'gatherpress' );
+		}
+
+		$return_url = (string) get_permalink( $post_id );
+
+		$message      = '';
+		$result       = Utility::get_http_input( INPUT_GET, 'gatherpress_rsvp_no_script' );
+		$saved_status = Utility::get_http_input( INPUT_GET, 'gatherpress_rsvp_status' );
+
+		if ( 'success' === $result ) {
+			$message = Status::WAITING_LIST->value === $saved_status
+				? __( 'You are on the waiting list.', 'gatherpress' )
+				: __( 'Your RSVP has been updated.', 'gatherpress' );
+		} elseif ( 'error' === $result ) {
+			$message = __( 'Your RSVP could not be saved. Please try again.', 'gatherpress' );
+		}
+
+		$form = sprintf(
+			'<noscript><form class="gatherpress-rsvp--no-script" method="post" action="%1$s">%2$s%3$s'
+			. '<input type="hidden" name="action" value="%4$s">'
+			. '<input type="hidden" name="post_id" value="%5$d">'
+			. '<input type="hidden" name="status" value="%6$s">'
+			. '<input type="hidden" name="return_url" value="%7$s">'
+			. '<button type="submit">%8$s</button></form></noscript>',
+			esc_url( admin_url( 'admin-post.php' ) ),
+			wp_nonce_field( Form::NO_SCRIPT_ACTION, Form::NONCE_NAME, true, false ),
+			$message ? sprintf( '<p role="status">%s</p>', esc_html( $message ) ) : '',
+			esc_attr( Form::NO_SCRIPT_ACTION ),
+			absint( $post_id ),
+			esc_attr( $next_status ),
+			esc_url( $return_url ),
+			esc_html( $button_text )
+		);
+
+		$closing_position = strrpos( $block_content, '</div>' );
+
+		if ( false === $closing_position ) {
+			return $block_content . $form;
+		}
+
+		return substr_replace( $block_content, $form, $closing_position, 0 );
 	}
 
 	/**

--- a/includes/core/classes/rsvp/class-form.php
+++ b/includes/core/classes/rsvp/class-form.php
@@ -39,6 +39,24 @@ final class Form {
 	use Singleton;
 
 	/**
+	 * The form action for no-JavaScript RSVP updates.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @var string
+	 */
+	public const NO_SCRIPT_ACTION = 'gatherpress_no_script_rsvp';
+
+	/**
+	 * The no-JavaScript RSVP nonce field name.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @var string
+	 */
+	public const NONCE_NAME = 'gatherpress_no_script_rsvp_nonce';
+
+	/**
 	 * Class constructor.
 	 *
 	 * This method initializes the object and sets up necessary hooks.
@@ -60,6 +78,99 @@ final class Form {
 	 */
 	protected function setup_hooks(): void {
 		add_action( 'init', array( $this, 'initialize_rsvp_form_handling' ) );
+		add_action( 'admin_post_' . self::NO_SCRIPT_ACTION, array( $this, 'handle_no_script_rsvp' ) );
+	}
+
+	/**
+	 * Process a no-JavaScript RSVP submission.
+	 *
+	 * The RSVP block renders a POST form inside <noscript> for logged-in users,
+	 * so the RSVP toggle still works when JavaScript never arrives. This handler
+	 * validates the request, saves the new status, and redirects back to the
+	 * event with a query flag the block turns into a status message.
+	 *
+	 * @since 0.36.0
+	 *
+	 * @return void
+	 */
+	public function handle_no_script_rsvp(): void {
+		$nonce = Utility::get_http_input( INPUT_POST, self::NONCE_NAME );
+
+		if (
+			! is_user_logged_in()
+			|| '' === $nonce
+			|| ! wp_verify_nonce( $nonce, self::NO_SCRIPT_ACTION )
+		) {
+			wp_die(
+				esc_html__( 'Your session expired. Please reload the page and try again.', 'gatherpress' ),
+				esc_html__( 'RSVP Not Saved', 'gatherpress' ),
+				403
+			);
+		}
+
+		$post_id = absint( Utility::get_http_input( INPUT_POST, 'post_id' ) );
+		$status  = Utility::get_http_input( INPUT_POST, 'status' );
+		$rsvp    = new Rsvp( $post_id );
+
+		if (
+			! $post_id
+			|| ! in_array( $status, array( Status::ATTENDING->value, Status::NOT_ATTENDING->value ), true )
+			|| ! Event::is_viewable( $post_id )
+			|| ! $rsvp->is_enabled()
+		) {
+			wp_die(
+				esc_html__( 'This RSVP is no longer available.', 'gatherpress' ),
+				esc_html__( 'RSVP Not Saved', 'gatherpress' ),
+				400
+			);
+		}
+
+		$event = new Event( $post_id );
+
+		if ( $event->has_event_past() ) {
+			wp_die(
+				esc_html__( 'Registration for this event is now closed.', 'gatherpress' ),
+				esc_html__( 'Event Has Passed', 'gatherpress' ),
+				400
+			);
+		}
+
+		$user_id = get_current_user_id();
+		$result  = $rsvp->save( $user_id, $status );
+		$saved   = $result['status'];
+
+		$return_url = Utility::get_http_input( INPUT_POST, 'return_url' );
+
+		if ( '' === $return_url ) {
+			$return_url = (string) get_permalink( $post_id );
+		}
+
+		$redirect_url = remove_query_arg(
+			array( 'gatherpress_rsvp_no_script', 'gatherpress_rsvp_status' ),
+			$return_url
+		);
+
+		if ( Status::NO_STATUS->value === $saved ) {
+			$redirect_url = add_query_arg(
+				array(
+					'gatherpress_rsvp_no_script' => 'error',
+				),
+				$redirect_url
+			);
+		} else {
+			$redirect_url = add_query_arg(
+				array(
+					'gatherpress_rsvp_no_script' => 'success',
+					'gatherpress_rsvp_status'    => $saved,
+				),
+				$redirect_url
+			);
+		}
+
+		wp_safe_redirect( esc_url_raw( $redirect_url ) );
+
+		// Tests intercept wp_redirect and throw before this line executes.
+		exit; // @codeCoverageIgnore
 	}
 
 	/**

--- a/src/blocks/rsvp/templates/attending.js
+++ b/src/blocks/rsvp/templates/attending.js
@@ -249,7 +249,7 @@ const ATTENDING = [
 											),
 											tagName: 'button',
 											className:
-												'gatherpress-rsvp--trigger-update',
+												'gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script',
 											metadata: {
 												name: _x(
 													'RSVP Button',

--- a/src/blocks/rsvp/templates/no-status.js
+++ b/src/blocks/rsvp/templates/no-status.js
@@ -161,7 +161,7 @@ const NO_STATUS = [
 											),
 											tagName: 'button',
 											className:
-												'gatherpress-rsvp--trigger-update',
+												'gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script',
 											metadata: {
 												name: _x(
 													'RSVP Button',

--- a/src/blocks/rsvp/templates/not-attending.js
+++ b/src/blocks/rsvp/templates/not-attending.js
@@ -218,7 +218,7 @@ const NOT_ATTENDING = [
 											),
 											tagName: 'button',
 											className:
-												'gatherpress-rsvp--trigger-update',
+												'gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script',
 											metadata: {
 												name: _x(
 													'RSVP Button',

--- a/src/blocks/rsvp/templates/waiting-list.js
+++ b/src/blocks/rsvp/templates/waiting-list.js
@@ -218,7 +218,7 @@ const WAITING_LIST = [
 											),
 											tagName: 'button',
 											className:
-												'gatherpress-rsvp--trigger-update',
+												'gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script',
 											metadata: {
 												name: _x(
 													'RSVP Button',

--- a/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
+++ b/test/unit/php/includes/tests/core/classes/blocks/class-test-rsvp.php
@@ -11,6 +11,7 @@ namespace GatherPress\Tests\Core\Blocks;
 use GatherPress\Core\Blocks\Rsvp;
 use GatherPress\Core\Event;
 use GatherPress\Core\Rsvp as Core_Rsvp;
+use GatherPress\Core\Rsvp\Form;
 use GatherPress\Core\Event\Setup;
 use GatherPress\Core\Settings;
 use GatherPress\Tests\Base;
@@ -62,6 +63,12 @@ class Test_Rsvp extends Base {
 				'name'     => $render_block_hook,
 				'priority' => 9,
 				'callback' => array( $instance, 'apply_guests_input_interactivity' ),
+			),
+			array(
+				'type'     => 'filter',
+				'name'     => $render_block_hook,
+				'priority' => 12,
+				'callback' => array( $instance, 'render_no_script_fallback' ),
 			),
 			array(
 				'type'     => 'filter',
@@ -975,5 +982,484 @@ class Test_Rsvp extends Base {
 
 		// Clean up.
 		remove_filter( $form_field_hook, array( $instance, 'handle_rsvp_form_fields' ) );
+	}
+
+	/**
+	 * Tests the render_no_script_fallback method for a logged-in user.
+	 *
+	 * Verifies that a marked RSVP block gets a <noscript> POST form with the
+	 * expected action URL, nonce, post ID, next status, and submit label.
+	 *
+	 * @since 0.36.0
+	 * @covers ::render_no_script_fallback
+	 *
+	 * @return void
+	 */
+	public function test_render_no_script_fallback_logged_in(): void {
+		$instance = Rsvp::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$this->mock->user( true )->get();
+
+		$block         = array(
+			'blockName' => Rsvp::BLOCK_NAME,
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+		$block_content = sprintf(
+			'<div class="wp-block-gatherpress-rsvp" data-post-id="%d">'
+			. '<button class="gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script">Attend</button>'
+			. '</div>',
+			$post_id
+		);
+
+		$result = $instance->render_no_script_fallback( $block_content, $block );
+
+		$this->assertStringContainsString( '<noscript>', $result, 'The fallback form must render inside <noscript>.' );
+		$this->assertStringContainsString(
+			'method="post"',
+			$result,
+			'The fallback form must submit via POST so link prefetchers cannot trigger an RSVP.'
+		);
+		$this->assertStringContainsString(
+			esc_attr( admin_url( 'admin-post.php' ) ),
+			$result,
+			'The fallback form must post to admin-post.php.'
+		);
+		$this->assertStringContainsString(
+			'name="post_id" value="' . $post_id . '"',
+			$result,
+			'The fallback form must carry the event post ID.'
+		);
+		$this->assertStringContainsString(
+			'name="status" value="attending"',
+			$result,
+			'The fallback form must default to the attending status for a user without an RSVP.'
+		);
+		$this->assertStringContainsString( 'Attend', $result, 'The fallback submit button must read Attend.' );
+		$this->assertStringContainsString(
+			'name="' . Form::NONCE_NAME . '"',
+			$result,
+			'The fallback form must include a nonce.'
+		);
+		$this->assertStringContainsString(
+			'name="return_url" value="' . esc_url( get_permalink( $post_id ) ) . '"',
+			$result,
+			'The fallback form must return to the event permalink.'
+		);
+	}
+
+	/**
+	 * Tests the render_no_script_fallback method when the user is logged out.
+	 *
+	 * Verifies that no fallback form is emitted for anonymous visitors.
+	 *
+	 * @since 0.36.0
+	 * @covers ::render_no_script_fallback
+	 *
+	 * @return void
+	 */
+	public function test_render_no_script_fallback_logged_out(): void {
+		$instance = Rsvp::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+
+		$block         = array(
+			'blockName' => Rsvp::BLOCK_NAME,
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+		$block_content = sprintf(
+			'<div class="wp-block-gatherpress-rsvp" data-post-id="%d">'
+			. '<button class="gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script">Attend</button>'
+			. '</div>',
+			$post_id
+		);
+
+		$result = $instance->render_no_script_fallback( $block_content, $block );
+
+		$this->assertSame(
+			$block_content,
+			$result,
+			'The fallback form must not render for logged-out users.'
+		);
+	}
+
+	/**
+	 * Tests the render_no_script_fallback method without the marker class.
+	 *
+	 * Verifies that unmarked RSVP blocks stay untouched.
+	 *
+	 * @since 0.36.0
+	 * @covers ::render_no_script_fallback
+	 *
+	 * @return void
+	 */
+	public function test_render_no_script_fallback_unmarked(): void {
+		$instance = Rsvp::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$this->mock->user( true )->get();
+
+		$block         = array(
+			'blockName' => Rsvp::BLOCK_NAME,
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+		$block_content = sprintf(
+			'<div class="wp-block-gatherpress-rsvp" data-post-id="%d">'
+			. '<button class="gatherpress-rsvp--trigger-update">Attend</button>'
+			. '</div>',
+			$post_id
+		);
+
+		$result = $instance->render_no_script_fallback( $block_content, $block );
+
+		$this->assertSame(
+			$block_content,
+			$result,
+			'The fallback form must not render without the no-script marker class.'
+		);
+	}
+
+	/**
+	 * Tests the render_no_script_fallback method for a user already attending.
+	 *
+	 * Verifies that the next status and the submit label flip to not_attending.
+	 *
+	 * @since 0.36.0
+	 * @covers ::render_no_script_fallback
+	 *
+	 * @return void
+	 */
+	public function test_render_no_script_fallback_attending_toggles_off(): void {
+		$instance = Rsvp::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$user     = $this->mock->user( true )->get();
+		( new Core_Rsvp( $post_id ) )->save( $user->ID, 'attending' );
+
+		$block         = array(
+			'blockName' => Rsvp::BLOCK_NAME,
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+		$block_content = sprintf(
+			'<div class="wp-block-gatherpress-rsvp" data-post-id="%d">'
+			. '<button class="gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script">'
+			. 'Not Attending</button></div>',
+			$post_id
+		);
+
+		$result = $instance->render_no_script_fallback( $block_content, $block );
+
+		$this->assertStringContainsString(
+			'name="status" value="not_attending"',
+			$result,
+			'The fallback form must offer not_attending to a user already attending.'
+		);
+		$this->assertStringContainsString( 'Not Attending', $result, 'The submit label must read Not Attending.' );
+	}
+
+	/**
+	 * Tests the render_no_script_fallback method on a past event.
+	 *
+	 * Verifies that no fallback form is emitted when the event has passed.
+	 *
+	 * @since 0.36.0
+	 * @covers ::render_no_script_fallback
+	 *
+	 * @return void
+	 */
+	public function test_render_no_script_fallback_past_event(): void {
+		$instance = Rsvp::get_instance();
+		$post     = $this->mock->post(
+			array(
+				'post_type' => Event::POST_TYPE,
+				'post_meta' => array(
+					'gatherpress_datetime' => wp_json_encode(
+						array(
+							'dateTimeStart' => '2024-01-22 18:00:00',
+							'dateTimeEnd'   => '2024-01-22 20:00:00',
+							'timezone'      => 'America/New_York',
+						)
+					),
+				),
+			)
+		)->get();
+
+		// Trigger to set datetimes.
+		Setup::get_instance()->set_datetimes( $post->ID );
+
+		$this->mock->user( true )->get();
+
+		$block         = array(
+			'blockName' => Rsvp::BLOCK_NAME,
+			'attrs'     => array( 'postId' => $post->ID ),
+		);
+		$block_content = sprintf(
+			'<div class="wp-block-gatherpress-rsvp" data-post-id="%d">'
+			. '<button class="gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script">Attend</button>'
+			. '</div>',
+			$post->ID
+		);
+
+		$result = $instance->render_no_script_fallback( $block_content, $block );
+
+		$this->assertStringNotContainsString(
+			'<noscript>',
+			$result,
+			'The fallback form must not render for a past event.'
+		);
+	}
+
+	/**
+	 * Tests the render_no_script_fallback method after a successful submission.
+	 *
+	 * Verifies that the success query flags produce a status message inside the form.
+	 *
+	 * @since 0.36.0
+	 * @covers ::render_no_script_fallback
+	 *
+	 * @return void
+	 */
+	public function test_render_no_script_fallback_success_message(): void {
+		$instance = Rsvp::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$this->mock->user( true )->get();
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, $type, $var_name ) {
+				if ( INPUT_GET === $type && 'gatherpress_rsvp_no_script' === $var_name ) {
+					return 'success';
+				}
+				if ( INPUT_GET === $type && 'gatherpress_rsvp_status' === $var_name ) {
+					return 'waiting_list';
+				}
+				return $pre_value;
+			},
+			10,
+			3
+		);
+
+		$block         = array(
+			'blockName' => Rsvp::BLOCK_NAME,
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+		$block_content = sprintf(
+			'<div class="wp-block-gatherpress-rsvp" data-post-id="%d">'
+			. '<button class="gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script">Attend</button>'
+			. '</div>',
+			$post_id
+		);
+
+		$result = $instance->render_no_script_fallback( $block_content, $block );
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+
+		$this->assertStringContainsString(
+			'You are on the waiting list.',
+			$result,
+			'The fallback form must surface the waiting list message after a waiting list placement.'
+		);
+		$this->assertStringContainsString( 'role="status"', $result, 'The status message must be announced politely.' );
+	}
+
+	/**
+	 * Tests the render_no_script_fallback method with an error result.
+	 *
+	 * Verifies that a failed save is communicated to the user.
+	 *
+	 * @since 0.36.0
+	 * @covers ::render_no_script_fallback
+	 *
+	 * @return void
+	 */
+	public function test_render_no_script_fallback_error_message(): void {
+		$instance = Rsvp::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$this->mock->user( true )->get();
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, $type, $var_name ) {
+				if ( INPUT_GET === $type && 'gatherpress_rsvp_no_script' === $var_name ) {
+					return 'error';
+				}
+				return $pre_value;
+			},
+			10,
+			3
+		);
+
+		$block         = array(
+			'blockName' => Rsvp::BLOCK_NAME,
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+		$block_content = sprintf(
+			'<div class="wp-block-gatherpress-rsvp" data-post-id="%d">'
+			. '<button class="gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script">Attend</button>'
+			. '</div>',
+			$post_id
+		);
+
+		$result = $instance->render_no_script_fallback( $block_content, $block );
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+
+		$this->assertStringContainsString(
+			'Your RSVP could not be saved. Please try again.',
+			$result,
+			'The fallback form must surface the error message.'
+		);
+	}
+
+	/**
+	 * Tests the render_no_script_fallback method with a non-waiting-list success.
+	 *
+	 * Verifies that a plain success shows the generic updated message.
+	 *
+	 * @since 0.36.0
+	 * @covers ::render_no_script_fallback
+	 *
+	 * @return void
+	 */
+	public function test_render_no_script_fallback_success_generic_message(): void {
+		$instance = Rsvp::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$this->mock->user( true )->get();
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, $type, $var_name ) {
+				if ( INPUT_GET === $type && 'gatherpress_rsvp_no_script' === $var_name ) {
+					return 'success';
+				}
+				if ( INPUT_GET === $type && 'gatherpress_rsvp_status' === $var_name ) {
+					return 'attending';
+				}
+				return $pre_value;
+			},
+			10,
+			3
+		);
+
+		$block         = array(
+			'blockName' => Rsvp::BLOCK_NAME,
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+		$block_content = sprintf(
+			'<div class="wp-block-gatherpress-rsvp" data-post-id="%d">'
+			. '<button class="gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script">Attend</button>'
+			. '</div>',
+			$post_id
+		);
+
+		$result = $instance->render_no_script_fallback( $block_content, $block );
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+
+		$this->assertStringContainsString(
+			'Your RSVP has been updated.',
+			$result,
+			'The fallback form must surface the generic success message.'
+		);
+	}
+
+	/**
+	 * Tests the render_no_script_fallback method when RSVP is disabled.
+	 *
+	 * Verifies that no fallback form is emitted when RSVP is disabled for the event.
+	 *
+	 * @since 0.36.0
+	 * @covers ::render_no_script_fallback
+	 *
+	 * @return void
+	 */
+	public function test_render_no_script_fallback_rsvp_disabled(): void {
+		$instance = Rsvp::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$this->mock->user( true )->get();
+
+		// Sitewide RSVP mode overrides the per-event meta, so switch the mode.
+		Settings::get_instance()->set( 'rsvp_mode', 'disabled' );
+
+		$block         = array(
+			'blockName' => Rsvp::BLOCK_NAME,
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+		$block_content = sprintf(
+			'<div class="wp-block-gatherpress-rsvp" data-post-id="%d">'
+			. '<button class="gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script">Attend</button>'
+			. '</div>',
+			$post_id
+		);
+
+		$result = $instance->render_no_script_fallback( $block_content, $block );
+
+		$this->assertStringNotContainsString(
+			'<noscript>',
+			$result,
+			'The fallback form must not render when RSVP is disabled for the event.'
+		);
+	}
+
+	/**
+	 * Tests the render_no_script_fallback method without a closing div.
+	 *
+	 * Verifies that the fallback form is appended when the block content has
+	 * no closing div to insert before.
+	 *
+	 * @since 0.36.0
+	 * @covers ::render_no_script_fallback
+	 *
+	 * @return void
+	 */
+	public function test_render_no_script_fallback_appends_without_closing_div(): void {
+		$instance = Rsvp::get_instance();
+		$post_id  = $this->factory()->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$this->mock->user( true )->get();
+
+		$block         = array(
+			'blockName' => Rsvp::BLOCK_NAME,
+			'attrs'     => array( 'postId' => $post_id ),
+		);
+		$block_content = sprintf(
+			'<button class="gatherpress-rsvp--trigger-update gatherpress-rsvp--trigger-no-script">Attend</button>',
+			$post_id
+		);
+
+		$result = $instance->render_no_script_fallback( $block_content, $block );
+
+		$this->assertStringEndsWith( '</noscript>', $result, 'The fallback form must be appended to the content.' );
 	}
 }

--- a/test/unit/php/includes/tests/core/classes/rsvp/class-test-form.php
+++ b/test/unit/php/includes/tests/core/classes/rsvp/class-test-form.php
@@ -60,6 +60,12 @@ class Test_Form extends Base {
 				'priority' => 10,
 				'callback' => array( $instance, 'initialize_rsvp_form_handling' ),
 			),
+			array(
+				'type'     => 'action',
+				'name'     => 'admin_post_' . Form::NO_SCRIPT_ACTION,
+				'priority' => 10,
+				'callback' => array( $instance, 'handle_no_script_rsvp' ),
+			),
 		);
 
 		$this->assert_hooks( $hooks, $instance );
@@ -3084,5 +3090,374 @@ class Test_Form extends Base {
 			get_comment_meta( $comment_id, 'gatherpress_custom_my_custom_field', true ),
 			'Custom field should be saved with custom prefix'
 		);
+	}
+
+	/**
+	 * Tests handle_no_script_rsvp when the user is logged out.
+	 *
+	 * Covers: wp_die for anonymous requests even with a valid nonce shape.
+	 *
+	 * @covers ::handle_no_script_rsvp
+	 * @return void
+	 */
+	public function test_handle_no_script_rsvp_logged_out(): void {
+		$instance = Form::get_instance();
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, $type, $var_name ) {
+				if ( INPUT_POST === $type && Form::NONCE_NAME === $var_name ) {
+					return wp_create_nonce( Form::NO_SCRIPT_ACTION );
+				}
+				return $pre_value;
+			},
+			10,
+			3
+		);
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'Your session expired. Please reload the page and try again.' );
+
+		$instance->handle_no_script_rsvp();
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+	}
+
+	/**
+	 * Tests handle_no_script_rsvp with an invalid or missing nonce.
+	 *
+	 * Covers: wp_die for a logged-in user without a valid nonce.
+	 *
+	 * @covers ::handle_no_script_rsvp
+	 * @return void
+	 */
+	public function test_handle_no_script_rsvp_invalid_nonce(): void {
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$instance = Form::get_instance();
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'Your session expired. Please reload the page and try again.' );
+
+		$instance->handle_no_script_rsvp();
+	}
+
+	/**
+	 * Tests handle_no_script_rsvp with an invalid status.
+	 *
+	 * Covers: wp_die when the submitted status is not attending or not_attending.
+	 *
+	 * @covers ::handle_no_script_rsvp
+	 * @return void
+	 */
+	public function test_handle_no_script_rsvp_invalid_status(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, $type, $var_name ) use ( $post_id ) {
+				if ( INPUT_POST === $type && Form::NONCE_NAME === $var_name ) {
+					return wp_create_nonce( Form::NO_SCRIPT_ACTION );
+				}
+				if ( INPUT_POST === $type && 'post_id' === $var_name ) {
+					return (string) $post_id;
+				}
+				if ( INPUT_POST === $type && 'status' === $var_name ) {
+					return 'waiting_list';
+				}
+				return $pre_value;
+			},
+			10,
+			3
+		);
+
+		$instance = Form::get_instance();
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'This RSVP is no longer available.' );
+
+		$instance->handle_no_script_rsvp();
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+	}
+
+	/**
+	 * Tests handle_no_script_rsvp on a past event.
+	 *
+	 * Covers: wp_die when the event has already ended.
+	 *
+	 * @covers ::handle_no_script_rsvp
+	 * @return void
+	 */
+	public function test_handle_no_script_rsvp_past_event(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$start = ( new \DateTimeImmutable( 'now', wp_timezone() ) )->modify( '-3 hours' );
+		$end   = ( new \DateTimeImmutable( 'now', wp_timezone() ) )->modify( '-1 hours' );
+
+		$event = new Event( $post_id );
+		$event->save_datetimes(
+			array(
+				'datetime_start' => $start->format( Event::DATETIME_FORMAT ),
+				'datetime_end'   => $end->format( Event::DATETIME_FORMAT ),
+			)
+		);
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, $type, $var_name ) use ( $post_id ) {
+				if ( INPUT_POST === $type && Form::NONCE_NAME === $var_name ) {
+					return wp_create_nonce( Form::NO_SCRIPT_ACTION );
+				}
+				if ( INPUT_POST === $type && 'post_id' === $var_name ) {
+					return (string) $post_id;
+				}
+				if ( INPUT_POST === $type && 'status' === $var_name ) {
+					return Status::ATTENDING->value;
+				}
+				return $pre_value;
+			},
+			10,
+			3
+		);
+
+		$instance = Form::get_instance();
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'Registration for this event is now closed.' );
+
+		$instance->handle_no_script_rsvp();
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+	}
+
+	/**
+	 * Tests handle_no_script_rsvp success path.
+	 *
+	 * Covers: saving the attending status for a logged-in user and the
+	 * redirect back to the event with success flags.
+	 *
+	 * @covers ::handle_no_script_rsvp
+	 * @return void
+	 */
+	public function test_handle_no_script_rsvp_success(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$permalink = (string) get_permalink( $post_id );
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, $type, $var_name ) use ( $post_id, $permalink ) {
+				if ( INPUT_POST === $type && Form::NONCE_NAME === $var_name ) {
+					return wp_create_nonce( Form::NO_SCRIPT_ACTION );
+				}
+				if ( INPUT_POST === $type && 'post_id' === $var_name ) {
+					return (string) $post_id;
+				}
+				if ( INPUT_POST === $type && 'status' === $var_name ) {
+					return Status::ATTENDING->value;
+				}
+				if ( INPUT_POST === $type && 'return_url' === $var_name ) {
+					return $permalink;
+				}
+				return $pre_value;
+			},
+			10,
+			3
+		);
+
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) {
+				throw new \WPDieException( esc_html( 'Redirect to: ' . $location ) );
+			},
+			10,
+			1
+		);
+
+		$instance = Form::get_instance();
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage(
+			esc_html(
+				'Redirect to: ' . add_query_arg(
+					array(
+						'gatherpress_rsvp_no_script' => 'success',
+						'gatherpress_rsvp_status'    => Status::ATTENDING->value,
+					),
+					$permalink
+				)
+			)
+		);
+
+		$instance->handle_no_script_rsvp();
+
+		$rsvp  = new Rsvp( $post_id );
+		$saved = $rsvp->get( $user_id );
+
+		$this->assertSame( Status::ATTENDING->value, $saved['status'], 'The RSVP must be saved as attending.' );
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+		remove_all_filters( 'wp_redirect' );
+	}
+
+	/**
+	 * Tests handle_no_script_rsvp saving failure path.
+	 *
+	 * Covers: redirect with the error flag when the save returns no_status.
+	 *
+	 * @covers ::handle_no_script_rsvp
+	 * @return void
+	 */
+	public function test_handle_no_script_rsvp_save_failure(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$permalink = (string) get_permalink( $post_id );
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, $type, $var_name ) use ( $post_id, $permalink ) {
+				if ( INPUT_POST === $type && Form::NONCE_NAME === $var_name ) {
+					return wp_create_nonce( Form::NO_SCRIPT_ACTION );
+				}
+				if ( INPUT_POST === $type && 'post_id' === $var_name ) {
+					return (string) $post_id;
+				}
+				if ( INPUT_POST === $type && 'status' === $var_name ) {
+					return Status::ATTENDING->value;
+				}
+				if ( INPUT_POST === $type && 'return_url' === $var_name ) {
+					return $permalink;
+				}
+				return $pre_value;
+			},
+			10,
+			3
+		);
+
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) {
+				throw new \WPDieException( esc_html( 'Redirect to: ' . $location ) );
+			},
+			10,
+			1
+		);
+
+		// Force the save to fail: delete the user after setting the current
+		// user context so get_current_user_id() still resolves but the RSVP
+		// identity cannot, and save() returns the default response.
+		wp_delete_user( $user_id );
+
+		$instance = Form::get_instance();
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage(
+			esc_html(
+				'Redirect to: ' . add_query_arg(
+					array(
+						'gatherpress_rsvp_no_script' => 'error',
+					),
+					$permalink
+				)
+			)
+		);
+
+		$instance->handle_no_script_rsvp();
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+		remove_all_filters( 'wp_redirect' );
+	}
+
+	/**
+	 * Tests handle_no_script_rsvp falling back to the event permalink.
+	 *
+	 * Covers: empty return_url resolves to the event permalink.
+	 *
+	 * @covers ::handle_no_script_rsvp
+	 * @return void
+	 */
+	public function test_handle_no_script_rsvp_empty_return_url(): void {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type' => Event::POST_TYPE,
+			)
+		);
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$permalink = (string) get_permalink( $post_id );
+
+		add_filter(
+			'gatherpress_pre_get_http_input',
+			static function ( $pre_value, $type, $var_name ) use ( $post_id ) {
+				if ( INPUT_POST === $type && Form::NONCE_NAME === $var_name ) {
+					return wp_create_nonce( Form::NO_SCRIPT_ACTION );
+				}
+				if ( INPUT_POST === $type && 'post_id' === $var_name ) {
+					return (string) $post_id;
+				}
+				if ( INPUT_POST === $type && 'status' === $var_name ) {
+					return Status::ATTENDING->value;
+				}
+				return $pre_value;
+			},
+			10,
+			3
+		);
+
+		add_filter(
+			'wp_redirect',
+			static function ( $location ) {
+				throw new \WPDieException( esc_html( 'Redirect to: ' . $location ) );
+			},
+			10,
+			1
+		);
+
+		$instance = Form::get_instance();
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage(
+			esc_html(
+				'Redirect to: ' . add_query_arg(
+					array(
+						'gatherpress_rsvp_no_script' => 'success',
+						'gatherpress_rsvp_status'    => Status::ATTENDING->value,
+					),
+					$permalink
+				)
+			)
+		);
+
+		$instance->handle_no_script_rsvp();
+
+		remove_all_filters( 'gatherpress_pre_get_http_input' );
+		remove_all_filters( 'wp_redirect' );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #2039

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a no-JavaScript fallback for the RSVP trigger. Logged-in users get a `<noscript>` form with a real submit button, rendered at the RSVP block wrapper level so it stays visible even though the status triggers live inside modals that are hidden without JS.
* The form posts to `admin-post.php` through a new handler in `Rsvp\Form`. It verifies the nonce, requires a logged-in user, whitelists the status to attending/not_attending, and checks event visibility, RSVP enabled state, and past events before saving through `Rsvp::save()`.
* The redirect back to the event reports the outcome: waiting-list placement when a full event converts the RSVP, a generic success message otherwise, and an error message when the save fails.
* Triggers opt in via a `gatherpress-rsvp--trigger-no-script` marker class, added to the four default RSVP templates. Existing saved blocks keep working unchanged since unmarked content is left alone.
* Toggle semantics mirror the JS path: no status or not attending submits attending; attending and waiting list submit not attending.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build the plugin or run the development server, and activate GatherPress.
* Log in and open an upcoming event page.
* Disable JavaScript in your browser (or use a browser profile with JS blocked).
* Result: the RSVP block shows an Attend or Not Attending button that works without JS. Submitting it reloads the page and shows a status message confirming the RSVP.
* Submit again to toggle the RSVP back, and check that the button and message reflect the change.
* Set the event's max attendance limit low, fill it with another RSVP, then submit Attend without JS. Result: the message says you are on the waiting list.
* Re-enable JavaScript and confirm the normal modal RSVP flow still works.
* Run `npm run test:unit:php` to see the new unit tests pass.

### Credit (for release notes)

<!-- First time contributing? Add your WordPress.org profile so we can credit you in the -->
<!-- release and on in-plugin Credits screen. -->
<!-- Your profile URL looks like: https://profiles.wordpress.org/USERNAME/ -->
<!-- Enter just the USERNAME (the last part of that URL) below. -->
<!-- Please open the link first to confirm it loads — credits are generated from this exact -->
<!-- username, so a typo or a non-existent profile gets skipped. -->
<!-- Don't have a WordPress.org account? Create one at https://login.wordpress.org/register -->

My WordPress.org username: faisalahammad

### Changelog entry

User-visible feature. The changelog entry file (`.github/changelog/2039-rsvp-no-js-fallback`) was pushed to the branch per the template's fork fallback, since the checkbox workflow cannot push to a fork.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

<!-- Add a changelog message here -->

Add a no-JavaScript RSVP fallback form for logged-in users so the RSVP trigger still works when JavaScript fails to load.

</details>